### PR TITLE
docs(#1218): 1080/1095 vol-regime bake-off re-run under candidate-self-v2 — negative result

### DIFF
--- a/docs/research/1218-artifacts/regime_1080_btc.json
+++ b/docs/research/1218-artifacts/regime_1080_btc.json
@@ -1,0 +1,2755 @@
+{
+  "symbol": "BTC/USDT",
+  "timeframe": "1h",
+  "in_sample": "is",
+  "held_out": "oos",
+  "target": "volatility",
+  "candidate_count": 18,
+  "significance_alpha": 0.05,
+  "bonferroni_alpha": 0.005555555555555556,
+  "bonferroni_denominator": 9,
+  "bonferroni_denominator_policy": "structurally ineligible candidates (k < incumbent-derived min_active_labels) are scored for evidence but excluded from the family-wise denominator",
+  "structurally_ineligible": [
+    {
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    }
+  ],
+  "n_perm": 1000,
+  "min_achievable_p_value": 0.000999000999000999,
+  "non_degeneracy_thresholds": {
+    "min_active_labels": 5,
+    "max_occupancy": 0.39199381938880623,
+    "min_transition_rate": 0.0686763372620127
+  },
+  "handrule_held_out": {
+    "kruskal_h": 85.69059649660267,
+    "p_value": 0.005994005994005994,
+    "transition_rate": 0.1373526745240254,
+    "abstained": false,
+    "permutation_steps_to_alpha": 44,
+    "knife_edge": false
+  },
+  "candidates": [
+    {
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 46.592415770166554,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.013986013986013986,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.03513145965548504
+        }
+      },
+      "model_kruskal_h": 46.592415770166554,
+      "model_p_value": 0.013986013986013986,
+      "stability_gain": 0.10222121486854036,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2150,
+          "pct": 0.4871969181962384
+        },
+        "ranging_volatile": {
+          "count": 2263,
+          "pct": 0.5128030818037617
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5682331212805254,
+          "transition_rate": 0.035303776683087026,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.568 > 0.392",
+            "min_transition_rate: 0.0353 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5128030818037617,
+          "transition_rate": 0.03513145965548504,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.513 > 0.392",
+            "min_transition_rate: 0.0351 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5485871812543074,
+          "transition_rate": 0.03526708788052843,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.549 > 0.392",
+            "min_transition_rate: 0.0353 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5087558658578459,
+          "transition_rate": 0.0383470695970696,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.509 > 0.392",
+            "min_transition_rate: 0.0383 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5310681871072842,
+          "transition_rate": 0.03235567970204842,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.531 > 0.392",
+            "min_transition_rate: 0.0324 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.00755126055449094,
+            0.18354201174585266,
+            0.23146087182239317,
+            36.85508276421143
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005683939134586702,
+            0.12318410209359588,
+            0.07791568270198539,
+            21.87381095910724
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 74.69963537831609,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.02097902097902098,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.044424297370806894
+        }
+      },
+      "model_kruskal_h": 74.69963537831609,
+      "model_p_value": 0.02097902097902098,
+      "stability_gain": 0.0929283771532185,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2125,
+          "pct": 0.48153183775209607
+        },
+        "trending_down_choppy": {
+          "count": 1289,
+          "pct": 0.29209154769997736
+        },
+        "trending_up_choppy": {
+          "count": 999,
+          "pct": 0.22637661454792657
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5448389082700595,
+          "transition_rate": 0.04187192118226601,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.545 > 0.392",
+            "min_transition_rate: 0.0419 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.48153183775209607,
+          "transition_rate": 0.044424297370806894,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.482 > 0.392",
+            "min_transition_rate: 0.0444 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5323914541695383,
+          "transition_rate": 0.04032165422171166,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.532 > 0.392",
+            "min_transition_rate: 0.0403 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4841478768455992,
+          "transition_rate": 0.04681776556776557,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.484 > 0.392",
+            "min_transition_rate: 0.0468 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.512217826390505,
+          "transition_rate": 0.04189944134078212,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.512 > 0.392",
+            "min_transition_rate: 0.0419 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00524331067616402,
+            0.12216174978953546,
+            0.07160931828841736,
+            21.96761195888488
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.10475628408767888,
+            0.17786530614441362,
+            0.212300950251665,
+            37.13169664606488
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.12493967054949551,
+            0.18493165309502024,
+            0.25164207675883726,
+            33.985550586827706
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 79.70415786133162,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.02197802197802198,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08363553943789664
+        }
+      },
+      "model_kruskal_h": 79.70415786133162,
+      "model_p_value": 0.02197802197802198,
+      "stability_gain": 0.05371713508612874,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1732,
+          "pct": 0.39247677317017904
+        },
+        "ranging_volatile": {
+          "count": 1089,
+          "pct": 0.2467709041468389
+        },
+        "trending_down_choppy": {
+          "count": 957,
+          "pct": 0.2168592794017675
+        },
+        "trending_up_choppy": {
+          "count": 635,
+          "pct": 0.1438930432812146
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.37779601887954034,
+          "transition_rate": 0.0812807881773399,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.39247677317017904,
+          "transition_rate": 0.08363553943789664,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.392 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3766368022053756,
+          "transition_rate": 0.08902929350947732,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.39487238182442486,
+          "transition_rate": 0.0850503663003663,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.395 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3912031649988364,
+          "transition_rate": 0.0947392923649907,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.005304241028108408,
+            0.14228848502567515,
+            0.12727315163306863,
+            26.43549789652893
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.122736288062705,
+            0.18749135701273506,
+            0.24754881783372096,
+            40.02275531027101
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14701434638993968,
+            0.2014930801859868,
+            0.29385455922992165,
+            36.55496800842193
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0019271255101770148,
+            0.11394121664098841,
+            0.04336154333875711,
+            20.51861500846088
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 59.30301533318925,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.025974025974025976,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.06754306436990028
+        }
+      },
+      "model_kruskal_h": 59.30301533318925,
+      "model_p_value": 0.025974025974025976,
+      "stability_gain": 0.06980961015412511,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1233,
+          "pct": 0.2794017675050986
+        },
+        "trending_down_choppy": {
+          "count": 1660,
+          "pct": 0.3761613414910492
+        },
+        "trending_up_choppy": {
+          "count": 1520,
+          "pct": 0.3444368910038523
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3539913810794172,
+          "transition_rate": 0.07655993431855501,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.3761613414910492,
+          "transition_rate": 0.06754306436990028,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "min_transition_rate: 0.0675 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.3658396508155295,
+          "transition_rate": 0.08661688684663986,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.39716149708137805,
+          "transition_rate": 0.07268772893772894,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.397 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.3618803816616244,
+          "transition_rate": 0.08426443202979515,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06858203092811292,
+            0.13660100493347754,
+            0.1434990528874797,
+            24.10252406232175
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13004439074913146,
+            0.19071522685542275,
+            0.26217293250219587,
+            41.18210134496014
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.06231675737044698,
+            0.1479476962528805,
+            0.12895368181959263,
+            28.84225779849284
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0009132888711901893,
+            0.11753247708653275,
+            0.03996660878847583,
+            21.292055426420568
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14996145956495005,
+            0.2032693542696212,
+            0.29922876998934556,
+            36.86192557168001
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 81.49093805047596,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.015984015984015984,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.078649138712602
+        }
+      },
+      "model_kruskal_h": 81.49093805047596,
+      "model_p_value": 0.015984015984015984,
+      "stability_gain": 0.05870353581142339,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 503,
+          "pct": 0.11398141853614321
+        },
+        "ranging_volatile": {
+          "count": 977,
+          "pct": 0.22139134375708136
+        },
+        "trending_down_choppy": {
+          "count": 1470,
+          "pct": 0.33310673011556763
+        },
+        "trending_up_choppy": {
+          "count": 1463,
+          "pct": 0.33152050759120777
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.30679253026882825,
+          "transition_rate": 0.08087027914614121,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.33310673011556763,
+          "transition_rate": 0.078649138712602,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.34918447048012863,
+          "transition_rate": 0.08477886272257323,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3848002746938308,
+          "transition_rate": 0.08195970695970696,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.34652082848498955,
+          "transition_rate": 0.08472998137802606,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.015576564159259062,
+            0.1409264693931202,
+            0.04904287048517281,
+            30.606690861198643
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.07171639208781058,
+            0.14925489298240077,
+            0.1489040332341788,
+            28.359693348998004
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13247631426400705,
+            0.19218777047541963,
+            0.26669870231960446,
+            41.43178959229569
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0032806352589625698,
+            0.11226572629636841,
+            0.044761126300617696,
+            18.905984474990973
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07035774771731626,
+            0.1381702946168062,
+            0.1470921661867227,
+            24.452193257436953
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.15079288674498723,
+            0.20385184522988262,
+            0.3007071101257731,
+            36.9852980486165
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 72.09895597191462,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.02197802197802198,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08340888485947416
+        }
+      },
+      "model_kruskal_h": 72.09895597191462,
+      "model_p_value": 0.02197802197802198,
+      "stability_gain": 0.053943789664551225,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 500,
+          "pct": 0.11330160888284614
+        },
+        "ranging_volatile": {
+          "count": 907,
+          "pct": 0.20552911851348288
+        },
+        "trending_down_choppy": {
+          "count": 1484,
+          "pct": 0.33627917516428735
+        },
+        "trending_up_choppy": {
+          "count": 1522,
+          "pct": 0.34489009743938365
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.32444079622409194,
+          "transition_rate": 0.09072249589490969,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.34489009743938365,
+          "transition_rate": 0.08340888485947416,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3607856650585803,
+          "transition_rate": 0.09144170017231476,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3947579260615772,
+          "transition_rate": 0.08871336996336997,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.395 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.36397486618571095,
+          "transition_rate": 0.09054934823091247,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0005027356107206483,
+            0.11224814725364951,
+            0.04079247667809589,
+            18.988498426771645
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06111146207075637,
+            0.1277461692846439,
+            0.1285781254011893,
+            21.72377877665248
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.015831001301463775,
+            0.14171160686435166,
+            0.05017179280590109,
+            30.846818863994507
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1323396028727731,
+            0.1921095054462609,
+            0.2664447892145779,
+            41.419318214636014
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.105654469546394,
+            0.16991364996595193,
+            0.21809980480108276,
+            32.00984351908438
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.07160917965624518,
+            0.14887466219276577,
+            0.14873261833412502,
+            28.223670437952606
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1858194821022053,
+            0.23319830462351757,
+            0.3611696456239619,
+            40.98326439356847
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 41.91367063147118,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.03896103896103896,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.04374433363553944
+        }
+      },
+      "model_kruskal_h": 41.91367063147118,
+      "model_p_value": 0.03896103896103896,
+      "stability_gain": 0.09360834088848595,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2121,
+          "pct": 0.4806254248810333
+        },
+        "ranging_volatile": {
+          "count": 2292,
+          "pct": 0.5193745751189667
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5731582187564129,
+          "transition_rate": 0.038998357963875206,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.573 > 0.392",
+            "min_transition_rate: 0.0390 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5193745751189667,
+          "transition_rate": 0.04374433363553944,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.519 > 0.392",
+            "min_transition_rate: 0.0437 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5569722030783367,
+          "transition_rate": 0.04055140723721999,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.557 > 0.392",
+            "min_transition_rate: 0.0406 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5143641982373812,
+          "transition_rate": 0.04429945054945055,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.514 > 0.392",
+            "min_transition_rate: 0.0443 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5396788457063068,
+          "transition_rate": 0.036080074487895714,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.540 > 0.392",
+            "min_transition_rate: 0.0361 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.005502734254364465,
+            0.18342747882528565,
+            0.23564357528921204,
+            36.44092213232946
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.004075595150556658,
+            0.12384805866393585,
+            0.07637036554941636,
+            22.317461369474312
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 75.42070759586932,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.028971028971028972,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.046010879419764276
+        }
+      },
+      "model_kruskal_h": 75.42070759586932,
+      "model_p_value": 0.028971028971028972,
+      "stability_gain": 0.0913417951042611,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2336,
+          "pct": 0.5293451167006572
+        },
+        "trending_down_choppy": {
+          "count": 1193,
+          "pct": 0.27033763879447087
+        },
+        "trending_up_choppy": {
+          "count": 884,
+          "pct": 0.20031724450487198
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5869074492099323,
+          "transition_rate": 0.04351395730706076,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.587 > 0.392",
+            "min_transition_rate: 0.0435 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5293451167006572,
+          "transition_rate": 0.046010879419764276,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.529 > 0.392",
+            "min_transition_rate: 0.0460 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5816678152997933,
+          "transition_rate": 0.0450315910396324,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.582 > 0.392",
+            "min_transition_rate: 0.0450 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5315325626645302,
+          "transition_rate": 0.0486492673992674,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.532 > 0.392",
+            "min_transition_rate: 0.0486 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5636490574819641,
+          "transition_rate": 0.04306331471135941,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.564 > 0.392",
+            "min_transition_rate: 0.0431 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005075012008396578,
+            0.12542688421784254,
+            0.07731733918469537,
+            22.80853912855038
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11169832379968075,
+            0.18075344293670947,
+            0.22614432446324395,
+            37.95211672005942
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1340999106165127,
+            0.19045167141845493,
+            0.26951698909831107,
+            34.75884620438009
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 79.41439963154335,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.014985014985014986,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.11536718041704443
+        }
+      },
+      "model_kruskal_h": 79.41439963154335,
+      "model_p_value": 0.014985014985014986,
+      "stability_gain": 0.02198549410698096,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1808,
+          "pct": 0.40969861772037164
+        },
+        "ranging_volatile": {
+          "count": 1099,
+          "pct": 0.2490369363244958
+        },
+        "trending_down_choppy": {
+          "count": 920,
+          "pct": 0.20847496034443688
+        },
+        "trending_up_choppy": {
+          "count": 586,
+          "pct": 0.13278948561069567
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.41719679868664067,
+          "transition_rate": 0.12315270935960591,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.417 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.40969861772037164,
+          "transition_rate": 0.11536718041704443,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.410 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.40167700436480586,
+          "transition_rate": 0.1283170591614015,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.402 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.41066727709740186,
+          "transition_rate": 0.11813186813186813,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.411 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.42168955084942983,
+          "transition_rate": 0.1287243947858473,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.422 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.00457184308135086,
+            0.14117198914657933,
+            0.13016782117280135,
+            26.279365223934754
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12806118155554375,
+            0.18917897023958513,
+            0.258518321860861,
+            40.69123511613657
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1531857875320342,
+            0.20370535438544335,
+            0.3062979664033859,
+            36.66833846625733
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0005503865234446904,
+            0.11672577515526995,
+            0.03512918327968835,
+            21.139713393407842
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 64.66643447978277,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.02097902097902098,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08091568449682683
+        }
+      },
+      "model_kruskal_h": 64.66643447978277,
+      "model_p_value": 0.02097902097902098,
+      "stability_gain": 0.056436990027198555,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1339,
+          "pct": 0.30342170858826195
+        },
+        "trending_down_choppy": {
+          "count": 1606,
+          "pct": 0.3639247677317018
+        },
+        "trending_up_choppy": {
+          "count": 1468,
+          "pct": 0.33265352368003626
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3511184075518161,
+          "transition_rate": 0.08805418719211823,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.3639247677317018,
+          "transition_rate": 0.08091568449682683,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.36928555019526765,
+          "transition_rate": 0.09259046524985641,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.3848002746938308,
+          "transition_rate": 0.08573717948717949,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.35233884105189667,
+          "transition_rate": 0.0947392923649907,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0706191130188882,
+            0.1381936326109156,
+            0.14737582484656542,
+            24.579787311899803
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1337649695157418,
+            0.19126000819091887,
+            0.2694825949680144,
+            41.155051147028196
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.06702725712046893,
+            0.14969901388622933,
+            0.1386605674979722,
+            29.35247888903386
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0004500652671430372,
+            0.11993989131217989,
+            0.04165722618700232,
+            21.900865684325883
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.15276097054683546,
+            0.20293583619438454,
+            0.30517825382212493,
+            36.533061068509596
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 67.97953532132124,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.012987012987012988,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12692656391659113
+        }
+      },
+      "model_kruskal_h": 67.97953532132124,
+      "model_p_value": 0.012987012987012988,
+      "stability_gain": 0.010426110607434258,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 460,
+          "pct": 0.10423748017221844
+        },
+        "ranging_volatile": {
+          "count": 1098,
+          "pct": 0.24881033310673012
+        },
+        "trending_down_choppy": {
+          "count": 1300,
+          "pct": 0.29458418309539997
+        },
+        "trending_up_choppy": {
+          "count": 1555,
+          "pct": 0.35236800362565146
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3303919556741227,
+          "transition_rate": 0.14942528735632185,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.35236800362565146,
+          "transition_rate": 0.12692656391659113,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.37606248564208594,
+          "transition_rate": 0.14198736358414704,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.4071191484491244,
+          "transition_rate": 0.1353021978021978,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.407 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3714219222713521,
+          "transition_rate": 0.1478119180633147,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.04366630374896207,
+            0.1376664538800906,
+            0.08970357405499844,
+            27.381210974078254
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08183455114005711,
+            0.15529976336577972,
+            0.16997439493176705,
+            30.400763213013317
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13835159772007966,
+            0.19365601953711425,
+            0.2779414009307426,
+            41.71191129682961
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0028228376070924925,
+            0.11896908510777429,
+            0.03376595501632661,
+            21.585861943722634
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06629388657860845,
+            0.13569875405916726,
+            0.1385579721518705,
+            24.01400144089481
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1497865291712852,
+            0.20083358057455686,
+            0.2995779001351577,
+            36.23587973180108
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 65.59212172530533,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.012987012987012988,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12941976427923843
+        }
+      },
+      "model_kruskal_h": 65.59212172530533,
+      "model_p_value": 0.012987012987012988,
+      "stability_gain": 0.007932910244786956,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 473,
+          "pct": 0.10718332200317245
+        },
+        "ranging_volatile": {
+          "count": 1056,
+          "pct": 0.23929299796057105
+        },
+        "trending_down_choppy": {
+          "count": 1303,
+          "pct": 0.295263992748697
+        },
+        "trending_up_choppy": {
+          "count": 1581,
+          "pct": 0.35825968728755947
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3400369382310692,
+          "transition_rate": 0.15722495894909688,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.35825968728755947,
+          "transition_rate": 0.12941976427923843,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.38295428440156215,
+          "transition_rate": 0.1488799540493969,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.41410094998283165,
+          "transition_rate": 0.13896520146520147,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.414 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.38259250639981385,
+          "transition_rate": 0.14827746741154563,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0022947929224514823,
+            0.11891198434975563,
+            0.03209652576498716,
+            21.592638263884417
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.05956804630290927,
+            0.13165520002611947,
+            0.1252215417900794,
+            23.202130277349845
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.043048333860697556,
+            0.13710792497169225,
+            0.08845741126450657,
+            27.243439041137435
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13835739445423156,
+            0.19366973147017236,
+            0.27794533852303344,
+            41.71623498569485
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11248705075507764,
+            0.1686760357895703,
+            0.23191841817007863,
+            31.162267944254612
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08165555504625843,
+            0.15522522322836885,
+            0.16958343466574566,
+            30.383448024235634
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18647829244425287,
+            0.23222873446749664,
+            0.3629435706729254,
+            40.44885185634014
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 43.9607670861169,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.03496503496503497,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.03150498640072529
+        }
+      },
+      "model_kruskal_h": 43.9607670861169,
+      "model_p_value": 0.03496503496503497,
+      "stability_gain": 0.10584768812330009,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1857,
+          "pct": 0.42080217539089054
+        },
+        "ranging_volatile": {
+          "count": 2556,
+          "pct": 0.5791978246091094
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.621998768725631,
+          "transition_rate": 0.031609195402298854,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.622 > 0.392",
+            "min_transition_rate: 0.0316 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5791978246091094,
+          "transition_rate": 0.03150498640072529,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.579 > 0.392",
+            "min_transition_rate: 0.0315 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.616815988973122,
+          "transition_rate": 0.03067202757036186,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.617 > 0.392",
+            "min_transition_rate: 0.0307 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.57456792949525,
+          "transition_rate": 0.03514194139194139,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.575 > 0.392",
+            "min_transition_rate: 0.0351 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5985571328834071,
+          "transition_rate": 0.031890130353817506,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.599 > 0.392",
+            "min_transition_rate: 0.0319 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.007813399107477342,
+            0.1904865163031385,
+            0.25024893920736746,
+            38.756658965445794
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.004223863177510036,
+            0.12679850085029357,
+            0.08651636360075063,
+            22.676732378006317
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 82.73756493551264,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.01998001998001998,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.04329102447869447
+        }
+      },
+      "model_kruskal_h": 82.73756493551264,
+      "model_p_value": 0.01998001998001998,
+      "stability_gain": 0.09406165004533092,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2384,
+          "pct": 0.5402220711534104
+        },
+        "trending_down_choppy": {
+          "count": 1178,
+          "pct": 0.2669385905279855
+        },
+        "trending_up_choppy": {
+          "count": 851,
+          "pct": 0.19283933831860411
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5910116971065053,
+          "transition_rate": 0.038998357963875206,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.591 > 0.392",
+            "min_transition_rate: 0.0390 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5402220711534104,
+          "transition_rate": 0.04329102447869447,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.540 > 0.392",
+            "min_transition_rate: 0.0433 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5869515276820584,
+          "transition_rate": 0.041240666283744974,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.587 > 0.392",
+            "min_transition_rate: 0.0412 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5414902140322765,
+          "transition_rate": 0.04475732600732601,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.541 > 0.392",
+            "min_transition_rate: 0.0448 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5696997905515476,
+          "transition_rate": 0.042132216014897576,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.570 > 0.392",
+            "min_transition_rate: 0.0421 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005703862336521655,
+            0.12519971663132562,
+            0.08049942929815943,
+            22.421079141202416
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11063853257456722,
+            0.18172433353657422,
+            0.22361199524957437,
+            38.883719283978984
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.13601736185684565,
+            0.19417634466913342,
+            0.2730405538751525,
+            35.77197895814321
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 83.58132637643939,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.025974025974025976,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.06300997280145058
+        }
+      },
+      "model_kruskal_h": 83.58132637643939,
+      "model_p_value": 0.025974025974025976,
+      "stability_gain": 0.0743427017225748,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1254,
+          "pct": 0.2841604350781781
+        },
+        "ranging_volatile": {
+          "count": 1587,
+          "pct": 0.35961930659415364
+        },
+        "trending_down_choppy": {
+          "count": 845,
+          "pct": 0.19147971901200997
+        },
+        "trending_up_choppy": {
+          "count": 727,
+          "pct": 0.16474053931565827
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.435665914221219,
+          "transition_rate": 0.059113300492610835,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.436 > 0.392",
+            "min_transition_rate: 0.0591 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.35961930659415364,
+          "transition_rate": 0.06300997280145058,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0630 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4182173213875488,
+          "transition_rate": 0.058472142446869615,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.418 > 0.392",
+            "min_transition_rate: 0.0585 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3639693258555568,
+          "transition_rate": 0.06421703296703296,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0642 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.40842448219688154,
+          "transition_rate": 0.06424581005586592,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.408 > 0.392",
+            "min_transition_rate: 0.0642 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.03111499811850684,
+            0.15307317373811,
+            0.12188998091521863,
+            30.741836550340736
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1302364740917169,
+            0.19141786651140588,
+            0.2623080043424838,
+            42.21137888848135
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14437983449509717,
+            0.19822121449445432,
+            0.28923010913455455,
+            35.87490695768459
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.015353963382247897,
+            0.11778292502558124,
+            0.07319223297479473,
+            20.025199288757197
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 66.83756122339764,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.022977022977022976,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.05371713508612874
+        }
+      },
+      "model_kruskal_h": 66.83756122339764,
+      "model_p_value": 0.022977022977022976,
+      "stability_gain": 0.08363553943789664,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1570,
+          "pct": 0.35576705189213687
+        },
+        "trending_down_choppy": {
+          "count": 1627,
+          "pct": 0.3686834353047813
+        },
+        "trending_up_choppy": {
+          "count": 1216,
+          "pct": 0.2755495128030818
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4186332854504412,
+          "transition_rate": 0.051313628899835796,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.419 > 0.392",
+            "min_transition_rate: 0.0513 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.3686834353047813,
+          "transition_rate": 0.05371713508612874,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "min_transition_rate: 0.0537 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.42625775327360443,
+          "transition_rate": 0.054106835152211374,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.426 > 0.392",
+            "min_transition_rate: 0.0541 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.3542405860135058,
+          "transition_rate": 0.05918040293040293,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "min_transition_rate: 0.0592 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.39515941354433326,
+          "transition_rate": 0.05307262569832402,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.395 > 0.392",
+            "min_transition_rate: 0.0531 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.09590165406039532,
+            0.16003864948167654,
+            0.1983251334724151,
+            29.19733925358716
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13489948796109844,
+            0.19536643125451025,
+            0.2714127427332896,
+            44.12095875263345
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.06648851329398535,
+            0.15670579591083997,
+            0.13819415744984556,
+            30.315549124053927
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.008768076157520661,
+            0.1171308289725782,
+            0.061307811092743025,
+            20.64450073774572
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1817757794927396,
+            0.23048051853754312,
+            0.3558671572017239,
+            42.41024516582192
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 69.37753922107913,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.03796203796203796,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.06799637352674524
+        }
+      },
+      "model_kruskal_h": 69.37753922107913,
+      "model_p_value": 0.03796203796203796,
+      "stability_gain": 0.06935630099728014,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 549,
+          "pct": 0.12440516655336506
+        },
+        "ranging_volatile": {
+          "count": 1390,
+          "pct": 0.3149784726943123
+        },
+        "trending_down_choppy": {
+          "count": 1332,
+          "pct": 0.3018354860639021
+        },
+        "trending_up_choppy": {
+          "count": 1142,
+          "pct": 0.2587808746884206
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3650728504001642,
+          "transition_rate": 0.07060755336617405,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3149784726943123,
+          "transition_rate": 0.06799637352674524,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0680 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3657247875028716,
+          "transition_rate": 0.06961516369902356,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3102895730800046,
+          "transition_rate": 0.07589285714285714,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3569932511054224,
+          "transition_rate": 0.0691340782122905,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.015388972835934208,
+            0.1420117187808927,
+            0.07587104500373561,
+            33.50969741647665
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08586259529252369,
+            0.1626032746940651,
+            0.17600760226413842,
+            26.91447608583654
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13452066957240058,
+            0.19500531338801652,
+            0.27035087691035375,
+            44.899385162738255
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009598950154765945,
+            0.11527523972597871,
+            0.06339269093574985,
+            19.224142413585
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0998408712518566,
+            0.16162666000473427,
+            0.2054539086860961,
+            28.62967818110436
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18206375718516551,
+            0.23071318148135136,
+            0.3562994339378191,
+            42.48038475325567
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 70.48007095643698,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.026973026973026972,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08046237533998186
+        }
+      },
+      "model_kruskal_h": 70.48007095643698,
+      "model_p_value": 0.026973026973026972,
+      "stability_gain": 0.05689029918404352,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 477,
+          "pct": 0.10808973487423522
+        },
+        "ranging_volatile": {
+          "count": 1137,
+          "pct": 0.2576478585995921
+        },
+        "trending_down_choppy": {
+          "count": 1352,
+          "pct": 0.30636755041921593
+        },
+        "trending_up_choppy": {
+          "count": 1447,
+          "pct": 0.32789485610695673
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3043299815308845,
+          "transition_rate": 0.08784893267651889,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.32789485610695673,
+          "transition_rate": 0.08046237533998186,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3350562830232024,
+          "transition_rate": 0.08868466398621482,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.37827629621151426,
+          "transition_rate": 0.08058608058608059,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3469862694903421,
+          "transition_rate": 0.0893854748603352,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.0034321147789508084,
+            0.11322747175818654,
+            0.04664463482156207,
+            19.566989035448586
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0667489383848353,
+            0.1313339445069582,
+            0.139463683982449,
+            21.42469826004001
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.021288697551426282,
+            0.14361104327825316,
+            0.07901135443885518,
+            34.72073854237792
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13445303668836828,
+            0.19492873657594934,
+            0.2701311805789483,
+            44.647351654445075
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11599479199967179,
+            0.17885066036634992,
+            0.23715477790820735,
+            32.459086285064295
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08468817595663619,
+            0.16178340871338243,
+            0.17405884060848012,
+            26.36216187536592
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.19365654195946694,
+            0.24094684356078727,
+            0.3750316921392831,
+            44.14655673534547
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "passes_bonferroni": false
+    }
+  ],
+  "winner": null
+}

--- a/docs/research/1218-artifacts/regime_1095_btc.json
+++ b/docs/research/1218-artifacts/regime_1095_btc.json
@@ -1,0 +1,15043 @@
+{
+  "issue": 1095,
+  "symbol": "BTC/USDT",
+  "timeframe": "1h",
+  "in_sample": "is",
+  "held_out": "oos",
+  "target": "volatility",
+  "htf_multiple": 4,
+  "candidate_count": 90,
+  "significance_alpha": 0.05,
+  "bonferroni_alpha": 0.0011111111111111111,
+  "bonferroni_denominator": 45,
+  "bonferroni_denominator_policy": "ONE family across all feature-subset ablations (#1095 4b): alpha is divided by the COMBINED structurally-eligible candidate count of the whole subsets x families x K grid; structurally ineligible candidates (k < incumbent-derived min_active_labels) are scored for evidence but excluded (#1160)",
+  "structurally_ineligible": [
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    }
+  ],
+  "n_perm": 1799,
+  "min_achievable_p_value": 0.0005555555555555556,
+  "non_degeneracy_thresholds": {
+    "min_active_labels": 5,
+    "max_occupancy": 0.39199381938880623,
+    "min_transition_rate": 0.0686763372620127
+  },
+  "subset_status": {
+    "canonical": "ok",
+    "funding": "ok",
+    "volume": "ok",
+    "htf": "ok",
+    "all_enriched": "ok"
+  },
+  "handrule_held_out": {
+    "canonical": {
+      "kruskal_h": 85.69059649660267,
+      "p_value": 0.0044444444444444444,
+      "transition_rate": 0.1373526745240254,
+      "abstained": false,
+      "permutation_steps_to_alpha": 82,
+      "knife_edge": false
+    },
+    "funding": {
+      "kruskal_h": 85.69059649660267,
+      "p_value": 0.0044444444444444444,
+      "transition_rate": 0.1373526745240254,
+      "abstained": false,
+      "permutation_steps_to_alpha": 82,
+      "knife_edge": false
+    },
+    "volume": {
+      "kruskal_h": 85.69059649660267,
+      "p_value": 0.0044444444444444444,
+      "transition_rate": 0.1373526745240254,
+      "abstained": false,
+      "permutation_steps_to_alpha": 82,
+      "knife_edge": false
+    },
+    "htf": {
+      "kruskal_h": 80.46779679379688,
+      "p_value": 0.005,
+      "transition_rate": 0.13860225140712945,
+      "abstained": false,
+      "permutation_steps_to_alpha": 81,
+      "knife_edge": false
+    },
+    "all_enriched": {
+      "kruskal_h": 80.46779679379688,
+      "p_value": 0.005,
+      "transition_rate": 0.13860225140712945,
+      "abstained": false,
+      "permutation_steps_to_alpha": 81,
+      "knife_edge": false
+    }
+  },
+  "baseline_note": "the merged #1080 evidence was measured at n_perm=200 with the incumbent at a knife-edge (OOS p = 10/201); handrule_held_out.canonical re-measures that baseline at this run's resolved n_perm so enriched-vs-baseline and the incumbent-trustworthy verdict share one resolution (#1095 4c)",
+  "ablation": {
+    "canonical": {
+      "status": "ok",
+      "best_kruskal_h": null,
+      "best_candidate": null,
+      "any_ships": false,
+      "separation_gain_vs_canonical": null
+    },
+    "funding": {
+      "status": "ok",
+      "best_kruskal_h": null,
+      "best_candidate": null,
+      "any_ships": false,
+      "separation_gain_vs_canonical": null
+    },
+    "volume": {
+      "status": "ok",
+      "best_kruskal_h": 107.83195003540277,
+      "best_candidate": {
+        "family": "gmm",
+        "k": 5
+      },
+      "any_ships": false,
+      "separation_gain_vs_canonical": null
+    },
+    "htf": {
+      "status": "ok",
+      "best_kruskal_h": null,
+      "best_candidate": null,
+      "any_ships": false,
+      "separation_gain_vs_canonical": null
+    },
+    "all_enriched": {
+      "status": "ok",
+      "best_kruskal_h": null,
+      "best_candidate": null,
+      "any_ships": false,
+      "separation_gain_vs_canonical": null
+    }
+  },
+  "candidates": [
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 46.592415770166554,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.02,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.03513145965548504
+        }
+      },
+      "model_kruskal_h": 46.592415770166554,
+      "model_p_value": 0.02,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.10222121486854036,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2150,
+          "pct": 0.4871969181962384
+        },
+        "ranging_volatile": {
+          "count": 2263,
+          "pct": 0.5128030818037617
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5682331212805254,
+          "transition_rate": 0.035303776683087026,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.568 > 0.392",
+            "min_transition_rate: 0.0353 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5128030818037617,
+          "transition_rate": 0.03513145965548504,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.513 > 0.392",
+            "min_transition_rate: 0.0351 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5485871812543074,
+          "transition_rate": 0.03526708788052843,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.549 > 0.392",
+            "min_transition_rate: 0.0353 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5087558658578459,
+          "transition_rate": 0.0383470695970696,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.509 > 0.392",
+            "min_transition_rate: 0.0383 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5310681871072842,
+          "transition_rate": 0.03235567970204842,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.531 > 0.392",
+            "min_transition_rate: 0.0324 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.00755126055449094,
+            0.18354201174585266,
+            0.23146087182239317,
+            36.85508276421143
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005683939134586702,
+            0.12318410209359588,
+            0.07791568270198539,
+            21.87381095910724
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 74.69963537831609,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.021666666666666667,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.044424297370806894
+        }
+      },
+      "model_kruskal_h": 74.69963537831609,
+      "model_p_value": 0.021666666666666667,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.0929283771532185,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2125,
+          "pct": 0.48153183775209607
+        },
+        "trending_down_choppy": {
+          "count": 1289,
+          "pct": 0.29209154769997736
+        },
+        "trending_up_choppy": {
+          "count": 999,
+          "pct": 0.22637661454792657
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5448389082700595,
+          "transition_rate": 0.04187192118226601,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.545 > 0.392",
+            "min_transition_rate: 0.0419 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.48153183775209607,
+          "transition_rate": 0.044424297370806894,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.482 > 0.392",
+            "min_transition_rate: 0.0444 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5323914541695383,
+          "transition_rate": 0.04032165422171166,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.532 > 0.392",
+            "min_transition_rate: 0.0403 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4841478768455992,
+          "transition_rate": 0.04681776556776557,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.484 > 0.392",
+            "min_transition_rate: 0.0468 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.512217826390505,
+          "transition_rate": 0.04189944134078212,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.512 > 0.392",
+            "min_transition_rate: 0.0419 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00524331067616402,
+            0.12216174978953546,
+            0.07160931828841736,
+            21.96761195888488
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.10475628408767888,
+            0.17786530614441362,
+            0.212300950251665,
+            37.13169664606488
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.12493967054949551,
+            0.18493165309502024,
+            0.25164207675883726,
+            33.985550586827706
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 79.70415786133162,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.021111111111111112,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08363553943789664
+        }
+      },
+      "model_kruskal_h": 79.70415786133162,
+      "model_p_value": 0.021111111111111112,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.05371713508612874,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1732,
+          "pct": 0.39247677317017904
+        },
+        "ranging_volatile": {
+          "count": 1089,
+          "pct": 0.2467709041468389
+        },
+        "trending_down_choppy": {
+          "count": 957,
+          "pct": 0.2168592794017675
+        },
+        "trending_up_choppy": {
+          "count": 635,
+          "pct": 0.1438930432812146
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.37779601887954034,
+          "transition_rate": 0.0812807881773399,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.39247677317017904,
+          "transition_rate": 0.08363553943789664,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.392 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3766368022053756,
+          "transition_rate": 0.08902929350947732,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.39487238182442486,
+          "transition_rate": 0.0850503663003663,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.395 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3912031649988364,
+          "transition_rate": 0.0947392923649907,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.005304241028108408,
+            0.14228848502567515,
+            0.12727315163306863,
+            26.43549789652893
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.122736288062705,
+            0.18749135701273506,
+            0.24754881783372096,
+            40.02275531027101
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14701434638993968,
+            0.2014930801859868,
+            0.29385455922992165,
+            36.55496800842193
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0019271255101770148,
+            0.11394121664098841,
+            0.04336154333875711,
+            20.51861500846088
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 59.30301533318925,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.03277777777777778,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.06754306436990028
+        }
+      },
+      "model_kruskal_h": 59.30301533318925,
+      "model_p_value": 0.03277777777777778,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.06980961015412511,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1233,
+          "pct": 0.2794017675050986
+        },
+        "trending_down_choppy": {
+          "count": 1660,
+          "pct": 0.3761613414910492
+        },
+        "trending_up_choppy": {
+          "count": 1520,
+          "pct": 0.3444368910038523
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3539913810794172,
+          "transition_rate": 0.07655993431855501,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.3761613414910492,
+          "transition_rate": 0.06754306436990028,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "min_transition_rate: 0.0675 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.3658396508155295,
+          "transition_rate": 0.08661688684663986,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.39716149708137805,
+          "transition_rate": 0.07268772893772894,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.397 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.3618803816616244,
+          "transition_rate": 0.08426443202979515,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06858203092811292,
+            0.13660100493347754,
+            0.1434990528874797,
+            24.10252406232175
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13004439074913146,
+            0.19071522685542275,
+            0.26217293250219587,
+            41.18210134496014
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.06231675737044698,
+            0.1479476962528805,
+            0.12895368181959263,
+            28.84225779849284
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0009132888711901893,
+            0.11753247708653275,
+            0.03996660878847583,
+            21.292055426420568
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14996145956495005,
+            0.2032693542696212,
+            0.29922876998934556,
+            36.86192557168001
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 81.49093805047596,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.011666666666666667,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.078649138712602
+        }
+      },
+      "model_kruskal_h": 81.49093805047596,
+      "model_p_value": 0.011666666666666667,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.05870353581142339,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 503,
+          "pct": 0.11398141853614321
+        },
+        "ranging_volatile": {
+          "count": 977,
+          "pct": 0.22139134375708136
+        },
+        "trending_down_choppy": {
+          "count": 1470,
+          "pct": 0.33310673011556763
+        },
+        "trending_up_choppy": {
+          "count": 1463,
+          "pct": 0.33152050759120777
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.30679253026882825,
+          "transition_rate": 0.08087027914614121,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.33310673011556763,
+          "transition_rate": 0.078649138712602,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.34918447048012863,
+          "transition_rate": 0.08477886272257323,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3848002746938308,
+          "transition_rate": 0.08195970695970696,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.34652082848498955,
+          "transition_rate": 0.08472998137802606,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.015576564159259062,
+            0.1409264693931202,
+            0.04904287048517281,
+            30.606690861198643
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.07171639208781058,
+            0.14925489298240077,
+            0.1489040332341788,
+            28.359693348998004
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13247631426400705,
+            0.19218777047541963,
+            0.26669870231960446,
+            41.43178959229569
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0032806352589625698,
+            0.11226572629636841,
+            0.044761126300617696,
+            18.905984474990973
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07035774771731626,
+            0.1381702946168062,
+            0.1470921661867227,
+            24.452193257436953
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.15079288674498723,
+            0.20385184522988262,
+            0.3007071101257731,
+            36.9852980486165
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 72.09895597191462,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.026111111111111113,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08340888485947416
+        }
+      },
+      "model_kruskal_h": 72.09895597191462,
+      "model_p_value": 0.026111111111111113,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.053943789664551225,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 500,
+          "pct": 0.11330160888284614
+        },
+        "ranging_volatile": {
+          "count": 907,
+          "pct": 0.20552911851348288
+        },
+        "trending_down_choppy": {
+          "count": 1484,
+          "pct": 0.33627917516428735
+        },
+        "trending_up_choppy": {
+          "count": 1522,
+          "pct": 0.34489009743938365
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.32444079622409194,
+          "transition_rate": 0.09072249589490969,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.34489009743938365,
+          "transition_rate": 0.08340888485947416,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3607856650585803,
+          "transition_rate": 0.09144170017231476,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3947579260615772,
+          "transition_rate": 0.08871336996336997,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.395 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.36397486618571095,
+          "transition_rate": 0.09054934823091247,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0005027356107206483,
+            0.11224814725364951,
+            0.04079247667809589,
+            18.988498426771645
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06111146207075637,
+            0.1277461692846439,
+            0.1285781254011893,
+            21.72377877665248
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.015831001301463775,
+            0.14171160686435166,
+            0.05017179280590109,
+            30.846818863994507
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1323396028727731,
+            0.1921095054462609,
+            0.2664447892145779,
+            41.419318214636014
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.105654469546394,
+            0.16991364996595193,
+            0.21809980480108276,
+            32.00984351908438
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.07160917965624518,
+            0.14887466219276577,
+            0.14873261833412502,
+            28.223670437952606
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1858194821022053,
+            0.23319830462351757,
+            0.3611696456239619,
+            40.98326439356847
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 41.91367063147118,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.03611111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.04374433363553944
+        }
+      },
+      "model_kruskal_h": 41.91367063147118,
+      "model_p_value": 0.03611111111111111,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.09360834088848595,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2121,
+          "pct": 0.4806254248810333
+        },
+        "ranging_volatile": {
+          "count": 2292,
+          "pct": 0.5193745751189667
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5731582187564129,
+          "transition_rate": 0.038998357963875206,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.573 > 0.392",
+            "min_transition_rate: 0.0390 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5193745751189667,
+          "transition_rate": 0.04374433363553944,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.519 > 0.392",
+            "min_transition_rate: 0.0437 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5569722030783367,
+          "transition_rate": 0.04055140723721999,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.557 > 0.392",
+            "min_transition_rate: 0.0406 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5143641982373812,
+          "transition_rate": 0.04429945054945055,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.514 > 0.392",
+            "min_transition_rate: 0.0443 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5396788457063068,
+          "transition_rate": 0.036080074487895714,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.540 > 0.392",
+            "min_transition_rate: 0.0361 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.005502734254364465,
+            0.18342747882528565,
+            0.23564357528921204,
+            36.44092213232946
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.004075595150556658,
+            0.12384805866393585,
+            0.07637036554941636,
+            22.317461369474312
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 75.42070759586932,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.028888888888888888,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.046010879419764276
+        }
+      },
+      "model_kruskal_h": 75.42070759586932,
+      "model_p_value": 0.028888888888888888,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.0913417951042611,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2336,
+          "pct": 0.5293451167006572
+        },
+        "trending_down_choppy": {
+          "count": 1193,
+          "pct": 0.27033763879447087
+        },
+        "trending_up_choppy": {
+          "count": 884,
+          "pct": 0.20031724450487198
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5869074492099323,
+          "transition_rate": 0.04351395730706076,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.587 > 0.392",
+            "min_transition_rate: 0.0435 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5293451167006572,
+          "transition_rate": 0.046010879419764276,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.529 > 0.392",
+            "min_transition_rate: 0.0460 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5816678152997933,
+          "transition_rate": 0.0450315910396324,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.582 > 0.392",
+            "min_transition_rate: 0.0450 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5315325626645302,
+          "transition_rate": 0.0486492673992674,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.532 > 0.392",
+            "min_transition_rate: 0.0486 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5636490574819641,
+          "transition_rate": 0.04306331471135941,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.564 > 0.392",
+            "min_transition_rate: 0.0431 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005075012008396578,
+            0.12542688421784254,
+            0.07731733918469537,
+            22.80853912855038
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11169832379968075,
+            0.18075344293670947,
+            0.22614432446324395,
+            37.95211672005942
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1340999106165127,
+            0.19045167141845493,
+            0.26951698909831107,
+            34.75884620438009
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 79.41439963154335,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.015,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.11536718041704443
+        }
+      },
+      "model_kruskal_h": 79.41439963154335,
+      "model_p_value": 0.015,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.02198549410698096,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1808,
+          "pct": 0.40969861772037164
+        },
+        "ranging_volatile": {
+          "count": 1099,
+          "pct": 0.2490369363244958
+        },
+        "trending_down_choppy": {
+          "count": 920,
+          "pct": 0.20847496034443688
+        },
+        "trending_up_choppy": {
+          "count": 586,
+          "pct": 0.13278948561069567
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.41719679868664067,
+          "transition_rate": 0.12315270935960591,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.417 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.40969861772037164,
+          "transition_rate": 0.11536718041704443,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.410 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.40167700436480586,
+          "transition_rate": 0.1283170591614015,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.402 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.41066727709740186,
+          "transition_rate": 0.11813186813186813,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.411 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.42168955084942983,
+          "transition_rate": 0.1287243947858473,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.422 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.00457184308135086,
+            0.14117198914657933,
+            0.13016782117280135,
+            26.279365223934754
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12806118155554375,
+            0.18917897023958513,
+            0.258518321860861,
+            40.69123511613657
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1531857875320342,
+            0.20370535438544335,
+            0.3062979664033859,
+            36.66833846625733
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0005503865234446904,
+            0.11672577515526995,
+            0.03512918327968835,
+            21.139713393407842
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 64.66643447978277,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.021111111111111112,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08091568449682683
+        }
+      },
+      "model_kruskal_h": 64.66643447978277,
+      "model_p_value": 0.021111111111111112,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.056436990027198555,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1339,
+          "pct": 0.30342170858826195
+        },
+        "trending_down_choppy": {
+          "count": 1606,
+          "pct": 0.3639247677317018
+        },
+        "trending_up_choppy": {
+          "count": 1468,
+          "pct": 0.33265352368003626
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3511184075518161,
+          "transition_rate": 0.08805418719211823,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.3639247677317018,
+          "transition_rate": 0.08091568449682683,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.36928555019526765,
+          "transition_rate": 0.09259046524985641,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.3848002746938308,
+          "transition_rate": 0.08573717948717949,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.35233884105189667,
+          "transition_rate": 0.0947392923649907,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0706191130188882,
+            0.1381936326109156,
+            0.14737582484656542,
+            24.579787311899803
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1337649695157418,
+            0.19126000819091887,
+            0.2694825949680144,
+            41.155051147028196
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.06702725712046893,
+            0.14969901388622933,
+            0.1386605674979722,
+            29.35247888903386
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0004500652671430372,
+            0.11993989131217989,
+            0.04165722618700232,
+            21.900865684325883
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.15276097054683546,
+            0.20293583619438454,
+            0.30517825382212493,
+            36.533061068509596
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 67.97953532132124,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.011111111111111112,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12692656391659113
+        }
+      },
+      "model_kruskal_h": 67.97953532132124,
+      "model_p_value": 0.011111111111111112,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.010426110607434258,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 460,
+          "pct": 0.10423748017221844
+        },
+        "ranging_volatile": {
+          "count": 1098,
+          "pct": 0.24881033310673012
+        },
+        "trending_down_choppy": {
+          "count": 1300,
+          "pct": 0.29458418309539997
+        },
+        "trending_up_choppy": {
+          "count": 1555,
+          "pct": 0.35236800362565146
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3303919556741227,
+          "transition_rate": 0.14942528735632185,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.35236800362565146,
+          "transition_rate": 0.12692656391659113,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.37606248564208594,
+          "transition_rate": 0.14198736358414704,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.4071191484491244,
+          "transition_rate": 0.1353021978021978,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.407 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3714219222713521,
+          "transition_rate": 0.1478119180633147,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.04366630374896207,
+            0.1376664538800906,
+            0.08970357405499844,
+            27.381210974078254
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08183455114005711,
+            0.15529976336577972,
+            0.16997439493176705,
+            30.400763213013317
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13835159772007966,
+            0.19365601953711425,
+            0.2779414009307426,
+            41.71191129682961
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0028228376070924925,
+            0.11896908510777429,
+            0.03376595501632661,
+            21.585861943722634
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06629388657860845,
+            0.13569875405916726,
+            0.1385579721518705,
+            24.01400144089481
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1497865291712852,
+            0.20083358057455686,
+            0.2995779001351577,
+            36.23587973180108
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 65.59212172530533,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.012222222222222223,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12941976427923843
+        }
+      },
+      "model_kruskal_h": 65.59212172530533,
+      "model_p_value": 0.012222222222222223,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.007932910244786956,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 473,
+          "pct": 0.10718332200317245
+        },
+        "ranging_volatile": {
+          "count": 1056,
+          "pct": 0.23929299796057105
+        },
+        "trending_down_choppy": {
+          "count": 1303,
+          "pct": 0.295263992748697
+        },
+        "trending_up_choppy": {
+          "count": 1581,
+          "pct": 0.35825968728755947
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3400369382310692,
+          "transition_rate": 0.15722495894909688,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.35825968728755947,
+          "transition_rate": 0.12941976427923843,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.38295428440156215,
+          "transition_rate": 0.1488799540493969,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.41410094998283165,
+          "transition_rate": 0.13896520146520147,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.414 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.38259250639981385,
+          "transition_rate": 0.14827746741154563,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0022947929224514823,
+            0.11891198434975563,
+            0.03209652576498716,
+            21.592638263884417
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.05956804630290927,
+            0.13165520002611947,
+            0.1252215417900794,
+            23.202130277349845
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.043048333860697556,
+            0.13710792497169225,
+            0.08845741126450657,
+            27.243439041137435
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13835739445423156,
+            0.19366973147017236,
+            0.27794533852303344,
+            41.71623498569485
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11248705075507764,
+            0.1686760357895703,
+            0.23191841817007863,
+            31.162267944254612
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08165555504625843,
+            0.15522522322836885,
+            0.16958343466574566,
+            30.383448024235634
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18647829244425287,
+            0.23222873446749664,
+            0.3629435706729254,
+            40.44885185634014
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 43.9607670861169,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.03277777777777778,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.03150498640072529
+        }
+      },
+      "model_kruskal_h": 43.9607670861169,
+      "model_p_value": 0.03277777777777778,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.10584768812330009,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1857,
+          "pct": 0.42080217539089054
+        },
+        "ranging_volatile": {
+          "count": 2556,
+          "pct": 0.5791978246091094
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.621998768725631,
+          "transition_rate": 0.031609195402298854,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.622 > 0.392",
+            "min_transition_rate: 0.0316 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5791978246091094,
+          "transition_rate": 0.03150498640072529,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.579 > 0.392",
+            "min_transition_rate: 0.0315 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.616815988973122,
+          "transition_rate": 0.03067202757036186,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.617 > 0.392",
+            "min_transition_rate: 0.0307 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.57456792949525,
+          "transition_rate": 0.03514194139194139,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.575 > 0.392",
+            "min_transition_rate: 0.0351 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5985571328834071,
+          "transition_rate": 0.031890130353817506,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.599 > 0.392",
+            "min_transition_rate: 0.0319 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.007813399107477342,
+            0.1904865163031385,
+            0.25024893920736746,
+            38.756658965445794
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.004223863177510036,
+            0.12679850085029357,
+            0.08651636360075063,
+            22.676732378006317
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 82.73756493551264,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.017777777777777778,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.04329102447869447
+        }
+      },
+      "model_kruskal_h": 82.73756493551264,
+      "model_p_value": 0.017777777777777778,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.09406165004533092,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2384,
+          "pct": 0.5402220711534104
+        },
+        "trending_down_choppy": {
+          "count": 1178,
+          "pct": 0.2669385905279855
+        },
+        "trending_up_choppy": {
+          "count": 851,
+          "pct": 0.19283933831860411
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5910116971065053,
+          "transition_rate": 0.038998357963875206,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.591 > 0.392",
+            "min_transition_rate: 0.0390 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5402220711534104,
+          "transition_rate": 0.04329102447869447,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.540 > 0.392",
+            "min_transition_rate: 0.0433 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5869515276820584,
+          "transition_rate": 0.041240666283744974,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.587 > 0.392",
+            "min_transition_rate: 0.0412 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5414902140322765,
+          "transition_rate": 0.04475732600732601,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.541 > 0.392",
+            "min_transition_rate: 0.0448 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5696997905515476,
+          "transition_rate": 0.042132216014897576,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.570 > 0.392",
+            "min_transition_rate: 0.0421 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005703862336521655,
+            0.12519971663132562,
+            0.08049942929815943,
+            22.421079141202416
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11063853257456722,
+            0.18172433353657422,
+            0.22361199524957437,
+            38.883719283978984
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.13601736185684565,
+            0.19417634466913342,
+            0.2730405538751525,
+            35.77197895814321
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 83.58132637643939,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.02666666666666667,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.06300997280145058
+        }
+      },
+      "model_kruskal_h": 83.58132637643939,
+      "model_p_value": 0.02666666666666667,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.0743427017225748,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1254,
+          "pct": 0.2841604350781781
+        },
+        "ranging_volatile": {
+          "count": 1587,
+          "pct": 0.35961930659415364
+        },
+        "trending_down_choppy": {
+          "count": 845,
+          "pct": 0.19147971901200997
+        },
+        "trending_up_choppy": {
+          "count": 727,
+          "pct": 0.16474053931565827
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.435665914221219,
+          "transition_rate": 0.059113300492610835,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.436 > 0.392",
+            "min_transition_rate: 0.0591 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.35961930659415364,
+          "transition_rate": 0.06300997280145058,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0630 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4182173213875488,
+          "transition_rate": 0.058472142446869615,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.418 > 0.392",
+            "min_transition_rate: 0.0585 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3639693258555568,
+          "transition_rate": 0.06421703296703296,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0642 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.40842448219688154,
+          "transition_rate": 0.06424581005586592,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.408 > 0.392",
+            "min_transition_rate: 0.0642 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.03111499811850684,
+            0.15307317373811,
+            0.12188998091521863,
+            30.741836550340736
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1302364740917169,
+            0.19141786651140588,
+            0.2623080043424838,
+            42.21137888848135
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14437983449509717,
+            0.19822121449445432,
+            0.28923010913455455,
+            35.87490695768459
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.015353963382247897,
+            0.11778292502558124,
+            0.07319223297479473,
+            20.025199288757197
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 66.83756122339764,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.027777777777777776,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.05371713508612874
+        }
+      },
+      "model_kruskal_h": 66.83756122339764,
+      "model_p_value": 0.027777777777777776,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.08363553943789664,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1570,
+          "pct": 0.35576705189213687
+        },
+        "trending_down_choppy": {
+          "count": 1627,
+          "pct": 0.3686834353047813
+        },
+        "trending_up_choppy": {
+          "count": 1216,
+          "pct": 0.2755495128030818
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4186332854504412,
+          "transition_rate": 0.051313628899835796,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.419 > 0.392",
+            "min_transition_rate: 0.0513 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.3686834353047813,
+          "transition_rate": 0.05371713508612874,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "min_transition_rate: 0.0537 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.42625775327360443,
+          "transition_rate": 0.054106835152211374,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.426 > 0.392",
+            "min_transition_rate: 0.0541 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.3542405860135058,
+          "transition_rate": 0.05918040293040293,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "min_transition_rate: 0.0592 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.39515941354433326,
+          "transition_rate": 0.05307262569832402,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.395 > 0.392",
+            "min_transition_rate: 0.0531 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.09590165406039532,
+            0.16003864948167654,
+            0.1983251334724151,
+            29.19733925358716
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13489948796109844,
+            0.19536643125451025,
+            0.2714127427332896,
+            44.12095875263345
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.06648851329398535,
+            0.15670579591083997,
+            0.13819415744984556,
+            30.315549124053927
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.008768076157520661,
+            0.1171308289725782,
+            0.061307811092743025,
+            20.64450073774572
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1817757794927396,
+            0.23048051853754312,
+            0.3558671572017239,
+            42.41024516582192
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 69.37753922107913,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.03777777777777778,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.06799637352674524
+        }
+      },
+      "model_kruskal_h": 69.37753922107913,
+      "model_p_value": 0.03777777777777778,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.06935630099728014,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 549,
+          "pct": 0.12440516655336506
+        },
+        "ranging_volatile": {
+          "count": 1390,
+          "pct": 0.3149784726943123
+        },
+        "trending_down_choppy": {
+          "count": 1332,
+          "pct": 0.3018354860639021
+        },
+        "trending_up_choppy": {
+          "count": 1142,
+          "pct": 0.2587808746884206
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3650728504001642,
+          "transition_rate": 0.07060755336617405,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3149784726943123,
+          "transition_rate": 0.06799637352674524,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0680 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3657247875028716,
+          "transition_rate": 0.06961516369902356,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3102895730800046,
+          "transition_rate": 0.07589285714285714,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3569932511054224,
+          "transition_rate": 0.0691340782122905,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.015388972835934208,
+            0.1420117187808927,
+            0.07587104500373561,
+            33.50969741647665
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08586259529252369,
+            0.1626032746940651,
+            0.17600760226413842,
+            26.91447608583654
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13452066957240058,
+            0.19500531338801652,
+            0.27035087691035375,
+            44.899385162738255
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009598950154765945,
+            0.11527523972597871,
+            0.06339269093574985,
+            19.224142413585
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0998408712518566,
+            0.16162666000473427,
+            0.2054539086860961,
+            28.62967818110436
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18206375718516551,
+            0.23071318148135136,
+            0.3562994339378191,
+            42.48038475325567
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 70.48007095643698,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.027777777777777776,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08046237533998186
+        }
+      },
+      "model_kruskal_h": 70.48007095643698,
+      "model_p_value": 0.027777777777777776,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.05689029918404352,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 477,
+          "pct": 0.10808973487423522
+        },
+        "ranging_volatile": {
+          "count": 1137,
+          "pct": 0.2576478585995921
+        },
+        "trending_down_choppy": {
+          "count": 1352,
+          "pct": 0.30636755041921593
+        },
+        "trending_up_choppy": {
+          "count": 1447,
+          "pct": 0.32789485610695673
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3043299815308845,
+          "transition_rate": 0.08784893267651889,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.32789485610695673,
+          "transition_rate": 0.08046237533998186,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3350562830232024,
+          "transition_rate": 0.08868466398621482,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.37827629621151426,
+          "transition_rate": 0.08058608058608059,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3469862694903421,
+          "transition_rate": 0.0893854748603352,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.0034321147789508084,
+            0.11322747175818654,
+            0.04664463482156207,
+            19.566989035448586
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0667489383848353,
+            0.1313339445069582,
+            0.139463683982449,
+            21.42469826004001
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.021288697551426282,
+            0.14361104327825316,
+            0.07901135443885518,
+            34.72073854237792
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13445303668836828,
+            0.19492873657594934,
+            0.2701311805789483,
+            44.647351654445075
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11599479199967179,
+            0.17885066036634992,
+            0.23715477790820735,
+            32.459086285064295
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08468817595663619,
+            0.16178340871338243,
+            0.17405884060848012,
+            26.36216187536592
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.19365654195946694,
+            0.24094684356078727,
+            0.3750316921392831,
+            44.14655673534547
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 44.01132258029611,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.009444444444444445,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08680870353581142
+        }
+      },
+      "model_kruskal_h": 44.01132258029611,
+      "model_p_value": 0.009444444444444445,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.05054397098821396,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1108,
+          "pct": 0.25107636528438704
+        },
+        "ranging_directional_up": {
+          "count": 3305,
+          "pct": 0.748923634715613
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5762364046788426,
+          "transition_rate": 0.08292282430213464,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.576 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.748923634715613,
+          "transition_rate": 0.08680870353581142,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.749 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.7613960113960114,
+          "transition_rate": 0.053428317008014245,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.761 > 0.392",
+            "min_transition_rate: 0.0534 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5572851093052535,
+          "transition_rate": 0.11183608058608059,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.557 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5161740749360019,
+          "transition_rate": 0.10032588454376164,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.516 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0005951275269955315,
+            0.16983566992439775,
+            0.18936667391916345,
+            32.38926040648409,
+            1.2061334230989697e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.00034592770192922026,
+            0.13315561434758483,
+            0.10868484916066735,
+            25.144117240962885,
+            1.2491200397671366e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 101.87781864963836,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.002777777777777778,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.09111514052583862
+        }
+      },
+      "model_kruskal_h": 101.87781864963836,
+      "model_p_value": 0.002777777777777778,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.04623753399818677,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 966,
+          "pct": 0.21889870836165873
+        },
+        "trending_down_choppy": {
+          "count": 888,
+          "pct": 0.20122365737593473
+        },
+        "trending_up_choppy": {
+          "count": 2559,
+          "pct": 0.5798776342624066
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5105684383336754,
+          "transition_rate": 0.08230706075533661,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.511 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5798776342624066,
+          "transition_rate": 0.09111514052583862,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.580 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.7345085470085471,
+          "transition_rate": 0.05983971504897596,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.735 > 0.392",
+            "min_transition_rate: 0.0598 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5064667506008927,
+          "transition_rate": 0.1166437728937729,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.506 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.463346520828485,
+          "transition_rate": 0.09962756052141528,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.463 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0029250764398177187,
+            0.12807346611138312,
+            0.09358249764555857,
+            23.84156155159805,
+            1.2491175092117759e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12330124718593012,
+            0.18728491811482006,
+            0.24713222270942883,
+            40.38335042382016,
+            9.018919116647993e-06
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.05922726333319109,
+            0.16105046333085837,
+            0.16609763289249052,
+            28.770152852727737,
+            1.3719098432432383e-05
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 76.27301524079485,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.013333333333333334,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.04465095194922938
+        }
+      },
+      "model_kruskal_h": 76.27301524079485,
+      "model_p_value": 0.013333333333333334,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.092701722574796,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2602,
+          "pct": 0.5896215726263313
+        },
+        "trending_down_choppy": {
+          "count": 1042,
+          "pct": 0.23612055291185136
+        },
+        "trending_up_choppy": {
+          "count": 769,
+          "pct": 0.17425787446181737
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.6858198235173405,
+          "transition_rate": 0.037561576354679806,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.686 > 0.392",
+            "min_transition_rate: 0.0376 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5896215726263313,
+          "transition_rate": 0.04465095194922938,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.590 > 0.392",
+            "min_transition_rate: 0.0447 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6132478632478633,
+          "transition_rate": 0.04968833481745325,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.613 > 0.392",
+            "min_transition_rate: 0.0497 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5951699668078287,
+          "transition_rate": 0.050022893772893776,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.595 > 0.392",
+            "min_transition_rate: 0.0500 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.660460786595299,
+          "transition_rate": 0.039804469273743016,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.660 > 0.392",
+            "min_transition_rate: 0.0398 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0025012988627732867,
+            0.12835945296895024,
+            0.09373028987353246,
+            23.831482214467236,
+            1.2493108685261146e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12117818179826158,
+            0.18724218638264606,
+            0.24270464978627054,
+            40.07876230241883,
+            8.672272706091769e-06
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.13161438983045504,
+            0.19846040114588467,
+            0.2800544238003103,
+            36.3123293500535,
+            1.8057685019134404e-05
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.008271992636850316,
+            0.12935809107160684,
+            0.07629660353554336,
+            22.631015462229566,
+            1.0839735074366895e-05
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 79.86194959786371,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.017777777777777778,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08567543064369901
+        }
+      },
+      "model_kruskal_h": 79.86194959786371,
+      "model_p_value": 0.017777777777777778,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.05167724388032638,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 644,
+          "pct": 0.14593247224110584
+        },
+        "ranging_volatile": {
+          "count": 2354,
+          "pct": 0.5334239746204396
+        },
+        "trending_down_choppy": {
+          "count": 903,
+          "pct": 0.20462270564242013
+        },
+        "trending_up_choppy": {
+          "count": 512,
+          "pct": 0.11602084749603445
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.47301457008003284,
+          "transition_rate": 0.09523809523809523,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.473 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5334239746204396,
+          "transition_rate": 0.08567543064369901,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.533 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.6582977207977208,
+          "transition_rate": 0.06375779162956367,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.658 > 0.392",
+            "min_transition_rate: 0.0638 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.4756781503948724,
+          "transition_rate": 0.11893315018315018,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.476 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.4610193158017221,
+          "transition_rate": 0.10707635009310987,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.461 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.002044191569159528,
+            0.11444686288009942,
+            0.04881182219240644,
+            20.98935011380128,
+            1.2489675787877486e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12994323993457896,
+            0.194523356724364,
+            0.25974918129788316,
+            41.99526062580405,
+            7.880126898181213e-06
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.001556688948217966,
+            0.1500925727992532,
+            0.1613493032722979,
+            28.95971062589657,
+            1.249427865876296e-05
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0065753129698495625,
+            0.13498168152170148,
+            0.08818733048155322,
+            23.961732486663493,
+            1.3417314397312215e-05
+          ],
+          "volatility_rank": 1
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.163788667080671,
+            0.21403790219465973,
+            0.3235573507004137,
+            37.60505744599055,
+            1.4924474705045348e-05
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": false,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 49.68976371302233,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.05388888888888889,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.06799637352674524
+        }
+      },
+      "model_kruskal_h": 49.68976371302233,
+      "model_p_value": 0.05388888888888889,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.06935630099728014,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2373,
+          "pct": 0.5377294357579878
+        },
+        "trending_down_choppy": {
+          "count": 1146,
+          "pct": 0.25968728755948334
+        },
+        "trending_up_choppy": {
+          "count": 894,
+          "pct": 0.2025832766825289
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.47321978247486146,
+          "transition_rate": 0.07266009852216748,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.473 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5377294357579878,
+          "transition_rate": 0.06799637352674524,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.538 > 0.392",
+            "min_transition_rate: 0.0680 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6677350427350427,
+          "transition_rate": 0.05004452359750668,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.668 > 0.392",
+            "min_transition_rate: 0.0500 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.48357559803136085,
+          "transition_rate": 0.09375,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.484 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.4700954154060973,
+          "transition_rate": 0.0856610800744879,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.470 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.08329985609962952,
+            0.14801586708747,
+            0.17388691212518503,
+            27.268157931605998,
+            1.2493231407176951e-05
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.07596099787319767,
+            0.1536602769019992,
+            0.1571786304451156,
+            30.88938267499238,
+            1.2491585290273065e-05
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1344216089069359,
+            0.19526905331211256,
+            0.26892389221961777,
+            42.412752270579546,
+            7.5618954744848026e-06
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005268576190554568,
+            0.13571879681189586,
+            0.08843343484890791,
+            23.954320336973804,
+            1.3226221688280426e-05
+          ],
+          "volatility_rank": 1
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0011734353938729531,
+            0.11512228527704801,
+            0.04614269580646892,
+            21.325841336339312,
+            1.2489294254731375e-05
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1651025633200017,
+            0.21505178955071,
+            0.325251856699979,
+            37.709581775469736,
+            1.5040675066832532e-05
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 62.9856386443189,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.03611111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.0727561196736174
+        }
+      },
+      "model_kruskal_h": 62.9856386443189,
+      "model_p_value": 0.03611111111111111,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.06459655485040798,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 143,
+          "pct": 0.032404260140493996
+        },
+        "ranging_volatile": {
+          "count": 2268,
+          "pct": 0.5139360978925901
+        },
+        "trending_down_choppy": {
+          "count": 1127,
+          "pct": 0.2553818264219352
+        },
+        "trending_up_choppy": {
+          "count": 875,
+          "pct": 0.19827781554498075
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.403037143443464,
+          "transition_rate": 0.08107553366174056,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.403 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5139360978925901,
+          "transition_rate": 0.0727561196736174,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.514 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3896011396011396,
+          "transition_rate": 0.06963490650044524,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.2800732516882225,
+          "transition_rate": 0.12248168498168498,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3914358855015127,
+          "transition_rate": 0.09799813780260708,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00992689085332825,
+            0.13437136099657276,
+            0.08567775829333671,
+            23.319078080593094,
+            1.8637482365874289e-06
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.001509959693303531,
+            0.11511970055680001,
+            0.04666071256905534,
+            21.314451096256786,
+            1.2490050528951648e-05
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.0760062636640181,
+            0.15382307273715193,
+            0.15729005553396122,
+            30.863848390093374,
+            1.2491797042294884e-05
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.16776897338955576,
+            0.2177364495231187,
+            0.3295880088688782,
+            37.90012053898961,
+            1.4274541532699147e-05
+          ],
+          "volatility_rank": 6
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.00035102645680569667,
+            0.1393809146173399,
+            0.10185959523784435,
+            25.862985094233707,
+            3.312798688560992e-05
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.08412323139824346,
+            0.1486727460687213,
+            0.1756133512506836,
+            27.388809313733653,
+            1.2493720589683372e-05
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13555305572012372,
+            0.19604350808373225,
+            0.2707096045723587,
+            42.59038808145708,
+            7.449161216622733e-06
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 45.46146327576389,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.006111111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.0985947416137806
+        }
+      },
+      "model_kruskal_h": 45.46146327576389,
+      "model_p_value": 0.006111111111111111,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.03875793291024479,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1276,
+          "pct": 0.28914570586902333
+        },
+        "ranging_directional_up": {
+          "count": 3137,
+          "pct": 0.7108542941309767
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6542171147137287,
+          "transition_rate": 0.08661740558292283,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.654 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.7108542941309767,
+          "transition_rate": 0.0985947416137806,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.711 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.7402065527065527,
+          "transition_rate": 0.05841495992876224,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.740 > 0.392",
+            "min_transition_rate: 0.0584 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5115028041661898,
+          "transition_rate": 0.11813186813186813,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.512 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5852920642308588,
+          "transition_rate": 0.10754189944134078,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.585 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.005823231943276982,
+            0.1648975265747676,
+            0.17250595240963765,
+            30.716076253742347,
+            1.1966989633694842e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.0030707670131173417,
+            0.14014206461345993,
+            0.12730562554565786,
+            26.902533488053095,
+            1.249187574376975e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 65.81230807164684,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.10516772438803264
+        }
+      },
+      "model_kruskal_h": 65.81230807164684,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.03218495013599275,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 3107,
+          "pct": 0.7040561975980059
+        },
+        "ranging_volatile": {
+          "count": 962,
+          "pct": 0.21799229549059596
+        },
+        "trending_down_choppy": {
+          "count": 344,
+          "pct": 0.07795150691139814
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.49107326082495384,
+          "transition_rate": 0.10036945812807882,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.491 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.7040561975980059,
+          "transition_rate": 0.10516772438803264,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.704 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.7507122507122507,
+          "transition_rate": 0.060908281389136246,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.751 > 0.392",
+            "min_transition_rate: 0.0609 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5255808629964519,
+          "transition_rate": 0.1304945054945055,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.526 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.45310681871072844,
+          "transition_rate": 0.10963687150837989,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.453 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.007919757006644998,
+            0.1286161660137137,
+            0.09380284323584448,
+            24.007973243838727,
+            1.2490975543795587e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12202345338024273,
+            0.18376038878377868,
+            0.247012613973769,
+            39.81115439441036,
+            1.2488930270028344e-05
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.028257137381009673,
+            0.16500035857786302,
+            0.17674166028381166,
+            30.272397669085464,
+            1.2002233208165244e-05
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 108.7580067017825,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0038888888888888888,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.10879419764279238
+        }
+      },
+      "model_kruskal_h": 108.7580067017825,
+      "model_p_value": 0.0038888888888888888,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.028558476881233003,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1040,
+          "pct": 0.23566734647631996
+        },
+        "ranging_volatile": {
+          "count": 1915,
+          "pct": 0.4339451620213007
+        },
+        "trending_down_choppy": {
+          "count": 914,
+          "pct": 0.20711534103784274
+        },
+        "trending_up_choppy": {
+          "count": 544,
+          "pct": 0.1232721504645366
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5456597578493741,
+          "transition_rate": 0.09339080459770115,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.546 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.4339451620213007,
+          "transition_rate": 0.10879419764279238,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.434 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5671296296296297,
+          "transition_rate": 0.07764915405164738,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.567 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.4147876845599176,
+          "transition_rate": 0.1349587912087912,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.415 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.495927391203165,
+          "transition_rate": 0.11056797020484171,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.496 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0025334159366780682,
+            0.13295308102321934,
+            0.10551938043940132,
+            25.05513725919129,
+            1.2492191073634213e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13060895778691248,
+            0.1922130783272437,
+            0.26197885959437023,
+            41.86607492764555,
+            8.573628473264408e-06
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.16216205592474384,
+            0.21124414824240828,
+            0.32153674075364996,
+            37.61375044576883,
+            1.4596456130861306e-05
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005600476947110686,
+            0.13574058440829218,
+            0.0884455942609299,
+            23.848389308082655,
+            1.3197789166387958e-05
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": false,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 51.163686610110744,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.051666666666666666,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08386219401631913
+        }
+      },
+      "model_kruskal_h": 51.163686610110744,
+      "model_p_value": 0.051666666666666666,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.05349048050770626,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 744,
+          "pct": 0.16859279401767505
+        },
+        "ranging_volatile": {
+          "count": 2556,
+          "pct": 0.5791978246091094
+        },
+        "trending_down_choppy": {
+          "count": 711,
+          "pct": 0.1611148878314072
+        },
+        "trending_up_choppy": {
+          "count": 402,
+          "pct": 0.09109449354180829
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.589985635132362,
+          "transition_rate": 0.07327586206896551,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.590 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5791978246091094,
+          "transition_rate": 0.08386219401631913,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.579 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.6871438746438746,
+          "transition_rate": 0.058771148708815675,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.687 > 0.392",
+            "min_transition_rate: 0.0588 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.5690740528785624,
+          "transition_rate": 0.09375,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.569 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.562718175471259,
+          "transition_rate": 0.09054934823091247,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.563 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.002662285643756873,
+            0.12011293835883124,
+            0.07212871686908184,
+            22.111388225995217,
+            1.2490721478395221e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1215411710621634,
+            0.19062907311368338,
+            0.2421037547937322,
+            39.88094607147281,
+            3.7244491819734127e-06
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.012808000062454862,
+            0.17362232370090142,
+            0.2190521526543061,
+            34.97554337783483,
+            1.2493934336897458e-05
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.008377282588000499,
+            0.13547027418324253,
+            0.09027619331306484,
+            23.857287625201995,
+            1.3083288265336589e-05
+          ],
+          "volatility_rank": 1
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17438877963660418,
+            0.22532750017136166,
+            0.33828581871189023,
+            39.31534804338216,
+            1.7797487993285567e-05
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": false,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 52.17882336259754,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.050555555555555555,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.06980961015412511
+        }
+      },
+      "model_kruskal_h": 52.17882336259754,
+      "model_p_value": 0.050555555555555555,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.06754306436990028,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2521,
+          "pct": 0.5712667119873103
+        },
+        "trending_down_choppy": {
+          "count": 1076,
+          "pct": 0.24382506231588488
+        },
+        "trending_up_choppy": {
+          "count": 816,
+          "pct": 0.1849082256968049
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5068746152267597,
+          "transition_rate": 0.0755336617405583,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.507 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5712667119873103,
+          "transition_rate": 0.06980961015412511,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.571 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6892806267806267,
+          "transition_rate": 0.04968833481745325,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.689 > 0.392",
+            "min_transition_rate: 0.0497 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5221471901110221,
+          "transition_rate": 0.0960393772893773,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.522 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5080288573423318,
+          "transition_rate": 0.08868715083798882,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.508 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0913896675222253,
+            0.1535378192708234,
+            0.1902914953120916,
+            28.209013072716683,
+            1.24918641943409e-05
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08372726254327184,
+            0.1581822551535291,
+            0.1733032800678975,
+            32.27947553176232,
+            1.2492383702898347e-05
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.14076999479271393,
+            0.19867404296360233,
+            0.27991830525708206,
+            42.87129258146703,
+            7.272513173808918e-06
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005047884113392871,
+            0.13763962790604972,
+            0.09461425358321693,
+            24.31846042413721,
+            1.2958665450730447e-05
+          ],
+          "volatility_rank": 1
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.000877560070678856,
+            0.11752601019523143,
+            0.05104126683554466,
+            21.949761633926695,
+            1.249004188816237e-05
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17509810228227474,
+            0.22237833704448332,
+            0.3422047516332706,
+            39.0777080944938,
+            1.5288537082004745e-05
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 51.22690999942097,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.04888888888888889,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.1199002719854941
+        }
+      },
+      "model_kruskal_h": 51.22690999942097,
+      "model_p_value": 0.04888888888888889,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.01745240253853128,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1170,
+          "pct": 0.26512576478586
+        },
+        "ranging_volatile": {
+          "count": 1607,
+          "pct": 0.3641513709494675
+        },
+        "trending_down_choppy": {
+          "count": 969,
+          "pct": 0.21957851801495581
+        },
+        "trending_up_choppy": {
+          "count": 667,
+          "pct": 0.15114434624971673
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.4221218961625282,
+          "transition_rate": 0.10775862068965517,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.422 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3641513709494675,
+          "transition_rate": 0.1199002719854941,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.369480056980057,
+          "transition_rate": 0.10204808548530721,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3265422914043722,
+          "transition_rate": 0.13713369963369965,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3979520595764487,
+          "transition_rate": 0.12243947858472998,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.398 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005843684668453983,
+            0.12422729546568657,
+            0.0534207115742925,
+            21.32386242026627,
+            1.0055562862810366e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0008951474811675947,
+            0.11796889814582336,
+            0.05310523855354783,
+            22.065595501461342,
+            1.2491012617910456e-05
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08527498478572501,
+            0.1592586804960217,
+            0.17648008393700831,
+            32.56390322256271,
+            1.2492779089074104e-05
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18596351450582663,
+            0.23197090762548203,
+            0.3610963433347527,
+            40.38637540955899,
+            1.5222269748600865e-05
+          ],
+          "volatility_rank": 6
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.0005225055495108225,
+            0.15802136767740757,
+            0.15843246689291357,
+            29.29824101691152,
+            1.4565549486040906e-05
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.09357421494785007,
+            0.1551491457625171,
+            0.19464029574589095,
+            28.500762111457497,
+            1.2491590597644227e-05
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.15080425677099873,
+            0.2043192330179528,
+            0.29796543013337984,
+            44.39216244303837,
+            8.345056034056093e-06
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 51.59394310566495,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.015555555555555555,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.028785131459655486
+        }
+      },
+      "model_kruskal_h": 51.59394310566495,
+      "model_p_value": 0.015555555555555555,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.1085675430643699,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1853,
+          "pct": 0.4198957625198278
+        },
+        "ranging_volatile": {
+          "count": 2560,
+          "pct": 0.5801042374801723
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6269238662015185,
+          "transition_rate": 0.032430213464696225,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.627 > 0.392",
+            "min_transition_rate: 0.0324 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5801042374801723,
+          "transition_rate": 0.028785131459655486,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.580 > 0.392",
+            "min_transition_rate: 0.0288 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5085470085470085,
+          "transition_rate": 0.04630454140694568,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.509 > 0.392",
+            "min_transition_rate: 0.0463 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5012017855099005,
+          "transition_rate": 0.048191391941391944,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.501 > 0.392",
+            "min_transition_rate: 0.0482 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5771468466371887,
+          "transition_rate": 0.037011173184357544,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.577 > 0.392",
+            "min_transition_rate: 0.0370 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.007604631459789008,
+            0.19052113399259707,
+            0.24976949410195054,
+            38.7509148774403,
+            1.3018035266272255e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.004124364108160889,
+            0.1267200943339431,
+            0.08661660378338801,
+            22.664626732064427,
+            1.1929952340559215e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 78.19810799593142,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.017222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.04215775158658205
+        }
+      },
+      "model_kruskal_h": 78.19810799593142,
+      "model_p_value": 0.017222222222222222,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.09519492293744333,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2390,
+          "pct": 0.5415816904600045
+        },
+        "trending_down_choppy": {
+          "count": 1184,
+          "pct": 0.26829820983457964
+        },
+        "trending_up_choppy": {
+          "count": 839,
+          "pct": 0.19012009970541582
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5959367945823928,
+          "transition_rate": 0.04043513957307061,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.596 > 0.392",
+            "min_transition_rate: 0.0404 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5415816904600045,
+          "transition_rate": 0.04215775158658205,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.542 > 0.392",
+            "min_transition_rate: 0.0422 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5016025641025641,
+          "transition_rate": 0.061086375779162955,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.502 > 0.392",
+            "min_transition_rate: 0.0611 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4796841020945405,
+          "transition_rate": 0.059065934065934064,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.480 > 0.392",
+            "min_transition_rate: 0.0591 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5613218524552013,
+          "transition_rate": 0.048417132216014895,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.561 > 0.392",
+            "min_transition_rate: 0.0484 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006129540000088855,
+            0.12544009431400055,
+            0.08105066234317512,
+            22.48503633447281,
+            1.2019823793787227e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11118333328501986,
+            0.18166472264981437,
+            0.22475072866160462,
+            38.87152347453755,
+            1.0753210733944953e-05
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1359549128528872,
+            0.19515786476878016,
+            0.2742054113384724,
+            35.95888044342744,
+            1.569422906208718e-05
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 78.85226256554961,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.017222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.07162284678150499
+        }
+      },
+      "model_kruskal_h": 78.85226256554961,
+      "model_p_value": 0.017222222222222222,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.0657298277425204,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1551,
+          "pct": 0.3514615907545887
+        },
+        "ranging_volatile": {
+          "count": 1356,
+          "pct": 0.30727396329027873
+        },
+        "trending_down_choppy": {
+          "count": 897,
+          "pct": 0.20326308633582596
+        },
+        "trending_up_choppy": {
+          "count": 609,
+          "pct": 0.1380013596193066
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3868253642520008,
+          "transition_rate": 0.06670771756978654,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0667 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3514615907545887,
+          "transition_rate": 0.07162284678150499,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.380519943019943,
+          "transition_rate": 0.07853962600178094,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3115485864713288,
+          "transition_rate": 0.08825549450549451,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.37049104026064694,
+          "transition_rate": 0.07960893854748603,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.003991322636565949,
+            0.1490156481519237,
+            0.12301158391356881,
+            29.1810784787515,
+            9.114007395069967e-06
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12517785537576342,
+            0.18839660355440085,
+            0.25242592360494553,
+            41.46073673801311,
+            1.0025462579013906e-05
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1479231285513661,
+            0.20294053780910634,
+            0.29720974566992936,
+            36.829676487610776,
+            1.656024769736842e-05
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.007777709330824391,
+            0.11619296930406725,
+            0.06730779345247091,
+            19.585336122753937,
+            1.4340912975164849e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 102.05139435345518,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.007222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08499546690843154
+        }
+      },
+      "model_kruskal_h": 102.05139435345518,
+      "model_p_value": 0.007222222222222222,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.05235720761559384,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1498,
+          "pct": 0.339451620213007
+        },
+        "ranging_directional_up": {
+          "count": 182,
+          "pct": 0.041241785633355996
+        },
+        "ranging_volatile": {
+          "count": 1267,
+          "pct": 0.2871062769091321
+        },
+        "trending_down_choppy": {
+          "count": 853,
+          "pct": 0.19329254475413551
+        },
+        "trending_up_choppy": {
+          "count": 613,
+          "pct": 0.13890777249036937
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.39092961214857375,
+          "transition_rate": 0.07471264367816093,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.339451620213007,
+          "transition_rate": 0.08499546690843154,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.39351851851851855,
+          "transition_rate": 0.09207479964381123,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.394 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.25134485521346,
+          "transition_rate": 0.12053571428571429,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.35280428205724923,
+          "transition_rate": 0.0893854748603352,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "ranging_directional_up",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.01181474881119112,
+            0.11664109608339576,
+            0.06944302825295973,
+            19.70748407665026,
+            1.1865194246031756e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12828557316021696,
+            0.19015620770254088,
+            0.25774796216766077,
+            41.85218783123385,
+            9.491957687074843e-06
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.0164391408822773,
+            0.15082382888964724,
+            0.12208182050688035,
+            30.12254886999107,
+            9.431820575221245e-06
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.015021733647454101,
+            0.15207358757148523,
+            0.13769343043902432,
+            27.442303068827673,
+            5.432950903225807e-05
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14846234497486674,
+            0.2002111232389437,
+            0.29702744255031865,
+            36.07066093809371,
+            1.2874099509001654e-05
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 61.26782793815801,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.049444444444444444,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.06980961015412511
+        }
+      },
+      "model_kruskal_h": 61.26782793815801,
+      "model_p_value": 0.049444444444444444,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.06754306436990028,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 198,
+          "pct": 0.04486743711760707
+        },
+        "ranging_volatile": {
+          "count": 1398,
+          "pct": 0.3167912984364378
+        },
+        "trending_down_choppy": {
+          "count": 1625,
+          "pct": 0.36823022886924994
+        },
+        "trending_up_choppy": {
+          "count": 1192,
+          "pct": 0.2701110355767052
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.38846706341063,
+          "transition_rate": 0.0650656814449918,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0651 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.36823022886924994,
+          "transition_rate": 0.06980961015412511,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.37589031339031337,
+          "transition_rate": 0.08833481745325023,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.2629048872610736,
+          "transition_rate": 0.10989010989010989,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.34954619501978124,
+          "transition_rate": 0.07495344506517691,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.09330685784605888,
+            0.15773854957037237,
+            0.19290861821172822,
+            28.52902926329717,
+            1.1013742009685231e-05
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.06351540067217201,
+            0.15476754384336427,
+            0.13387010176343708,
+            30.493831879421556,
+            9.616898437500019e-06
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13476958069226055,
+            0.19510948606774206,
+            0.2702969061687388,
+            43.643643747930426,
+            9.563369360269365e-06
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.009611148744759095,
+            0.14949762264331248,
+            0.12991558884201876,
+            26.9019369663364,
+            5.486297414965986e-05
+          ],
+          "volatility_rank": 1
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.007077015310359053,
+            0.1165924092386643,
+            0.0593695619673822,
+            20.43195397158093,
+            1.1538954600301662e-05
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18023357716761523,
+            0.22792929229757075,
+            0.35373917900697194,
+            42.05401175845568,
+            1.478492730375428e-05
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 64.16434205802761,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.03611111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.06595648232094288
+        }
+      },
+      "model_kruskal_h": 64.16434205802761,
+      "model_p_value": 0.03611111111111111,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.0713961922030825,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 78,
+          "pct": 0.017675050985723997
+        },
+        "ranging_volatile": {
+          "count": 2055,
+          "pct": 0.46566961250849764
+        },
+        "trending_down_choppy": {
+          "count": 1299,
+          "pct": 0.2943575798776343
+        },
+        "trending_up_choppy": {
+          "count": 981,
+          "pct": 0.22229775662814413
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.4401805869074492,
+          "transition_rate": 0.06444991789819376,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.440 > 0.392",
+            "min_transition_rate: 0.0644 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.46566961250849764,
+          "transition_rate": 0.06595648232094288,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.466 > 0.392",
+            "min_transition_rate: 0.0660 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.37304131054131057,
+          "transition_rate": 0.08530721282279609,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.29014535881881653,
+          "transition_rate": 0.11675824175824176,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.42448219688154526,
+          "transition_rate": 0.07332402234636871,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.424 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005937206462228185,
+            0.1408169916034539,
+            0.0865214107331545,
+            24.48174848135755,
+            -4.442928571428578e-06
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0065852171360181585,
+            0.11659724609580865,
+            0.061833361005573045,
+            20.452693563798007,
+            1.3450249458483687e-05
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.07013360411824553,
+            0.155644261065367,
+            0.145364155753985,
+            31.29612578384596,
+            1.1763379434167573e-05
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18210150739360656,
+            0.22992394221198592,
+            0.3565383023697811,
+            42.32221739668575,
+            1.410685709090908e-05
+          ],
+          "volatility_rank": 6
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.01551326551691984,
+            0.16576930084665445,
+            0.1584417273866739,
+            30.12500165338281,
+            6.468154270833335e-05
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.09715288997436569,
+            0.16040059842680363,
+            0.20079383026237058,
+            29.21514587495744,
+            1.2480402122015906e-05
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1369229596579905,
+            0.19712326195651747,
+            0.2742097218774999,
+            44.34290850793343,
+            9.337890310786112e-06
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 42.25284112896588,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.012777777777777779,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08499546690843154
+        }
+      },
+      "model_kruskal_h": 42.25284112896588,
+      "model_p_value": 0.012777777777777779,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.05235720761559384,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2341,
+          "pct": 0.5304781327894856
+        },
+        "ranging_volatile": {
+          "count": 2072,
+          "pct": 0.46952186721051437
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5243176687871948,
+          "transition_rate": 0.08087027914614121,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.524 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5304781327894856,
+          "transition_rate": 0.08499546690843154,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.530 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5021824029405008,
+          "transition_rate": 0.07696726019529006,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.502 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5291289916447293,
+          "transition_rate": 0.08562271062271062,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.529 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5026762857807773,
+          "transition_rate": 0.07844506517690875,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.503 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.0054107931026439685,
+            0.1782324219870699,
+            0.2204350761131032,
+            35.485750550334316,
+            0.39306159281381653
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00485525845663413,
+            0.12305599153512663,
+            0.07541198606585983,
+            21.88717223001445,
+            -0.24254456707524633
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 44.36423134439974,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.011666666666666667,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.1099274705349048
+        }
+      },
+      "model_kruskal_h": 44.36423134439974,
+      "model_p_value": 0.011666666666666667,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.027425203989120586,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2563,
+          "pct": 0.5807840471334693
+        },
+        "ranging_volatile": {
+          "count": 1850,
+          "pct": 0.4192159528665307
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5282167042889391,
+          "transition_rate": 0.10467980295566502,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.528 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5807840471334693,
+          "transition_rate": 0.1099274705349048,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.581 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.552951987135309,
+          "transition_rate": 0.10959218839747271,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.553 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5856701384914731,
+          "transition_rate": 0.11721611721611722,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.586 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5527111938561787,
+          "transition_rate": 0.10172253258845437,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.553 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_down",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006332780027042223,
+            0.1218846637655425,
+            0.07156814977780115,
+            21.61221470400534,
+            -0.3211838476589461
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.008508132886427846,
+            0.18397249634805946,
+            0.23092199112707218,
+            36.68122365309547,
+            -0.3871463657389423
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.0010402820515154829,
+            0.15626019911044398,
+            0.17195468451260046,
+            30.39268152240163,
+            1.6652511184454308
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 82.60305358287769,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.006666666666666667,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12216681776971895
+        }
+      },
+      "model_kruskal_h": 82.60305358287769,
+      "model_p_value": 0.006666666666666667,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.015185856754306434,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1383,
+          "pct": 0.3133922501699524
+        },
+        "ranging_volatile": {
+          "count": 1215,
+          "pct": 0.27532290958531613
+        },
+        "trending_down_choppy": {
+          "count": 1035,
+          "pct": 0.2345343303874915
+        },
+        "trending_up_choppy": {
+          "count": 780,
+          "pct": 0.17675050985723997
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.33921608865175457,
+          "transition_rate": 0.10796387520525452,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3133922501699524,
+          "transition_rate": 0.12216681776971895,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.34091431196875716,
+          "transition_rate": 0.10591614014933946,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.32585555682728623,
+          "transition_rate": 0.11893315018315018,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3374447288806144,
+          "transition_rate": 0.11987895716945997,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.00016414492421066388,
+            0.14293438084469626,
+            0.11735564897029876,
+            26.36054672139753,
+            -0.3685341282575701
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11909178795629934,
+            0.18470609784412909,
+            0.24036108388984306,
+            39.922496926358214,
+            0.3432843827486749
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.13558539127823077,
+            0.19203886807578127,
+            0.27244284981177025,
+            35.17173457458591,
+            0.35281865977835575
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0027043985269420675,
+            0.11358517645866661,
+            0.05201609007281367,
+            20.176102712382338,
+            0.1876138207729863
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 102.45918605336192,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0022222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.21509519492293744
+        }
+      },
+      "model_kruskal_h": 102.45918605336192,
+      "model_p_value": 0.0022222222222222222,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": -0.07774252039891205,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 660,
+          "pct": 0.1495581237253569
+        },
+        "ranging_directional_up": {
+          "count": 1377,
+          "pct": 0.31203263086335825
+        },
+        "ranging_volatile": {
+          "count": 995,
+          "pct": 0.22547020167686382
+        },
+        "trending_down_choppy": {
+          "count": 812,
+          "pct": 0.18400181282574213
+        },
+        "trending_up_choppy": {
+          "count": 569,
+          "pct": 0.1289372309086789
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.3217730350913195,
+          "transition_rate": 0.19930213464696223,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.31203263086335825,
+          "transition_rate": 0.21509519492293744,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.28233402251320927,
+          "transition_rate": 0.20413555427914992,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3090305596886803,
+          "transition_rate": 0.21119505494505494,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.32790318827088666,
+          "transition_rate": 0.21135940409683426,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.007058298766270132,
+            0.1440715787536963,
+            0.13548231570192748,
+            27.583490659606934,
+            2.0049515978930645
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1264078399312074,
+            0.18981001012758175,
+            0.2553730735570897,
+            41.22079610173396,
+            -0.19029942611209064
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0010442031485267031,
+            0.14405312423799116,
+            0.12746152120763013,
+            26.538699281880778,
+            -0.4014395321630921
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0028174101308796324,
+            0.11326187729045303,
+            0.042648278608770296,
+            20.29889071990365,
+            -0.2874232664556113
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1499056259211001,
+            0.2030634316380972,
+            0.29916767267044414,
+            36.936056026728835,
+            -0.07487426886635615
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 94.46965595896654,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0011111111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.17724388032638258
+        }
+      },
+      "model_kruskal_h": 94.46965595896654,
+      "model_p_value": 0.0011111111111111111,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": -0.039891205802357194,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 531,
+          "pct": 0.1203263086335826
+        },
+        "ranging_volatile": {
+          "count": 1115,
+          "pct": 0.2526625878087469
+        },
+        "trending_down_choppy": {
+          "count": 1420,
+          "pct": 0.32177656922728304
+        },
+        "trending_up_choppy": {
+          "count": 1347,
+          "pct": 0.3052345343303875
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3010465832136261,
+          "transition_rate": 0.17733990147783252,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.32177656922728304,
+          "transition_rate": 0.17724388032638258,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.31484033999540545,
+          "transition_rate": 0.183917288914417,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.35744534737324024,
+          "transition_rate": 0.18246336996336995,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3267395857575052,
+          "transition_rate": 0.19157355679702048,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.069721597426732,
+            0.1374742314605966,
+            0.1454148021586286,
+            24.068145710273733,
+            -0.3115807011102513
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.06748645993334564,
+            0.1531081894317299,
+            0.1394487427823104,
+            29.77982501506845,
+            -0.3963891477761488
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13566117555555665,
+            0.1942227789464182,
+            0.27278622216297027,
+            42.60434177197266,
+            -0.06637851179212456
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.000911236690811066,
+            0.11675544295098808,
+            0.040735424946735266,
+            21.105467848698066,
+            -0.31826200702971547
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.012022829831905604,
+            0.1410054963053166,
+            0.12247092753182917,
+            27.088870012486048,
+            2.1691656786981106
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1525403344259837,
+            0.20465183545940197,
+            0.3039191123524573,
+            37.144338576209556,
+            -0.0018512205885163058
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 115.63174087771222,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.13553943789664552
+        }
+      },
+      "model_kruskal_h": 115.63174087771222,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.0018132366273798661,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1047,
+          "pct": 0.23725356900067981
+        },
+        "ranging_volatile": {
+          "count": 764,
+          "pct": 0.1731248583729889
+        },
+        "trending_down_choppy": {
+          "count": 1309,
+          "pct": 0.2966236120552912
+        },
+        "trending_up_choppy": {
+          "count": 1293,
+          "pct": 0.2929979605710401
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.2686230248306998,
+          "transition_rate": 0.14039408866995073,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.2966236120552912,
+          "transition_rate": 0.13553943789664552,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3050769584194808,
+          "transition_rate": 0.14417001723147616,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.34645759413986493,
+          "transition_rate": 0.14136904761904762,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.31440539911566207,
+          "transition_rate": 0.15200186219739292,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_down",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.004830553954339846,
+            0.10793852636247464,
+            0.04642745875774999,
+            18.325359588671766,
+            -0.2774132853799565
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.0033447408515968552,
+            0.13413048600534483,
+            0.10505978091922258,
+            25.75932806082733,
+            1.9200322226870825
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.01081732851231775,
+            0.13856343255963274,
+            0.047199523432547616,
+            27.8216580568751,
+            -0.3913991110612428
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13990860356973048,
+            0.19586349453436397,
+            0.2794473652553776,
+            42.24297974543726,
+            0.3960064099057716
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0734579881257146,
+            0.14051276426023815,
+            0.15302910549667914,
+            24.94997256101409,
+            -0.3176095835313854
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.07866989975537447,
+            0.15761164681909104,
+            0.16307104302640998,
+            30.69338717879952,
+            -0.39473031314148166
+          ],
+          "volatility_rank": 4
+        },
+        "6": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1546108247042533,
+            0.20589388833344785,
+            0.3082361082630817,
+            37.03555715917008,
+            0.11289930295353004
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 65.77314073857269,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0011111111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.121260199456029
+        }
+      },
+      "model_kruskal_h": 65.77314073857269,
+      "model_p_value": 0.0011111111111111111,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.01609247506799638,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2355,
+          "pct": 0.5336505778382054
+        },
+        "ranging_volatile": {
+          "count": 2058,
+          "pct": 0.4663494221617947
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5259593679458239,
+          "transition_rate": 0.11576354679802955,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.526 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5336505778382054,
+          "transition_rate": 0.121260199456029,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.534 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5134390075809786,
+          "transition_rate": 0.12130959218839747,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.513 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5363397047041318,
+          "transition_rate": 0.12522893772893773,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.536 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5012799627647195,
+          "transition_rate": 0.11568901303538175,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.501 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.003705211201014776,
+            0.1753710721408313,
+            0.21682775697217294,
+            34.672097990089206,
+            0.5018189115986702
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0033552212492258117,
+            0.12558914742842478,
+            0.07863862550956413,
+            22.60658297496903,
+            -0.33762969379878305
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 35.97137851104526,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.010555555555555556,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.11536718041704443
+        }
+      },
+      "model_kruskal_h": 35.97137851104526,
+      "model_p_value": 0.010555555555555556,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.02198549410698096,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2594,
+          "pct": 0.5878087468842057
+        },
+        "ranging_volatile": {
+          "count": 1819,
+          "pct": 0.41219125311579424
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5335522265544839,
+          "transition_rate": 0.10960591133004927,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.534 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5878087468842057,
+          "transition_rate": 0.11536718041704443,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.588 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5594991959568114,
+          "transition_rate": 0.12085008615738081,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.559 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5923085727366373,
+          "transition_rate": 0.12477106227106227,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.592 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5552711193856179,
+          "transition_rate": 0.10917132216014898,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.555 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_down",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0049439957436726726,
+            0.12215366781419468,
+            0.069064245079174,
+            21.87422444662534,
+            -0.33165059835736094
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.006295466733469249,
+            0.1808699597222428,
+            0.22868090756654663,
+            35.83447375574681,
+            -0.391227976358501
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.0006729565713033714,
+            0.15728526340576948,
+            0.17240074775402045,
+            30.340479433526035,
+            1.6929308892512984
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 85.13754581670037,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.005,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.15684496826835903
+        }
+      },
+      "model_kruskal_h": 85.13754581670037,
+      "model_p_value": 0.005,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": -0.019492293744333644,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1429,
+          "pct": 0.32381599818717427
+        },
+        "ranging_volatile": {
+          "count": 1270,
+          "pct": 0.2877860865624292
+        },
+        "trending_down_choppy": {
+          "count": 988,
+          "pct": 0.22388397915250396
+        },
+        "trending_up_choppy": {
+          "count": 726,
+          "pct": 0.16451393609789258
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.35337574389493126,
+          "transition_rate": 0.1481937602627258,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.32381599818717427,
+          "transition_rate": 0.15684496826835903,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.370434183321847,
+          "transition_rate": 0.1514072372199885,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.32619892411582924,
+          "transition_rate": 0.15396062271062272,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.36141494065627183,
+          "transition_rate": 0.15758845437616387,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.00019620787081995198,
+            0.14186004285305484,
+            0.11938759410565326,
+            26.517919696060716,
+            -0.4077277861299529
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12452350077966721,
+            0.18768138160316158,
+            0.2506042538232307,
+            40.38753771992026,
+            0.4431032765975037
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1411961391186137,
+            0.1955931366812646,
+            0.2829577320819609,
+            35.45947843628754,
+            0.4459294083001553
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0022001789970537804,
+            0.11589091042023866,
+            0.05364267097836997,
+            20.74099888184009,
+            0.32843998833733207
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 107.83195003540277,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.25385312783318226
+        }
+      },
+      "model_kruskal_h": 107.83195003540277,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": -0.11650045330915687,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 777,
+          "pct": 0.1760707002039429
+        },
+        "ranging_directional_up": {
+          "count": 1399,
+          "pct": 0.3170179016542035
+        },
+        "ranging_volatile": {
+          "count": 1034,
+          "pct": 0.2343077271697258
+        },
+        "trending_down_choppy": {
+          "count": 738,
+          "pct": 0.1672331747110809
+        },
+        "trending_up_choppy": {
+          "count": 465,
+          "pct": 0.1053704962610469
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.32464600861892057,
+          "transition_rate": 0.2395320197044335,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.3170179016542035,
+          "transition_rate": 0.25385312783318226,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.28405697220307835,
+          "transition_rate": 0.2530729465824239,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.30559688680325053,
+          "transition_rate": 0.2557234432234432,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3383756108913195,
+          "transition_rate": 0.2532588454376164,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.001222206528599256,
+            0.1484632061050328,
+            0.1488005130350307,
+            28.423934099378112,
+            1.9243952426215445
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1301889515577073,
+            0.19088864645128356,
+            0.2632225798256184,
+            41.700310424266306,
+            -0.23244334982435763
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0022445617285649813,
+            0.143686991730312,
+            0.1350552292813441,
+            26.736981186035997,
+            -0.40749977811942445
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0012436942771718597,
+            0.11631025523936103,
+            0.037547368547097504,
+            20.9572952979064,
+            -0.3006418505457218
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.15747255303812177,
+            0.207832392849934,
+            0.3129905631760901,
+            37.06890044591893,
+            -0.22192115760982703
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 85.33160433888042,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.21736174070716227
+        }
+      },
+      "model_kruskal_h": 85.33160433888042,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": -0.08000906618313688,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 660,
+          "pct": 0.1495581237253569
+        },
+        "ranging_volatile": {
+          "count": 1197,
+          "pct": 0.27124405166553367
+        },
+        "trending_down_choppy": {
+          "count": 1308,
+          "pct": 0.2963970088375255
+        },
+        "trending_up_choppy": {
+          "count": 1248,
+          "pct": 0.28280081577158395
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3143853888774882,
+          "transition_rate": 0.2029967159277504,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.2963970088375255,
+          "transition_rate": 0.21736174070716227,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3136917068688261,
+          "transition_rate": 0.21458931648477886,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.33798786768913813,
+          "transition_rate": 0.2135989010989011,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.31021643006748895,
+          "transition_rate": 0.21135940409683426,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07190715308971483,
+            0.1388890018122834,
+            0.14983684962582405,
+            24.648386122954385,
+            -0.3505234497491322
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.07240896685523976,
+            0.15488203887127244,
+            0.14982002501027533,
+            30.457732632330814,
+            -0.4129503346185499
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13928537550279588,
+            0.19534165097604478,
+            0.27971573455185794,
+            42.60582752195801,
+            -0.14029043159168358
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00027401458771975757,
+            0.11888524219039613,
+            0.04199425535086093,
+            21.613439839738433,
+            -0.3277083331863043
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.007599573514279505,
+            0.1448205428927709,
+            0.1349663480339637,
+            27.812374770673745,
+            2.076383262017738
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1564723204236687,
+            0.20644447601241672,
+            0.3112571163035658,
+            37.014347651455935,
+            -0.12959628256270517
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 58.57770628399885,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.006111111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.2157751586582049
+        }
+      },
+      "model_kruskal_h": 58.57770628399885,
+      "model_p_value": 0.006111111111111111,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": -0.07842248413417952,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1254,
+          "pct": 0.2841604350781781
+        },
+        "ranging_volatile": {
+          "count": 832,
+          "pct": 0.18853387718105596
+        },
+        "trending_down_choppy": {
+          "count": 1072,
+          "pct": 0.2429186494448221
+        },
+        "trending_up_choppy": {
+          "count": 1255,
+          "pct": 0.2843870382959438
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.2799097065462754,
+          "transition_rate": 0.2077175697865353,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.2843870382959438,
+          "transition_rate": 0.2157751586582049,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.29405008040431885,
+          "transition_rate": 0.21631246410109134,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3373011331120522,
+          "transition_rate": 0.21119505494505494,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3109145915755178,
+          "transition_rate": 0.22299813780260708,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_down",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.003983280890632539,
+            0.11444206026814391,
+            0.032869867332448705,
+            20.08250450619047,
+            -0.25201365063363296
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.004861434268406997,
+            0.14750017191601997,
+            0.14502243591619457,
+            28.385959885267077,
+            2.143247909656711
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.02286555772735001,
+            0.13540514519357824,
+            0.07425470230729386,
+            26.540140782406475,
+            -0.42588207705122694
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.14493451934018456,
+            0.19887059497346823,
+            0.29018215998596203,
+            43.06906915695208,
+            -0.11015991186778457
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07016973043704515,
+            0.13694451021253579,
+            0.14625117593853415,
+            24.06743267333092,
+            -0.3405144860221616
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08673196184605056,
+            0.16106322663915085,
+            0.18017495648496062,
+            32.37343875995492,
+            -0.4003242893832437
+          ],
+          "volatility_rank": 4
+        },
+        "6": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.15383887019304202,
+            0.20470594205217701,
+            0.3060974736516455,
+            36.66858760120195,
+            -0.21470547267294307
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 48.20875701916884,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.017222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.034224841341795105
+        }
+      },
+      "model_kruskal_h": 48.20875701916884,
+      "model_p_value": 0.017222222222222222,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.10312783318223029,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1867,
+          "pct": 0.42306820756854746
+        },
+        "ranging_volatile": {
+          "count": 2546,
+          "pct": 0.5769317924314525
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6207674943566591,
+          "transition_rate": 0.035303776683087026,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.621 > 0.392",
+            "min_transition_rate: 0.0353 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5769317924314525,
+          "transition_rate": 0.034224841341795105,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.577 > 0.392",
+            "min_transition_rate: 0.0342 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6134849529060418,
+          "transition_rate": 0.033199310740953475,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.613 > 0.392",
+            "min_transition_rate: 0.0332 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5725077257639922,
+          "transition_rate": 0.03743131868131868,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.573 > 0.392",
+            "min_transition_rate: 0.0374 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5966953688619967,
+          "transition_rate": 0.03468342644320298,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.597 > 0.392",
+            "min_transition_rate: 0.0347 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.0067150704852833015,
+            0.1902987602378494,
+            0.2501022916631217,
+            38.731517955073315,
+            0.1646670550531507
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0036618358870494742,
+            0.12677829422319212,
+            0.0862855078896715,
+            22.65977771481008,
+            -0.004069080096298271
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 47.377920768813055,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0044444444444444444,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.09406165004533092
+        }
+      },
+      "model_kruskal_h": 47.377920768813055,
+      "model_p_value": 0.0044444444444444444,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.04329102447869447,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2098,
+          "pct": 0.4754135508724224
+        },
+        "ranging_volatile": {
+          "count": 2315,
+          "pct": 0.5245864491275776
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5672070593063822,
+          "transition_rate": 0.09236453201970443,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.567 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5245864491275776,
+          "transition_rate": 0.09406165004533092,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.525 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5574316563289685,
+          "transition_rate": 0.08776565192418151,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.557 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5229483804509557,
+          "transition_rate": 0.09432234432234432,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.523 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5471259017919479,
+          "transition_rate": 0.0947392923649907,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.547 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_down",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0033147714512257245,
+            0.12637785246186234,
+            0.0841726047108727,
+            22.592309534208024,
+            -0.22921716607636208
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.005070819309954485,
+            0.1906893722836201,
+            0.25070572522104656,
+            38.781063251904676,
+            -0.17929348637333012
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.004540276276906842,
+            0.15233917587939325,
+            0.1628859856155848,
+            29.062003329370235,
+            3.416134249598344
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 83.01605851882778,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.019444444444444445,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.0741160471441523
+        }
+      },
+      "model_kruskal_h": 83.01605851882778,
+      "model_p_value": 0.019444444444444445,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.06323662737987308,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1227,
+          "pct": 0.2780421481985044
+        },
+        "ranging_volatile": {
+          "count": 1614,
+          "pct": 0.36573759347382734
+        },
+        "trending_down_choppy": {
+          "count": 857,
+          "pct": 0.1941989576251983
+        },
+        "trending_up_choppy": {
+          "count": 715,
+          "pct": 0.16202130070246998
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.43730761337984814,
+          "transition_rate": 0.07573891625615764,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.437 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.36573759347382734,
+          "transition_rate": 0.0741160471441523,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.42304158051918217,
+          "transition_rate": 0.07122343480758185,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.423 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.36580061806111935,
+          "transition_rate": 0.07566391941391941,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.409588084710263,
+          "transition_rate": 0.07472067039106145,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.410 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.030980731734981694,
+            0.15313093235809228,
+            0.12227668462183905,
+            30.808395493295137,
+            -0.22087809439122727
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1297283364211666,
+            0.19104076256071856,
+            0.2609350951904761,
+            41.989957984160654,
+            0.3194559812427362
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1442636471029179,
+            0.19850313263976788,
+            0.289099678711903,
+            35.941659302702284,
+            0.161199680146396
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.014959403046504257,
+            0.11822354072106038,
+            0.07383618440485322,
+            20.164113612392256,
+            0.09214181549731532
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 70.57045467601347,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.017222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12080689029918404
+        }
+      },
+      "model_kruskal_h": 70.57045467601347,
+      "model_p_value": 0.017222222222222222,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.016545784224841348,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1543,
+          "pct": 0.34964876501246317
+        },
+        "ranging_volatile": {
+          "count": 1442,
+          "pct": 0.32676184001812825
+        },
+        "trending_down_choppy": {
+          "count": 787,
+          "pct": 0.1783367323815998
+        },
+        "trending_up_choppy": {
+          "count": 641,
+          "pct": 0.14525266258780875
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3940077980710035,
+          "transition_rate": 0.11083743842364532,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.394 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.34964876501246317,
+          "transition_rate": 0.12080689029918404,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.38513668734206297,
+          "transition_rate": 0.1054566341183228,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3417649078631109,
+          "transition_rate": 0.11481227106227106,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3700255992552944,
+          "transition_rate": 0.11289571694599627,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.008224826754059226,
+            0.14836523619250247,
+            0.1495004143348548,
+            28.10129827088451,
+            3.5500522278293505
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12982382089032546,
+            0.19146844432439508,
+            0.26198954564539856,
+            42.49045191339893,
+            -0.10223402141576893
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.02850132656995187,
+            0.1530729923509146,
+            0.12325172582338004,
+            30.662592868294393,
+            -0.2632210683967978
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.014742815623017606,
+            0.11748716888828212,
+            0.07110013184664839,
+            19.96758952961688,
+            -0.20646502657061064
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1469722392931596,
+            0.20047132573330181,
+            0.2938271781072868,
+            36.20350719214809,
+            -0.08147034079520854
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 70.34975688753548,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.005555555555555556,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.14324569356300998
+        }
+      },
+      "model_kruskal_h": 70.34975688753548,
+      "model_p_value": 0.005555555555555556,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": -0.005893019038984593,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 331,
+          "pct": 0.07500566508044414
+        },
+        "ranging_volatile": {
+          "count": 1474,
+          "pct": 0.33401314298663043
+        },
+        "trending_down_choppy": {
+          "count": 1482,
+          "pct": 0.335825968728756
+        },
+        "trending_up_choppy": {
+          "count": 1126,
+          "pct": 0.2551552232041695
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.38826185101580135,
+          "transition_rate": 0.14490968801313628,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.335825968728756,
+          "transition_rate": 0.14324569356300998,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.39972432804962094,
+          "transition_rate": 0.12843193566915564,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.400 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3306626988668879,
+          "transition_rate": 0.14285714285714285,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3716546427740284,
+          "transition_rate": 0.13221601489757914,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0964327297831264,
+            0.16029799318410992,
+            0.1993216054950414,
+            29.166304000193893,
+            -0.19251032620870198
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.06656665758022923,
+            0.1575051133427173,
+            0.1385151383299591,
+            30.326908194768674,
+            -0.25952046409497154
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1351425705551375,
+            0.19544908340911638,
+            0.27250190214367986,
+            44.49307813242184,
+            -0.08261151329043936
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.008436771317770889,
+            0.11690635129489557,
+            0.06032510392971914,
+            20.649537411275897,
+            -0.21083451391298144
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.011023199316872121,
+            0.14823632835504758,
+            0.1484994121459026,
+            28.0597248699074,
+            3.586155355558356
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18222954434235605,
+            0.2311790364681714,
+            0.35565666744905866,
+            42.721866340461744,
+            0.08410618581275578
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.69059649660267,
+          "model_kruskal_h": 67.53263210910154,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.015555555555555555,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.13236627379873073
+        }
+      },
+      "model_kruskal_h": 67.53263210910154,
+      "model_p_value": 0.015555555555555555,
+      "handrule_kruskal_h": 85.69059649660267,
+      "stability_gain": 0.00498640072529466,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 801,
+          "pct": 0.18150917743031952
+        },
+        "ranging_volatile": {
+          "count": 1315,
+          "pct": 0.2979832313618853
+        },
+        "trending_down_choppy": {
+          "count": 1241,
+          "pct": 0.2812145932472241
+        },
+        "trending_up_choppy": {
+          "count": 1056,
+          "pct": 0.23929299796057105
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.34249948696901295,
+          "transition_rate": 0.138752052545156,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.2979832313618853,
+          "transition_rate": 0.13236627379873073,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.34792097404089134,
+          "transition_rate": 0.11924181504882252,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.29346457594139863,
+          "transition_rate": 0.13679029304029305,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3388410518966721,
+          "transition_rate": 0.12686219739292365,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_down",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009502779841389662,
+            0.11540491761158422,
+            0.06223819584488684,
+            19.21187577159735,
+            -0.19656558429664686
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.011245878653777078,
+            0.14849308653314058,
+            0.14888810735684077,
+            28.163363029139703,
+            3.668059532252752
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.015426200429221923,
+            0.14115897308028436,
+            0.07642664334719779,
+            33.75499086159826,
+            -0.2267034289067312
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1348254149554739,
+            0.1949732401786896,
+            0.2716254379984643,
+            45.14459430738758,
+            -0.08205058047413097
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.10093086935829862,
+            0.16213336351153018,
+            0.20731864343222056,
+            28.587062405265073,
+            -0.18349951099968673
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08489744493656762,
+            0.16355240594301862,
+            0.17457399504129711,
+            26.98279086958344,
+            -0.26211977646803
+          ],
+          "volatility_rank": 4
+        },
+        "6": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1826358264361191,
+            0.23177990995900066,
+            0.35657814352368117,
+            42.83913840839783,
+            0.08711329922382038
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 60.5922668257208,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.013888888888888888,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.03424015009380863
+        }
+      },
+      "model_kruskal_h": 60.5922668257208,
+      "model_p_value": 0.013888888888888888,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.10436210131332083,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2033,
+          "pct": 0.47667057444314187
+        },
+        "ranging_volatile": {
+          "count": 2232,
+          "pct": 0.5233294255568581
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5729100529100529,
+          "transition_rate": 0.03323454699407282,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.573 > 0.392",
+            "min_transition_rate: 0.0332 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5233294255568581,
+          "transition_rate": 0.03424015009380863,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.523 > 0.392",
+            "min_transition_rate: 0.0342 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5438186492171068,
+          "transition_rate": 0.034708425850181135,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.544 > 0.392",
+            "min_transition_rate: 0.0347 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5054139015019211,
+          "transition_rate": 0.03854215183977643,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.505 > 0.392",
+            "min_transition_rate: 0.0385 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5343456254519161,
+          "transition_rate": 0.029170684667309547,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.534 > 0.392",
+            "min_transition_rate: 0.0292 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.005422062126225129,
+            0.18221547171589036,
+            0.2321585869657425,
+            37.05084597861473,
+            0.17181629006753052
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005556369949216343,
+            0.12317206716390974,
+            0.07730674928196764,
+            21.876216942872663,
+            0.14573301272887362
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 81.24536332828393,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.013888888888888888,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.042917448405253286
+        }
+      },
+      "model_kruskal_h": 81.24536332828393,
+      "model_p_value": 0.013888888888888888,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.09568480300187616,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2063,
+          "pct": 0.48370457209847595
+        },
+        "trending_down_choppy": {
+          "count": 1286,
+          "pct": 0.3015240328253224
+        },
+        "trending_up_choppy": {
+          "count": 916,
+          "pct": 0.21477139507620163
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5367195767195767,
+          "transition_rate": 0.03789161727349703,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.537 > 0.392",
+            "min_transition_rate: 0.0379 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.48370457209847595,
+          "transition_rate": 0.042917448405253286,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.484 > 0.392",
+            "min_transition_rate: 0.0429 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5086468801121757,
+          "transition_rate": 0.0428888629192474,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.509 > 0.392",
+            "min_transition_rate: 0.0429 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.46955408080102456,
+          "transition_rate": 0.04517931998136935,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.470 > 0.392",
+            "min_transition_rate: 0.0452 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5116895637503013,
+          "transition_rate": 0.03953712632594021,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.512 > 0.392",
+            "min_transition_rate: 0.0395 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006108476165882547,
+            0.12198560377914283,
+            0.07123314987246447,
+            21.738777918387175,
+            0.14437414586248998
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1029282369686711,
+            0.17425325893321786,
+            0.20894059294746176,
+            37.344991257417945,
+            0.16639820450621803
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.12348168175352808,
+            0.18450804801563467,
+            0.24928652669865625,
+            34.10603290994657,
+            0.17759616990441265
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 75.96494350097419,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.03777777777777778,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.04080675422138837
+        }
+      },
+      "model_kruskal_h": 75.96494350097419,
+      "model_p_value": 0.03777777777777778,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.09779549718574108,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2328,
+          "pct": 0.5458382180539273
+        },
+        "trending_down_choppy": {
+          "count": 1109,
+          "pct": 0.26002344665885113
+        },
+        "trending_up_choppy": {
+          "count": 828,
+          "pct": 0.19413833528722158
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5980952380952381,
+          "transition_rate": 0.03831498729889924,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.598 > 0.392",
+            "min_transition_rate: 0.0383 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5458382180539273,
+          "transition_rate": 0.04080675422138837,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.546 > 0.392",
+            "min_transition_rate: 0.0408 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5829633091843889,
+          "transition_rate": 0.03903237115811616,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.583 > 0.392",
+            "min_transition_rate: 0.0390 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5366166026312725,
+          "transition_rate": 0.04110386585933861,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.537 > 0.392",
+            "min_transition_rate: 0.0411 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5796577488551459,
+          "transition_rate": 0.036885245901639344,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.580 > 0.392",
+            "min_transition_rate: 0.0369 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006426207047002319,
+            0.12461368033255729,
+            0.07525259951287191,
+            21.73019144912455,
+            0.11796818002663713
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.13049710528156366,
+            0.18921440244922752,
+            0.2630371629530682,
+            35.1815193215839,
+            0.17623077819349106
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11269058799955738,
+            0.1790479723738248,
+            0.22860081892863676,
+            38.372816448768575,
+            0.16211181929951948
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.001260359425370758,
+            0.125418285992311,
+            0.07841508063098973,
+            23.71127615888643,
+            0.18570700152003625
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 58.80770364124328,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.034444444444444444,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.06941838649155722
+        }
+      },
+      "model_kruskal_h": 58.80770364124328,
+      "model_p_value": 0.034444444444444444,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.06918386491557223,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1199,
+          "pct": 0.2811254396248535
+        },
+        "trending_down_choppy": {
+          "count": 1626,
+          "pct": 0.381242672919109
+        },
+        "trending_up_choppy": {
+          "count": 1440,
+          "pct": 0.3376318874560375
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3502645502645503,
+          "transition_rate": 0.07768839966130398,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.381242672919109,
+          "transition_rate": 0.06941838649155722,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.37275064267352187,
+          "transition_rate": 0.08659576954540142,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.40144370706717897,
+          "transition_rate": 0.07172799254774104,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.401 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.3579175704989154,
+          "transition_rate": 0.08775313404050145,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.06139458832889615,
+            0.1457658505894175,
+            0.12738579669616823,
+            28.794854622119615,
+            0.1592306710867848
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14649564757365346,
+            0.2016398453818111,
+            0.29270648267067334,
+            36.769195256367595,
+            0.18146137160278392
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06730906554733715,
+            0.13466367576737215,
+            0.14124124074072777,
+            23.81921747330232,
+            0.15296214795461838
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0006712101074520102,
+            0.11741850735057047,
+            0.03925658245483633,
+            21.26378482625137,
+            0.14359802157534055
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12851154497747153,
+            0.18879330598607613,
+            0.25944320204218496,
+            41.29077013357269,
+            0.16529145599457337
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 137.873137576491,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.07387429643527205
+        }
+      },
+      "model_kruskal_h": 137.873137576491,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.0647279549718574,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 293,
+          "pct": 0.06869871043376319
+        },
+        "ranging_volatile": {
+          "count": 1103,
+          "pct": 0.2586166471277843
+        },
+        "trending_down_choppy": {
+          "count": 1517,
+          "pct": 0.3556858147713951
+        },
+        "trending_up_choppy": {
+          "count": 1352,
+          "pct": 0.31699882766705745
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3144973544973545,
+          "transition_rate": 0.07070279424216766,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3556858147713951,
+          "transition_rate": 0.07387429643527205,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3296330918438888,
+          "transition_rate": 0.07409138716840014,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3580160670625218,
+          "transition_rate": 0.07207731718677224,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3138105567606652,
+          "transition_rate": 0.07738669238187078,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06905614734257728,
+            0.13609747437858552,
+            0.14486602922736752,
+            23.793133998923317,
+            0.14210686811263487
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0077404701278491845,
+            0.1392333105287102,
+            0.09247821359292337,
+            28.249858605014946,
+            0.23634239639302834
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12950238566429018,
+            0.18932365716204436,
+            0.26136601634949447,
+            41.602492696310755,
+            0.1652716678077228
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00018088788474430583,
+            0.11750418883224496,
+            0.04078193270092595,
+            21.117291911081136,
+            0.13671792927294132
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.15176965840423348,
+            0.20416855907011694,
+            0.3029548765436063,
+            37.259847836744996,
+            0.17909130083629854
+          ],
+          "volatility_rank": 5
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.06596338680190354,
+            0.14623864135796938,
+            0.13742639022173114,
+            28.434633805963582,
+            0.1487925279521393
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 117.43078746975152,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.005,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.07575046904315197
+        }
+      },
+      "model_kruskal_h": 117.43078746975152,
+      "model_p_value": 0.005,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.06285178236397748,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 276,
+          "pct": 0.06471277842907386
+        },
+        "ranging_volatile": {
+          "count": 1089,
+          "pct": 0.2553341148886284
+        },
+        "trending_down_choppy": {
+          "count": 1524,
+          "pct": 0.35732708089097304
+        },
+        "trending_up_choppy": {
+          "count": 1376,
+          "pct": 0.3226260257913247
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3111111111111111,
+          "transition_rate": 0.081922099915326,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.35732708089097304,
+          "transition_rate": 0.07575046904315197,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3305678896938537,
+          "transition_rate": 0.08086946359705505,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3565025032017697,
+          "transition_rate": 0.07755006986492781,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.31863099542058326,
+          "transition_rate": 0.08293153326904533,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11443746234272141,
+            0.1738201852204455,
+            0.23659196208463218,
+            31.34045190058547,
+            0.1482397753527773
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1848323202616336,
+            0.2345709014869793,
+            0.35791835520087667,
+            41.54995673969141,
+            0.2016293872541328
+          ],
+          "volatility_rank": 6
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06134305161322433,
+            0.12824474300694366,
+            0.1297889757682802,
+            22.50986992921156,
+            0.14119367758123155
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12893638349382214,
+            0.1890278112556122,
+            0.26026344403910895,
+            41.5656691888101,
+            0.16510011361111174
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.0005799466825554292,
+            0.11753119396604639,
+            0.037976657725324325,
+            21.10606523406933,
+            0.1371909032538826
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0018922944892990324,
+            0.14241219133758248,
+            0.10557587353711884,
+            29.88827770303851,
+            0.23718015724822525
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.0641894349267041,
+            0.14493828867959027,
+            0.13410748762170763,
+            27.70433419894083,
+            0.14368756125577273
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 48.927325717606436,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.019444444444444445,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.040337711069418386
+        }
+      },
+      "model_kruskal_h": 48.927325717606436,
+      "model_p_value": 0.019444444444444445,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.09826454033771106,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2032,
+          "pct": 0.4764361078546307
+        },
+        "ranging_volatile": {
+          "count": 2233,
+          "pct": 0.5235638921453692
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5752380952380952,
+          "transition_rate": 0.03492802709568162,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.575 > 0.392",
+            "min_transition_rate: 0.0349 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5235638921453692,
+          "transition_rate": 0.040337711069418386,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.524 > 0.392",
+            "min_transition_rate: 0.0403 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5503622341668614,
+          "transition_rate": 0.04055159518522847,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.550 > 0.392",
+            "min_transition_rate: 0.0406 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5070438933519618,
+          "transition_rate": 0.04343269678621332,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.507 > 0.392",
+            "min_transition_rate: 0.0434 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5403711737768137,
+          "transition_rate": 0.034474445515911285,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.540 > 0.392",
+            "min_transition_rate: 0.0345 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.0036442413064233245,
+            0.18198425116700076,
+            0.235137263455018,
+            36.68812585667635,
+            0.17098206107440747
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.004215265320590622,
+            0.12366512953951767,
+            0.07601790407494566,
+            22.22137108826002,
+            0.14647807799426538
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 72.309550801976,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.019444444444444445,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.04549718574108818
+        }
+      },
+      "model_kruskal_h": 72.309550801976,
+      "model_p_value": 0.019444444444444445,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.09310506566604126,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2279,
+          "pct": 0.5343493552168816
+        },
+        "trending_down_choppy": {
+          "count": 1167,
+          "pct": 0.27362250879249705
+        },
+        "trending_up_choppy": {
+          "count": 819,
+          "pct": 0.19202813599062132
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5906878306878307,
+          "transition_rate": 0.04276037256562235,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.591 > 0.392",
+            "min_transition_rate: 0.0428 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5343493552168816,
+          "transition_rate": 0.04549718574108818,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.534 > 0.392",
+            "min_transition_rate: 0.0455 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5736153306847395,
+          "transition_rate": 0.043122589692649295,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.574 > 0.392",
+            "min_transition_rate: 0.0431 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5247409477238328,
+          "transition_rate": 0.04855612482533768,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.525 > 0.392",
+            "min_transition_rate: 0.0486 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5707399373342974,
+          "transition_rate": 0.0431533269045323,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.571 > 0.392",
+            "min_transition_rate: 0.0432 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005165159046318386,
+            0.12500859273393508,
+            0.07700446468490522,
+            22.776697716235653,
+            0.1479079508196912
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11160488187452618,
+            0.17897555537312446,
+            0.22632128245604174,
+            38.24002491987147,
+            0.16527530168718646
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.13352816563004272,
+            0.1905061617034894,
+            0.268825267036637,
+            34.98326555632588,
+            0.17728646392393616
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 75.29058819424972,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.02277777777777778,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.11374296435272045
+        }
+      },
+      "model_kruskal_h": 75.29058819424972,
+      "model_p_value": 0.02277777777777778,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.024859287054409,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1676,
+          "pct": 0.3929660023446659
+        },
+        "ranging_volatile": {
+          "count": 1094,
+          "pct": 0.25650644783118404
+        },
+        "trending_down_choppy": {
+          "count": 922,
+          "pct": 0.21617819460726848
+        },
+        "trending_up_choppy": {
+          "count": 573,
+          "pct": 0.1343493552168816
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.40613756613756613,
+          "transition_rate": 0.12320067739204064,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.406 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3929660023446659,
+          "transition_rate": 0.11374296435272045,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.393 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.39051180182285583,
+          "transition_rate": 0.1251606871567138,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.40482011875654905,
+          "transition_rate": 0.11877037727061016,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.405 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.4215473608098337,
+          "transition_rate": 0.1289778206364513,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.422 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00032522580087759715,
+            0.11703566606489849,
+            0.03484598009505789,
+            21.18493428449207,
+            0.14334672633536125
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.15115536164249685,
+            0.20273057985030377,
+            0.3025361441634888,
+            36.81835470045956,
+            0.18026639796967966
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1261952250000539,
+            0.1870957073868693,
+            0.25517877678374035,
+            40.77321601931237,
+            0.1649808283099994
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0053454982214461485,
+            0.1393031467290001,
+            0.1289068226452449,
+            26.07860615683028,
+            0.1560898776310799
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 54.647131601193905,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.041666666666666664,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.08208255159474671
+        }
+      },
+      "model_kruskal_h": 54.647131601193905,
+      "model_p_value": 0.041666666666666664,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.05651969981238274,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1218,
+          "pct": 0.28558030480656504
+        },
+        "trending_down_choppy": {
+          "count": 1620,
+          "pct": 0.3798358733880422
+        },
+        "trending_up_choppy": {
+          "count": 1427,
+          "pct": 0.33458382180539276
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3470899470899471,
+          "transition_rate": 0.09398814563928874,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.3798358733880422,
+          "transition_rate": 0.08208255159474671,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.37017994858611825,
+          "transition_rate": 0.09594484048147715,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.39899871929211783,
+          "transition_rate": 0.08593386120167676,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.399 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.35357917570498915,
+          "transition_rate": 0.09908389585342334,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.06266623424590431,
+            0.1453721117955732,
+            0.12989205109955906,
+            28.84050378780514,
+            0.1584931198119062
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14731009012691282,
+            0.19941783590689785,
+            0.29509009365525085,
+            36.247417278294364,
+            0.17940261228300056
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06660824107086313,
+            0.1348016655539671,
+            0.13949916447052998,
+            23.918655063902577,
+            0.15304980192752932
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.000649578542789699,
+            0.1190981514173526,
+            0.03806634100878635,
+            21.692804370359134,
+            0.14515853355001346
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1295030869794064,
+            0.18786939873727887,
+            0.2616854207210891,
+            40.79334830953262,
+            0.16476662041300502
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 62.056952221777465,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.017222222222222222,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.13133208255159476
+        }
+      },
+      "model_kruskal_h": 62.056952221777465,
+      "model_p_value": 0.017222222222222222,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.007270168855534692,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 448,
+          "pct": 0.10504103165298945
+        },
+        "ranging_volatile": {
+          "count": 1030,
+          "pct": 0.24150058616647127
+        },
+        "trending_down_choppy": {
+          "count": 1295,
+          "pct": 0.30363423212192264
+        },
+        "trending_up_choppy": {
+          "count": 1492,
+          "pct": 0.34982415005861667
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3424338624338624,
+          "transition_rate": 0.15389500423370026,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.34982415005861667,
+          "transition_rate": 0.13133208255159476,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.38677261042299604,
+          "transition_rate": 0.14514432628257568,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.4142507858889277,
+          "transition_rate": 0.13705170004657663,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.414 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.37117377681369007,
+          "transition_rate": 0.1487463837994214,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06355910587433766,
+            0.13314990653137498,
+            0.13324530163540393,
+            23.554762896342197,
+            0.15236036527815383
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.04176711143260991,
+            0.13564228962500097,
+            0.08583594246770634,
+            27.098581128671213,
+            0.15797627545437315
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1357191414450745,
+            0.19106748272949772,
+            0.2733067053108982,
+            41.749547975110566,
+            0.1654102193172213
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.002426676594851008,
+            0.118632704840261,
+            0.0319718238170275,
+            21.548566370423522,
+            0.1444385828507743
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1456533502523157,
+            0.1983500246466771,
+            0.2919242293893619,
+            36.07079150049879,
+            0.1791346984130929
+          ],
+          "volatility_rank": 5
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.07951894084974026,
+            0.15233611741169853,
+            0.16551053905665564,
+            30.145269824182076,
+            0.15717956355737572
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 53.29364264679316,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.042777777777777776,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.08208255159474671
+        }
+      },
+      "model_kruskal_h": 53.29364264679316,
+      "model_p_value": 0.042777777777777776,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.05651969981238274,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1240,
+          "pct": 0.29073856975381007
+        },
+        "trending_down_choppy": {
+          "count": 1577,
+          "pct": 0.3697538100820633
+        },
+        "trending_up_choppy": {
+          "count": 1448,
+          "pct": 0.3395076201641266
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3358730158730159,
+          "transition_rate": 0.09462320067739204,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.3697538100820633,
+          "transition_rate": 0.08208255159474671,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.39086235101659267,
+          "transition_rate": 0.09150403178684119,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.40272441494935385,
+          "transition_rate": 0.08802980903586399,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.403 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.3627380091588335,
+          "transition_rate": 0.09546769527483125,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11740293456373885,
+            0.1708547900041789,
+            0.24285663923934225,
+            30.810798348121416,
+            0.14927388112054266
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.189722273136291,
+            0.23584692739898988,
+            0.3683863347255144,
+            41.44064575052818,
+            0.19309183412251962
+          ],
+          "volatility_rank": 6
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06292572806109802,
+            0.13217271180316592,
+            0.131936231171,
+            23.445547752764654,
+            0.1458885306756457
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13083290563208153,
+            0.1887284592611378,
+            0.2641710741598359,
+            41.04488421241817,
+            0.16510571128645654
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.00028817814704937045,
+            0.11921659011885827,
+            0.038991624277106215,
+            21.816451424010424,
+            0.14449255856286958
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.067567102706303,
+            0.16408229590362372,
+            0.15539445738545807,
+            32.47709289596343,
+            0.2877471612693846
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.065231873030751,
+            0.1458154092627873,
+            0.13527173457279507,
+            28.96788994263952,
+            0.15682319459393856
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 50.390159699898504,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.026111111111111113,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.0300187617260788
+        }
+      },
+      "model_kruskal_h": 50.390159699898504,
+      "model_p_value": 0.026111111111111113,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.10858348968105065,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1844,
+          "pct": 0.43235638921453695
+        },
+        "ranging_volatile": {
+          "count": 2421,
+          "pct": 0.5676436107854631
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6139682539682539,
+          "transition_rate": 0.03281117696867062,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.614 > 0.392",
+            "min_transition_rate: 0.0328 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5676436107854631,
+          "transition_rate": 0.0300187617260788,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.568 > 0.392",
+            "min_transition_rate: 0.0300 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5986211731713017,
+          "transition_rate": 0.032137431342760314,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.599 > 0.392",
+            "min_transition_rate: 0.0321 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5618814763069042,
+          "transition_rate": 0.034816022356776895,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.562 > 0.392",
+            "min_transition_rate: 0.0348 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5941190648349,
+          "transition_rate": 0.033992285438765674,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.594 > 0.392",
+            "min_transition_rate: 0.0340 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.005165886053750178,
+            0.1884033680413758,
+            0.24716420966136385,
+            38.590667878304394,
+            0.17537566717208808
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.004266444522101502,
+            0.1259583890148398,
+            0.0852855307602728,
+            22.620041398678918,
+            0.14651082539575386
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 78.16753110857462,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.02,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.04127579737335835
+        }
+      },
+      "model_kruskal_h": 78.16753110857462,
+      "model_p_value": 0.02,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.0973264540337711,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2305,
+          "pct": 0.5404454865181711
+        },
+        "trending_down_choppy": {
+          "count": 1173,
+          "pct": 0.27502930832356387
+        },
+        "trending_up_choppy": {
+          "count": 787,
+          "pct": 0.18452520515826495
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5936507936507937,
+          "transition_rate": 0.03725656223539373,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.594 > 0.392",
+            "min_transition_rate: 0.0373 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5404454865181711,
+          "transition_rate": 0.04127579737335835,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.540 > 0.392",
+            "min_transition_rate: 0.0413 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5788735685907922,
+          "transition_rate": 0.039382961318219,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.579 > 0.392",
+            "min_transition_rate: 0.0394 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5306787751775527,
+          "transition_rate": 0.04424778761061947,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.531 > 0.392",
+            "min_transition_rate: 0.0442 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5707399373342974,
+          "transition_rate": 0.03929604628736741,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.571 > 0.392",
+            "min_transition_rate: 0.0393 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0063380669244127354,
+            0.12454751580163806,
+            0.0802512186035826,
+            22.475356221327054,
+            0.14586488007201645
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.10882255182375247,
+            0.17960861301323505,
+            0.22040070833028153,
+            38.814118766572165,
+            0.16944745278382944
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.13620299929044788,
+            0.19423986986768643,
+            0.27326350742241917,
+            35.72745878992036,
+            0.18070118707509875
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": false,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 71.62811114370925,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.07611111111111112,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.04221388367729831
+        }
+      },
+      "model_kruskal_h": 71.62811114370925,
+      "model_p_value": 0.07611111111111112,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.09638836772983114,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 872,
+          "pct": 0.2044548651817116
+        },
+        "ranging_volatile": {
+          "count": 1673,
+          "pct": 0.3922626025791325
+        },
+        "trending_down_choppy": {
+          "count": 1015,
+          "pct": 0.23798358733880423
+        },
+        "trending_up_choppy": {
+          "count": 705,
+          "pct": 0.1652989449003517
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.42518518518518517,
+          "transition_rate": 0.03662150719729043,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.425 > 0.392",
+            "min_transition_rate: 0.0366 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3922626025791325,
+          "transition_rate": 0.04221388367729831,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.392 > 0.392",
+            "min_transition_rate: 0.0422 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.40172937602243514,
+          "transition_rate": 0.036110786490592496,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.402 > 0.392",
+            "min_transition_rate: 0.0361 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3215741064151822,
+          "transition_rate": 0.043782021425244524,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0438 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.37888647866955893,
+          "transition_rate": 0.03712632594021215,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0371 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.008943387362343376,
+            0.1263101211467647,
+            0.08137260534186647,
+            22.031642603888738,
+            0.12664220194826653
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14331699274572973,
+            0.19964746705795727,
+            0.2865891080511613,
+            36.42245901499824,
+            0.17352997437340512
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11711027079906294,
+            0.18299620532247104,
+            0.2370645186689218,
+            40.39686448321347,
+            0.16190354265382634
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.004087949295910411,
+            0.12982597281431374,
+            0.0952642257560351,
+            25.43683896819987,
+            0.20279793794271028
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 111.75116188000902,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.017222222222222222,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.04924953095684803
+        }
+      },
+      "model_kruskal_h": 111.75116188000902,
+      "model_p_value": 0.017222222222222222,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.08935272045028142,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 634,
+          "pct": 0.14865181711606096
+        },
+        "ranging_volatile": {
+          "count": 1706,
+          "pct": 0.4
+        },
+        "trending_down_choppy": {
+          "count": 1016,
+          "pct": 0.23821805392731535
+        },
+        "trending_up_choppy": {
+          "count": 909,
+          "pct": 0.21313012895662367
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.4505820105820106,
+          "transition_rate": 0.04635901778154107,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.451 > 0.392",
+            "min_transition_rate: 0.0464 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.4,
+          "transition_rate": 0.04924953095684803,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.400 > 0.392",
+            "min_transition_rate: 0.0492 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4104931058658565,
+          "transition_rate": 0.04522613065326633,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.410 > 0.392",
+            "min_transition_rate: 0.0452 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.33985330073349634,
+          "transition_rate": 0.05600838379133675,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0560 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.40298867196914917,
+          "transition_rate": 0.047492767598842814,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.403 > 0.392",
+            "min_transition_rate: 0.0475 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.009981520261705843,
+            0.13903876708101257,
+            0.10263132035029433,
+            27.696602728710367,
+            0.21464401119101734
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18422045599030623,
+            0.23663220584775102,
+            0.3547325865830753,
+            44.47649880744757,
+            0.2145818660072411
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1089247822652265,
+            0.1691203060441465,
+            0.2259880849110138,
+            30.444389477762254,
+            0.1474641629179333
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0023487611307535573,
+            0.12206473432881818,
+            0.07245072950936976,
+            21.4070984490523,
+            0.1322880146258575
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11781780660872287,
+            0.1832130149302676,
+            0.23855708634846573,
+            40.294493644425245,
+            0.16055147792053243
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 110.38339777968577,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.015,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.0525328330206379
+        }
+      },
+      "model_kruskal_h": 110.38339777968577,
+      "model_p_value": 0.015,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.08606941838649154,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 440,
+          "pct": 0.10316529894490035
+        },
+        "ranging_volatile": {
+          "count": 1451,
+          "pct": 0.34021101992966
+        },
+        "trending_down_choppy": {
+          "count": 1385,
+          "pct": 0.324736225087925
+        },
+        "trending_up_choppy": {
+          "count": 989,
+          "pct": 0.23188745603751465
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.39894179894179893,
+          "transition_rate": 0.05292125317527519,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.399 > 0.392",
+            "min_transition_rate: 0.0529 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.34021101992966,
+          "transition_rate": 0.0525328330206379,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0525 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3505491937368544,
+          "transition_rate": 0.04803085193408905,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0480 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.2960763767609733,
+          "transition_rate": 0.058220773171867725,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0582 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3461074957821162,
+          "transition_rate": 0.04652844744455159,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0465 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.10496055831556181,
+            0.16555120295529407,
+            0.2181248500905259,
+            29.553331882991394,
+            0.14695965552584747
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.004087744194884096,
+            0.13688834686847534,
+            0.10336743269514449,
+            28.00963211237336,
+            0.2255873821687031
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13352364292808064,
+            0.19339342155801031,
+            0.2681744887360883,
+            44.564810387132745,
+            0.17078099334314234
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.010418593937033642,
+            0.11793560871885704,
+            0.06301526471252078,
+            20.532747173371995,
+            0.13515944185917117
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1810158123802765,
+            0.23298681638290591,
+            0.3506907825835518,
+            43.85029373033703,
+            0.20797813960685818
+          ],
+          "volatility_rank": 5
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.07191012524556836,
+            0.15756630767654908,
+            0.15139366846159197,
+            30.13957174313361,
+            0.13842161483637871
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 131.4454251680636,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.06965290806754221
+        }
+      },
+      "model_kruskal_h": 131.4454251680636,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.06894934333958724,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 363,
+          "pct": 0.08511137162954278
+        },
+        "ranging_volatile": {
+          "count": 1148,
+          "pct": 0.2691676436107855
+        },
+        "trending_down_choppy": {
+          "count": 1431,
+          "pct": 0.3355216881594373
+        },
+        "trending_up_choppy": {
+          "count": 1323,
+          "pct": 0.3101992966002345
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.31703703703703706,
+          "transition_rate": 0.06795088907705335,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0680 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3355216881594373,
+          "transition_rate": 0.06965290806754221,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3181818181818182,
+          "transition_rate": 0.061820731564800745,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0618 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3490511118872977,
+          "transition_rate": 0.06415929203539823,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0642 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.30826705230175944,
+          "transition_rate": 0.06846673095467695,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0685 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.13108525430979076,
+            0.18792488115075362,
+            0.26745066964033726,
+            33.33895035581687,
+            0.15198076800885837
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.19190310851981662,
+            0.24588556408948425,
+            0.36458259473737553,
+            48.10162001318464,
+            0.2379167234018357
+          ],
+          "volatility_rank": 6
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.06885268548289075,
+            0.13470534050921976,
+            0.14517559226905977,
+            23.010005541710253,
+            0.14421802978747833
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1325091732344044,
+            0.1928192777190449,
+            0.26625201180639657,
+            44.13758781617661,
+            0.169387536479396
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.0010730353246424856,
+            0.11461123917562842,
+            0.04673772040970288,
+            20.352445799592694,
+            0.1354405100946928
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.010389717164440579,
+            0.13800220030887314,
+            0.1023251187532764,
+            28.614877134758448,
+            0.2289417596248497
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.0679525665393515,
+            0.15644785139514214,
+            0.14509312405234576,
+            29.683864021541083,
+            0.13662423968671306
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 65.16540905580587,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.10834896810506567
+        }
+      },
+      "model_kruskal_h": 65.16540905580587,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.030253283302063783,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1073,
+          "pct": 0.2515826494724502
+        },
+        "ranging_directional_up": {
+          "count": 3192,
+          "pct": 0.7484173505275499
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5849735449735449,
+          "transition_rate": 0.14500423370025403,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.585 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.7484173505275499,
+          "transition_rate": 0.10834896810506567,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.748 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.7656695156695157,
+          "transition_rate": 0.0780053428317008,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.766 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5517522412387939,
+          "transition_rate": 0.1511411271541686,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.552 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5237406604000964,
+          "transition_rate": 0.15646094503375121,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.524 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.009185129585334942,
+            0.16203493713628508,
+            0.17059719547452265,
+            30.91052243247447,
+            1.2232386596752709e-05,
+            0.48465718789011314,
+            0.1670032155789591
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.004986973085247747,
+            0.13809598035700793,
+            0.12262664799659773,
+            26.394355817384195,
+            1.2489897077100538e-05,
+            -0.2479289473462413,
+            0.14939024157184097
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 97.50472610743782,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0011111111111111111,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.100140712945591
+        }
+      },
+      "model_kruskal_h": 97.50472610743782,
+      "model_p_value": 0.0011111111111111111,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.03846153846153845,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 887,
+          "pct": 0.20797186400937867
+        },
+        "trending_down_choppy": {
+          "count": 844,
+          "pct": 0.19788980070339976
+        },
+        "trending_up_choppy": {
+          "count": 2534,
+          "pct": 0.5941383352872216
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4943915343915344,
+          "transition_rate": 0.111346316680779,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.494 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5941383352872216,
+          "transition_rate": 0.100140712945591,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.594 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.7451923076923077,
+          "transition_rate": 0.07159394479073909,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.745 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5143788566771452,
+          "transition_rate": 0.13751746623195157,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.514 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.45529043142926007,
+          "transition_rate": 0.1333172613307618,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.455 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0029585633284010104,
+            0.1289642739293655,
+            0.09666803149900206,
+            23.998210992242214,
+            1.2489205241371347e-05,
+            -0.20909871509650177,
+            0.14616735499505124
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12416703466911835,
+            0.18666031502007757,
+            0.24891973440526477,
+            41.59166775905904,
+            9.180128902542234e-06,
+            0.23166400193331022,
+            0.16607798986351108
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.053751864515393474,
+            0.15772087601820406,
+            0.15979705123013835,
+            28.354626246280993,
+            1.3658203534034453e-05,
+            0.3543128480231099,
+            0.16740300025156682
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 74.87924463994204,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.017222222222222222,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.039165103189493435
+        }
+      },
+      "model_kruskal_h": 74.87924463994204,
+      "model_p_value": 0.017222222222222222,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.09943714821763602,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2610,
+          "pct": 0.611957796014068
+        },
+        "trending_down_choppy": {
+          "count": 927,
+          "pct": 0.21735052754982415
+        },
+        "trending_up_choppy": {
+          "count": 728,
+          "pct": 0.17069167643610786
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.7043386243386244,
+          "transition_rate": 0.03111769686706181,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.704 > 0.392",
+            "min_transition_rate: 0.0311 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.611957796014068,
+          "transition_rate": 0.039165103189493435,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.612 > 0.392",
+            "min_transition_rate: 0.0392 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5621438746438746,
+          "transition_rate": 0.054496883348174534,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.562 > 0.392",
+            "min_transition_rate: 0.0545 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5844685062288975,
+          "transition_rate": 0.0551932929669306,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.584 > 0.392",
+            "min_transition_rate: 0.0552 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6741383465895396,
+          "transition_rate": 0.047974927675988426,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.674 > 0.392",
+            "min_transition_rate: 0.0480 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.002321066954066391,
+            0.1290398226617703,
+            0.09658943521284236,
+            23.937644646543532,
+            1.2491888487677863e-05,
+            -0.30600871808029373,
+            0.14605730592577576
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.12726945182327354,
+            0.1981949110852748,
+            0.27356302218158957,
+            36.57259177329492,
+            1.9090523675698503e-05,
+            0.10816181650585344,
+            0.19145532754343392
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12448039571779068,
+            0.18695425758169223,
+            0.24970624765397767,
+            41.446773356936376,
+            8.87905349178769e-06,
+            0.23634319163999148,
+            0.16610202633101345
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006006886660784946,
+            0.1299710854655367,
+            0.08469278483389628,
+            23.178538997953805,
+            1.0539160874898254e-05,
+            0.6053655951016613,
+            0.1507949626805841
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 92.31605833600042,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.17424953095684803
+        }
+      },
+      "model_kruskal_h": 92.31605833600042,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": -0.03564727954971858,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 642,
+          "pct": 0.15052754982415006
+        },
+        "ranging_volatile": {
+          "count": 2294,
+          "pct": 0.5378663540445486
+        },
+        "trending_down_choppy": {
+          "count": 759,
+          "pct": 0.1779601406799531
+        },
+        "trending_up_choppy": {
+          "count": 570,
+          "pct": 0.1336459554513482
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.6294179894179894,
+          "transition_rate": 0.14225232853513972,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.629 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5378663540445486,
+          "transition_rate": 0.17424953095684803,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.538 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.6339031339031339,
+          "transition_rate": 0.16010685663401603,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.634 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.6020491326114799,
+          "transition_rate": 0.1599906846762925,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.602 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.6281031573873223,
+          "transition_rate": 0.15429122468659595,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.628 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009305088539435284,
+            0.13329037695337675,
+            0.07961122118595479,
+            22.75963781057106,
+            1.3433386104470027e-05,
+            -0.3356529650943023,
+            0.15991336758715968
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14780405590847379,
+            0.20086289421777365,
+            0.2949868022786929,
+            37.01750027786057,
+            1.4639055105463097e-05,
+            -0.10539238399995049,
+            0.1830586835796608
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0012041804855310524,
+            0.12720570192654462,
+            0.09065448493006675,
+            23.635695299504256,
+            1.2490979501582193e-05,
+            -0.24957132865036832,
+            0.1461101105593614
+          ],
+          "volatility_rank": 0
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.017841550061419416,
+            0.15054556620635132,
+            0.1519340758508166,
+            29.806210352445827,
+            1.1761414932805906e-05,
+            2.4887831881240694,
+            0.1547574751096724
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12300450826007354,
+            0.18591189228417337,
+            0.24787549153881572,
+            41.224888407629535,
+            9.285432860414408e-06,
+            -0.2311936816555817,
+            0.16605061376172664
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 83.61943678748321,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.18151969981238275
+        }
+      },
+      "model_kruskal_h": 83.61943678748321,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": -0.0429174484052533,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 552,
+          "pct": 0.12942555685814772
+        },
+        "ranging_directional_up": {
+          "count": 806,
+          "pct": 0.18898007033997655
+        },
+        "ranging_volatile": {
+          "count": 1927,
+          "pct": 0.4518171160609613
+        },
+        "trending_down_choppy": {
+          "count": 635,
+          "pct": 0.1488862837045721
+        },
+        "trending_up_choppy": {
+          "count": 345,
+          "pct": 0.08089097303634232
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.4055026455026455,
+          "transition_rate": 0.15474174428450466,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.406 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.4518171160609613,
+          "transition_rate": 0.18151969981238275,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.452 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.40153133903133903,
+          "transition_rate": 0.1383793410507569,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.402 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.32774478984747935,
+          "transition_rate": 0.19503959012575686,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.4025066281031574,
+          "transition_rate": 0.18539054966248794,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.403 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00175138404261942,
+            0.11516283224452206,
+            0.04610771887572711,
+            21.214383263091612,
+            1.2489553607859418e-05,
+            -0.3205664715228136,
+            0.14190755843121997
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.04681841902714946,
+            0.19506036935322532,
+            0.24629951722020854,
+            37.64011353887047,
+            2.257507911938343e-05,
+            1.274596386195281,
+            0.18935131157241322
+          ],
+          "volatility_rank": 5
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12256049606665803,
+            0.186083554039553,
+            0.2472221032000987,
+            41.49075965211936,
+            8.79760496986723e-06,
+            -0.24525612535577537,
+            0.16607069402328756
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.0037772001531684238,
+            0.14211251652275717,
+            0.14109893434492665,
+            26.891856675695905,
+            1.2491873661284422e-05,
+            0.419220234890776,
+            0.15134496472081416
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.13794029028336466,
+            0.19138796955439064,
+            0.27765330680169054,
+            34.63127773757544,
+            1.0877571990140156e-05,
+            -0.28875841567623106,
+            0.17252527438656814
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009540701357970747,
+            0.12828689999784817,
+            0.07697958632480296,
+            22.170597817151318,
+            1.0292624792605586e-05,
+            -0.23762488946479612,
+            0.15425111360746982
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 71.39373746439014,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.2077861163227017
+        }
+      },
+      "model_kruskal_h": 71.39373746439014,
+      "model_p_value": 0.005555555555555556,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": -0.06918386491557224,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 392,
+          "pct": 0.09191090269636577
+        },
+        "ranging_directional_up": {
+          "count": 985,
+          "pct": 0.2309495896834701
+        },
+        "ranging_volatile": {
+          "count": 1914,
+          "pct": 0.4487690504103165
+        },
+        "trending_down_choppy": {
+          "count": 644,
+          "pct": 0.15099648300117233
+        },
+        "trending_up_choppy": {
+          "count": 330,
+          "pct": 0.07737397420867527
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.39216931216931217,
+          "transition_rate": 0.2019475021168501,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.392 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.4487690504103165,
+          "transition_rate": 0.2077861163227017,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.449 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.43945868945868943,
+          "transition_rate": 0.1682991985752449,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.439 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3482361159622773,
+          "transition_rate": 0.23614345598509548,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.39045553145336226,
+          "transition_rate": 0.24035679845708777,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_volatile",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1485043757565571,
+            0.20007675681182607,
+            0.2966635503958879,
+            34.69682867290772,
+            1.032428604576102e-05,
+            -0.22611842426904136,
+            0.16117848505045995
+          ],
+          "volatility_rank": 6
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.04575397816489915,
+            0.1914803127756489,
+            0.2382632642504385,
+            37.126088154530024,
+            2.3061576417006e-05,
+            1.2940638599357843,
+            0.1905692811582461
+          ],
+          "volatility_rank": 5
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.005870497716493926,
+            0.14779121643744902,
+            0.1565173431721578,
+            29.071758596184385,
+            1.2491965386543712e-05,
+            -0.4204162753813776,
+            0.1619058460435548
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12739551502029725,
+            0.1904664040355347,
+            0.25576882440522253,
+            42.204039491474326,
+            8.314339979753987e-06,
+            -0.20133565691154878,
+            0.16764173928715853
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0017090612963614434,
+            0.11434488933316198,
+            0.04313777583886391,
+            20.958551796920027,
+            1.2488854430463425e-05,
+            -0.31574115255096546,
+            0.13951391824217624
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.008937103096613743,
+            0.12910611617619652,
+            0.07774034085643128,
+            22.167862289156844,
+            1.0214239296633807e-05,
+            -0.253611264422104,
+            0.15444561452281608
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.002108163446019628,
+            0.1358872777953472,
+            0.12674455856280162,
+            25.764601486106255,
+            1.2488204923237367e-05,
+            1.5563518864809764,
+            0.14509153667234756
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 50.64527951513992,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0011111111111111111,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.12288930581613508
+        }
+      },
+      "model_kruskal_h": 50.64527951513992,
+      "model_p_value": 0.0011111111111111111,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.01571294559099437,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1131,
+          "pct": 0.2651817116060961
+        },
+        "ranging_directional_up": {
+          "count": 3134,
+          "pct": 0.7348182883939038
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5934391534391534,
+          "transition_rate": 0.1661727349703641,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.593 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.7348182883939038,
+          "transition_rate": 0.12288930581613508,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.735 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.7621082621082621,
+          "transition_rate": 0.08833481745325023,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.762 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5351030387705205,
+          "transition_rate": 0.17862133209129016,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.535 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5372378886478669,
+          "transition_rate": 0.1800867888138862,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.537 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.006507082523434551,
+            0.15805700788536903,
+            0.16070753830418785,
+            29.830583482048173,
+            1.2227630814191976e-05,
+            0.5714685968853309,
+            0.16364577891755003
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.0029353591090369403,
+            0.14118413358431509,
+            0.13014143009449525,
+            27.20477923571174,
+            1.2489554854669231e-05,
+            -0.29762774075164866,
+            0.15196014899303073
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 64.6321355145883,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.1177298311444653
+        }
+      },
+      "model_kruskal_h": 64.6321355145883,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.020872420262664157,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 3161,
+          "pct": 0.7411488862837046
+        },
+        "ranging_volatile": {
+          "count": 819,
+          "pct": 0.19202813599062132
+        },
+        "trending_down_choppy": {
+          "count": 285,
+          "pct": 0.0668229777256741
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4433862433862434,
+          "transition_rate": 0.15347163420829804,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.443 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.7411488862837046,
+          "transition_rate": 0.1177298311444653,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.741 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.7763532763532763,
+          "transition_rate": 0.08085485307212822,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.776 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5646757480498312,
+          "transition_rate": 0.168141592920354,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.565 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.4856591949867438,
+          "transition_rate": 0.16682738669238187,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.486 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009796303501269542,
+            0.12738043950836064,
+            0.09086820374838425,
+            23.67086875900902,
+            1.2488036911454478e-05,
+            -0.264604384511094,
+            0.14622314720378313
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1148918053673374,
+            0.17878172256534688,
+            0.23484253222963797,
+            38.84377825162788,
+            1.2483858638643743e-05,
+            -0.29411075452021784,
+            0.16505905570355042
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.021649523905905736,
+            0.16157454514781358,
+            0.17239395455278206,
+            30.317345736190642,
+            1.2247085080848401e-05,
+            0.4819313244329435,
+            0.16546741198551526
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 62.72487586279749,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0022222222222222222,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.11303939962476547
+        }
+      },
+      "model_kruskal_h": 62.72487586279749,
+      "model_p_value": 0.0022222222222222222,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.025562851782363977,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 3206,
+          "pct": 0.7516998827667057
+        },
+        "ranging_volatile": {
+          "count": 749,
+          "pct": 0.17561547479484174
+        },
+        "trending_down_choppy": {
+          "count": 310,
+          "pct": 0.07268464243845252
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.45312169312169315,
+          "transition_rate": 0.14923793395427604,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.453 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.7516998827667057,
+          "transition_rate": 0.11303939962476547,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.752 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.7868589743589743,
+          "transition_rate": 0.0755120213713268,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.787 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5734078472464781,
+          "transition_rate": 0.16185374941779226,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.573 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5037358399614364,
+          "transition_rate": 0.15597878495660558,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.504 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.008034806287419764,
+            0.12451620748444525,
+            0.08302871151011357,
+            23.08718320093395,
+            1.2488305545533945e-05,
+            -0.24601433166560785,
+            0.14442356801755787
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.03608153559249962,
+            0.16463979964712738,
+            0.17647995786308093,
+            30.695003171702265,
+            1.3018142035898655e-05,
+            -0.39179901188610844,
+            0.17101506530842997
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11121254089839729,
+            0.17671492487123078,
+            0.22738680035918835,
+            38.04683704378113,
+            1.2488316520072452e-05,
+            -0.28544013822901937,
+            0.16523509935115596
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.006811105253557346,
+            0.15706454433574404,
+            0.17009516718609446,
+            29.77107697056074,
+            1.0906895444899807e-05,
+            1.8924739397991865,
+            0.15645626111827524
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 109.60734157604202,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.20051594746716697
+        }
+      },
+      "model_kruskal_h": 109.60734157604202,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": -0.06191369606003752,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 815,
+          "pct": 0.1910902696365768
+        },
+        "ranging_volatile": {
+          "count": 2357,
+          "pct": 0.5526377491207503
+        },
+        "trending_down_choppy": {
+          "count": 660,
+          "pct": 0.15474794841735054
+        },
+        "trending_up_choppy": {
+          "count": 433,
+          "pct": 0.1015240328253224
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.6554497354497355,
+          "transition_rate": 0.1651143099068586,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.655 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5526377491207503,
+          "transition_rate": 0.20051594746716697,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.553 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.6499287749287749,
+          "transition_rate": 0.178806767586821,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.650 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.6173011992082896,
+          "transition_rate": 0.17629250116441547,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.617 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.6517233068209207,
+          "transition_rate": 0.17695274831243973,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.652 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.007675546513873258,
+            0.13285153875935118,
+            0.08084631253866088,
+            23.116391289423877,
+            1.3434051764627207e-05,
+            -0.34810473386990703,
+            0.1590289711084791
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.15819345603316556,
+            0.20966399630614163,
+            0.3130486848918532,
+            37.90119215402744,
+            1.5611292726295762e-05,
+            -0.2777550876105418,
+            0.1875945137196195
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0025277721518114004,
+            0.13061083794239756,
+            0.0995082760697597,
+            24.481335647284986,
+            1.2490767426409158e-05,
+            -0.25602500319474797,
+            0.14751614578374253
+          ],
+          "volatility_rank": 0
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.009360099439076936,
+            0.1568209343257646,
+            0.1705993847409256,
+            30.542400518119955,
+            1.136613088762123e-05,
+            2.3314588893863233,
+            0.15814821167158402
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12504600667267204,
+            0.1870829552310016,
+            0.25276882283759095,
+            41.92748536627528,
+            9.054018425348795e-06,
+            -0.3191963887035125,
+            0.16716610876717894
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 116.32579527636153,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.2270168855534709
+        }
+      },
+      "model_kruskal_h": 116.32579527636153,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": -0.08841463414634146,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 508,
+          "pct": 0.11910902696365767
+        },
+        "ranging_directional_up": {
+          "count": 905,
+          "pct": 0.21219226260257915
+        },
+        "ranging_volatile": {
+          "count": 2064,
+          "pct": 0.4839390386869871
+        },
+        "trending_down_choppy": {
+          "count": 532,
+          "pct": 0.12473622508792497
+        },
+        "trending_up_choppy": {
+          "count": 256,
+          "pct": 0.060023446658851114
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.513015873015873,
+          "transition_rate": 0.20046570702794242,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.513 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.4839390386869871,
+          "transition_rate": 0.2270168855534709,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.484 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.4179131054131054,
+          "transition_rate": 0.18058771148708816,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.418 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.4097100943066713,
+          "transition_rate": 0.23684210526315788,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.410 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.4940949626416004,
+          "transition_rate": 0.22034715525554485,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.494 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0015186191414493897,
+            0.12288079303494856,
+            0.07582422702250746,
+            22.680354522434758,
+            1.249103645940806e-05,
+            -0.3710270906906449,
+            0.14518945882560746
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.04003445072005373,
+            0.1877259866424839,
+            0.23091834511567633,
+            35.22752258564231,
+            2.1227075014906862e-05,
+            1.1046673394136424,
+            0.18798998763268854
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12286835877615196,
+            0.18595611743879592,
+            0.24864408955133543,
+            41.95884393020144,
+            8.468926259676916e-06,
+            -0.37730822433465694,
+            0.1690142003286395
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.007588860643704798,
+            0.15365021601076426,
+            0.16941414774563096,
+            30.13384687727868,
+            1.249338668419992e-05,
+            0.9096606253469433,
+            0.1517998601082312
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14276152999443978,
+            0.19543385831508542,
+            0.2848595999306052,
+            35.43427817291947,
+            1.0755814315152587e-05,
+            -0.3943258451474866,
+            0.17935009291047804
+          ],
+          "volatility_rank": 5
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009489620957648447,
+            0.13021459561477128,
+            0.07783584514404125,
+            22.57949217080766,
+            1.0297379549921894e-05,
+            -0.3176206261932969,
+            0.15448233102798092
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 96.8058673891428,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.23874296435272044
+        }
+      },
+      "model_kruskal_h": 96.8058673891428,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": -0.10014071294559099,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 370,
+          "pct": 0.08675263774912075
+        },
+        "ranging_directional_up": {
+          "count": 1161,
+          "pct": 0.27221570926143024
+        },
+        "ranging_volatile": {
+          "count": 1282,
+          "pct": 0.30058616647127784
+        },
+        "trending_down_choppy": {
+          "count": 378,
+          "pct": 0.08862837045720985
+        },
+        "trending_up_choppy": {
+          "count": 1074,
+          "pct": 0.2518171160609613
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.43386243386243384,
+          "transition_rate": 0.21104995766299747,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.434 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.30058616647127784,
+          "transition_rate": 0.23874296435272044,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.400997150997151,
+          "transition_rate": 0.18272484416740872,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.401 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3358947490976831,
+          "transition_rate": 0.22519795062878434,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.39744516751024345,
+          "transition_rate": 0.22878495660559306,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.397 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1276083803740011,
+            0.18249164566880116,
+            0.26068496289477106,
+            33.695210778663586,
+            1.2481337020243203e-05,
+            -0.348958020639338,
+            0.17351823900134575
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.055046209009339625,
+            0.20378372948317067,
+            0.2776042719975045,
+            37.52989348854123,
+            1.940983751483733e-05,
+            0.9030385104100174,
+            0.18584799647502417
+          ],
+          "volatility_rank": 6
+        },
+        "2": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0019895628787310327,
+            0.12205670504934274,
+            0.07287497242651345,
+            22.493372778236726,
+            1.2490726247640726e-05,
+            -0.3785563487300819,
+            0.1442370946729063
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1310418008176476,
+            0.1886112089543347,
+            0.264956460675778,
+            43.61455823025348,
+            1.0479098220086558e-05,
+            -0.3550072581860101,
+            0.16859539089941272
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0019389806217614382,
+            0.11692638813031644,
+            0.0369172216239146,
+            20.044449754930675,
+            1.173201957846953e-05,
+            0.21965193545169592,
+            0.15091813679864025
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.00934051994841741,
+            0.14587449762807408,
+            0.1279498664808898,
+            26.541964164524657,
+            8.850773288547833e-06,
+            -0.3762093105266283,
+            0.15958396167727293
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.025408268953924625,
+            0.15192974661862377,
+            0.16036369075047144,
+            30.2096984960038,
+            1.2493364727696525e-05,
+            1.015928534002656,
+            0.1534354992777479
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 57.50409715283604,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.015,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.03095684803001876
+        }
+      },
+      "model_kruskal_h": 57.50409715283604,
+      "model_p_value": 0.015,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.10764540337711069,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1856,
+          "pct": 0.4351699882766706
+        },
+        "ranging_volatile": {
+          "count": 2409,
+          "pct": 0.5648300117233295
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6203174603174603,
+          "transition_rate": 0.03746824724809483,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.620 > 0.392",
+            "min_transition_rate: 0.0375 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5648300117233295,
+          "transition_rate": 0.03095684803001876,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.565 > 0.392",
+            "min_transition_rate: 0.0310 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5381054131054132,
+          "transition_rate": 0.04879786286731968,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.538 > 0.392",
+            "min_transition_rate: 0.0488 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5139131447199907,
+          "transition_rate": 0.055775500698649276,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.514 > 0.392",
+            "min_transition_rate: 0.0558 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5654374548083876,
+          "transition_rate": 0.04170684667309547,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.565 > 0.392",
+            "min_transition_rate: 0.0417 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.004917097203319159,
+            0.18808197133441698,
+            0.24664687654782258,
+            38.59466405572063,
+            1.3499069560047501e-05,
+            0.17513929701427183,
+            0.17517591057726745
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.004153725428503685,
+            0.1259718722316957,
+            0.08514590698957536,
+            22.575846005234588,
+            1.1765292573118583e-05,
+            -0.007278701444229832,
+            0.14654535443232225
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 74.91685771206357,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.044444444444444446,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.040572232645403376
+        }
+      },
+      "model_kruskal_h": 74.91685771206357,
+      "model_p_value": 0.044444444444444446,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": 0.09803001876172607,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2290,
+          "pct": 0.536928487690504
+        },
+        "trending_down_choppy": {
+          "count": 1159,
+          "pct": 0.27174677608440795
+        },
+        "trending_up_choppy": {
+          "count": 816,
+          "pct": 0.19132473622508792
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5928042328042328,
+          "transition_rate": 0.04339542760372565,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.593 > 0.392",
+            "min_transition_rate: 0.0434 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.536928487690504,
+          "transition_rate": 0.040572232645403376,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.537 > 0.392",
+            "min_transition_rate: 0.0406 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.45032051282051283,
+          "transition_rate": 0.05948352626892253,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.450 > 0.392",
+            "min_transition_rate: 0.0595 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4597741297007801,
+          "transition_rate": 0.06776897997205403,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.460 > 0.392",
+            "min_transition_rate: 0.0678 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.549771029163654,
+          "transition_rate": 0.04990356798457088,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.550 > 0.392",
+            "min_transition_rate: 0.0499 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005581221288697551,
+            0.12472374868202335,
+            0.08035842191523851,
+            22.474704257548,
+            1.1765255826744529e-05,
+            0.0005940409096082469,
+            0.14563844767769962
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11071764327313129,
+            0.17982195150188168,
+            0.22427251485540284,
+            39.238165628758395,
+            1.024701180487805e-05,
+            0.14458007261477968,
+            0.16694313355894871
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1284690778876011,
+            0.19285385307219313,
+            0.2658875654165594,
+            35.4190769670878,
+            1.741960050568895e-05,
+            0.15488314746778004,
+            0.18432925276380527
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 72.20458705055535,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.011111111111111112,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.1449343339587242
+        }
+      },
+      "model_kruskal_h": 72.20458705055535,
+      "model_p_value": 0.011111111111111112,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": -0.006332082551594759,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 367,
+          "pct": 0.08604923798358734
+        },
+        "ranging_volatile": {
+          "count": 2107,
+          "pct": 0.494021101992966
+        },
+        "trending_down_choppy": {
+          "count": 1049,
+          "pct": 0.2459554513481829
+        },
+        "trending_up_choppy": {
+          "count": 742,
+          "pct": 0.17397420867526378
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5470899470899471,
+          "transition_rate": 0.1380186282811177,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.547 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.494021101992966,
+          "transition_rate": 0.1449343339587242,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.494 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4154202279202279,
+          "transition_rate": 0.1355298308103295,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.415 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.4263592967749447,
+          "transition_rate": 0.14951094550535632,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.426 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.5119305856832972,
+          "transition_rate": 0.13886210221793635,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.512 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006330347659502082,
+            0.12441689383501435,
+            0.07915662457616132,
+            22.396752248919707,
+            1.179019227941171e-05,
+            -0.22357444940757756,
+            0.14569350826568217
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.13209810229550742,
+            0.19526586262853934,
+            0.2707275263709294,
+            35.84866717477829,
+            1.743506390041489e-05,
+            -0.10797402696385416,
+            0.1851347188517445
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.10962217445992453,
+            0.1793261848711535,
+            0.22273089579389332,
+            39.24806151961809,
+            1.016611465696466e-05,
+            -0.1736848220487635,
+            0.16820991325293314
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.009061602437800772,
+            0.14869788508692716,
+            0.15203093486140312,
+            28.18792709172509,
+            1.2664199374999984e-05,
+            3.5178366618049997,
+            0.15195848239603824
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 125.30886613415714,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.15619136960600374
+        }
+      },
+      "model_kruskal_h": 125.30886613415714,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": -0.017589118198874293,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 358,
+          "pct": 0.0839390386869871
+        },
+        "ranging_directional_up": {
+          "count": 392,
+          "pct": 0.09191090269636577
+        },
+        "ranging_volatile": {
+          "count": 1915,
+          "pct": 0.4490035169988277
+        },
+        "trending_down_choppy": {
+          "count": 952,
+          "pct": 0.22321219226260258
+        },
+        "trending_up_choppy": {
+          "count": 648,
+          "pct": 0.15193434935521688
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.49164021164021166,
+          "transition_rate": 0.132303132938188,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.492 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.4490035169988277,
+          "transition_rate": 0.15619136960600374,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.449 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.3803418803418803,
+          "transition_rate": 0.13178984861976847,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3396204447549191,
+          "transition_rate": 0.16034000931532372,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.44805977343938297,
+          "transition_rate": 0.1359691417550627,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.448 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.007211051362372937,
+            0.14160546858677883,
+            0.11415160743089081,
+            28.54127944525993,
+            2.4099860288065795e-05,
+            -0.20296151674863647,
+            0.2314277038364005
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1461513005027302,
+            0.2014343814231933,
+            0.2913024353052273,
+            36.246875928566105,
+            1.3119164715719086e-05,
+            -0.09326807229786563,
+            0.16933583279855732
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006249193479846497,
+            0.12442125621654926,
+            0.07920560520432417,
+            22.19413112981984,
+            1.0927094284556147e-05,
+            -0.21649015846058176,
+            0.13739281174713763
+          ],
+          "volatility_rank": 0
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.007983916181268338,
+            0.14893228780167772,
+            0.1526566005450796,
+            28.314766038444635,
+            1.170315324675325e-05,
+            3.5749641021145138,
+            0.14916304417178117
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1148862977029361,
+            0.1819744589285813,
+            0.23309935657254532,
+            39.946837509082684,
+            9.685583025404166e-06,
+            -0.16184631532545204,
+            0.16392196173833207
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 100.83371743544922,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0022222222222222222,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.1428236397748593
+        }
+      },
+      "model_kruskal_h": 100.83371743544922,
+      "model_p_value": 0.0022222222222222222,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": -0.004221388367729839,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 341,
+          "pct": 0.07995310668229777
+        },
+        "ranging_directional_up": {
+          "count": 165,
+          "pct": 0.038686987104337635
+        },
+        "ranging_volatile": {
+          "count": 2284,
+          "pct": 0.5355216881594372
+        },
+        "trending_down_choppy": {
+          "count": 851,
+          "pct": 0.19953106682297772
+        },
+        "trending_up_choppy": {
+          "count": 624,
+          "pct": 0.1463071512309496
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.571005291005291,
+          "transition_rate": 0.12912785774767147,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.571 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.5355216881594372,
+          "transition_rate": 0.1428236397748593,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.536 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.4082977207977208,
+          "transition_rate": 0.1280498664292075,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.408 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.43590639189661196,
+          "transition_rate": 0.16080577550069866,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.436 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.5442275247047481,
+          "transition_rate": 0.13886210221793635,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.544 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006636650959941216,
+            0.12575306418685328,
+            0.07979917573244262,
+            21.86105314351976,
+            1.2680498897272145e-05,
+            -0.22285340537644768,
+            0.12162407567640943
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.03687202341325122,
+            0.17843489410155045,
+            0.1773657068708333,
+            32.21194771569179,
+            6.213389902912622e-05,
+            0.0018656847441894525,
+            0.23162382526594436
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11716697344643671,
+            0.18313194152132084,
+            0.2374504272420875,
+            40.634327637648134,
+            9.634763459196107e-06,
+            -0.14572504854576773,
+            0.16380374320706304
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.008251757076200465,
+            0.1485879341462017,
+            0.15154086425792643,
+            28.279174367762298,
+            1.1343120132013201e-05,
+            3.5831158435861648,
+            0.14955563608196404
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14321366825080306,
+            0.19762689801584107,
+            0.2861932735302051,
+            36.18864910592508,
+            1.2154844353518812e-05,
+            -0.0863033471772279,
+            0.17045607012477676
+          ],
+          "volatility_rank": 5
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.000281166030741323,
+            0.12758716200700104,
+            0.08803146131027514,
+            24.561393236244726,
+            9.867021477663234e-06,
+            -0.22087030034971158,
+            0.19177059191031148
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.46779679379688,
+          "model_kruskal_h": 78.66454389462888,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.006111111111111111,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.14071294559099437
+        }
+      },
+      "model_kruskal_h": 78.66454389462888,
+      "model_p_value": 0.006111111111111111,
+      "handrule_kruskal_h": 80.46779679379688,
+      "stability_gain": -0.0021106941838649196,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 661,
+          "pct": 0.15498241500586166
+        },
+        "ranging_volatile": {
+          "count": 1964,
+          "pct": 0.4604923798358734
+        },
+        "trending_down_choppy": {
+          "count": 820,
+          "pct": 0.19226260257913247
+        },
+        "trending_up_choppy": {
+          "count": 820,
+          "pct": 0.19226260257913247
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.4931216931216931,
+          "transition_rate": 0.12129551227773074,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.493 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.4604923798358734,
+          "transition_rate": 0.14071294559099437,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.460 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.41933760683760685,
+          "transition_rate": 0.12341941228851291,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.419 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.34171614856211435,
+          "transition_rate": 0.1452026082906381,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.4376958303205592,
+          "transition_rate": 0.13187078109932499,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.438 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1425395698038731,
+            0.19772939578925414,
+            0.2850705911330397,
+            35.42981235866798,
+            1.136517386759582e-05,
+            -0.08337272789018801,
+            0.1628451079384642
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07499284220638557,
+            0.21047644897214457,
+            0.2458467381524227,
+            37.10474936775375,
+            6.538541445783133e-05,
+            -0.10843074918853371,
+            0.24727556028916187
+          ],
+          "volatility_rank": 6
+        },
+        "2": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0017648384924874323,
+            0.13480238731546176,
+            0.09076541913592304,
+            23.250755227450707,
+            1.3755985633116813e-05,
+            -0.20717635868207138,
+            0.11369234976602893
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11870143097157777,
+            0.18396626812384353,
+            0.24085451230103294,
+            40.69550014938723,
+            9.459430594184581e-06,
+            -0.13673926826995422,
+            0.16389314082449075
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.008835383998315686,
+            0.11468446317719155,
+            0.06805408726679286,
+            21.23270492217093,
+            8.447217704122866e-06,
+            -0.2166655586063553,
+            0.1587350709028632
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.0003014290802225433,
+            0.13918997717871123,
+            0.11386032833090089,
+            28.68320364815126,
+            1.6009245205479418e-05,
+            -0.2325524783493055,
+            0.22721425098869485
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.009190837904877394,
+            0.14860419525489268,
+            0.1522518296768094,
+            28.42112367992152,
+            1.1774089562289564e-05,
+            3.634823416179236,
+            0.14954955354160604
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    }
+  ],
+  "winner": null,
+  "live_wiring_delta": "Enriched models decode from ENRICHED_COLUMNS; live check_regime.py builds only CANONICAL_COLUMNS. Live wiring (#1074) must feed funding_rate + volume_z + htf_range_eff on-cycle in this exact order, or forward_filter_labels reads garbage."
+}

--- a/docs/research/1218-artifacts/regime_1095_eth.json
+++ b/docs/research/1218-artifacts/regime_1095_eth.json
@@ -1,0 +1,15252 @@
+{
+  "issue": 1095,
+  "symbol": "ETH/USDT",
+  "timeframe": "1h",
+  "in_sample": "is",
+  "held_out": "oos",
+  "target": "volatility",
+  "htf_multiple": 4,
+  "candidate_count": 90,
+  "significance_alpha": 0.05,
+  "bonferroni_alpha": 0.0016666666666666668,
+  "bonferroni_denominator": 30,
+  "bonferroni_denominator_policy": "ONE family across all feature-subset ablations (#1095 4b): alpha is divided by the COMBINED structurally-eligible candidate count of the whole subsets x families x K grid; structurally ineligible candidates (k < incumbent-derived min_active_labels) are scored for evidence but excluded (#1160)",
+  "structurally_ineligible": [
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    }
+  ],
+  "n_perm": 1199,
+  "min_achievable_p_value": 0.0008333333333333334,
+  "non_degeneracy_thresholds": {
+    "min_active_labels": 6,
+    "max_occupancy": 0.39964876501246316,
+    "min_transition_rate": 0.06950028719126938
+  },
+  "subset_status": {
+    "canonical": "ok",
+    "funding": "ok",
+    "volume": "ok",
+    "htf": "ok",
+    "all_enriched": "ok"
+  },
+  "handrule_held_out": {
+    "canonical": {
+      "kruskal_h": 85.2101297016361,
+      "p_value": 0.005833333333333334,
+      "transition_rate": 0.14075249320036265,
+      "abstained": false,
+      "permutation_steps_to_alpha": 53,
+      "knife_edge": false
+    },
+    "funding": {
+      "kruskal_h": 85.2101297016361,
+      "p_value": 0.005833333333333334,
+      "transition_rate": 0.14075249320036265,
+      "abstained": false,
+      "permutation_steps_to_alpha": 53,
+      "knife_edge": false
+    },
+    "volume": {
+      "kruskal_h": 85.2101297016361,
+      "p_value": 0.005833333333333334,
+      "transition_rate": 0.14075249320036265,
+      "abstained": false,
+      "permutation_steps_to_alpha": 53,
+      "knife_edge": false
+    },
+    "htf": {
+      "kruskal_h": 88.71948682990842,
+      "p_value": 0.005,
+      "transition_rate": 0.1425891181988743,
+      "abstained": false,
+      "permutation_steps_to_alpha": 54,
+      "knife_edge": false
+    },
+    "all_enriched": {
+      "kruskal_h": 88.71948682990842,
+      "p_value": 0.005,
+      "transition_rate": 0.1425891181988743,
+      "abstained": false,
+      "permutation_steps_to_alpha": 54,
+      "knife_edge": false
+    }
+  },
+  "baseline_note": "the merged #1080 evidence was measured at n_perm=200 with the incumbent at a knife-edge (OOS p = 10/201); handrule_held_out.canonical re-measures that baseline at this run's resolved n_perm so enriched-vs-baseline and the incumbent-trustworthy verdict share one resolution (#1095 4c)",
+  "ablation": {
+    "canonical": {
+      "status": "ok",
+      "best_kruskal_h": null,
+      "best_candidate": null,
+      "any_ships": false,
+      "separation_gain_vs_canonical": null
+    },
+    "funding": {
+      "status": "ok",
+      "best_kruskal_h": null,
+      "best_candidate": null,
+      "any_ships": false,
+      "separation_gain_vs_canonical": null
+    },
+    "volume": {
+      "status": "ok",
+      "best_kruskal_h": null,
+      "best_candidate": null,
+      "any_ships": false,
+      "separation_gain_vs_canonical": null
+    },
+    "htf": {
+      "status": "ok",
+      "best_kruskal_h": null,
+      "best_candidate": null,
+      "any_ships": false,
+      "separation_gain_vs_canonical": null
+    },
+    "all_enriched": {
+      "status": "ok",
+      "best_kruskal_h": null,
+      "best_candidate": null,
+      "any_ships": false,
+      "separation_gain_vs_canonical": null
+    }
+  },
+  "candidates": [
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 88.9367991068957,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03241160471441523
+        }
+      },
+      "model_kruskal_h": 88.9367991068957,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.10834088848594742,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1902,
+          "pct": 0.4309993201903467
+        },
+        "ranging_volatile": {
+          "count": 2511,
+          "pct": 0.5690006798096533
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5860865996306177,
+          "transition_rate": 0.03201970443349754,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.586 > 0.400",
+            "min_transition_rate: 0.0320 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5690006798096533,
+          "transition_rate": 0.03241160471441523,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.569 > 0.400",
+            "min_transition_rate: 0.0324 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6219848380427292,
+          "transition_rate": 0.02906375646180356,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.622 > 0.400",
+            "min_transition_rate: 0.0291 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5936820418908092,
+          "transition_rate": 0.028960622710622712,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.594 > 0.400",
+            "min_transition_rate: 0.0290 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6143821270653944,
+          "transition_rate": 0.03328677839851024,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.614 > 0.400",
+            "min_transition_rate: 0.0333 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.009081372270795909,
+            0.21042919642549873,
+            0.27566644569057003,
+            37.32678127873311
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006783825235659949,
+            0.13709963879586332,
+            0.08763409506775825,
+            21.338046895749788
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 88.08843844530384,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.021666666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.037398005439709885
+        }
+      },
+      "model_kruskal_h": 88.08843844530384,
+      "model_p_value": 0.021666666666666667,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.10335448776065276,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2388,
+          "pct": 0.5411284840244731
+        },
+        "trending_down_choppy": {
+          "count": 1253,
+          "pct": 0.28393383186041243
+        },
+        "trending_up_choppy": {
+          "count": 772,
+          "pct": 0.17493768411511443
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5604350502770368,
+          "transition_rate": 0.034688013136289,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.560 > 0.400",
+            "min_transition_rate: 0.0347 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5411284840244731,
+          "transition_rate": 0.037398005439709885,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.541 > 0.400",
+            "min_transition_rate: 0.0374 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6065931541465656,
+          "transition_rate": 0.03205054566341183,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.607 > 0.400",
+            "min_transition_rate: 0.0321 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5753691198351837,
+          "transition_rate": 0.03456959706959707,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.575 > 0.400",
+            "min_transition_rate: 0.0346 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5920409588084711,
+          "transition_rate": 0.039338919925512104,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.592 > 0.400",
+            "min_transition_rate: 0.0393 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009809026696675521,
+            0.13610801650199172,
+            0.08239149102997922,
+            21.133775277481618
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.15613665271388247,
+            0.21976619999094518,
+            0.30353260787692876,
+            35.92867150555509
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12276377556292303,
+            0.1958398628464102,
+            0.24132326123473935,
+            37.02253219436053
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 91.59774535648285,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0075,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.05439709882139619
+        }
+      },
+      "model_kruskal_h": 91.59774535648285,
+      "model_p_value": 0.0075,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.08635539437896646,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1780,
+          "pct": 0.40335372762293226
+        },
+        "trending_down_choppy": {
+          "count": 1372,
+          "pct": 0.3108996147745298
+        },
+        "trending_up_choppy": {
+          "count": 1261,
+          "pct": 0.285746657602538
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.40201108146932074,
+          "transition_rate": 0.055623973727422005,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.402 > 0.400",
+            "min_transition_rate: 0.0556 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.40335372762293226,
+          "transition_rate": 0.05439709882139619,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.403 > 0.400",
+            "min_transition_rate: 0.0544 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.4655410062026189,
+          "transition_rate": 0.05180930499712809,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.466 > 0.400",
+            "min_transition_rate: 0.0518 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4337873411926291,
+          "transition_rate": 0.05151098901098901,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.434 > 0.400",
+            "min_transition_rate: 0.0515 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.4335582964859204,
+          "transition_rate": 0.05772811918063315,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.434 > 0.400",
+            "min_transition_rate: 0.0577 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0824237789453056,
+            0.1600840040441132,
+            0.1648760272970914,
+            22.760947342299332
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1792475502134432,
+            0.23949656299902483,
+            0.3452545568492571,
+            39.917549924650665
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11674581510872285,
+            0.1920592619529609,
+            0.22931729997040026,
+            35.81895665942249
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.00400415942923364,
+            0.1293373214231748,
+            0.060123037795185505,
+            20.98778022017175
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 70.36002500256473,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.011666666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.07502266545784225
+        }
+      },
+      "model_kruskal_h": 70.36002500256473,
+      "model_p_value": 0.011666666666666667,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.0657298277425204,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1423,
+          "pct": 0.3224563788805801
+        },
+        "trending_down_choppy": {
+          "count": 1609,
+          "pct": 0.36460457738499885
+        },
+        "trending_up_choppy": {
+          "count": 1381,
+          "pct": 0.31293904373442105
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.37102400985019496,
+          "transition_rate": 0.06691297208538588,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "min_transition_rate: 0.0669 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.36460457738499885,
+          "transition_rate": 0.07502266545784225,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.38605559384332644,
+          "transition_rate": 0.07260195290063182,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.37163786196635,
+          "transition_rate": 0.07303113553113554,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.3637421456830347,
+          "transition_rate": 0.07844506517690875,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.002084359266472704,
+            0.12695355916753648,
+            0.04459697561022739,
+            21.103623157839515
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16451871390310271,
+            0.23211418244427146,
+            0.3191199216579527,
+            41.43197570173985
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07369026830467722,
+            0.15266459060236762,
+            0.1478002056282246,
+            21.46558059034102
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17322062185793166,
+            0.2347025809081095,
+            0.334394728693557,
+            38.921944922771736
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.0849453728312693,
+            0.16434168071526217,
+            0.16887520012474222,
+            30.535980796682484
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 66.64900030211538,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.011666666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.08726201269265639
+        }
+      },
+      "model_kruskal_h": 66.64900030211538,
+      "model_p_value": 0.011666666666666667,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.05349048050770626,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1300,
+          "pct": 0.29458418309539997
+        },
+        "trending_down_choppy": {
+          "count": 1639,
+          "pct": 0.37140267391796966
+        },
+        "trending_up_choppy": {
+          "count": 1474,
+          "pct": 0.33401314298663043
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3901087625692592,
+          "transition_rate": 0.07450738916256158,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.37140267391796966,
+          "transition_rate": 0.08726201269265639,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.36538019756489776,
+          "transition_rate": 0.08110281447443998,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.39098088588760443,
+          "transition_rate": 0.07852564102564102,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.3453572259716081,
+          "transition_rate": 0.08449720670391062,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11647251232104845,
+            0.1860963849219834,
+            0.23299237343965015,
+            28.940159981301186
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.058940879363899856,
+            0.14287036863770214,
+            0.11773275898525701,
+            19.583986632040826
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16263000999906319,
+            0.22993512373685987,
+            0.31554832964671353,
+            41.51808149729469
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.20373505691214802,
+            0.25608044126112617,
+            0.3878475127049935,
+            43.46047600343901
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.004570477399312873,
+            0.12769465869300584,
+            0.040622451278830254,
+            21.326740585634063
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08381646985294128,
+            0.16307549501565144,
+            0.16672788117819926,
+            30.07744096598905
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": false,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 41.85192176554847,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.06,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.0883952855847688
+        }
+      },
+      "model_kruskal_h": 41.85192176554847,
+      "model_p_value": 0.06,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.05235720761559384,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1018,
+          "pct": 0.23068207568547475
+        },
+        "trending_down_choppy": {
+          "count": 1864,
+          "pct": 0.4223883979152504
+        },
+        "trending_up_choppy": {
+          "count": 1531,
+          "pct": 0.3469295263992749
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3999589575210343,
+          "transition_rate": 0.0841543513957307,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.400 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.4223883979152504,
+          "transition_rate": 0.0883952855847688,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.422 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.37238685963703194,
+          "transition_rate": 0.10040206777713957,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.40299874098660865,
+          "transition_rate": 0.09031593406593406,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.403 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.3718873632767047,
+          "transition_rate": 0.09916201117318436,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.05439015572981092,
+            0.14981850149119963,
+            0.1074680322940196,
+            24.935501731852657
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00045948030971342067,
+            0.12537499883032158,
+            0.03233668404838011,
+            20.78566169594224
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11605261643314635,
+            0.1857141439868845,
+            0.23218806732072034,
+            28.85357954190147
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1679662191552873,
+            0.2345633840951214,
+            0.32588214458067366,
+            41.53146505858071
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.20349365867337732,
+            0.25595065286201557,
+            0.3874133807669227,
+            43.40521832829283
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.05770806927370332,
+            0.14184647121223512,
+            0.11534536679555787,
+            19.660971651274565
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.10228124933118385,
+            0.17168423938484728,
+            0.20359375223750426,
+            34.360375505704916
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 85.04395752962773,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03467815049864007
+        }
+      },
+      "model_kruskal_h": 85.04395752962773,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.10607434270172258,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1855,
+          "pct": 0.42034896895535917
+        },
+        "ranging_volatile": {
+          "count": 2558,
+          "pct": 0.5796510310446409
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5977837061358506,
+          "transition_rate": 0.034482758620689655,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.598 > 0.400",
+            "min_transition_rate: 0.0345 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5796510310446409,
+          "transition_rate": 0.03467815049864007,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.580 > 0.400",
+            "min_transition_rate: 0.0347 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6328968527452332,
+          "transition_rate": 0.029523262492820217,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.633 > 0.400",
+            "min_transition_rate: 0.0295 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6051276181755751,
+          "transition_rate": 0.030334249084249084,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.605 > 0.400",
+            "min_transition_rate: 0.0303 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6267163137072376,
+          "transition_rate": 0.03282122905027933,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.627 > 0.400",
+            "min_transition_rate: 0.0328 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.010878319703770697,
+            0.21164611586166412,
+            0.28047181560115503,
+            37.482512468240124
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005677776447105442,
+            0.13820359282286868,
+            0.08937214352815723,
+            21.64983408667506
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 94.13141785739754,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.015,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03921124206708976
+        }
+      },
+      "model_kruskal_h": 94.13141785739754,
+      "model_p_value": 0.015,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.10154125113327289,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2592,
+          "pct": 0.5873555404486743
+        },
+        "trending_down_choppy": {
+          "count": 1165,
+          "pct": 0.2639927486970315
+        },
+        "trending_up_choppy": {
+          "count": 656,
+          "pct": 0.14865171085429413
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5949107326082496,
+          "transition_rate": 0.03694581280788178,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.595 > 0.400",
+            "min_transition_rate: 0.0369 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5873555404486743,
+          "transition_rate": 0.03921124206708976,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.587 > 0.400",
+            "min_transition_rate: 0.0392 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6428899609464737,
+          "transition_rate": 0.029982768523836877,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.643 > 0.400",
+            "min_transition_rate: 0.0300 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6150852695433215,
+          "transition_rate": 0.03502747252747253,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.615 > 0.400",
+            "min_transition_rate: 0.0350 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6353269723062602,
+          "transition_rate": 0.03794227188081937,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.635 > 0.400",
+            "min_transition_rate: 0.0379 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00993350357720869,
+            0.1388487122353543,
+            0.08933156317592186,
+            21.689840174923358
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.16458343697673314,
+            0.22657302344914865,
+            0.3190475590212749,
+            37.197260344765915
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12864916922841999,
+            0.19887772910320134,
+            0.252402514838336,
+            37.91827005520633
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 77.92803884313253,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0125,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.05190389845874887
+        }
+      },
+      "model_kruskal_h": 77.92803884313253,
+      "model_p_value": 0.0125,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.08884859474161377,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2168,
+          "pct": 0.49127577611602086
+        },
+        "trending_down_choppy": {
+          "count": 1254,
+          "pct": 0.2841604350781781
+        },
+        "trending_up_choppy": {
+          "count": 991,
+          "pct": 0.22456378880580105
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5156987482043915,
+          "transition_rate": 0.05008210180623974,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.516 > 0.400",
+            "min_transition_rate: 0.0501 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.49127577611602086,
+          "transition_rate": 0.05190389845874887,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.491 > 0.400",
+            "min_transition_rate: 0.0519 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5675396278428669,
+          "transition_rate": 0.048248133256748996,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.568 > 0.400",
+            "min_transition_rate: 0.0482 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5236351150280416,
+          "transition_rate": 0.04830586080586081,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.524 > 0.400",
+            "min_transition_rate: 0.0483 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5475913427973005,
+          "transition_rate": 0.0542364990689013,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.548 > 0.400",
+            "min_transition_rate: 0.0542 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.10806207677858172,
+            0.17858203019715552,
+            0.21586337686143087,
+            27.197451941543516
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.19688983253049538,
+            0.25090898696124286,
+            0.3766373518311746,
+            42.18161812930413
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12410712222540246,
+            0.19539979701382787,
+            0.2437411141587349,
+            36.90969304580499
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0036004018767343106,
+            0.13520005770351518,
+            0.07444042701120276,
+            21.25988366746528
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 88.72107034737746,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.006666666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.06595648232094288
+        }
+      },
+      "model_kruskal_h": 88.72107034737746,
+      "model_p_value": 0.006666666666666667,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.07479601087941977,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1920,
+          "pct": 0.43507817811012917
+        },
+        "trending_down_choppy": {
+          "count": 1391,
+          "pct": 0.31520507591207797
+        },
+        "trending_up_choppy": {
+          "count": 1102,
+          "pct": 0.2497167459777929
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.44551610917299406,
+          "transition_rate": 0.07307060755336617,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.446 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.43507817811012917,
+          "transition_rate": 0.06595648232094288,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.435 > 0.400",
+            "min_transition_rate: 0.0660 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5086147484493453,
+          "transition_rate": 0.06375646180356118,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.509 > 0.400",
+            "min_transition_rate: 0.0638 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.465377131738583,
+          "transition_rate": 0.06318681318681318,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.465 > 0.400",
+            "min_transition_rate: 0.0632 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.49010937863625786,
+          "transition_rate": 0.06983240223463687,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.490 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00521564562450201,
+            0.13310837077602955,
+            0.06369853578917586,
+            21.07561903487891
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16671713412773503,
+            0.23276041829255367,
+            0.3235663882650076,
+            41.59631177381956
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.09781629844418294,
+            0.16952686231878805,
+            0.19545723580328905,
+            25.128472095754045
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18935445591228714,
+            0.24535040991091928,
+            0.363844496788274,
+            41.12338792721511
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09319032614407388,
+            0.16790633355011997,
+            0.18500613457568027,
+            32.0690859278418
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 72.33517581654996,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.009166666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.08952855847688124
+        }
+      },
+      "model_kruskal_h": 72.33517581654996,
+      "model_p_value": 0.009166666666666667,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.05122393472348141,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1457,
+          "pct": 0.33016088828461365
+        },
+        "trending_down_choppy": {
+          "count": 1555,
+          "pct": 0.35236800362565146
+        },
+        "trending_up_choppy": {
+          "count": 1401,
+          "pct": 0.3174711080897349
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3792325056433409,
+          "transition_rate": 0.08025451559934318,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.35236800362565146,
+          "transition_rate": 0.08952855847688124,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.3955892487939352,
+          "transition_rate": 0.08248133256748995,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.37427034451184615,
+          "transition_rate": 0.08402014652014653,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.3779380963462881,
+          "transition_rate": 0.09404096834264432,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11743968246375047,
+            0.18618412861867534,
+            0.23432245665403867,
+            28.83844260287284
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.062420781311295186,
+            0.14395551666209278,
+            0.12509759264041245,
+            19.99407739292834
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16426780580608522,
+            0.23026976919209782,
+            0.3188540061764217,
+            41.426524229098604
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.20216908755599725,
+            0.25464907630538164,
+            0.3856756553634807,
+            43.094632873361434
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.003713350525580302,
+            0.1298794415692209,
+            0.0445964630281495,
+            21.33356061998665
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08683352733169271,
+            0.16425294629494885,
+            0.17258965226424833,
+            30.65375286106022
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 49.387573790307215,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.03,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.09836808703535811
+        }
+      },
+      "model_kruskal_h": 49.387573790307215,
+      "model_p_value": 0.03,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.04238440616500454,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1061,
+          "pct": 0.2404260140493995
+        },
+        "trending_down_choppy": {
+          "count": 1819,
+          "pct": 0.41219125311579424
+        },
+        "trending_up_choppy": {
+          "count": 1533,
+          "pct": 0.34738273283480625
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4003693823106916,
+          "transition_rate": 0.09482758620689655,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.400 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.41219125311579424,
+          "transition_rate": 0.09836808703535811,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.412 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.3720422696990581,
+          "transition_rate": 0.1102814474439977,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.40219755064667506,
+          "transition_rate": 0.09878663003663003,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.402 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.36211310216430065,
+          "transition_rate": 0.10940409683426443,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.05491235529257406,
+            0.14905016832420365,
+            0.10886956067338502,
+            24.792243650611887
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.00042039197494952475,
+            0.12708724614606212,
+            0.03251028767244585,
+            21.08585083777254
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11526680828374247,
+            0.1843040490545302,
+            0.23008750154491792,
+            28.472263709434838
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16826161642289206,
+            0.2339490026259864,
+            0.3265672695041081,
+            41.60478656924272
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.2011493524259188,
+            0.2539459194216666,
+            0.38389894945657466,
+            42.907993759298925
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.05774302832867487,
+            0.14209562259477096,
+            0.11575414234348351,
+            19.93755287142011
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.10167092622944164,
+            0.1708230045289953,
+            0.20199084698013434,
+            33.67636374595119
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 74.54213964490555,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.005833333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03014505893019039
+        }
+      },
+      "model_kruskal_h": 74.54213964490555,
+      "model_p_value": 0.005833333333333334,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.11060743427017226,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1583,
+          "pct": 0.35871289372309084
+        },
+        "ranging_volatile": {
+          "count": 2830,
+          "pct": 0.6412871062769091
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6601682741637594,
+          "transition_rate": 0.026272577996715927,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.660 > 0.400",
+            "min_transition_rate: 0.0263 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.6412871062769091,
+          "transition_rate": 0.03014505893019039,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.641 > 0.400",
+            "min_transition_rate: 0.0301 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6865380197564898,
+          "transition_rate": 0.022171165996553704,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.687 > 0.400",
+            "min_transition_rate: 0.0222 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6575483575598031,
+          "transition_rate": 0.026213369963369964,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.658 > 0.400",
+            "min_transition_rate: 0.0262 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6788457063067256,
+          "transition_rate": 0.029562383612662942,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.679 > 0.400",
+            "min_transition_rate: 0.0296 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.018036251960858327,
+            0.2229507953439403,
+            0.3013825888317332,
+            40.09144509555085
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.003062090239283801,
+            0.14184767736105997,
+            0.1026983492092417,
+            22.35772892459727
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 98.21995066219642,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.014166666666666666,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03241160471441523
+        }
+      },
+      "model_kruskal_h": 98.21995066219642,
+      "model_p_value": 0.014166666666666666,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.10834088848594742,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2667,
+          "pct": 0.6043507817811012
+        },
+        "trending_down_choppy": {
+          "count": 1139,
+          "pct": 0.2581010650351235
+        },
+        "trending_up_choppy": {
+          "count": 607,
+          "pct": 0.1375481531837752
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.6105068746152268,
+          "transition_rate": 0.031609195402298854,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.611 > 0.400",
+            "min_transition_rate: 0.0316 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.6043507817811012,
+          "transition_rate": 0.03241160471441523,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.604 > 0.400",
+            "min_transition_rate: 0.0324 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6540317022742936,
+          "transition_rate": 0.02745548535324526,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.654 > 0.400",
+            "min_transition_rate: 0.0275 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6298500629506696,
+          "transition_rate": 0.03250915750915751,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.630 > 0.400",
+            "min_transition_rate: 0.0325 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6467302769373982,
+          "transition_rate": 0.03468342644320298,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.647 > 0.400",
+            "min_transition_rate: 0.0347 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.011362761905602299,
+            0.13948930488191816,
+            0.09349591756501334,
+            21.547271489047084
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1686088177698161,
+            0.23155718355300992,
+            0.32655345896492577,
+            38.48640984398101
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1288237459670977,
+            0.20003650102828813,
+            0.2523864791590236,
+            38.69163152773807
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 72.2322253224047,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.016666666666666666,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.046010879419764276
+        }
+      },
+      "model_kruskal_h": 72.2322253224047,
+      "model_p_value": 0.016666666666666666,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.09474161378059837,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2201,
+          "pct": 0.49875368230228867
+        },
+        "trending_down_choppy": {
+          "count": 1198,
+          "pct": 0.27147065488329936
+        },
+        "trending_up_choppy": {
+          "count": 1014,
+          "pct": 0.22977566281441197
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5237020316027088,
+          "transition_rate": 0.04228243021346469,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.524 > 0.400",
+            "min_transition_rate: 0.0423 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.49875368230228867,
+          "transition_rate": 0.046010879419764276,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.499 > 0.400",
+            "min_transition_rate: 0.0460 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5755800597289226,
+          "transition_rate": 0.041470419299253304,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.576 > 0.400",
+            "min_transition_rate: 0.0415 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5260386860478425,
+          "transition_rate": 0.03983516483516483,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.526 > 0.400",
+            "min_transition_rate: 0.0398 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5485222248080056,
+          "transition_rate": 0.047253258845437615,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.549 > 0.400",
+            "min_transition_rate: 0.0473 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.108634714566478,
+            0.18121261302394065,
+            0.21606959995256786,
+            27.51075555259618
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1985382607559364,
+            0.2545877959583349,
+            0.3790544885781678,
+            43.91062392215285
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1276066780274795,
+            0.19950315519926215,
+            0.25008243235716165,
+            38.5348359225141
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.0009738566663557522,
+            0.1350933237686613,
+            0.07877189200930211,
+            21.00680315993921
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 83.67454024325161,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.010833333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.05326382592928377
+        }
+      },
+      "model_kruskal_h": 83.67454024325161,
+      "model_p_value": 0.010833333333333334,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.08748866727107887,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1866,
+          "pct": 0.4228416043507818
+        },
+        "trending_down_choppy": {
+          "count": 1482,
+          "pct": 0.335825968728756
+        },
+        "trending_up_choppy": {
+          "count": 1065,
+          "pct": 0.24133242692046228
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.44982556946439567,
+          "transition_rate": 0.049055829228243024,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.450 > 0.400",
+            "min_transition_rate: 0.0491 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.4228416043507818,
+          "transition_rate": 0.05326382592928377,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.423 > 0.400",
+            "min_transition_rate: 0.0533 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5034458993797382,
+          "transition_rate": 0.050201033888569786,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.503 > 0.400",
+            "min_transition_rate: 0.0502 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4604555339361337,
+          "transition_rate": 0.047847985347985345,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.460 > 0.400",
+            "min_transition_rate: 0.0478 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.4728880614382127,
+          "transition_rate": 0.050512104283054006,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.473 > 0.400",
+            "min_transition_rate: 0.0505 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009191844511987594,
+            0.13084227428804987,
+            0.0692237273552371,
+            19.981804648424006
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16735603317690687,
+            0.23621437624780595,
+            0.32310262785697563,
+            44.879939613054454
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.10683010686617289,
+            0.1805129457243913,
+            0.21257840434625858,
+            27.421659336547133
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1983762359729188,
+            0.25432938197373917,
+            0.37864456835186844,
+            43.8383526974705
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09053146019471629,
+            0.1706608917801729,
+            0.17999087918585577,
+            31.904676106393996
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 85.23627606580521,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.011666666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.0627833182230281
+        }
+      },
+      "model_kruskal_h": 85.23627606580521,
+      "model_p_value": 0.011666666666666667,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.07796917497733455,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1587,
+          "pct": 0.35961930659415364
+        },
+        "trending_down_choppy": {
+          "count": 1515,
+          "pct": 0.3433038749150238
+        },
+        "trending_up_choppy": {
+          "count": 1311,
+          "pct": 0.29707681849082257
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3580956289759902,
+          "transition_rate": 0.06629720853858785,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "min_transition_rate: 0.0663 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.35961930659415364,
+          "transition_rate": 0.0627833182230281,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "min_transition_rate: 0.0628 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.4238456237077877,
+          "transition_rate": 0.0639862148190695,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.424 > 0.400",
+            "min_transition_rate: 0.0640 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.3882339475792606,
+          "transition_rate": 0.06192765567765568,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "min_transition_rate: 0.0619 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.3956248545496858,
+          "transition_rate": 0.06750465549348231,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "min_transition_rate: 0.0675 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1422368413298863,
+            0.21289257644971257,
+            0.27901163698117537,
+            32.39750509885974
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07546626101794847,
+            0.15528687999136098,
+            0.15192518804675337,
+            21.471335467391313
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16772808627435506,
+            0.23634953580401558,
+            0.3238008985967664,
+            45.07327087019288
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.21490981947085272,
+            0.26520474436350816,
+            0.4095600377751536,
+            49.3623411222127
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.0034492118909808054,
+            0.12703359428203576,
+            0.05583583729091948,
+            20.37672494225289
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09082403738926717,
+            0.1711827970248258,
+            0.18076275143763418,
+            31.87693237025458
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 126.65759838602207,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.07502266545784225
+        }
+      },
+      "model_kruskal_h": 126.65759838602207,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.0657298277425204,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1018,
+          "pct": 0.23068207568547475
+        },
+        "ranging_volatile": {
+          "count": 1007,
+          "pct": 0.22818944029005211
+        },
+        "trending_down_choppy": {
+          "count": 1166,
+          "pct": 0.2642193519147972
+        },
+        "trending_up_choppy": {
+          "count": 1222,
+          "pct": 0.27690913210967594
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3264929201723784,
+          "transition_rate": 0.0812807881773399,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.27690913210967594,
+          "transition_rate": 0.07502266545784225,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.306570181484034,
+          "transition_rate": 0.07857553130384837,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3338674602266224,
+          "transition_rate": 0.07692307692307693,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.2811263672329532,
+          "transition_rate": 0.08356610800744879,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.029546514429325932,
+            0.15021842384756123,
+            0.08539826780749266,
+            27.07442603443352
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006871018715765001,
+            0.12133272100240955,
+            0.05347745032320514,
+            17.651706806580762
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1424907303657935,
+            0.21338943808886005,
+            0.27917384606948925,
+            32.4850717550184
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.17498712426960858,
+            0.24367786639245714,
+            0.3376706127243908,
+            47.32693000137403
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.21490981947085272,
+            0.26520474436350816,
+            0.4095600377751536,
+            49.3623411222127
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.08074894410741987,
+            0.15484594070034033,
+            0.16176795525682527,
+            21.18938247859502
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.10858907178125976,
+            0.17942088565910075,
+            0.2156809905302767,
+            33.85521683446028
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 91.47075089775717,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.039664551223934724
+        }
+      },
+      "model_kruskal_h": 91.47075089775717,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.10108794197642793,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 2072,
+          "pct": 0.46952186721051437
+        },
+        "ranging_volatile": {
+          "count": 2341,
+          "pct": 0.5304781327894856
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5577672891442643,
+          "transition_rate": 0.042692939244663386,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.558 > 0.400",
+            "min_transition_rate: 0.0427 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5304781327894856,
+          "transition_rate": 0.039664551223934724,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.530 > 0.400",
+            "min_transition_rate: 0.0397 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6527777777777778,
+          "transition_rate": 0.045592163846838826,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.653 > 0.400",
+            "min_transition_rate: 0.0456 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.580977452214719,
+          "transition_rate": 0.07337454212454213,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.581 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5387479636956016,
+          "transition_rate": 0.054702048417132214,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.539 > 0.400",
+            "min_transition_rate: 0.0547 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.00907885995580387,
+            0.20470922883932402,
+            0.26154111465892993,
+            36.57895576746782,
+            1.3169489496277385e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0066819257666804206,
+            0.13818259780789646,
+            0.08999450472234209,
+            21.19032849593158,
+            1.0608846375287354e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 108.11872720033716,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.005833333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.04306436990027199
+        }
+      },
+      "model_kruskal_h": 108.11872720033716,
+      "model_p_value": 0.005833333333333334,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.09768812330009066,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2255,
+          "pct": 0.5109902560616361
+        },
+        "trending_down_choppy": {
+          "count": 1309,
+          "pct": 0.2966236120552912
+        },
+        "trending_up_choppy": {
+          "count": 849,
+          "pct": 0.19238613188307274
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5339626513441412,
+          "transition_rate": 0.042487684729064036,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.534 > 0.400",
+            "min_transition_rate: 0.0425 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5109902560616361,
+          "transition_rate": 0.04306436990027199,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.511 > 0.400",
+            "min_transition_rate: 0.0431 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.4675925925925926,
+          "transition_rate": 0.057702582368655386,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.468 > 0.400",
+            "min_transition_rate: 0.0577 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4217694860936248,
+          "transition_rate": 0.07818223443223443,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.422 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5392134047009541,
+          "transition_rate": 0.05330540037243948,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.539 > 0.400",
+            "min_transition_rate: 0.0533 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009236835834268292,
+            0.13602891751548107,
+            0.08138230645034174,
+            20.953397888034065,
+            1.0511083978652498e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12087033673816544,
+            0.19499494690240582,
+            0.23789582601806067,
+            36.87996867553251,
+            5.847101545095579e-06
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14300503106280468,
+            0.2112689665668848,
+            0.28425559100693437,
+            34.71913922156307,
+            2.096293462849498e-05
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 98.19978871708554,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.005,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.051677243880326386
+        }
+      },
+      "model_kruskal_h": 98.19978871708554,
+      "model_p_value": 0.005,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.08907524932003627,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1852,
+          "pct": 0.4196691593020621
+        },
+        "trending_down_choppy": {
+          "count": 1403,
+          "pct": 0.31792431452526626
+        },
+        "trending_up_choppy": {
+          "count": 1158,
+          "pct": 0.26240652617267163
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4500307818592243,
+          "transition_rate": 0.053366174055829226,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.450 > 0.400",
+            "min_transition_rate: 0.0534 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.4196691593020621,
+          "transition_rate": 0.051677243880326386,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.420 > 0.400",
+            "min_transition_rate: 0.0517 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.42396723646723644,
+          "transition_rate": 0.06678539626001781,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.424 > 0.400",
+            "min_transition_rate: 0.0668 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.38880622639349893,
+          "transition_rate": 0.07371794871794872,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.4482196881545264,
+          "transition_rate": 0.05540037243947858,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.448 > 0.400",
+            "min_transition_rate: 0.0554 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.09221129934834293,
+            0.1682425945600596,
+            0.18354496536151413,
+            24.894839276602973,
+            1.5017085468682704e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1861247533324776,
+            0.24477803262323994,
+            0.3608476368453506,
+            41.29265553829208,
+            2.3475300598643716e-05
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1180688209125215,
+            0.19291553760066718,
+            0.23238642920290453,
+            36.26910032165665,
+            6.584808529366651e-06
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0002854592383277404,
+            0.13200540071463002,
+            0.06827441962553696,
+            20.815561789880583,
+            1.0321479142077263e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 72.64696891008316,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.015,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.0713961922030825
+        }
+      },
+      "model_kruskal_h": 72.64696891008316,
+      "model_p_value": 0.015,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.06935630099728014,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1438,
+          "pct": 0.3258554271470655
+        },
+        "trending_down_choppy": {
+          "count": 1610,
+          "pct": 0.36483118060276454
+        },
+        "trending_up_choppy": {
+          "count": 1365,
+          "pct": 0.30931339225016996
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3685614611122512,
+          "transition_rate": 0.06629720853858785,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "min_transition_rate: 0.0663 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.36483118060276454,
+          "transition_rate": 0.0713961922030825,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.35345441595441596,
+          "transition_rate": 0.07586821015138023,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.37919194231429554,
+          "transition_rate": 0.07394688644688645,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.3635094251803584,
+          "transition_rate": 0.0782122905027933,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.0014201095132754318,
+            0.12678257683853378,
+            0.04536916313520099,
+            21.061513105718813,
+            1.0917807776323243e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16498905683857681,
+            0.2323888901866003,
+            0.3197587731351277,
+            41.65291794440094,
+            1.8439849757245629e-06
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07567253306637745,
+            0.1546853367112426,
+            0.1515927044764735,
+            21.71943816996984,
+            1.2455824750079583e-05
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17509679657554747,
+            0.235956489186332,
+            0.3379019321386464,
+            39.355369682642966,
+            2.3063231998929107e-05
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08542882291652075,
+            0.165004801595129,
+            0.16985477043446343,
+            30.558356114897556,
+            8.776105397973161e-06
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 58.250611863575614,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.041666666666666664,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.0770625566636446
+        }
+      },
+      "model_kruskal_h": 58.250611863575614,
+      "model_p_value": 0.041666666666666664,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.06368993653671805,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1978,
+          "pct": 0.4482211647405393
+        },
+        "trending_down_choppy": {
+          "count": 1462,
+          "pct": 0.3312939043734421
+        },
+        "trending_up_choppy": {
+          "count": 973,
+          "pct": 0.2204849308860186
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3665093371639647,
+          "transition_rate": 0.07307060755336617,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.4482211647405393,
+          "transition_rate": 0.0770625566636446,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.448 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5655270655270656,
+          "transition_rate": 0.057168299198575245,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.566 > 0.400",
+            "min_transition_rate: 0.0572 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.465377131738583,
+          "transition_rate": 0.08173076923076923,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.465 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.4514777751919944,
+          "transition_rate": 0.08496275605214153,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.451 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07034353909138161,
+            0.15456646355539866,
+            0.140307364597493,
+            21.53494486913592,
+            1.248089471955468e-05
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.02918651748765376,
+            0.14400616725167598,
+            0.10723912233676917,
+            23.560439770098053,
+            1.1651691211694165e-05
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16357869429325048,
+            0.23151386935069757,
+            0.3168669675306461,
+            41.88397397903692,
+            1.2676099715209738e-06
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1776723119430366,
+            0.23785564866759662,
+            0.34270628811591275,
+            39.81278748005305,
+            2.2518436628561306e-05
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.006132031337088244,
+            0.12435041116963871,
+            0.04209814611928238,
+            20.45922452241105,
+            1.0950472881496644e-05
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08711740800545688,
+            0.16507951835168094,
+            0.17339588711337042,
+            30.640700124083843,
+            9.385232967251094e-06
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 84.3578856961285,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.015,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.05417044424297371
+        }
+      },
+      "model_kruskal_h": 84.3578856961285,
+      "model_p_value": 0.015,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.08658204895738894,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2087,
+          "pct": 0.47292091547699977
+        },
+        "trending_down_choppy": {
+          "count": 1265,
+          "pct": 0.2866530704736007
+        },
+        "trending_up_choppy": {
+          "count": 1061,
+          "pct": 0.2404260140493995
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.49497229632669815,
+          "transition_rate": 0.051313628899835796,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.495 > 0.400",
+            "min_transition_rate: 0.0513 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.47292091547699977,
+          "transition_rate": 0.05417044424297371,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.473 > 0.400",
+            "min_transition_rate: 0.0542 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5044515669515669,
+          "transition_rate": 0.05218165627782725,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.504 > 0.400",
+            "min_transition_rate: 0.0522 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4952500858418221,
+          "transition_rate": 0.05311355311355311,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.495 > 0.400",
+            "min_transition_rate: 0.0531 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5289737025831975,
+          "transition_rate": 0.05865921787709497,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.529 > 0.400",
+            "min_transition_rate: 0.0587 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.0016052953577557882,
+            0.13153833674610296,
+            0.06042692413242001,
+            21.909743328905314,
+            8.19722720106653e-06
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.007650357168597174,
+            0.13513779053163852,
+            0.07619011885925982,
+            20.522753936847884,
+            1.2483590002353736e-05
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11386070772210612,
+            0.1880760311831054,
+            0.2225360355283785,
+            28.500271482933346,
+            1.2482829825791978e-05
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16880686236309317,
+            0.2361887963651028,
+            0.32698187843296933,
+            42.115296684630344,
+            1.3075665515726301e-06
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.20196445206833957,
+            0.25596831114228097,
+            0.3867882850509877,
+            43.83850906853738,
+            2.5400449584727188e-05
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.100870170126327,
+            0.16976684725111907,
+            0.2052171859105471,
+            26.39547792270933,
+            2.0022375825941747e-05
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09698580394199934,
+            0.17063864627091835,
+            0.19306186205715106,
+            33.10505251953151,
+            8.125773259030584e-06
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 88.76784555162703,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.056890299184043515
+        }
+      },
+      "model_kruskal_h": 88.76784555162703,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.08386219401631914,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 2210,
+          "pct": 0.50079311126218
+        },
+        "ranging_volatile": {
+          "count": 2203,
+          "pct": 0.4992068887378201
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5512004925097476,
+          "transition_rate": 0.05213464696223317,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.551 > 0.400",
+            "min_transition_rate: 0.0521 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.50079311126218,
+          "transition_rate": 0.056890299184043515,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.501 > 0.400",
+            "min_transition_rate: 0.0569 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6746794871794872,
+          "transition_rate": 0.05200356188780053,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.675 > 0.400",
+            "min_transition_rate: 0.0520 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.591049559345313,
+          "transition_rate": 0.08298992673992674,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.591 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5077961368396555,
+          "transition_rate": 0.07378957169459963,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.508 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.00998729724888988,
+            0.2025833185016591,
+            0.25727047055609065,
+            35.98524238263593,
+            1.2632007685074826e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005931506139810398,
+            0.13899972957633738,
+            0.09114260561436283,
+            21.460064588839646,
+            1.1001044382443276e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 101.52886577185927,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0075,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.044424297370806894
+        }
+      },
+      "model_kruskal_h": 101.52886577185927,
+      "model_p_value": 0.0075,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.09632819582955576,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2406,
+          "pct": 0.5452073419442556
+        },
+        "trending_down_choppy": {
+          "count": 1221,
+          "pct": 0.27668252889191025
+        },
+        "trending_up_choppy": {
+          "count": 786,
+          "pct": 0.17811012916383412
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5618715370408373,
+          "transition_rate": 0.043924466338259444,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.562 > 0.400",
+            "min_transition_rate: 0.0439 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5452073419442556,
+          "transition_rate": 0.044424297370806894,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.545 > 0.400",
+            "min_transition_rate: 0.0444 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.45584045584045585,
+          "transition_rate": 0.06268922528940338,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.456 > 0.400",
+            "min_transition_rate: 0.0627 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4517568959597116,
+          "transition_rate": 0.08070054945054946,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.452 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.574121480102397,
+          "transition_rate": 0.04818435754189944,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.574 > 0.400",
+            "min_transition_rate: 0.0482 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009151016794959511,
+            0.13824444392927085,
+            0.08662923547793581,
+            21.438431216360367,
+            1.0614140494224214e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12585959251504458,
+            0.1971188555160777,
+            0.2472757243641353,
+            37.523998185519886,
+            5.8691447850830876e-06
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14736262306261916,
+            0.21585631949326387,
+            0.2944793944409515,
+            35.59637436158426,
+            2.1126607433097627e-05
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 84.79001820670419,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.015833333333333335,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.05598368087035358
+        }
+      },
+      "model_kruskal_h": 84.79001820670419,
+      "model_p_value": 0.015833333333333335,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.08476881233000907,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1985,
+          "pct": 0.44980738726489916
+        },
+        "trending_down_choppy": {
+          "count": 1375,
+          "pct": 0.3115794244278269
+        },
+        "trending_up_choppy": {
+          "count": 1053,
+          "pct": 0.23861318830727396
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.48512210137492306,
+          "transition_rate": 0.054187192118226604,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.485 > 0.400",
+            "min_transition_rate: 0.0542 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.44980738726489916,
+          "transition_rate": 0.05598368087035358,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.450 > 0.400",
+            "min_transition_rate: 0.0560 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.38497150997151,
+          "transition_rate": 0.07088156723063224,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.3868604784250887,
+          "transition_rate": 0.08081501831501832,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.482895043053293,
+          "transition_rate": 0.06610800744878957,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.483 > 0.400",
+            "min_transition_rate: 0.0661 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.10120539136361437,
+            0.17256851651938857,
+            0.20147994194208893,
+            26.017386589656073,
+            1.532369426678423e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18964999849205094,
+            0.24729316116533168,
+            0.367916103130608,
+            41.720190716697864,
+            2.36493652713376e-05
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11993627799070303,
+            0.19302559288270874,
+            0.23586288993424914,
+            36.47462065069479,
+            6.574772427546762e-06
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0027520064755360164,
+            0.1345093098174464,
+            0.0719470562622372,
+            21.04559509230378,
+            1.0554073006294043e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 83.32637857562986,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.06459655485040798
+        }
+      },
+      "model_kruskal_h": 83.32637857562986,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.07615593834995467,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1934,
+          "pct": 0.43825062315884883
+        },
+        "trending_down_choppy": {
+          "count": 1381,
+          "pct": 0.31293904373442105
+        },
+        "trending_up_choppy": {
+          "count": 1098,
+          "pct": 0.24881033310673012
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.44490047198850813,
+          "transition_rate": 0.07389162561576355,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.445 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.43825062315884883,
+          "transition_rate": 0.06459655485040798,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.438 > 0.400",
+            "min_transition_rate: 0.0646 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.4337606837606838,
+          "transition_rate": 0.07123775601068566,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.434 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4384800274693831,
+          "transition_rate": 0.07131410256410256,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.438 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.4919711426576681,
+          "transition_rate": 0.07006517690875233,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.492 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0051602145921585485,
+            0.13310713810427208,
+            0.06381205912523355,
+            21.072668214368942,
+            1.0993883130278907e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16378902797831704,
+            0.2303122032469208,
+            0.3177120893440727,
+            41.40584407217824,
+            1.8284954502282175e-06
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.09790009925898394,
+            0.16955160824311977,
+            0.19511894338180213,
+            24.96377955395569,
+            1.3021306455555915e-05
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18661660523480167,
+            0.2430456678091612,
+            0.3594103754979905,
+            40.89613269976323,
+            2.4941874478587637e-05
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09379619999162275,
+            0.16854883702227041,
+            0.18630327020231147,
+            32.0647127514315,
+            8.721409089111776e-06
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 116.03463860230113,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.08182230281051678
+        }
+      },
+      "model_kruskal_h": 116.03463860230113,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.05893019038984587,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 754,
+          "pct": 0.17085882619533196
+        },
+        "ranging_volatile": {
+          "count": 2375,
+          "pct": 0.5381826421935192
+        },
+        "trending_down_choppy": {
+          "count": 890,
+          "pct": 0.20167686381146613
+        },
+        "trending_up_choppy": {
+          "count": 394,
+          "pct": 0.08928166779968276
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5249333059716806,
+          "transition_rate": 0.07758620689655173,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.525 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5381826421935192,
+          "transition_rate": 0.08182230281051678,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.538 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5847578347578347,
+          "transition_rate": 0.06945681211041853,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.585 > 0.400",
+            "min_transition_rate: 0.0695 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.5522490557399565,
+          "transition_rate": 0.09329212454212454,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.552 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.5699325110542238,
+          "transition_rate": 0.09287709497206705,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.570 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.004236225402467306,
+            0.18373892298467917,
+            0.21095591128244318,
+            30.590545931540486,
+            1.247823131655653e-05
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00966615921934637,
+            0.13679763726535418,
+            0.08526767748179724,
+            22.56080678889306,
+            9.35922486817239e-06
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.17757369231484119,
+            0.24283940809842633,
+            0.3443881701062005,
+            44.87163307868494,
+            -2.4512521419042734e-06
+          ],
+          "volatility_rank": 5
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18236514615712784,
+            0.24007579748218072,
+            0.3524548628640106,
+            40.17307023371917,
+            2.5312261013006206e-05
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.01010467297437343,
+            0.13336914714836956,
+            0.07278620164702035,
+            20.349367885565673,
+            1.2478055596222514e-05
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.10021111211022146,
+            0.17007229205472307,
+            0.19908586335287387,
+            34.013247938163914,
+            2.483128852992056e-06
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 84.99052150627904,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.010833333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.05915684496826836
+        }
+      },
+      "model_kruskal_h": 84.99052150627904,
+      "model_p_value": 0.010833333333333334,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.08159564823209428,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2216,
+          "pct": 0.5021527305687741
+        },
+        "trending_down_choppy": {
+          "count": 1213,
+          "pct": 0.2748697031497847
+        },
+        "trending_up_choppy": {
+          "count": 984,
+          "pct": 0.2229775662814412
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5241124563923661,
+          "transition_rate": 0.05213464696223317,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.524 > 0.400",
+            "min_transition_rate: 0.0521 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5021527305687741,
+          "transition_rate": 0.05915684496826836,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.502 > 0.400",
+            "min_transition_rate: 0.0592 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5363247863247863,
+          "transition_rate": 0.0578806767586821,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.536 > 0.400",
+            "min_transition_rate: 0.0579 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5330204875815497,
+          "transition_rate": 0.055288461538461536,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.533 > 0.400",
+            "min_transition_rate: 0.0553 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.577379567139865,
+          "transition_rate": 0.0654096834264432,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.577 > 0.400",
+            "min_transition_rate: 0.0654 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.001224150465838866,
+            0.1325307197863449,
+            0.0635605904916238,
+            22.130148170570873,
+            8.34733468999191e-06
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.008337700286693272,
+            0.13812094084183094,
+            0.08171370507782369,
+            21.022136842343826,
+            1.2477660507296333e-05
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.12472754698501724,
+            0.195351894573375,
+            0.2437701603876654,
+            30.02920100777912,
+            1.2481957612229611e-05
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.17054288846121843,
+            0.23633143384798255,
+            0.33048721305301143,
+            42.1903986366674,
+            1.1327911678390592e-06
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.20401400987013807,
+            0.25539300271068316,
+            0.39087222130437815,
+            43.67879780972147,
+            2.5974095200826144e-05
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.10394875694437278,
+            0.17162545049296388,
+            0.21094070372912965,
+            26.649254869951626,
+            2.010123796508081e-05
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.10080134933271243,
+            0.17241696377140125,
+            0.20037004149549195,
+            33.770999670629024,
+            7.852103624121023e-06
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 75.73727416836482,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.031051677243880325
+        }
+      },
+      "model_kruskal_h": 75.73727416836482,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.10970081595648232,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1578,
+          "pct": 0.3575798776342624
+        },
+        "ranging_volatile": {
+          "count": 2835,
+          "pct": 0.6424201223657376
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6661194336137902,
+          "transition_rate": 0.029556650246305417,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.666 > 0.400",
+            "min_transition_rate: 0.0296 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.6424201223657376,
+          "transition_rate": 0.031051677243880325,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.642 > 0.400",
+            "min_transition_rate: 0.0311 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5349002849002849,
+          "transition_rate": 0.04416740872662511,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.535 > 0.400",
+            "min_transition_rate: 0.0442 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5847544923886918,
+          "transition_rate": 0.0451007326007326,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.585 > 0.400",
+            "min_transition_rate: 0.0451 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6804747498254596,
+          "transition_rate": 0.03514897579143389,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.680 > 0.400",
+            "min_transition_rate: 0.0351 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.01856914946809174,
+            0.2230445640632568,
+            0.3015055621125169,
+            40.08054427550777,
+            1.3111961716171655e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.002830585951012359,
+            0.14185367695194778,
+            0.10276120327679909,
+            22.373209024271834,
+            1.1094503275759367e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 99.0958609638783,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.010833333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.0328649138712602
+        }
+      },
+      "model_kruskal_h": 99.0958609638783,
+      "model_p_value": 0.010833333333333334,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.10788757932910245,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2661,
+          "pct": 0.6029911624745071
+        },
+        "trending_down_choppy": {
+          "count": 1151,
+          "pct": 0.2608203036483118
+        },
+        "trending_up_choppy": {
+          "count": 601,
+          "pct": 0.13618853387718105
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.6049661399548533,
+          "transition_rate": 0.0361247947454844,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.605 > 0.400",
+            "min_transition_rate: 0.0361 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.6029911624745071,
+          "transition_rate": 0.0328649138712602,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.603 > 0.400",
+            "min_transition_rate: 0.0329 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.49786324786324787,
+          "transition_rate": 0.05627782724844167,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.498 > 0.400",
+            "min_transition_rate: 0.0563 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5515623211628705,
+          "transition_rate": 0.05460164835164835,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.552 > 0.400",
+            "min_transition_rate: 0.0546 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6350942518035839,
+          "transition_rate": 0.04259776536312849,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.635 > 0.400",
+            "min_transition_rate: 0.0426 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.01184533522517588,
+            0.13948627979922618,
+            0.09362526656940051,
+            21.513416699863797,
+            1.1353376746474246e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1272805368341519,
+            0.19951670890903223,
+            0.24966142602973507,
+            38.57974543012017,
+            4.857152657004937e-06
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.16889264586748334,
+            0.23125944351303657,
+            0.32698356589743605,
+            38.437029712091245,
+            2.215001939163488e-05
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 87.85842493077507,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.011666666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.04510426110607434
+        }
+      },
+      "model_kruskal_h": 87.85842493077507,
+      "model_p_value": 0.011666666666666667,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.0956482320942883,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2227,
+          "pct": 0.5046453659641967
+        },
+        "trending_down_choppy": {
+          "count": 1212,
+          "pct": 0.274643099932019
+        },
+        "trending_up_choppy": {
+          "count": 974,
+          "pct": 0.22071153410378427
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5259593679458239,
+          "transition_rate": 0.04433497536945813,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.526 > 0.400",
+            "min_transition_rate: 0.0443 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5046453659641967,
+          "transition_rate": 0.04510426110607434,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.505 > 0.400",
+            "min_transition_rate: 0.0451 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.4561965811965812,
+          "transition_rate": 0.06019590382902939,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.456 > 0.400",
+            "min_transition_rate: 0.0602 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.47419022547785283,
+          "transition_rate": 0.058493589743589744,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.474 > 0.400",
+            "min_transition_rate: 0.0585 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5387479636956016,
+          "transition_rate": 0.050046554934823094,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.539 > 0.400",
+            "min_transition_rate: 0.0500 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11533483661606628,
+            0.18671851474541556,
+            0.22756848252477363,
+            28.08903406175065,
+            1.3146450977835709e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.19894426680052693,
+            0.25460611040605097,
+            0.381641120082185,
+            44.99955574077237,
+            3.0109591421568714e-05
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12648405916484717,
+            0.19915183773300227,
+            0.24789517294297725,
+            38.36713266404889,
+            4.914975332068419e-06
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0004994277187101142,
+            0.1351205487649349,
+            0.07954498178215749,
+            20.99402223350745,
+            1.1184394402420564e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 94.7338196444125,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0075,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.051450589301903896
+        }
+      },
+      "model_kruskal_h": 94.7338196444125,
+      "model_p_value": 0.0075,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.08930190389845875,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1891,
+          "pct": 0.4285066847949241
+        },
+        "trending_down_choppy": {
+          "count": 1498,
+          "pct": 0.339451620213007
+        },
+        "trending_up_choppy": {
+          "count": 1024,
+          "pct": 0.2320416949920689
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4582392776523702,
+          "transition_rate": 0.04782430213464696,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.458 > 0.400",
+            "min_transition_rate: 0.0478 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.4285066847949241,
+          "transition_rate": 0.051450589301903896,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.429 > 0.400",
+            "min_transition_rate: 0.0515 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.4252136752136752,
+          "transition_rate": 0.059305431878895816,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.425 > 0.400",
+            "min_transition_rate: 0.0593 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4352752661096486,
+          "transition_rate": 0.054372710622710624,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.435 > 0.400",
+            "min_transition_rate: 0.0544 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.4733535024435653,
+          "transition_rate": 0.05027932960893855,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.473 > 0.400",
+            "min_transition_rate: 0.0503 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.010292925560905143,
+            0.13133297549764386,
+            0.07122216063296463,
+            20.049296208119824,
+            1.1532890567685578e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1667163956090894,
+            0.23571606192428843,
+            0.3221252751502923,
+            44.928027456174846,
+            5.53669367088663e-07
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11438290265429898,
+            0.18617395833999628,
+            0.22574857506466667,
+            28.11128334307223,
+            1.303897216494844e-05
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.19894191932495203,
+            0.2546229427508011,
+            0.38150657529650567,
+            44.90603941504495,
+            3.0023850000000087e-05
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09022731894629753,
+            0.1711880291528053,
+            0.17955711132570065,
+            31.902164954813543,
+            8.046830638722539e-06
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 96.94325988254786,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.06663644605621033
+        }
+      },
+      "model_kruskal_h": 96.94325988254786,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.07411604714415232,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1514,
+          "pct": 0.3430772716972581
+        },
+        "trending_down_choppy": {
+          "count": 1555,
+          "pct": 0.35236800362565146
+        },
+        "trending_up_choppy": {
+          "count": 1344,
+          "pct": 0.30455472467709044
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.35255489431561665,
+          "transition_rate": 0.06773399014778325,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "min_transition_rate: 0.0677 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.35236800362565146,
+          "transition_rate": 0.06663644605621033,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "min_transition_rate: 0.0666 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.43785612535612534,
+          "transition_rate": 0.07640249332146037,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.438 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4456907405287856,
+          "transition_rate": 0.07921245421245421,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.446 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.37398184780079125,
+          "transition_rate": 0.07006517690875233,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.13860429363850044,
+            0.21176150983687486,
+            0.27073704797584536,
+            32.14013815298176,
+            1.1028239662447262e-05
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07078262720621878,
+            0.15306710099685564,
+            0.1471755135731529,
+            21.06565716356325,
+            1.6140802983425613e-05
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16728475063416962,
+            0.23625078279937378,
+            0.3230930136010307,
+            45.502636722238805,
+            2.575194225722326e-07
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.20431152830110788,
+            0.2545242665216722,
+            0.3924957012191026,
+            46.258365107219916,
+            3.300163314121045e-05
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.004292487520397908,
+            0.12716308525408643,
+            0.055644720328826086,
+            20.582814630293644,
+            1.0094520430107516e-05
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09178691553447567,
+            0.17250033966175113,
+            0.18289407342707098,
+            31.826250779032893,
+            7.906358858858845e-06
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 120.11759587900815,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.08046237533998186
+        }
+      },
+      "model_kruskal_h": 120.11759587900815,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.060290117860380785,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1072,
+          "pct": 0.2429186494448221
+        },
+        "ranging_volatile": {
+          "count": 984,
+          "pct": 0.2229775662814412
+        },
+        "trending_down_choppy": {
+          "count": 1137,
+          "pct": 0.2576478585995921
+        },
+        "trending_up_choppy": {
+          "count": 1220,
+          "pct": 0.27645592567414456
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.33880566386209726,
+          "transition_rate": 0.0827175697865353,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.27645592567414456,
+          "transition_rate": 0.08046237533998186,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.40544871794871795,
+          "transition_rate": 0.09100623330365093,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.405 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.4265766281332265,
+          "transition_rate": 0.09157509157509157,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.427 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.2911333488480335,
+          "transition_rate": 0.09869646182495345,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.029112462585728194,
+            0.15202571763423517,
+            0.09174604146836814,
+            27.073360346952356,
+            8.022831568016598e-06
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0047853847705110085,
+            0.12140181800835509,
+            0.05109806756383231,
+            17.91595394433734,
+            1.0346708598726105e-05
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.13747913233987755,
+            0.2107990114920387,
+            0.26869757430088737,
+            32.000763189455526,
+            1.113494834710744e-05
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.17794272385177815,
+            0.2453692554682022,
+            0.34293829218241506,
+            47.833912228008664,
+            -1.4921021660649879e-06
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.2049752287314198,
+            0.25541930857775746,
+            0.3936701003126737,
+            46.34652633977221,
+            3.251196156069372e-05
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07340658399306892,
+            0.15043405675162164,
+            0.1526979602503703,
+            20.577592625675827,
+            1.7815685438144548e-05
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11085924331945261,
+            0.1819322932895084,
+            0.2199421941000161,
+            34.41595752367807,
+            8.233979118028519e-06
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 88.61024860845646,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03467815049864007
+        }
+      },
+      "model_kruskal_h": 88.61024860845646,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.10607434270172258,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1923,
+          "pct": 0.4357579877634262
+        },
+        "ranging_volatile": {
+          "count": 2490,
+          "pct": 0.5642420122365738
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5840344756823312,
+          "transition_rate": 0.03489326765188834,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.584 > 0.400",
+            "min_transition_rate: 0.0349 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5642420122365738,
+          "transition_rate": 0.03467815049864007,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.564 > 0.400",
+            "min_transition_rate: 0.0347 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.620491614978176,
+          "transition_rate": 0.03113153360137852,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.620 > 0.400",
+            "min_transition_rate: 0.0311 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5928808515508756,
+          "transition_rate": 0.03216575091575091,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.593 > 0.400",
+            "min_transition_rate: 0.0322 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6129858040493368,
+          "transition_rate": 0.034217877094972066,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.613 > 0.400",
+            "min_transition_rate: 0.0342 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.009931510914565388,
+            0.2104843779272324,
+            0.27595699004578667,
+            37.284530792488354,
+            0.1502122974157241
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006199758546452026,
+            0.13714810837855154,
+            0.08765550642797937,
+            21.386081598446854,
+            -0.07981231885524126
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 105.05127420696772,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.0713961922030825
+        }
+      },
+      "model_kruskal_h": 105.05127420696772,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.06935630099728014,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1720,
+          "pct": 0.3897575345569907
+        },
+        "ranging_directional_up": {
+          "count": 1074,
+          "pct": 0.2433718558803535
+        },
+        "ranging_volatile": {
+          "count": 1619,
+          "pct": 0.36687060956265577
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4001641699158629,
+          "transition_rate": 0.06834975369458128,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.400 > 0.400",
+            "min_transition_rate: 0.0683 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.3897575345569907,
+          "transition_rate": 0.0713961922030825,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.4290144727773949,
+          "transition_rate": 0.06858127512923608,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.429 > 0.400",
+            "min_transition_rate: 0.0686 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4015108160695891,
+          "transition_rate": 0.07520604395604395,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.402 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.4005119851058878,
+          "transition_rate": 0.07239292364990689,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.401 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009231577629926022,
+            0.12744960287484977,
+            0.06640515603366523,
+            19.82288640656347,
+            -0.1849297672776903
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.043805342405822734,
+            0.23950472431714526,
+            0.33703942274310816,
+            41.35353276422798,
+            0.1731729701712033
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.014806460508330082,
+            0.16822945747012993,
+            0.17127208750193812,
+            28.82513496651536,
+            0.13821837778680887
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 79.45167048694202,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.016666666666666666,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03603807796917498
+        }
+      },
+      "model_kruskal_h": 79.45167048694202,
+      "model_p_value": 0.016666666666666666,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.10471441523118767,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2917,
+          "pct": 0.6610015862225244
+        },
+        "trending_down_choppy": {
+          "count": 966,
+          "pct": 0.21889870836165873
+        },
+        "trending_up_choppy": {
+          "count": 530,
+          "pct": 0.12009970541581691
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.6698132567207059,
+          "transition_rate": 0.035303776683087026,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.670 > 0.400",
+            "min_transition_rate: 0.0353 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.6610015862225244,
+          "transition_rate": 0.03603807796917498,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.661 > 0.400",
+            "min_transition_rate: 0.0360 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.7026188835286009,
+          "transition_rate": 0.03480758184951178,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.703 > 0.400",
+            "min_transition_rate: 0.0348 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6808973331807257,
+          "transition_rate": 0.03456959706959707,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.681 > 0.400",
+            "min_transition_rate: 0.0346 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.7002559925529439,
+          "transition_rate": 0.03677839851024209,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.700 > 0.400",
+            "min_transition_rate: 0.0368 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.008415417731259017,
+            0.16129753385078846,
+            0.14568644648277854,
+            24.541820610415954,
+            -0.18471166046432339
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17053699009698026,
+            0.23281590185967255,
+            0.32927860561113204,
+            38.452112383624936,
+            0.33362327548808407
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1365147571279726,
+            0.20667757194855438,
+            0.2664033736698018,
+            40.01812376191631,
+            0.14461598430877176
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005364452423341439,
+            0.1235965107812122,
+            0.05814608216492108,
+            20.222300877394577,
+            -0.012286917545887014
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 79.0450350353367,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.02666666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.11196736174070716
+        }
+      },
+      "model_kruskal_h": 79.0450350353367,
+      "model_p_value": 0.02666666666666667,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.028785131459655486,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1365,
+          "pct": 0.30931339225016996
+        },
+        "ranging_volatile": {
+          "count": 1750,
+          "pct": 0.3965556310899615
+        },
+        "trending_down_choppy": {
+          "count": 822,
+          "pct": 0.18626784500339905
+        },
+        "trending_up_choppy": {
+          "count": 476,
+          "pct": 0.10786313165646952
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.43340857787810383,
+          "transition_rate": 0.12541050903119869,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.433 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3965556310899615,
+          "transition_rate": 0.11196736174070716,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4792097404089134,
+          "transition_rate": 0.11200459506031017,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.479 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.43710655831521117,
+          "transition_rate": 0.12328296703296704,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.437 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.41936234582266696,
+          "transition_rate": 0.13384543761638734,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.419 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006703190873293222,
+            0.12374138204776075,
+            0.055934288580752736,
+            19.769605394148826,
+            -0.25700316116147115
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.14524290605920803,
+            0.21570330305630403,
+            0.28261989994720194,
+            41.330028743640355,
+            0.16372000135112516
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.007012125074658562,
+            0.16421708936045792,
+            0.1556204760892654,
+            26.38624404150922,
+            -0.46128309116626415
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.175462581153348,
+            0.2368221844581369,
+            0.3382345292324532,
+            39.4616290598842,
+            0.19132649525148693
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.01684499458477651,
+            0.15083047950630898,
+            0.1328215605410502,
+            23.716297698008233,
+            1.3727534325856021
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 59.26527851003084,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.07978241160471441
+        }
+      },
+      "model_kruskal_h": 59.26527851003084,
+      "model_p_value": 0.025,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.060970081595648234,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1089,
+          "pct": 0.2467709041468389
+        },
+        "trending_down_choppy": {
+          "count": 1853,
+          "pct": 0.4198957625198278
+        },
+        "trending_up_choppy": {
+          "count": 1471,
+          "pct": 0.3333333333333333
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3864149394623435,
+          "transition_rate": 0.07573891625615764,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.4198957625198278,
+          "transition_rate": 0.07978241160471441,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.420 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.36181943487250173,
+          "transition_rate": 0.09396898334290638,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.39040860707336617,
+          "transition_rate": 0.08218864468864469,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.3730509657900861,
+          "transition_rate": 0.09636871508379888,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0714607837399639,
+            0.15068051113574135,
+            0.14317946201528806,
+            21.26889515640951,
+            0.04299006141161928
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0025392083597263453,
+            0.12476983195411018,
+            0.03591561618200684,
+            20.606671367681983,
+            -0.16169419711215172
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1662391541858888,
+            0.2323169722053023,
+            0.3228388864307934,
+            41.4289225165903,
+            0.3263809887151658
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1722278885663252,
+            0.23385624517888498,
+            0.33292250729246625,
+            38.8585420338676,
+            0.20570896021215257
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.05454182503878871,
+            0.1500937064017533,
+            0.1078805295778515,
+            25.02177749408476,
+            0.10464420648872107
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.10172936409544782,
+            0.1721476578318134,
+            0.2022681146190766,
+            34.3214246196568,
+            -0.23626105939052808
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 48.76631615563565,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.041666666666666664,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.08726201269265639
+        }
+      },
+      "model_kruskal_h": 48.76631615563565,
+      "model_p_value": 0.041666666666666664,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.05349048050770626,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1015,
+          "pct": 0.23000226603217766
+        },
+        "trending_down_choppy": {
+          "count": 1868,
+          "pct": 0.42329481078631315
+        },
+        "trending_up_choppy": {
+          "count": 1530,
+          "pct": 0.3467029231815092
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4005745947055202,
+          "transition_rate": 0.08641215106732349,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.401 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.42329481078631315,
+          "transition_rate": 0.08726201269265639,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.423 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.37250172294968986,
+          "transition_rate": 0.10074669730040207,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4034565640379993,
+          "transition_rate": 0.09088827838827838,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.403 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.37561089131952524,
+          "transition_rate": 0.09916201117318436,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0005439425378389474,
+            0.1252519608187645,
+            0.03237182181645801,
+            20.73079396843752,
+            -0.12903868118577894
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.05438274257064293,
+            0.1496380622672627,
+            0.10762187545397324,
+            24.98896366797629,
+            0.09354846578001938
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.114858377982165,
+            0.1836962131013481,
+            0.22998169911668132,
+            28.56269667726767,
+            0.3296479486178314
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16579462316726049,
+            0.23187842431589206,
+            0.32201717440543975,
+            41.41276808176311,
+            0.33747987213425856
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.2011884136943275,
+            0.25617406245298513,
+            0.3831820502833389,
+            43.243892581659935,
+            0.09180285231713531
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.05748876643499691,
+            0.1414544637118303,
+            0.11485562297087015,
+            19.58316697914081,
+            -0.10626485440992507
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1016236333388963,
+            0.17200801495846468,
+            0.2020249348618816,
+            34.26834445177817,
+            -0.256971125677373
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 108.99048895929263,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.062330009066183134
+        }
+      },
+      "model_kruskal_h": 108.99048895929263,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.07842248413417952,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1992,
+          "pct": 0.451393609789259
+        },
+        "ranging_volatile": {
+          "count": 2421,
+          "pct": 0.548606390210741
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5665914221218962,
+          "transition_rate": 0.06568144499178982,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.567 > 0.400",
+            "min_transition_rate: 0.0657 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.548606390210741,
+          "transition_rate": 0.062330009066183134,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.549 > 0.400",
+            "min_transition_rate: 0.0623 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5994716287617735,
+          "transition_rate": 0.061688684663986214,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.599 > 0.400",
+            "min_transition_rate: 0.0617 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5781160581435275,
+          "transition_rate": 0.061469780219780217,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.578 > 0.400",
+            "min_transition_rate: 0.0615 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5925063998138236,
+          "transition_rate": 0.0728584729981378,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.593 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.011126609600200366,
+            0.20707009712376603,
+            0.2686774644745883,
+            36.50223919432127,
+            0.336833839870164
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0052272847118849785,
+            0.13777086105731418,
+            0.08816356875591594,
+            21.551982429068584,
+            -0.22261860676982673
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 125.18091505869597,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.08544877606527652
+        }
+      },
+      "model_kruskal_h": 125.18091505869597,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.055303717135086125,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 2161,
+          "pct": 0.489689553591661
+        },
+        "ranging_volatile": {
+          "count": 2252,
+          "pct": 0.510310446408339
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5308844654217115,
+          "transition_rate": 0.09072249589490969,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.531 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.510310446408339,
+          "transition_rate": 0.08544877606527652,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.510 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5622559154606018,
+          "transition_rate": 0.09661114302125215,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.562 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5370264392812178,
+          "transition_rate": 0.09993131868131869,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.537 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5543402373749128,
+          "transition_rate": 0.11149906890130354,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.554 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006172053280091608,
+            0.13665922590339108,
+            0.08466293843544677,
+            21.225595762447135,
+            -0.3092034321383168
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.011961635855633878,
+            0.214151782751413,
+            0.2827240375913968,
+            38.185519846906836,
+            -0.30888158947867644
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0047098573019325966,
+            0.1756372676037407,
+            0.19697604796214363,
+            29.70472552521564,
+            1.64813214578484
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 100.60803348097943,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.11786038077969176
+        }
+      },
+      "model_kruskal_h": 100.60803348097943,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.022892112420670893,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1381,
+          "pct": 0.31293904373442105
+        },
+        "ranging_volatile": {
+          "count": 1673,
+          "pct": 0.37910718332200316
+        },
+        "trending_down_choppy": {
+          "count": 835,
+          "pct": 0.18921368683435305
+        },
+        "trending_up_choppy": {
+          "count": 524,
+          "pct": 0.11874008610922275
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.410014364867638,
+          "transition_rate": 0.12602627257799673,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.410 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.37910718332200316,
+          "transition_rate": 0.11786038077969176,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4564668045026419,
+          "transition_rate": 0.11051120045950603,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.456 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.41913700354812866,
+          "transition_rate": 0.11813186813186813,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.419 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.42355131487084013,
+          "transition_rate": 0.12197392923649907,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.424 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.004692006561165264,
+            0.16383232723139374,
+            0.16235482496425496,
+            27.017239946673218,
+            -0.4187191490415647
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17278454046245995,
+            0.23198741403402603,
+            0.3339599243836496,
+            38.31333066444121,
+            0.47588516857323954
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1480139190301913,
+            0.21626213582347298,
+            0.2885495636076294,
+            40.42920546177693,
+            0.4069005546673823
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006043959474664448,
+            0.12908150181070174,
+            0.06146541475535555,
+            20.53051547414164,
+            0.07058756083349929
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 81.26295945002857,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.009166666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.13259292837715322
+        }
+      },
+      "model_kruskal_h": 81.26295945002857,
+      "model_p_value": 0.009166666666666667,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.008159564823209425,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1307,
+          "pct": 0.2961704056197598
+        },
+        "ranging_volatile": {
+          "count": 1938,
+          "pct": 0.43915703602991163
+        },
+        "trending_down_choppy": {
+          "count": 736,
+          "pct": 0.1667799682755495
+        },
+        "trending_up_choppy": {
+          "count": 432,
+          "pct": 0.09789259007477906
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.46357479991791506,
+          "transition_rate": 0.15004105090311987,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.464 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.43915703602991163,
+          "transition_rate": 0.13259292837715322,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.439 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5147025040202159,
+          "transition_rate": 0.12326249282021827,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.515 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.47556369463202475,
+          "transition_rate": 0.14354395604395603,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.476 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.47381894344891784,
+          "transition_rate": 0.15130353817504655,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.474 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005351250801701119,
+            0.12715595699342316,
+            0.05367334642097259,
+            20.201766387975937,
+            -0.37397317213587655
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.15857077006383724,
+            0.2260458414583939,
+            0.30841504823782845,
+            41.906114510062686,
+            0.30856211207240397
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.010861117572208727,
+            0.16759016666855292,
+            0.17286363987685144,
+            28.223502042470322,
+            -0.46937266052978605
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18416290033339877,
+            0.2420345345778605,
+            0.3545414260334847,
+            40.45136640785693,
+            0.23223750273378208
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.015155169478344704,
+            0.14752433258421613,
+            0.12392602533086028,
+            23.370108601011047,
+            1.2797587692679688
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 61.10653306758104,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.02,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.08272892112420671
+        }
+      },
+      "model_kruskal_h": 61.10653306758104,
+      "model_p_value": 0.02,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.05802357207615594,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2093,
+          "pct": 0.47428053478359394
+        },
+        "trending_down_choppy": {
+          "count": 1302,
+          "pct": 0.29503738953093134
+        },
+        "trending_up_choppy": {
+          "count": 1018,
+          "pct": 0.23068207568547475
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.485737738559409,
+          "transition_rate": 0.09236453201970443,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.486 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.47428053478359394,
+          "transition_rate": 0.08272892112420671,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.474 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.549161497817597,
+          "transition_rate": 0.07455485353245261,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.549 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5018885200869864,
+          "transition_rate": 0.07932692307692307,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.502 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5271119385617873,
+          "transition_rate": 0.0935754189944134,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.527 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0987556769632895,
+            0.17073840854507488,
+            0.1972169600653029,
+            25.375980192077886,
+            -0.29422034945567027
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006022350496790466,
+            0.1320679489089706,
+            0.06180904193844665,
+            20.711607845833626,
+            -0.4264677901489847
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1632711280723551,
+            0.22942847484362133,
+            0.31729553710001024,
+            41.626317657995074,
+            0.33930853244690573
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18704145094989,
+            0.243436951176063,
+            0.3599719342078359,
+            40.762032957894604,
+            0.28723639807121876
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.003791644628224203,
+            0.14343640367483473,
+            0.10169749772366159,
+            23.204674513168897,
+            1.420553137566423
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09407142944587808,
+            0.16917468325665427,
+            0.18659783700350774,
+            32.32327594580013,
+            -0.40120886954572943
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 44.716464872422875,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0425,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.11106074342701723
+        }
+      },
+      "model_kruskal_h": 44.716464872422875,
+      "model_p_value": 0.0425,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.02969174977334542,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1701,
+          "pct": 0.38545207341944254
+        },
+        "trending_down_choppy": {
+          "count": 1425,
+          "pct": 0.32290958531611147
+        },
+        "trending_up_choppy": {
+          "count": 1287,
+          "pct": 0.29163834126444593
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3691770982967371,
+          "transition_rate": 0.11904761904761904,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.38545207341944254,
+          "transition_rate": 0.11106074342701723,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.4566965311279577,
+          "transition_rate": 0.10488225157955199,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.457 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.40528785624356184,
+          "transition_rate": 0.11641483516483517,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.405 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.42774028391901325,
+          "transition_rate": 0.13058659217877094,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.428 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.0029786860286036883,
+            0.12823669171429322,
+            0.041911590736689916,
+            20.95595483341993,
+            -0.3814498868509362
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.003839813580491595,
+            0.14546125554532283,
+            0.1066824686669588,
+            23.72600299992314,
+            1.5744499989004275
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11794939282616225,
+            0.18777105737061717,
+            0.234637575238553,
+            29.136662192550933,
+            -0.11656118465543035
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1610174449404235,
+            0.2275967814303901,
+            0.31310165106504106,
+            41.47081351353459,
+            0.31305755525433393
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.19982118425557363,
+            0.25247057622647323,
+            0.38227178110394167,
+            42.71787087329132,
+            0.27054491562978406
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.062247890635821236,
+            0.14360017724166732,
+            0.12509914664580354,
+            19.935861023874523,
+            -0.37443882757608543
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08864129856460465,
+            0.16615995449819118,
+            0.17583845094520315,
+            31.065334978645865,
+            -0.43701905105258754
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 71.87276930730513,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.010833333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.031958295557570265
+        }
+      },
+      "model_kruskal_h": 71.87276930730513,
+      "model_p_value": 0.010833333333333334,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.10879419764279238,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1582,
+          "pct": 0.35848629050532516
+        },
+        "ranging_volatile": {
+          "count": 2831,
+          "pct": 0.6415137094946748
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6618099733223887,
+          "transition_rate": 0.027914614121510674,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.662 > 0.400",
+            "min_transition_rate: 0.0279 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.6415137094946748,
+          "transition_rate": 0.031958295557570265,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.642 > 0.400",
+            "min_transition_rate: 0.0320 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6883758327590168,
+          "transition_rate": 0.02469844916714532,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.688 > 0.400",
+            "min_transition_rate: 0.0247 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6559459768799359,
+          "transition_rate": 0.027815934065934064,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.656 > 0.400",
+            "min_transition_rate: 0.0278 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6825692343495462,
+          "transition_rate": 0.029562383612662942,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.683 > 0.400",
+            "min_transition_rate: 0.0296 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.019521377793891945,
+            0.22360552879904153,
+            0.3026848803593148,
+            40.05796647627371,
+            0.18967788311770528
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0024771130675424156,
+            0.14196527381023197,
+            0.10312058306106797,
+            22.46199548369064,
+            -0.06395142504393973
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 93.94093527095538,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.08680870353581142
+        }
+      },
+      "model_kruskal_h": 93.94093527095538,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.053943789664551225,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1788,
+          "pct": 0.4051665533650578
+        },
+        "ranging_volatile": {
+          "count": 2625,
+          "pct": 0.5948334466349422
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6084547506669403,
+          "transition_rate": 0.09729064039408868,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.608 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5948334466349422,
+          "transition_rate": 0.08680870353581142,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.595 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6308293131173903,
+          "transition_rate": 0.0945433658816772,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.631 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6037541490214032,
+          "transition_rate": 0.09970238095238096,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.604 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6283453572259716,
+          "transition_rate": 0.11056797020484171,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.628 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.002700579838683737,
+            0.14142506821994602,
+            0.1015346969862079,
+            22.277067002976278,
+            -0.27731223962594387
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.020849147745431063,
+            0.2247971054558101,
+            0.3034313586855756,
+            40.495460657537414,
+            -0.13265575002530663
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0018282671636770222,
+            0.16895588464392536,
+            0.17854176827156532,
+            28.19315292805376,
+            2.770720513308974
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 101.13987237565016,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.0883952855847688
+        }
+      },
+      "model_kruskal_h": 101.13987237565016,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.05235720761559384,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1426,
+          "pct": 0.32313618853387716
+        },
+        "ranging_volatile": {
+          "count": 1642,
+          "pct": 0.3720824835712667
+        },
+        "trending_down_choppy": {
+          "count": 873,
+          "pct": 0.19782460910944935
+        },
+        "trending_up_choppy": {
+          "count": 472,
+          "pct": 0.10695671878540676
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.41617073671249744,
+          "transition_rate": 0.09523809523809523,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.416 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3720824835712667,
+          "transition_rate": 0.0883952855847688,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4492304158051918,
+          "transition_rate": 0.0800689259046525,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.449 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.41490214032276523,
+          "transition_rate": 0.08836996336996338,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.415 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.41331161275308353,
+          "transition_rate": 0.09101489757914338,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.413 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.005663130430038441,
+            0.16607980086525428,
+            0.15620301193460653,
+            27.039602936334646,
+            -0.32922146230698474
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17943301624198163,
+            0.23882457338892915,
+            0.34613444514083047,
+            40.08117595833316,
+            0.29660432911604734
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.14013948299828016,
+            0.20976939295638453,
+            0.27266510874509403,
+            40.81568481190444,
+            0.17330413525364616
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009463908450059233,
+            0.12824518245989425,
+            0.07008091792127144,
+            19.563130415646917,
+            0.09447942435529398
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 133.5403262340733,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.1373526745240254
+        }
+      },
+      "model_kruskal_h": 133.5403262340733,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.003399818676337263,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1342,
+          "pct": 0.304101518241559
+        },
+        "ranging_directional_up": {
+          "count": 327,
+          "pct": 0.07409925220938138
+        },
+        "ranging_volatile": {
+          "count": 1580,
+          "pct": 0.3580330840697938
+        },
+        "trending_down_choppy": {
+          "count": 743,
+          "pct": 0.16836619079990936
+        },
+        "trending_up_choppy": {
+          "count": 421,
+          "pct": 0.09539995467935644
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.39872768315206236,
+          "transition_rate": 0.1473727422003284,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.3580330840697938,
+          "transition_rate": 0.1373526745240254,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.42637261658626235,
+          "transition_rate": 0.1360137851809305,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.426 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.39967952386402655,
+          "transition_rate": 0.15739468864468864,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.400 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.39166860600418896,
+          "transition_rate": 0.16457169459962756,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.012824237708183162,
+            0.12941658577436485,
+            0.07148720771563859,
+            19.252747896872204,
+            -0.25786935156708013
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.15091225282139828,
+            0.2207984710037759,
+            0.29207259605107794,
+            42.75236597219731,
+            -0.020865083605882098
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.014230132840734747,
+            0.1679557245723894,
+            0.1660458307004641,
+            28.967453343994826,
+            -0.3073701733214702
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18170081800851656,
+            0.24126230993341552,
+            0.34954351280388885,
+            40.60093556331208,
+            0.021388841216556737
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.009529732375554054,
+            0.16135036177547815,
+            0.15796168558442955,
+            26.57418910993238,
+            2.8875167588250923
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 102.83841248134013,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.12647325475974613
+        }
+      },
+      "model_kruskal_h": 102.83841248134013,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.014279238440616515,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 314,
+          "pct": 0.07115341037842737
+        },
+        "ranging_volatile": {
+          "count": 1765,
+          "pct": 0.39995467935644685
+        },
+        "trending_down_choppy": {
+          "count": 1366,
+          "pct": 0.30953999546793565
+        },
+        "trending_up_choppy": {
+          "count": 968,
+          "pct": 0.21935191479719013
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.4252000820849579,
+          "transition_rate": 0.12910509031198686,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.425 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.39995467935644685,
+          "transition_rate": 0.12647325475974613,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.400 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4735814380886745,
+          "transition_rate": 0.13107409534750145,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.474 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.43241387203845716,
+          "transition_rate": 0.13782051282051283,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.432 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.44263439609029553,
+          "transition_rate": 0.14594972067039105,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.443 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1076826455759808,
+            0.1814784757777106,
+            0.21389970522422797,
+            27.868472575174607,
+            -0.19515328962351466
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009204998707918232,
+            0.13125069148645063,
+            0.07005728359023154,
+            19.91361454035915,
+            -0.2779724364875021
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.17033067574268174,
+            0.2387689879054511,
+            0.3291049665686582,
+            45.469208533575596,
+            0.13705381448107734
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1993372284197829,
+            0.25547651647507114,
+            0.38035915747580035,
+            44.09779490171881,
+            0.04507044226184777
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.011763274414507084,
+            0.1588766216416314,
+            0.15221848363032958,
+            26.003598355319426,
+            2.8302336712709537
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09267234325582244,
+            0.17233173386804115,
+            0.1839456354895932,
+            32.38449062993427,
+            -0.2957035579692628
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.2101297016361,
+          "model_kruskal_h": 101.69041007643682,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.13667271078875792
+        }
+      },
+      "model_kruskal_h": 101.69041007643682,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.2101297016361,
+      "stability_gain": 0.0040797824116047265,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 304,
+          "pct": 0.06888737820077045
+        },
+        "ranging_volatile": {
+          "count": 1484,
+          "pct": 0.33627917516428735
+        },
+        "trending_down_choppy": {
+          "count": 1413,
+          "pct": 0.3201903467029232
+        },
+        "trending_up_choppy": {
+          "count": 1212,
+          "pct": 0.274643099932019
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3363431151241535,
+          "transition_rate": 0.14142036124794746,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.33627917516428735,
+          "transition_rate": 0.13667271078875792,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.40041350792556857,
+          "transition_rate": 0.13957495692130958,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.400 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.36694517568959595,
+          "transition_rate": 0.1450320512820513,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.36723295322317895,
+          "transition_rate": 0.15595903165735567,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.003927887776013113,
+            0.12728597650747844,
+            0.05592424300691538,
+            20.331487570843304,
+            -0.25202369180026685
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.01071468832996898,
+            0.15948323598374547,
+            0.1526087450761904,
+            26.40199464025296,
+            2.933985995727722
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1419194447812552,
+            0.21326751768050994,
+            0.27774909845069573,
+            32.415889697196086,
+            -0.07816486920492356
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16977686795831398,
+            0.2383367039773286,
+            0.32784766156826817,
+            45.530306245798556,
+            0.13866588025901452
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.21409238284675647,
+            0.2647248950756555,
+            0.40840880208626984,
+            49.2133804284486,
+            0.09110775212678958
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07452418752317462,
+            0.15468808193665623,
+            0.15032821214042338,
+            21.367133947918582,
+            -0.27666812281263947
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09284199464786871,
+            0.17250523430633025,
+            0.18463939364259868,
+            32.17434848508409,
+            -0.29387533482783434
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 113.4134393463628,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.028377110694183864
+        }
+      },
+      "model_kruskal_h": 113.4134393463628,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.11421200750469043,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1764,
+          "pct": 0.41359906213364594
+        },
+        "ranging_volatile": {
+          "count": 2501,
+          "pct": 0.586400937866354
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5995767195767195,
+          "transition_rate": 0.029212531752751906,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.600 > 0.400",
+            "min_transition_rate: 0.0292 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.586400937866354,
+          "transition_rate": 0.028377110694183864,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.586 > 0.400",
+            "min_transition_rate: 0.0284 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6403365272259873,
+          "transition_rate": 0.026527988781114877,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.640 > 0.400",
+            "min_transition_rate: 0.0265 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6034462684829432,
+          "transition_rate": 0.027130880298090358,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.603 > 0.400",
+            "min_transition_rate: 0.0271 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6302723547842853,
+          "transition_rate": 0.030617164898746385,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.630 > 0.400",
+            "min_transition_rate: 0.0306 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.013548544438709035,
+            0.2114457323052713,
+            0.2785143201304661,
+            37.86212327356053,
+            0.1867675919018435
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006089672070217427,
+            0.13752984372397697,
+            0.090769362700906,
+            21.447076363020663,
+            0.16053420709262323
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 112.99557195868147,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.036585365853658534
+        }
+      },
+      "model_kruskal_h": 112.99557195868147,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.10600375234521575,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2351,
+          "pct": 0.5512309495896834
+        },
+        "trending_down_choppy": {
+          "count": 1247,
+          "pct": 0.29237983587338806
+        },
+        "trending_up_choppy": {
+          "count": 667,
+          "pct": 0.1563892145369285
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5574603174603174,
+          "transition_rate": 0.03408128704487722,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.557 > 0.400",
+            "min_transition_rate: 0.0341 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5512309495896834,
+          "transition_rate": 0.036585365853658534,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.551 > 0.400",
+            "min_transition_rate: 0.0366 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.613811638233232,
+          "transition_rate": 0.03120252424915274,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.614 > 0.400",
+            "min_transition_rate: 0.0312 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5794621026894865,
+          "transition_rate": 0.03295295761527713,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.579 > 0.400",
+            "min_transition_rate: 0.0330 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6001446131597975,
+          "transition_rate": 0.03929604628736741,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.600 > 0.400",
+            "min_transition_rate: 0.0393 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.011433566697571824,
+            0.1356038210475926,
+            0.08381902484615578,
+            21.096104051910224,
+            0.16042505268297721
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.11989689681320748,
+            0.1932952258605128,
+            0.23591241556785927,
+            36.79803580236397,
+            0.17276265612819425
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.15782052075783357,
+            0.22203450408286451,
+            0.30701042644840715,
+            36.41507125351555,
+            0.19802975597828829
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 104.15160880220901,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.005833333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.03353658536585366
+        }
+      },
+      "model_kruskal_h": 104.15160880220901,
+      "model_p_value": 0.005833333333333334,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.10905253283302063,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2566,
+          "pct": 0.6016412661195779
+        },
+        "trending_down_choppy": {
+          "count": 1164,
+          "pct": 0.27291910902696365
+        },
+        "trending_up_choppy": {
+          "count": 535,
+          "pct": 0.1254396248534584
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.6148148148148148,
+          "transition_rate": 0.0283657917019475,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.615 > 0.400",
+            "min_transition_rate: 0.0284 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.6016412661195779,
+          "transition_rate": 0.03353658536585366,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.602 > 0.400",
+            "min_transition_rate: 0.0335 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6514372516943211,
+          "transition_rate": 0.02746289587472245,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.651 > 0.400",
+            "min_transition_rate: 0.0275 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6414017929910351,
+          "transition_rate": 0.029576152771308803,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.641 > 0.400",
+            "min_transition_rate: 0.0296 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6572668112798264,
+          "transition_rate": 0.0349566055930569,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.657 > 0.400",
+            "min_transition_rate: 0.0350 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17057138134983119,
+            0.2330383263682429,
+            0.3298866676533155,
+            38.712525050540776,
+            0.1972807740001682
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.027017371400157794,
+            0.14923808367244645,
+            0.11048440080618219,
+            23.712693856242996,
+            0.20504974192048334
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12428939083338897,
+            0.19457179330688198,
+            0.24429286601599937,
+            37.518749301924586,
+            0.17066430263550275
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00669183354146224,
+            0.13239433990716115,
+            0.08069382114011932,
+            20.205028633506036,
+            0.13682697776137365
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 72.57035352896673,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.006666666666666667,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.07199812382739212
+        }
+      },
+      "model_kruskal_h": 72.57035352896673,
+      "model_p_value": 0.006666666666666667,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.07059099437148217,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1418,
+          "pct": 0.3324736225087925
+        },
+        "trending_down_choppy": {
+          "count": 1581,
+          "pct": 0.37069167643610784
+        },
+        "trending_up_choppy": {
+          "count": 1266,
+          "pct": 0.2968347010550996
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.371005291005291,
+          "transition_rate": 0.06689246401354784,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "min_transition_rate: 0.0669 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.37069167643610784,
+          "transition_rate": 0.07199812382739212,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.39132974994157516,
+          "transition_rate": 0.07116980250087647,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.3737338456164862,
+          "transition_rate": 0.06951560316721006,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.3755121716076163,
+          "transition_rate": 0.07690453230472517,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.08474554577303862,
+            0.16450674526784406,
+            0.16826538446308545,
+            30.167918724719,
+            0.1599486365875838
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07479718234117903,
+            0.15302714345732393,
+            0.15037983482160466,
+            21.640039454585967,
+            0.17046897962730037
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17443739565388167,
+            0.23606007955347866,
+            0.3365778537568653,
+            39.22554998789569,
+            0.20045951378616464
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.0014764536096485877,
+            0.1265961720819987,
+            0.045303135129644886,
+            20.985955541623195,
+            0.15903862153014392
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16341226173776444,
+            0.22795659399038104,
+            0.3178982028821827,
+            42.746053783300056,
+            0.19037968556758672
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 79.47408500190613,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0225,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.0525328330206379
+        }
+      },
+      "model_kruskal_h": 79.47408500190613,
+      "model_p_value": 0.0225,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.09005628517823638,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1944,
+          "pct": 0.45580304806565064
+        },
+        "trending_down_choppy": {
+          "count": 1360,
+          "pct": 0.31887456037514655
+        },
+        "trending_up_choppy": {
+          "count": 961,
+          "pct": 0.2253223915592028
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.46645502645502646,
+          "transition_rate": 0.05059271803556308,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.466 > 0.400",
+            "min_transition_rate: 0.0506 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.45580304806565064,
+          "transition_rate": 0.0525328330206379,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.456 > 0.400",
+            "min_transition_rate: 0.0525 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5271091376489834,
+          "transition_rate": 0.04873203225429473,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.527 > 0.400",
+            "min_transition_rate: 0.0487 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4817790196763302,
+          "transition_rate": 0.047741034000931534,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.482 > 0.400",
+            "min_transition_rate: 0.0477 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5145818269462521,
+          "transition_rate": 0.05424300867888139,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.515 > 0.400",
+            "min_transition_rate: 0.0542 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.193246897115381,
+            0.24900901823045368,
+            0.3702833679266134,
+            41.896460171431826,
+            0.20447643412262412
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09134654049147946,
+            0.16714757137595787,
+            0.18084088407987145,
+            32.139562983437564,
+            0.1580259913824633
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1022151193619331,
+            0.17595072270888984,
+            0.20427457800238502,
+            26.80489107099741,
+            0.17964144108299399
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0075025976847429765,
+            0.13065103881762147,
+            0.0672561670368558,
+            19.69857955984334,
+            0.14063448490016647
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.007353847540222034,
+            0.13786934711862878,
+            0.07372989911131711,
+            23.03495326806372,
+            0.22088375384774958
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16406174753039376,
+            0.2293112559689225,
+            0.31905798572301214,
+            42.80317933163424,
+            0.1914357456497566
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 74.14040339045096,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.020833333333333332,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.052063789868667915
+        }
+      },
+      "model_kruskal_h": 74.14040339045096,
+      "model_p_value": 0.020833333333333332,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.09052532833020638,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1910,
+          "pct": 0.447831184056272
+        },
+        "trending_down_choppy": {
+          "count": 1231,
+          "pct": 0.28862837045720985
+        },
+        "trending_up_choppy": {
+          "count": 1124,
+          "pct": 0.26354044548651817
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.46814814814814815,
+          "transition_rate": 0.04593564775613886,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.468 > 0.400",
+            "min_transition_rate: 0.0459 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.447831184056272,
+          "transition_rate": 0.052063789868667915,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.448 > 0.400",
+            "min_transition_rate: 0.0521 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5227856975928955,
+          "transition_rate": 0.04359004323945308,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.523 > 0.400",
+            "min_transition_rate: 0.0436 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4787518919548259,
+          "transition_rate": 0.04343269678621332,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.479 > 0.400",
+            "min_transition_rate: 0.0434 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5179561340081947,
+          "transition_rate": 0.04604628736740598,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.518 > 0.400",
+            "min_transition_rate: 0.0460 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.12702346054417635,
+            0.19916066424546075,
+            0.2535238207212325,
+            31.434908485775942,
+            0.19475804481027092
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.006615051754833264,
+            0.12879870247482125,
+            0.06324455493276473,
+            21.250545199584284,
+            0.16495318052454344
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.2085465028073811,
+            0.260595111011987,
+            0.39670171983677227,
+            44.76838260924695,
+            0.20825177639392628
+          ],
+          "volatility_rank": 6
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.01231757392273914,
+            0.13789435566779393,
+            0.08641372754960323,
+            21.71779636171656,
+            0.22915556760775746
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.0762700615232289,
+            0.15426809135044023,
+            0.14991011197128742,
+            21.65826532499588,
+            0.1530753350355968
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.007132068690909784,
+            0.1338511916243254,
+            0.0715861339375853,
+            20.579779673166307,
+            0.11338616335357765
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12118414616956846,
+            0.19360277386053049,
+            0.23850106603339882,
+            37.05398480592805,
+            0.17165401004203543
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 105.30978328985657,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.03025328330206379
+        }
+      },
+      "model_kruskal_h": 105.30978328985657,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.11233583489681051,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1717,
+          "pct": 0.40257913247362254
+        },
+        "ranging_volatile": {
+          "count": 2548,
+          "pct": 0.5974208675263775
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6088888888888889,
+          "transition_rate": 0.03217612193056731,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.609 > 0.400",
+            "min_transition_rate: 0.0322 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5974208675263775,
+          "transition_rate": 0.03025328330206379,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.597 > 0.400",
+            "min_transition_rate: 0.0303 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6495676559943913,
+          "transition_rate": 0.027930349421526234,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.650 > 0.400",
+            "min_transition_rate: 0.0279 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6108976597974153,
+          "transition_rate": 0.028761061946902654,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.611 > 0.400",
+            "min_transition_rate: 0.0288 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6440106049650518,
+          "transition_rate": 0.03254580520732883,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.644 > 0.400",
+            "min_transition_rate: 0.0325 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.016780734154174977,
+            0.21231169760260923,
+            0.2830181706425401,
+            37.84690321093151,
+            0.18693508283594767
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.004249253169095793,
+            0.13846004560538255,
+            0.09171473499448682,
+            21.78130018189347,
+            0.16095036028125864
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 116.74209487349799,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.008333333333333333,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.0349437148217636
+        }
+      },
+      "model_kruskal_h": 116.74209487349799,
+      "model_p_value": 0.008333333333333333,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.10764540337711069,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2522,
+          "pct": 0.591324736225088
+        },
+        "trending_down_choppy": {
+          "count": 1153,
+          "pct": 0.27033997655334113
+        },
+        "trending_up_choppy": {
+          "count": 590,
+          "pct": 0.13833528722157093
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5934391534391534,
+          "transition_rate": 0.03556308213378493,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.593 > 0.400",
+            "min_transition_rate: 0.0356 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.591324736225088,
+          "transition_rate": 0.0349437148217636,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.591 > 0.400",
+            "min_transition_rate: 0.0349 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.646880112175742,
+          "transition_rate": 0.02980016360874138,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.647 > 0.400",
+            "min_transition_rate: 0.0298 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6142740714867855,
+          "transition_rate": 0.034699580810433166,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.614 > 0.400",
+            "min_transition_rate: 0.0347 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.64352856109906,
+          "transition_rate": 0.03833172613307618,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.644 > 0.400",
+            "min_transition_rate: 0.0383 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009933049610985378,
+            0.13842892564770876,
+            0.08945425021678713,
+            21.628172266540055,
+            0.1616074723738555
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12678681341819184,
+            0.19626404171011344,
+            0.24901353552666,
+            37.93701045601447,
+            0.17329254074525988
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1642703395092552,
+            0.2266613231718531,
+            0.31870034640883715,
+            37.286104765781786,
+            0.1990589112764592
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 120.52092401730806,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.09216697936210132
+        }
+      },
+      "model_kruskal_h": 120.52092401730806,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.050422138836772976,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1634,
+          "pct": 0.3831184056271981
+        },
+        "ranging_volatile": {
+          "count": 1436,
+          "pct": 0.336694021101993
+        },
+        "trending_down_choppy": {
+          "count": 792,
+          "pct": 0.18569753810082062
+        },
+        "trending_up_choppy": {
+          "count": 403,
+          "pct": 0.09449003516998827
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3691005291005291,
+          "transition_rate": 0.09398814563928874,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3831184056271981,
+          "transition_rate": 0.09216697936210132,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3993923813975228,
+          "transition_rate": 0.08636204277199953,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.36930958202351843,
+          "transition_rate": 0.09024219841639497,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.38467100506146057,
+          "transition_rate": 0.09305689488910318,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1809384657930981,
+            0.24011838168349856,
+            0.3489927268835633,
+            40.025526561948126,
+            0.20299044640453554
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0033502328616117957,
+            0.16096498094723366,
+            0.16037984462286947,
+            26.03570144012729,
+            0.1664183060892308
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.14835072118552312,
+            0.21410899056970448,
+            0.28907531197204217,
+            41.409390386555124,
+            0.18157714072841158
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.00446743416381886,
+            0.12680260338636187,
+            0.05172983707836752,
+            20.347144262125724,
+            0.15929689659665444
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 92.66635992362535,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.07152908067542214
+        }
+      },
+      "model_kruskal_h": 92.66635992362535,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.07106003752345215,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1767,
+          "pct": 0.41430246189917935
+        },
+        "trending_down_choppy": {
+          "count": 1409,
+          "pct": 0.33036342321219225
+        },
+        "trending_up_choppy": {
+          "count": 1089,
+          "pct": 0.2553341148886284
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4002116402116402,
+          "transition_rate": 0.07768839966130398,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.400 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.41430246189917935,
+          "transition_rate": 0.07152908067542214,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.414 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.472774012619771,
+          "transition_rate": 0.0707023489540727,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.473 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4286878565607172,
+          "transition_rate": 0.06520726595249185,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.429 > 0.400",
+            "min_transition_rate: 0.0652 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.46324415521812484,
+          "transition_rate": 0.0703953712632594,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.463 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09148454960668098,
+            0.16693091822345774,
+            0.18152509801332517,
+            31.517788876328623,
+            0.16150099605046245
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.08907989944412063,
+            0.1628641286445737,
+            0.17839445215512356,
+            23.71821116340751,
+            0.17577540836722505
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1843304144389902,
+            0.24198042659230395,
+            0.3552029918718801,
+            40.559036332583574,
+            0.2024704568461149
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0023154716925138834,
+            0.13129703581222604,
+            0.05758841394481577,
+            21.011374878664235,
+            0.15942442320615194
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16684383149810228,
+            0.23009185735388357,
+            0.3243465488894811,
+            42.572914339507584,
+            0.18925867049084608
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 91.43537690013909,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.006666666666666667,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.06308630393996248
+        }
+      },
+      "model_kruskal_h": 91.43537690013909,
+      "model_p_value": 0.006666666666666667,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.07950281425891181,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1962,
+          "pct": 0.4600234466588511
+        },
+        "trending_down_choppy": {
+          "count": 1338,
+          "pct": 0.3137162954279015
+        },
+        "trending_up_choppy": {
+          "count": 965,
+          "pct": 0.22626025791324736
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4617989417989418,
+          "transition_rate": 0.06435224386113463,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.462 > 0.400",
+            "min_transition_rate: 0.0644 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.4600234466588511,
+          "transition_rate": 0.06308630393996248,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.460 > 0.400",
+            "min_transition_rate: 0.0631 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5293292825426501,
+          "transition_rate": 0.05737992287016478,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.529 > 0.400",
+            "min_transition_rate: 0.0574 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4791011759226918,
+          "transition_rate": 0.058919422449930134,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.479 > 0.400",
+            "min_transition_rate: 0.0589 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5184381778741866,
+          "transition_rate": 0.06460945033751206,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.518 > 0.400",
+            "min_transition_rate: 0.0646 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1920411705017448,
+            0.2473211414653357,
+            0.3687449909283733,
+            41.61789868771314,
+            0.20389716615773276
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.0938748012892531,
+            0.16839490824046466,
+            0.1862368692596278,
+            32.12155329357365,
+            0.1615689679939354
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.10080907985185002,
+            0.17237716075531762,
+            0.2018429271884888,
+            25.940331646248055,
+            0.1806691653448059
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006055514498142519,
+            0.13348421135325006,
+            0.06661184887939417,
+            20.462377243708406,
+            0.14449939263711803
+          ],
+          "volatility_rank": 1
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.006197977162416817,
+            0.1318805468366793,
+            0.06396542450476204,
+            23.007586034178107,
+            0.22241461744308055
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16748522236861524,
+            0.2306880871853019,
+            0.3255540866407826,
+            42.62860562244262,
+            0.18952534224392
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 88.56880890221328,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.06941838649155722
+        }
+      },
+      "model_kruskal_h": 88.56880890221328,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.07317073170731707,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1742,
+          "pct": 0.4084407971864009
+        },
+        "trending_down_choppy": {
+          "count": 1370,
+          "pct": 0.3212192262602579
+        },
+        "trending_up_choppy": {
+          "count": 1153,
+          "pct": 0.27033997655334113
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.3887830687830688,
+          "transition_rate": 0.06879762912785775,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "min_transition_rate: 0.0688 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.4084407971864009,
+          "transition_rate": 0.06941838649155722,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.408 > 0.400",
+            "min_transition_rate: 0.0694 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.4629586351951391,
+          "transition_rate": 0.06275563865840832,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.463 > 0.400",
+            "min_transition_rate: 0.0628 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.41867504948189543,
+          "transition_rate": 0.0656730321378668,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.419 > 0.400",
+            "min_transition_rate: 0.0657 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.4408291154495059,
+          "transition_rate": 0.06967213114754098,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.441 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.12368339034941409,
+            0.19270456835756958,
+            0.2467013628977318,
+            30.137974074729044,
+            0.18658666399376894
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.002853001970846005,
+            0.13136633047021753,
+            0.058955051078690326,
+            20.646408959681047,
+            0.16132643735898117
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.2054503560578968,
+            0.2565535752283019,
+            0.391575666260345,
+            43.74907718920316,
+            0.20737930753726755
+          ],
+          "volatility_rank": 6
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0004633805655245675,
+            0.12651717095329093,
+            0.0448416351758994,
+            23.46476392068508,
+            0.21900508159744547
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.07087604952125365,
+            0.14909587467682384,
+            0.14226986910408518,
+            20.765691362451108,
+            0.1711100469782303
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.007103816305075715,
+            0.13199186477597685,
+            0.06016605466202839,
+            20.381129450040042,
+            0.11400147168258724
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1145676585038702,
+            0.18798107835018668,
+            0.22548593630661573,
+            35.310822756250296,
+            0.17205663779578445
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 98.09994813348567,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.02673545966228893
+        }
+      },
+      "model_kruskal_h": 98.09994813348567,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.11585365853658536,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1367,
+          "pct": 0.3205158264947245
+        },
+        "ranging_volatile": {
+          "count": 2898,
+          "pct": 0.6794841735052755
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6865608465608466,
+          "transition_rate": 0.027095681625740897,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.687 > 0.400",
+            "min_transition_rate: 0.0271 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.6794841735052755,
+          "transition_rate": 0.02673545966228893,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.679 > 0.400",
+            "min_transition_rate: 0.0267 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.7171068006543585,
+          "transition_rate": 0.02021736589926376,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.717 > 0.400",
+            "min_transition_rate: 0.0202 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.676795901734777,
+          "transition_rate": 0.026665114112715417,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.677 > 0.400",
+            "min_transition_rate: 0.0267 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.7124608339358882,
+          "transition_rate": 0.02579556412729026,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.712 > 0.400",
+            "min_transition_rate: 0.0258 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0395331066210884,
+            0.22607003208783916,
+            0.3096019841912122,
+            40.223425641216856,
+            0.1975308253896981
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.003044154198886517,
+            0.14306181032223003,
+            0.10721601367763822,
+            23.026138962510466,
+            0.16029371868986972
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 115.9695389298613,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.006666666666666667,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.03119136960600375
+        }
+      },
+      "model_kruskal_h": 115.9695389298613,
+      "model_p_value": 0.006666666666666667,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.11139774859287055,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2572,
+          "pct": 0.6030480656506448
+        },
+        "trending_down_choppy": {
+          "count": 1130,
+          "pct": 0.264947245017585
+        },
+        "trending_up_choppy": {
+          "count": 563,
+          "pct": 0.13200468933177023
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.6014814814814815,
+          "transition_rate": 0.03048264182895851,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.601 > 0.400",
+            "min_transition_rate: 0.0305 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.6030480656506448,
+          "transition_rate": 0.03119136960600375,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.603 > 0.400",
+            "min_transition_rate: 0.0312 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.653306847394251,
+          "transition_rate": 0.02816407619492813,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.653 > 0.400",
+            "min_transition_rate: 0.0282 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6231225986727209,
+          "transition_rate": 0.03213786679087098,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.623 > 0.400",
+            "min_transition_rate: 0.0321 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6488310436249699,
+          "transition_rate": 0.033992285438765674,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.649 > 0.400",
+            "min_transition_rate: 0.0340 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.010827993684025481,
+            0.13884941743562706,
+            0.09290845747270374,
+            21.49093933546125,
+            0.1605563904013232
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1265106024466458,
+            0.1973355856430425,
+            0.24840514729767238,
+            38.68152561208445,
+            0.17399419354976717
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.16662332244374836,
+            0.22980822524041122,
+            0.3226069326180082,
+            38.05516151228598,
+            0.20430562144555658
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 103.5996347020864,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.03025328330206379
+        }
+      },
+      "model_kruskal_h": 103.5996347020864,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.11233583489681051,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2677,
+          "pct": 0.6276670574443142
+        },
+        "trending_down_choppy": {
+          "count": 1085,
+          "pct": 0.2543962485345838
+        },
+        "trending_up_choppy": {
+          "count": 503,
+          "pct": 0.11793669402110199
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.6372486772486773,
+          "transition_rate": 0.0275190516511431,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.637 > 0.400",
+            "min_transition_rate: 0.0275 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.6276670574443142,
+          "transition_rate": 0.03025328330206379,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.628 > 0.400",
+            "min_transition_rate: 0.0303 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6792474877307783,
+          "transition_rate": 0.026294262007712982,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.679 > 0.400",
+            "min_transition_rate: 0.0263 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6614274071486785,
+          "transition_rate": 0.029809035863996275,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.661 > 0.400",
+            "min_transition_rate: 0.0298 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6885996625692938,
+          "transition_rate": 0.029170684667309547,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.689 > 0.400",
+            "min_transition_rate: 0.0292 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1755234875178817,
+            0.23737588174729546,
+            0.33830960437621016,
+            39.74250731709796,
+            0.2011423238139872
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.022614036944388058,
+            0.1467072612072752,
+            0.11494015671431745,
+            23.3037762804852,
+            0.22132624060525047
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12927214104080822,
+            0.1984500522355812,
+            0.25324927406140013,
+            39.3050518521937,
+            0.17362267208326768
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.008755563568953684,
+            0.13892591045063088,
+            0.09269155342692889,
+            21.254981209313485,
+            0.1409109162546187
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 99.70796538977629,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0075,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.036116322701688554
+        }
+      },
+      "model_kruskal_h": 99.70796538977629,
+      "model_p_value": 0.0075,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.10647279549718575,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2389,
+          "pct": 0.5601406799531067
+        },
+        "trending_down_choppy": {
+          "count": 1348,
+          "pct": 0.3160609613130129
+        },
+        "trending_up_choppy": {
+          "count": 528,
+          "pct": 0.12379835873388043
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5786243386243386,
+          "transition_rate": 0.0283657917019475,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.579 > 0.400",
+            "min_transition_rate: 0.0284 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5601406799531067,
+          "transition_rate": 0.036116322701688554,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.560 > 0.400",
+            "min_transition_rate: 0.0361 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.614746436083197,
+          "transition_rate": 0.033422928596470725,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.615 > 0.400",
+            "min_transition_rate: 0.0334 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6105483758295495,
+          "transition_rate": 0.03376804843968328,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.611 > 0.400",
+            "min_transition_rate: 0.0338 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6297903109182935,
+          "transition_rate": 0.0349566055930569,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.630 > 0.400",
+            "min_transition_rate: 0.0350 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.0885503546627741,
+            0.17202881821159907,
+            0.18615511478416574,
+            32.40887166641097,
+            0.15622673363078393
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.030252155809757077,
+            0.14633259775206267,
+            0.11144593426206181,
+            23.085696250742068,
+            0.22359181368996373
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1762401687103304,
+            0.23761675322471465,
+            0.339834345354554,
+            39.73207309866581,
+            0.2015213234190066
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.018776003431460905,
+            0.1351153110951957,
+            0.08493847860446493,
+            20.25642427979416,
+            0.14051449212852138
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1655572227234858,
+            0.23184046191332003,
+            0.3223756570833449,
+            45.82952775968972,
+            0.1970298913249664
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 65.57850643140227,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.03,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.04573170731707317
+        }
+      },
+      "model_kruskal_h": 65.57850643140227,
+      "model_p_value": 0.03,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.09685741088180112,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2063,
+          "pct": 0.48370457209847595
+        },
+        "trending_down_choppy": {
+          "count": 1355,
+          "pct": 0.31770222743259086
+        },
+        "trending_up_choppy": {
+          "count": 847,
+          "pct": 0.19859320046893317
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5053968253968254,
+          "transition_rate": 0.04149026248941575,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.505 > 0.400",
+            "min_transition_rate: 0.0415 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.48370457209847595,
+          "transition_rate": 0.04573170731707317,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.484 > 0.400",
+            "min_transition_rate: 0.0457 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5556204720729142,
+          "transition_rate": 0.04207081921234077,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.556 > 0.400",
+            "min_transition_rate: 0.0421 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5284666433810689,
+          "transition_rate": 0.044364229156963204,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.528 > 0.400",
+            "min_transition_rate: 0.0444 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5555555555555556,
+          "transition_rate": 0.044599807135969144,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.556 > 0.400",
+            "min_transition_rate: 0.0446 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.20439839861780998,
+            0.2567476603329103,
+            0.39005816654401293,
+            46.01027947572118,
+            0.21796644539657906
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09415702586595788,
+            0.17114036127535315,
+            0.18613416196559485,
+            32.318584561661204,
+            0.1568773305154599
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.12139130808893082,
+            0.19438414990744352,
+            0.24004592743021883,
+            29.74353272896396,
+            0.1744871029375746
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.01138841294114279,
+            0.13197777082089107,
+            0.07451904860768814,
+            19.65567590835484,
+            0.14010602168719255
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.01773960845488094,
+            0.1411934809368612,
+            0.09416984228412996,
+            22.483449565139715,
+            0.22585150518397198
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1655572227234858,
+            0.23184046191332003,
+            0.3223756570833449,
+            45.82952775968972,
+            0.1970298913249664
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 76.71623913299845,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.015833333333333335,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.05089118198874296
+        }
+      },
+      "model_kruskal_h": 76.71623913299845,
+      "model_p_value": 0.015833333333333335,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.09169793621013134,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2066,
+          "pct": 0.48440797186400936
+        },
+        "trending_down_choppy": {
+          "count": 1120,
+          "pct": 0.26260257913247365
+        },
+        "trending_up_choppy": {
+          "count": 1079,
+          "pct": 0.252989449003517
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5136507936507937,
+          "transition_rate": 0.04826418289585097,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.514 > 0.400",
+            "min_transition_rate: 0.0483 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.48440797186400936,
+          "transition_rate": 0.05089118198874296,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.484 > 0.400",
+            "min_transition_rate: 0.0509 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5653189997663005,
+          "transition_rate": 0.04323945307935024,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.565 > 0.400",
+            "min_transition_rate: 0.0432 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5264873675631622,
+          "transition_rate": 0.042151839776432234,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.526 > 0.400",
+            "min_transition_rate: 0.0422 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5649554109423958,
+          "transition_rate": 0.0467695274831244,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.565 > 0.400",
+            "min_transition_rate: 0.0468 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.14803100628469065,
+            0.22088460395708634,
+            0.2897803776966341,
+            33.39176792105019,
+            0.185572085799443
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.011329789291733726,
+            0.13216143952058973,
+            0.06923580831230804,
+            21.820643183714925,
+            0.16631162344704448
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.2160938693443312,
+            0.26143592343061883,
+            0.4114093915599135,
+            50.23401971169115,
+            0.23338418784965498
+          ],
+          "volatility_rank": 6
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.022864139785704188,
+            0.14421762009449338,
+            0.11079359124887679,
+            21.651608378927886,
+            0.2325255556084864
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.08406423714536318,
+            0.1586418474215524,
+            0.16668456216121108,
+            22.59476033963837,
+            0.1489198297408955
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.014178586220064697,
+            0.13701133252315387,
+            0.08067371851691486,
+            21.044155287684653,
+            0.1133850130192871
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1291829848914044,
+            0.1985690321976849,
+            0.2530760759880524,
+            39.33687208160283,
+            0.17392312652581227
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 113.33340844727172,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.0424484052532833
+        }
+      },
+      "model_kruskal_h": 113.33340844727172,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.10014071294559099,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1978,
+          "pct": 0.4637749120750293
+        },
+        "ranging_volatile": {
+          "count": 2287,
+          "pct": 0.5362250879249707
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5585185185185185,
+          "transition_rate": 0.04360711261642676,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.559 > 0.400",
+            "min_transition_rate: 0.0436 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5362250879249707,
+          "transition_rate": 0.0424484052532833,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.536 > 0.400",
+            "min_transition_rate: 0.0424 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6520655270655271,
+          "transition_rate": 0.047373107747105965,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.652 > 0.400",
+            "min_transition_rate: 0.0474 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5847013622074747,
+          "transition_rate": 0.07370749883558454,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.585 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5437454808387563,
+          "transition_rate": 0.059546769527483126,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.544 > 0.400",
+            "min_transition_rate: 0.0595 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.015258744401610036,
+            0.2039355749716604,
+            0.2606527272814001,
+            36.671510161346994,
+            1.3384593612426142e-05,
+            0.13858721290530623,
+            0.18570475270174747
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.004268285695686289,
+            0.13811996822894979,
+            0.09134301263416589,
+            21.214431558641383,
+            1.0668202206864127e-05,
+            -0.08010902791906248,
+            0.15952229913698412
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 98.08352071187255,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.03095684803001876
+        }
+      },
+      "model_kruskal_h": 98.08352071187255,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.11163227016885553,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1232,
+          "pct": 0.28886283704572097
+        },
+        "ranging_volatile": {
+          "count": 3033,
+          "pct": 0.711137162954279
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.7536507936507937,
+          "transition_rate": 0.023708721422523286,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.754 > 0.400",
+            "min_transition_rate: 0.0237 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.711137162954279,
+          "transition_rate": 0.03095684803001876,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.711 > 0.400",
+            "min_transition_rate: 0.0310 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6385327635327636,
+          "transition_rate": 0.0365093499554764,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.639 > 0.400",
+            "min_transition_rate: 0.0365 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6896029805565258,
+          "transition_rate": 0.038775034932463905,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.690 > 0.400",
+            "min_transition_rate: 0.0388 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.7464449264883104,
+          "transition_rate": 0.033510125361620055,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.746 > 0.400",
+            "min_transition_rate: 0.0335 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_volatile",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            3.8860380075229906e-05,
+            0.1487088313650216,
+            0.11852201916966464,
+            23.727708425002085,
+            1.2484692566559148e-05,
+            -0.03049118636726017,
+            0.16146026916866912
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.00769678237644055,
+            0.1393959328300854,
+            0.10274495652029367,
+            23.30064007838084,
+            8.26216715322669e-06,
+            -0.10811293384894471,
+            0.1637294577312752
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0442123701075933,
+            0.23043109325295788,
+            0.3206759572472351,
+            41.02335264281915,
+            1.4186423363035316e-05,
+            0.2302079189464104,
+            0.1970864562830784
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 100.21056441603105,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.0323639774859287
+        }
+      },
+      "model_kruskal_h": 100.21056441603105,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.11022514071294559,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2714,
+          "pct": 0.6363423212192263
+        },
+        "trending_down_choppy": {
+          "count": 1036,
+          "pct": 0.24290738569753811
+        },
+        "trending_up_choppy": {
+          "count": 515,
+          "pct": 0.12075029308323564
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.6497354497354497,
+          "transition_rate": 0.03132938187976291,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.650 > 0.400",
+            "min_transition_rate: 0.0313 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.6363423212192263,
+          "transition_rate": 0.0323639774859287,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.636 > 0.400",
+            "min_transition_rate: 0.0324 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6381766381766382,
+          "transition_rate": 0.037399821905609976,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.638 > 0.400",
+            "min_transition_rate: 0.0374 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6532774478984748,
+          "transition_rate": 0.041802515137401026,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.653 > 0.400",
+            "min_transition_rate: 0.0418 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6917329476982406,
+          "transition_rate": 0.03254580520732883,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.692 > 0.400",
+            "min_transition_rate: 0.0325 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.16821737261591835,
+            0.2328814788331715,
+            0.32827526417432673,
+            38.61837963032785,
+            2.1359394361407882e-05,
+            0.22685294551906732,
+            0.20240626738195222
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005292043845931682,
+            0.13648985706023176,
+            0.090389975940117,
+            22.282655007148765,
+            9.208746170248072e-06,
+            0.15886041212355667,
+            0.16414470835332207
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.13034299543850633,
+            0.1993451240902276,
+            0.25577165258737977,
+            39.3069122397573,
+            5.427365385711822e-06,
+            0.07467071879359412,
+            0.17339675817404224
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.011748575356897422,
+            0.14296313191070847,
+            0.10157098100653515,
+            21.770461988285614,
+            1.2479552928546689e-05,
+            -0.17376767798144965,
+            0.1612181232704228
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 115.31556143108719,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.06941838649155722
+        }
+      },
+      "model_kruskal_h": 115.31556143108719,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.07317073170731707,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 699,
+          "pct": 0.16389214536928487
+        },
+        "ranging_volatile": {
+          "count": 2342,
+          "pct": 0.5491207502930833
+        },
+        "trending_down_choppy": {
+          "count": 827,
+          "pct": 0.19390386869871043
+        },
+        "trending_up_choppy": {
+          "count": 397,
+          "pct": 0.09308323563892146
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5362962962962963,
+          "transition_rate": 0.07006773920406435,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.536 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5491207502930833,
+          "transition_rate": 0.06941838649155722,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.549 > 0.400",
+            "min_transition_rate: 0.0694 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5771011396011396,
+          "transition_rate": 0.061086375779162955,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.577 > 0.400",
+            "min_transition_rate: 0.0611 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.5444172779136104,
+          "transition_rate": 0.091988821611551,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.544 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.576524463726199,
+          "transition_rate": 0.08148505303760849,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.577 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.011863004843122506,
+            0.1319678027180182,
+            0.07599081408627816,
+            20.02208551045429,
+            1.2481566005160527e-05,
+            -0.11160537233144555,
+            0.15760763454421434
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0005184065324277103,
+            0.1372532862694032,
+            0.09334455191073414,
+            22.723308062830466,
+            8.855352057806242e-06,
+            -0.10057589142265437,
+            0.16462966913313923
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17558452616899928,
+            0.23827708422945587,
+            0.34208213949728794,
+            39.90277399964678,
+            2.365026294805638e-05,
+            0.16466656354866763,
+            0.20713738750177785
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "centroid_raw": [
+            -0.01098672276351577,
+            0.18131174968893557,
+            0.2011539357500855,
+            30.68761306299566,
+            1.2479707753113954e-05,
+            0.1509385698127424,
+            0.16946291430055838
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1456821598000823,
+            0.21281853386338195,
+            0.28427747187466623,
+            41.72183113752836,
+            3.99966468804076e-07,
+            0.16397531275015123,
+            0.1814829909036311
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 100.5180712990732,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.055581613508442776
+        }
+      },
+      "model_kruskal_h": 100.5180712990732,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.08700750469043152,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2248,
+          "pct": 0.5270808909730363
+        },
+        "trending_down_choppy": {
+          "count": 1208,
+          "pct": 0.2832356389214537
+        },
+        "trending_up_choppy": {
+          "count": 809,
+          "pct": 0.18968347010550995
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5373544973544974,
+          "transition_rate": 0.04720575783234547,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.537 > 0.400",
+            "min_transition_rate: 0.0472 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5270808909730363,
+          "transition_rate": 0.055581613508442776,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.527 > 0.400",
+            "min_transition_rate: 0.0556 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5911680911680912,
+          "transition_rate": 0.047907390917186106,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.591 > 0.400",
+            "min_transition_rate: 0.0479 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5694492956106648,
+          "transition_rate": 0.05659059152305543,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.569 > 0.400",
+            "min_transition_rate: 0.0566 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6008676789587852,
+          "transition_rate": 0.05665380906460945,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.601 > 0.400",
+            "min_transition_rate: 0.0567 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1966987809667644,
+            0.25177520954399435,
+            0.37662021205520035,
+            42.68188343022965,
+            2.5871153059443263e-05,
+            0.14197336655773293,
+            0.20672812224719558
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.012011792292163238,
+            0.1373074816740614,
+            0.08277903951806583,
+            20.68089196935164,
+            1.24842169648166e-05,
+            -0.05122731689765167,
+            0.15864058922505037
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09750185172856317,
+            0.17108597645504386,
+            0.19403411953169541,
+            33.04864866197602,
+            8.392199949210147e-06,
+            -0.13799654376280965,
+            0.1622743232161822
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11261568983977188,
+            0.18356224215829364,
+            0.2249882065451408,
+            28.758698680972923,
+            1.3639152165225774e-05,
+            0.2688814143670047,
+            0.18512600205666696
+          ],
+          "volatility_rank": 3
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0015784526825490235,
+            0.13166601610397405,
+            0.06743568923577924,
+            21.82296446070483,
+            9.554559633126851e-06,
+            -0.09876990613491739,
+            0.16398149070512896
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16702684472686039,
+            0.23159941255954378,
+            0.3240543158247019,
+            43.16556090619454,
+            5.427299003159835e-07,
+            0.314519327964251,
+            0.1908568865846202
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 129.27650229268693,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.057692307692307696
+        }
+      },
+      "model_kruskal_h": 129.27650229268693,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.0848968105065666,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 302,
+          "pct": 0.07080890973036343
+        },
+        "ranging_volatile": {
+          "count": 2150,
+          "pct": 0.5041031652989449
+        },
+        "trending_down_choppy": {
+          "count": 1165,
+          "pct": 0.2731535756154748
+        },
+        "trending_up_choppy": {
+          "count": 648,
+          "pct": 0.15193434935521688
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.47978835978835976,
+          "transition_rate": 0.0569432684165961,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.480 > 0.400",
+            "min_transition_rate: 0.0569 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5041031652989449,
+          "transition_rate": 0.057692307692307696,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.504 > 0.400",
+            "min_transition_rate: 0.0577 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4166666666666667,
+          "transition_rate": 0.06073018699910953,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.417 > 0.400",
+            "min_transition_rate: 0.0607 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.42822214460356267,
+          "transition_rate": 0.08139264089427108,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.428 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.5382019763798506,
+          "transition_rate": 0.06123432979749277,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.538 > 0.400",
+            "min_transition_rate: 0.0612 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.11206955082297708,
+            0.18771586238105406,
+            0.21960542974614833,
+            28.544791456630687,
+            1.247592633623703e-05,
+            0.30936297278910896,
+            0.17821227969737927
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.015890246811393387,
+            0.1519565258245122,
+            0.12329435465021793,
+            27.442941760836295,
+            1.9101879217236795e-05,
+            -0.15704192366599454,
+            0.22469910632358198
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18850610634517506,
+            0.24538508024349703,
+            0.36358598828649624,
+            41.727067237927066,
+            2.612454975500377e-05,
+            0.20881270913248298,
+            0.20466069541231502
+          ],
+          "volatility_rank": 6
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09948083466883743,
+            0.17190075169222796,
+            0.19778173269126326,
+            33.50658232393643,
+            8.512242989657411e-06,
+            -0.1351136093423481,
+            0.15914693766454618
+          ],
+          "volatility_rank": 3
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009052394495464725,
+            0.13449024199903614,
+            0.07954627384774965,
+            20.401217683048102,
+            5.9910783517166365e-06,
+            0.17066232052838273,
+            0.14464413539254578
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.007871528622457375,
+            0.13386204749868505,
+            0.07613257373349096,
+            20.39870474256059,
+            1.2482082881779526e-05,
+            -0.191736738094167,
+            0.1575864331540167
+          ],
+          "volatility_rank": 0
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.16681065923230734,
+            0.23110979520550023,
+            0.3236554589798778,
+            43.2361102827897,
+            3.9102745853675844e-07,
+            0.308302954946493,
+            0.19078715870925286
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 124.33095471103843,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.08724202626641651
+        }
+      },
+      "model_kruskal_h": 124.33095471103843,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.05534709193245778,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 2060,
+          "pct": 0.48300117233294254
+        },
+        "ranging_volatile": {
+          "count": 2205,
+          "pct": 0.5169988276670574
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5695238095238095,
+          "transition_rate": 0.07917019475021168,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.570 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5169988276670574,
+          "transition_rate": 0.08724202626641651,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.517 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6638176638176638,
+          "transition_rate": 0.06945681211041853,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.664 > 0.400",
+            "min_transition_rate: 0.0695 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5820235184538363,
+          "transition_rate": 0.10700978108989287,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.582 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5273559893950349,
+          "transition_rate": 0.10969141755062681,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.527 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.019667231640627884,
+            0.20209517088049547,
+            0.2558802871348309,
+            35.8869030421517,
+            1.307701371319997e-05,
+            0.3466404251828544,
+            0.1846812359826273
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0012720798433980456,
+            0.14073528366463883,
+            0.09809855650985927,
+            22.08516915489595,
+            1.0944755050374212e-05,
+            -0.22732533781653247,
+            0.16077482215199607
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 106.32086564950623,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.05722326454033771
+        }
+      },
+      "model_kruskal_h": 106.32086564950623,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.08536585365853658,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1259,
+          "pct": 0.2951934349355217
+        },
+        "ranging_volatile": {
+          "count": 3006,
+          "pct": 0.7048065650644784
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.7466666666666667,
+          "transition_rate": 0.04276037256562235,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.747 > 0.400",
+            "min_transition_rate: 0.0428 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.7048065650644784,
+          "transition_rate": 0.05722326454033771,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.705 > 0.400",
+            "min_transition_rate: 0.0572 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.594017094017094,
+          "transition_rate": 0.05627782724844167,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.594 > 0.400",
+            "min_transition_rate: 0.0563 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6700430783560368,
+          "transition_rate": 0.0650908244061481,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.670 > 0.400",
+            "min_transition_rate: 0.0651 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.7336707640395276,
+          "transition_rate": 0.05617164898746384,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.734 > 0.400",
+            "min_transition_rate: 0.0562 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_volatile",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0006222479435897561,
+            0.15081620684083627,
+            0.12316073641623285,
+            24.236718280735985,
+            1.2478338391712188e-05,
+            -0.07910117627488229,
+            0.16248097493672095
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.006365877187341412,
+            0.1384915120449443,
+            0.09653496994116213,
+            23.07044493157649,
+            7.851824273945621e-06,
+            -0.2368289360869605,
+            0.16333808230890398
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.040723098727884606,
+            0.22535665092647778,
+            0.3135243506426434,
+            39.96179312550906,
+            1.427510499864664e-05,
+            0.44249788733510087,
+            0.19509500643164834
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 96.76589005105598,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.005833333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.03377110694183865
+        }
+      },
+      "model_kruskal_h": 96.76589005105598,
+      "model_p_value": 0.005833333333333334,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.10881801125703564,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2899,
+          "pct": 0.6797186400937867
+        },
+        "trending_down_choppy": {
+          "count": 915,
+          "pct": 0.21453692848769051
+        },
+        "trending_up_choppy": {
+          "count": 451,
+          "pct": 0.10574443141852286
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.7111111111111111,
+          "transition_rate": 0.03513971210838273,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.711 > 0.400",
+            "min_transition_rate: 0.0351 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.6797186400937867,
+          "transition_rate": 0.03377110694183865,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.680 > 0.400",
+            "min_transition_rate: 0.0338 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6531339031339032,
+          "transition_rate": 0.04060552092609083,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.653 > 0.400",
+            "min_transition_rate: 0.0406 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6840144370706718,
+          "transition_rate": 0.04285048905449464,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.684 > 0.400",
+            "min_transition_rate: 0.0429 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.7329476982405398,
+          "transition_rate": 0.040742526518804244,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.733 > 0.400",
+            "min_transition_rate: 0.0407 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17382409526724052,
+            0.23550388574218406,
+            0.3399110879167679,
+            39.175436496549565,
+            2.2237088202913097e-05,
+            0.27545263996946484,
+            0.20336545575211917
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.002342985082454364,
+            0.13858977097411135,
+            0.09503352801158453,
+            22.809515360701678,
+            9.263733746710888e-06,
+            0.3000362248015557,
+            0.1632325156981057
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.14451357659951677,
+            0.21156669887330087,
+            0.2822851035129733,
+            41.1325848490761,
+            3.0041590513295125e-06,
+            0.22484583691910456,
+            0.17948865444000978
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.003080045502658329,
+            0.1487060364801988,
+            0.1172181613443668,
+            23.661375969117405,
+            1.2474533039090046e-05,
+            -0.28862068456358014,
+            0.1626408969872962
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 113.7878093199688,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.13414634146341464
+        }
+      },
+      "model_kruskal_h": 113.7878093199688,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.00844277673545965,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 597,
+          "pct": 0.1399765533411489
+        },
+        "ranging_volatile": {
+          "count": 2501,
+          "pct": 0.586400937866354
+        },
+        "trending_down_choppy": {
+          "count": 838,
+          "pct": 0.19648300117233294
+        },
+        "trending_up_choppy": {
+          "count": 329,
+          "pct": 0.07713950762016412
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.6455026455026455,
+          "transition_rate": 0.1390770533446232,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.646 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.586400937866354,
+          "transition_rate": 0.13414634146341464,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.586 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5982905982905983,
+          "transition_rate": 0.13998219056099734,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.598 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.6281290022121317,
+          "transition_rate": 0.14368886818816953,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.628 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.6461798023620149,
+          "transition_rate": 0.1485053037608486,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.646 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005706046155230953,
+            0.14698980582111754,
+            0.11237865743262163,
+            23.16563738345491,
+            1.24762773418263e-05,
+            -0.18583397025221682,
+            0.16196415112476434
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0008404521628034723,
+            0.13411067772866647,
+            0.08128963896822528,
+            22.007663763470422,
+            9.220026358385502e-06,
+            -0.3555217211294562,
+            0.16422902929144775
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1824836841649749,
+            0.2426254652404207,
+            0.3545616403046002,
+            40.9905402349327,
+            2.4300810750602553e-05,
+            -0.07316536091517302,
+            0.20834016759789253
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.014928046300236988,
+            0.17726548904310863,
+            0.20026635440542528,
+            29.534780173961522,
+            9.442574626423564e-06,
+            1.8718905644770534,
+            0.1704507401300448
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1373958422682749,
+            0.20589090548232428,
+            0.26987835429755436,
+            40.38352180375307,
+            3.658880258364563e-06,
+            -0.2836830393957904,
+            0.17844722998171694
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 118.74720068694842,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.12429643527204502
+        }
+      },
+      "model_kruskal_h": 118.74720068694842,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.01829268292682927,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 675,
+          "pct": 0.15826494724501758
+        },
+        "ranging_volatile": {
+          "count": 2190,
+          "pct": 0.5134818288393904
+        },
+        "trending_down_choppy": {
+          "count": 1052,
+          "pct": 0.2466588511137163
+        },
+        "trending_up_choppy": {
+          "count": 348,
+          "pct": 0.08159437280187573
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5576719576719577,
+          "transition_rate": 0.13145639288738356,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.558 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5134818288393904,
+          "transition_rate": 0.12429643527204502,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.513 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5694444444444444,
+          "transition_rate": 0.13018699910952805,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.569 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.5851670741646292,
+          "transition_rate": 0.1347228691197019,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.585 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.5854422752470475,
+          "transition_rate": 0.14199614271938282,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.585 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.18293831564340882,
+            0.24160355241136988,
+            0.3522667453251008,
+            40.8601306121321,
+            2.456178067350388e-05,
+            0.013897791962837618,
+            0.2053442257913174
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.014750534064983466,
+            0.14234429341206561,
+            0.0974498366038738,
+            21.627286279112734,
+            1.2477177281220671e-05,
+            -0.19225292723630635,
+            0.16151297995112804
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.10411131984664192,
+            0.17492991946550004,
+            0.20639758490385723,
+            34.668555668288406,
+            7.473800130067312e-06,
+            -0.37449212015898087,
+            0.16358065787282836
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.04221571824056179,
+            0.1662894168727988,
+            0.1731006671940901,
+            26.998671711968612,
+            1.0272537768620927e-05,
+            1.4694718865035579,
+            0.1713543896559628
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.0022302143274853716,
+            0.13135017673098026,
+            0.06955203207483156,
+            21.64276740106395,
+            9.958265531136607e-06,
+            -0.35690751077212085,
+            0.16427432871324452
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.17371180109128834,
+            0.23606138407455812,
+            0.3364387271289541,
+            43.9553528366646,
+            -1.1645612174349591e-07,
+            0.3048564271208641,
+            0.1900595131105116
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 124.14667297394953,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.13180112570356473
+        }
+      },
+      "model_kruskal_h": 124.14667297394953,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.010787992495309567,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 698,
+          "pct": 0.16365767878077375
+        },
+        "ranging_volatile": {
+          "count": 1907,
+          "pct": 0.4471277842907386
+        },
+        "trending_down_choppy": {
+          "count": 1117,
+          "pct": 0.26189917936694024
+        },
+        "trending_up_choppy": {
+          "count": 543,
+          "pct": 0.1273153575615475
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.46793650793650793,
+          "transition_rate": 0.12849280270956817,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.468 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.4471277842907386,
+          "transition_rate": 0.13180112570356473,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.447 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.35167378917378916,
+          "transition_rate": 0.1195013357079252,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3854930725346373,
+          "transition_rate": 0.1520726595249185,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.5001205109664979,
+          "transition_rate": 0.14971070395371264,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.500 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.12375582611607634,
+            0.19616164881588732,
+            0.24252759323576595,
+            30.553827883432287,
+            1.2479325563346449e-05,
+            -0.04585307482187408,
+            0.18174779173512318
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.00014222633998263803,
+            0.12972124473683805,
+            0.05874867950363517,
+            21.096401556375444,
+            5.825173591045066e-06,
+            -0.40197985424176236,
+            0.1594803131753042
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.19932667599444123,
+            0.25211561901389823,
+            0.38306173996952547,
+            43.10929438362126,
+            2.684697840112062e-05,
+            0.15547270228881693,
+            0.21138861885738325
+          ],
+          "volatility_rank": 6
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.10193078040823318,
+            0.17383383439937675,
+            0.20238538433649783,
+            33.955084604289276,
+            7.96895576743976e-06,
+            -0.3539900289644568,
+            0.1638875139950921
+          ],
+          "volatility_rank": 3
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.03561050245888024,
+            0.15655449620321515,
+            0.15171901228532872,
+            25.775410408399562,
+            1.5783133842897595e-05,
+            1.06787120600972,
+            0.1751569374308447
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.007823959100803395,
+            0.13770167646449855,
+            0.08244665046800706,
+            20.895588123104755,
+            1.2477225727636326e-05,
+            -0.17663925560895524,
+            0.15932236602500674
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.172092256108624,
+            0.23445184064498464,
+            0.33368281806585376,
+            43.68410536665764,
+            1.3753967842630077e-07,
+            0.36025033613181356,
+            0.1893211675417115
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 113.8050639105004,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.03095684803001876
+        }
+      },
+      "model_kruskal_h": 113.8050639105004,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.11163227016885553,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1328,
+          "pct": 0.31137162954279013
+        },
+        "ranging_volatile": {
+          "count": 2937,
+          "pct": 0.6886283704572098
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.7005291005291006,
+          "transition_rate": 0.03048264182895851,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.701 > 0.400",
+            "min_transition_rate: 0.0305 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.6886283704572098,
+          "transition_rate": 0.03095684803001876,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.689 > 0.400",
+            "min_transition_rate: 0.0310 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5464743589743589,
+          "transition_rate": 0.04879786286731968,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.546 > 0.400",
+            "min_transition_rate: 0.0488 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6028641285365002,
+          "transition_rate": 0.04855612482533768,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.603 > 0.400",
+            "min_transition_rate: 0.0486 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.7073993733429742,
+          "transition_rate": 0.0349566055930569,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.707 > 0.400",
+            "min_transition_rate: 0.0350 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.04405750961743497,
+            0.226278038861672,
+            0.3112981241124926,
+            40.241278038724026,
+            1.4623435790273583e-05,
+            0.23693714000980004,
+            0.1980224498583403
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.004503478735211739,
+            0.14354155575674019,
+            0.10792670807054146,
+            23.13527473208829,
+            1.076970539747729e-05,
+            -0.07140079366998278,
+            0.16035516652013165
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 104.1763449904629,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.028611632270168854
+        }
+      },
+      "model_kruskal_h": 104.1763449904629,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.11397748592870544,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1213,
+          "pct": 0.2844079718640094
+        },
+        "ranging_volatile": {
+          "count": 3052,
+          "pct": 0.7155920281359907
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.7360846560846561,
+          "transition_rate": 0.023708721422523286,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.736 > 0.400",
+            "min_transition_rate: 0.0237 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.7155920281359907,
+          "transition_rate": 0.028611632270168854,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.716 > 0.400",
+            "min_transition_rate: 0.0286 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6159188034188035,
+          "transition_rate": 0.03793410507569012,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.616 > 0.400",
+            "min_transition_rate: 0.0379 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6773780416812202,
+          "transition_rate": 0.041802515137401026,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.677 > 0.400",
+            "min_transition_rate: 0.0418 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.7536755844781875,
+          "transition_rate": 0.029170684667309547,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.754 > 0.400",
+            "min_transition_rate: 0.0292 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_volatile",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            -0.005975297516906036,
+            0.14341454300806697,
+            0.10699466370244988,
+            23.142652105618538,
+            9.418790145149007e-06,
+            -0.031001782569584843,
+            0.1424649255652699
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.005464604433139304,
+            0.15262843615401167,
+            0.13386862093413648,
+            24.341330991109274,
+            1.573485468431776e-05,
+            -0.15064097694822878,
+            0.21965724283042695
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.0470261431058886,
+            0.23268859094962563,
+            0.3253506345014938,
+            42.075576190996586,
+            1.408741982222224e-05,
+            0.2644409571220081,
+            0.1942859725256431
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 145.75965661401096,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.1174953095684803
+        }
+      },
+      "model_kruskal_h": 145.75965661401096,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.025093808630393996,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 341,
+          "pct": 0.07995310668229777
+        },
+        "ranging_volatile": {
+          "count": 2371,
+          "pct": 0.5559202813599062
+        },
+        "trending_down_choppy": {
+          "count": 1070,
+          "pct": 0.2508792497069168
+        },
+        "trending_up_choppy": {
+          "count": 483,
+          "pct": 0.11324736225087925
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5487830687830688,
+          "transition_rate": 0.13272650296359018,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.549 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5559202813599062,
+          "transition_rate": 0.1174953095684803,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.556 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4547720797720798,
+          "transition_rate": 0.13873552983081033,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.455 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.5009896379089533,
+          "transition_rate": 0.1468327899394504,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.501 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.586406362979031,
+          "transition_rate": 0.1523625843780135,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.586 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.16926529225736212,
+            0.23215270557898057,
+            0.3268908013426932,
+            38.82876366183989,
+            2.2691642048517305e-05,
+            -0.02525440601128024,
+            0.20640278898132894
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.009530426940195902,
+            0.16033110367173548,
+            0.15653999454135709,
+            26.336434224042907,
+            1.1985142741935486e-05,
+            2.721925115427974,
+            0.16299803345029582
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.12562017738449324,
+            0.1980106188910188,
+            0.24714322125845437,
+            38.93961741323922,
+            4.7832624321390105e-06,
+            -0.1496331489701613,
+            0.17477943062139295
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.01084882577792199,
+            0.13860476007902237,
+            0.0926340965798574,
+            21.321260094656992,
+            1.1248071003717483e-05,
+            -0.29278857726594487,
+            0.16077706810808387
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 130.79769926727386,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.11045966228893059
+        }
+      },
+      "model_kruskal_h": 130.79769926727386,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.032129455909943705,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 322,
+          "pct": 0.07549824150058616
+        },
+        "ranging_volatile": {
+          "count": 2503,
+          "pct": 0.5868698710433763
+        },
+        "trending_down_choppy": {
+          "count": 1020,
+          "pct": 0.2391559202813599
+        },
+        "trending_up_choppy": {
+          "count": 420,
+          "pct": 0.0984759671746776
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5911111111111111,
+          "transition_rate": 0.11685012701100762,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.591 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5868698710433763,
+          "transition_rate": 0.11045966228893059,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.587 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5345441595441596,
+          "transition_rate": 0.1195013357079252,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.535 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.5791128187216207,
+          "transition_rate": 0.129832324173265,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.579 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.6305133767172812,
+          "transition_rate": 0.13886210221793635,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.631 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.009253364432012861,
+            0.1383454811141479,
+            0.09118695688347146,
+            21.096955987314324,
+            9.996099093078793e-06,
+            -0.2561121034265552,
+            0.14162838102889122
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.02394401879580852,
+            0.14733115650935086,
+            0.11455391306460422,
+            23.307591433562163,
+            1.5851522025316493e-05,
+            -0.2729013288098128,
+            0.22235482780539095
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17922994383501278,
+            0.23985721584453334,
+            0.3450310665265258,
+            40.58202778835605,
+            2.2781063125000023e-05,
+            0.018221400339355254,
+            0.20301829462390275
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.006450068014753801,
+            0.16507100269120867,
+            0.16852801765384315,
+            27.11026291877717,
+            1.1309395987654325e-05,
+            2.9191923108122,
+            0.16072097700394133
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1283918216629413,
+            0.19851374786268003,
+            0.2518644438992972,
+            39.335993680913774,
+            4.851269977168983e-06,
+            -0.15631178978313823,
+            0.17451053578806366
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 119.06221605011706,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.11116322701688555
+        }
+      },
+      "model_kruskal_h": 119.06221605011706,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.03142589118198874,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 318,
+          "pct": 0.07456037514654162
+        },
+        "ranging_volatile": {
+          "count": 2264,
+          "pct": 0.5308323563892146
+        },
+        "trending_down_choppy": {
+          "count": 1250,
+          "pct": 0.29308323563892147
+        },
+        "trending_up_choppy": {
+          "count": 433,
+          "pct": 0.1015240328253224
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5394708994708994,
+          "transition_rate": 0.11325148179508891,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.539 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5308323563892146,
+          "transition_rate": 0.11116322701688555,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.531 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5108618233618234,
+          "transition_rate": 0.11433659839715049,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.511 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.5517522412387939,
+          "transition_rate": 0.1228458313926409,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.552 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.5827910339840926,
+          "transition_rate": 0.133076181292189,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.583 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1794670808811851,
+            0.24001319304516966,
+            0.3453967120549136,
+            40.60511749921886,
+            2.278877037617557e-05,
+            0.018197087044204117,
+            0.2029764640431946
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.01860168273217509,
+            0.13524124876121266,
+            0.08489766240137007,
+            20.278655044313926,
+            1.0451325735687545e-05,
+            -0.2522721879674605,
+            0.14126098756675873
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09366076401821077,
+            0.1740703401143317,
+            0.19122062388070354,
+            32.74707498199728,
+            7.342043468208129e-06,
+            -0.2625934812308066,
+            0.15859681356348432
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.015650662289797473,
+            0.1621681779806779,
+            0.1612959215279187,
+            26.475933570088607,
+            1.1825220000000003e-05,
+            2.950219374870518,
+            0.16087515092216395
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.029226372718187094,
+            0.14693722430915307,
+            0.11159369422226231,
+            23.18360428902925,
+            1.624964426450746e-05,
+            -0.2678140453629001,
+            0.22451448593126383
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.1695532647792718,
+            0.23553136782761208,
+            0.329842419165474,
+            47.03052717214999,
+            -3.678899022801158e-07,
+            0.17611598681419002,
+            0.19906885348577774
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.71948682990842,
+          "model_kruskal_h": 122.1325858099026,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.10952157598499061
+        }
+      },
+      "model_kruskal_h": 122.1325858099026,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 88.71948682990842,
+      "stability_gain": 0.03306754221388368,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 297,
+          "pct": 0.06963657678780774
+        },
+        "ranging_volatile": {
+          "count": 2235,
+          "pct": 0.5240328253223916
+        },
+        "trending_down_choppy": {
+          "count": 1240,
+          "pct": 0.29073856975381007
+        },
+        "trending_up_choppy": {
+          "count": 493,
+          "pct": 0.11559202813599062
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5318518518518518,
+          "transition_rate": 0.11282811176968671,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.532 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5240328253223916,
+          "transition_rate": 0.10952157598499061,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.524 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4700854700854701,
+          "transition_rate": 0.11985752448797862,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.470 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.5231109558737921,
+          "transition_rate": 0.12761993479273404,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.523 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.571704025066281,
+          "transition_rate": 0.13813886210221793,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.572 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.17322661642315537,
+            0.23802776464980258,
+            0.33358616441066996,
+            39.67890962062493,
+            1.3930423758865273e-05,
+            0.008795088420161377,
+            0.1868416258106454
+          ],
+          "volatility_rank": 6
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.027078391170756208,
+            0.1459710352231596,
+            0.10853151132495588,
+            23.010803326418472,
+            1.5306844016506227e-05,
+            -0.26267763278740786,
+            0.2242373330071877
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "centroid_raw": [
+            0.1756415401221201,
+            0.22856930055932737,
+            0.34660155792164593,
+            40.1304772242911,
+            6.37944857142857e-05,
+            0.05432058850959051,
+            0.2639198208752026
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.09637694321355511,
+            0.17358108600975042,
+            0.19134294512602712,
+            32.877349213363544,
+            7.383085411764742e-06,
+            -0.2644226435069372,
+            0.15867249047511314
+          ],
+          "volatility_rank": 3
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "centroid_raw": [
+            0.012505230962796345,
+            0.1612391473982729,
+            0.15847065178015818,
+            26.24779019085923,
+            1.1757187290969903e-05,
+            2.9788185899027075,
+            0.16139439640546963
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "centroid_raw": [
+            0.017932079857837156,
+            0.13493369290112495,
+            0.08410003740217725,
+            20.22738762574985,
+            1.0399270372369143e-05,
+            -0.2551150469648291,
+            0.14116443365125672
+          ],
+          "volatility_rank": 0
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "centroid_raw": [
+            -0.169725878280737,
+            0.2358175419945451,
+            0.33010483607811514,
+            47.01401606898691,
+            -4.0994183006534393e-07,
+            0.1777335172320508,
+            0.19898351049718685
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "passes_bonferroni": false
+    }
+  ],
+  "winner": null,
+  "live_wiring_delta": "Enriched models decode from ENRICHED_COLUMNS; live check_regime.py builds only CANONICAL_COLUMNS. Live wiring (#1074) must feed funding_rate + volume_z + htf_range_eff on-cycle in this exact order, or forward_filter_labels reads garbage."
+}

--- a/docs/research/1218-vol-regime-bakeoff-rerun-v2.md
+++ b/docs/research/1218-vol-regime-bakeoff-rerun-v2.md
@@ -1,0 +1,104 @@
+# #1218 — Re-run of the #1080/#1095 vol-regime bake-offs under candidate-self-v2 gate semantics
+
+**Verdict: NEGATIVE — no candidate ships.** Under the #1211 candidate-self-v2 gate
+(`ship = separation_ok and stability_ok`, judged on the candidate's own block-shuffle
+permutation significance + non-inferiority + stability gain), no k-means / GMM / HMM
+candidate on any feature subset survives the full promotion bar (raw `verdict.ship` +
+family-wise Bonferroni significance + non-degeneracy on all five eval windows) on
+BTC or ETH. **#1074 blocker 2 is now measured, and it failed.**
+
+The failure mode changed, though: the pre-#1211 runs abstained every verdict on the
+incumbent-trustworthy hard-gate. Under v2, `incumbent_trustworthy=true` everywhere and
+many candidates now pass the raw gate — what kills every one of them is **non-degeneracy**
+(collapsing to fewer active labels than the incumbent-derived floor), and in one notable
+BTC case **stability** (more label churn than the hand-rule).
+
+## Commands (harnesses unchanged — no gate or threshold edits)
+
+Run at repo SHA `e7d4660` (branch base = `origin/main`), 2026-07-05:
+
+```
+uv run --no-sync python backtest/research/regime_1080_unsupervised_vol_model.py \
+    --json docs/research/1218-artifacts/regime_1080_btc.json
+uv run --no-sync python backtest/research/regime_1095_enriched_vol_model.py \
+    --json docs/research/1218-artifacts/regime_1095_btc.json
+uv run --no-sync python backtest/research/regime_1095_enriched_vol_model.py \
+    --symbol ETH/USDT --timeframe 1h \
+    --json docs/research/1218-artifacts/regime_1095_eth.json
+```
+
+Full per-candidate reports (every `verdict`, non-degeneracy breakdown, states/mappings)
+are the three JSON artifacts in `docs/research/1218-artifacts/`. Each 1095 run swept the
+full 90-candidate family (5 subsets × 3 families × K=2..7) in one invocation, so the
+Bonferroni correction divides alpha across the combined structurally-eligible grid.
+
+## Resolved permutation counts and corrected alphas
+
+| Run | swept | structurally eligible (Bonferroni denom) | resolved `n_perm` | corrected alpha | min achievable p |
+|---|---|---|---|---|---|
+| 1080 BTC/USDT 1h | 18 | 9 | 1000 | 0.005556 | 0.000999 |
+| 1095 BTC/USDT 1h | 90 | 45 | 1799 | 0.001111 | 0.000556 |
+| 1095 ETH/USDT 1h | 90 | 30 | 1199 | 0.001667 | 0.000833 |
+
+All five 1095 feature subsets built successfully on both assets
+(`subset_status`: `canonical`/`funding`/`volume`/`htf`/`all_enriched` all `"ok"` —
+no funding-unavailable arm). Incumbent hand-rule held-out separation was significant
+in all three runs (`knife_edge=false`; BTC p=0.0044, steps_to_alpha=82; ETH p=0.0058,
+steps_to_alpha=53; 1080 run p=0.0060, steps_to_alpha=44), so v2's non-inferiority
+arm was compared against a live, non-abstained incumbent.
+
+## Results
+
+### #1080 (canonical four features, BTC 1h): winner = none
+
+`verdict.ship=true` for 3 of 18 candidates (hmm k=6, kmeans k=3, kmeans k=4), but:
+
+- **No candidate passes the corrected alpha** — best eligible p=0.01299 (gmm k=6/k=7)
+  vs alpha 0.005556.
+- **Every one of the 18 candidates is degenerate on at least one eval window**
+  (`non_degenerate_all=false` across the board), overwhelmingly
+  `min_active_labels: 4 < 5` — the models persistently occupy only 4 states.
+
+### #1095 (enriched features): winner = none on both assets; every subset `any_ships=false`
+
+**BTC:** 15/90 raw `verdict.ship=true`; 7 pass Bonferroni; only 2 are non-degenerate on
+all windows — and the three sets never intersect. Closest misses:
+
+- `htf:hmm:k=6` — passes everything except non-degeneracy: p=0.00056 (min achievable),
+  KW-H=137.9 vs incumbent 85.7, stability gain +0.065, `ship=true`, Bonferroni pass —
+  but sits at exactly 4 active labels on **all five** windows (floor is 5).
+- `volume:gmm:k=5` — the inverse miss: non-degenerate on **all** windows AND
+  Bonferroni-significant (p=0.00056, KW-H=107.8), but the **stability arm** fails —
+  it churns **more** than the hand-rule (stability gain −0.1165, i.e. transition rate
+  ≈0.254 vs the incumbent's 0.137), so `ship=false`.
+
+**ETH:** 60/90 raw ships; 5 pass Bonferroni; **zero** non-degenerate on all windows
+(ETH's incumbent-derived floor is 6 active labels). Closest misses — all three
+ship+Bonferroni candidates (`canonical:kmeans:k=7`, `funding:kmeans:k=6`,
+`all_enriched:kmeans:k=6`) fail only non-degeneracy: 3–4 active labels on every
+window (plus `max_occupancy` breaches for the funding/all_enriched arms).
+
+### Which arm failed (the record #1218 asked for)
+
+- **Separation significance:** clearable — several candidates hit the minimum
+  achievable p under the family correction on both assets.
+- **Non-inferiority (KW-H vs incumbent):** clearable — e.g. BTC `htf:hmm:k=6`
+  at 137.9 vs 85.7.
+- **Stability:** the binding arm for the best BTC volume-subset models (GMM churns
+  more than the hand-rule).
+- **Non-degeneracy:** the binding arm for everything else — the single dominant
+  failure. Unsupervised fits keep collapsing to ~4 effective states, below the
+  incumbent-derived `min_active_labels` floor (5 on BTC, 6 on ETH).
+
+## Disposition
+
+- **#1074 blocker 2: measured negative.** No hand-off to the #1081 economic gate or
+  #1082 bounded-window validation — nothing shipped. Live wiring stays blocked.
+- No gate-semantics or threshold change proposed here (out of scope per #1218; any such
+  change belongs to #1211's lineage). If a future issue wants to pursue the near-misses,
+  the evidence points at the state-collapse problem (fit-time K ≠ decoded effective
+  states), not at significance power — `n_perm` resolution is no longer the binding
+  constraint anywhere.
+
+---
+Created with LLM: Fable 5 | high | Harness: Claude Code


### PR DESCRIPTION
Closes #1218

Re-ran the #1080 (canonical, BTC) and #1095 (enriched, BTC + ETH) unsupervised vol-regime bake-offs **unchanged** under the #1211 candidate-self-v2 gate semantics, full candidate family in one invocation each (Bonferroni over the combined structurally-eligible grid; resolved n_perm = 1000 / 1799 / 1199).

**Result: negative — no candidate ships on either asset; #1074 blocker 2 is now measured, and failed.** Under v2 the blanket incumbent-trustworthy abstain is gone and many candidates pass the raw gate; what kills every one is non-degeneracy (state collapse below the incumbent-derived active-label floor: 5 on BTC, 6 on ETH), plus one BTC stability failure. Closest misses per arm are recorded in the doc (e.g. BTC `htf:hmm:k=6` passes everything except non-degeneracy; BTC `volume:gmm:k=5` is non-degenerate + significant but churns more than the hand-rule).

No hand-off to #1081/#1082 (nothing shipped); no gate or threshold edits; no live/Go path touched.

**Contents:** `docs/research/1218-vol-regime-bakeoff-rerun-v2.md` + the three full JSON report artifacts under `docs/research/1218-artifacts/`.

**Verification:** docs-only PR — evidence is the harness output itself (all three runs exited 0 and wrote complete reports; numbers in the doc cross-checked against the JSONs).

---
Created with LLM: Fable 5 | high | Harness: Claude Code
