### PR TITLE
test(#1233): audit money/PnL/fee accounting tests; close bug-class coverage gaps

### DIFF
--- a/scheduler/cashflow_journal.go
+++ b/scheduler/cashflow_journal.go
@@ -558,6 +558,12 @@ var cashflowJournalPendingStreaks = &cashflowJournalPendingTracker{}
 // always logs the journal-vs-ledger comparison so operators see both bases every
 // cycle, and mutates results IN PLACE (the matching HL wallet's alarm fields).
 func applyCashflowJournalDriftBasis(results []sharedWalletDriftResult, key SharedWalletKey, rec *cashflowJournalReconcile, enabled bool) {
+	// #1233 shadow-only enforcement: only the Hyperliquid journal is LIVE as a
+	// drift-alarm basis (OKX/TopStep journals are shadow-only). Refuse any
+	// non-HL key without mutating results or the pending-streak tracker.
+	if key.Platform != "hyperliquid" {
+		return
+	}
 	if rec == nil {
 		return
 	}

--- a/scheduler/cashflow_journal_audit_test.go
+++ b/scheduler/cashflow_journal_audit_test.go
@@ -1,0 +1,249 @@
+package main
+
+// #1233 cashflow-journal audit gaps: journal-drift override semantics, the
+// shadow-only (HL-only) guard on applyCashflowJournalDriftBasis, exact
+// watermark/cutoff boundary booking, closed_pnl_gross exclusion from the sum,
+// and zero-amount event booking. Reuses fixtures from cashflow_journal_test.go
+// (newCashflowJournalTestDB, cashflowCutoffAll), okx_cashflow_journal_test.go
+// (newOKXJournalKey), topstep_cashflow_journal_test.go (newTopStepJournalKey).
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+// A usable journal reading with NON-ZERO drift must override the ledger drift
+// (and the mirror: a zero journal drift overrides a non-zero ledger drift),
+// carrying ExpectedEquity and resetting the pending streak.
+func TestApplyCashflowJournalDriftBasis_UsableNonZeroJournalDriftOverridesLedger(t *testing.T) {
+	prevPending := cashflowJournalPendingStreaks
+	cashflowJournalPendingStreaks = &cashflowJournalPendingTracker{}
+	defer func() { cashflowJournalPendingStreaks = prevPending }()
+
+	hlKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xaudit"}
+	label := sharedWalletKeyLabel(hlKey)
+
+	// Seed a non-zero pending streak so the usable cycle must reset it.
+	cashflowJournalPendingStreaks.mark(label)
+	cashflowJournalPendingStreaks.mark(label)
+
+	res := []sharedWalletDriftResult{{Key: hlKey, Drift: 0.02, Balance: 1000, MemberSum: 999.98}}
+	rec := &cashflowJournalReconcile{Key: hlKey, Usable: true, Drift: 50.0, ExpectedEquity: 950, AccountValue: 1000}
+	applyCashflowJournalDriftBasis(res, hlKey, rec, true)
+
+	if res[0].Basis != driftBasisJournal {
+		t.Errorf("Basis = %q, want %q", res[0].Basis, driftBasisJournal)
+	}
+	if math.Abs(res[0].Drift-50.0) > 1e-9 {
+		t.Errorf("journal drift must override ledger drift: got %v, want 50.0", res[0].Drift)
+	}
+	if math.Abs(res[0].ExpectedEquity-950) > 1e-9 {
+		t.Errorf("ExpectedEquity = %v, want 950", res[0].ExpectedEquity)
+	}
+	if res[0].JournalPending {
+		t.Errorf("usable cycle must not be journal-pending: %+v", res[0])
+	}
+	// A usable cycle resets the streak: the next mark must count from 1.
+	if got := cashflowJournalPendingStreaks.mark(label); got != 1 {
+		t.Errorf("pending streak not reset by usable cycle: next mark = %d, want 1", got)
+	}
+	cashflowJournalPendingStreaks.reset(label)
+
+	// Mirror: non-zero ledger drift, zero journal drift -> journal (0.0) governs.
+	res = []sharedWalletDriftResult{{Key: hlKey, Drift: 0.40, Balance: 1000, MemberSum: 999.6}}
+	rec = &cashflowJournalReconcile{Key: hlKey, Usable: true, Drift: 0.0, ExpectedEquity: 1000, AccountValue: 1000}
+	applyCashflowJournalDriftBasis(res, hlKey, rec, true)
+	if res[0].Basis != driftBasisJournal || math.Abs(res[0].Drift) > 1e-9 {
+		t.Errorf("zero journal drift must override ledger 0.40: %+v", res[0])
+	}
+	if math.Abs(res[0].ExpectedEquity-1000) > 1e-9 {
+		t.Errorf("ExpectedEquity = %v, want 1000", res[0].ExpectedEquity)
+	}
+}
+
+// #1233 shadow-only enforcement: applyCashflowJournalDriftBasis refuses a
+// non-Hyperliquid key entirely — no basis switch, no drift mutation — even when
+// handed a usable journal rec for that key.
+func TestApplyCashflowJournalDriftBasis_RefusesNonHLKey(t *testing.T) {
+	prevPending := cashflowJournalPendingStreaks
+	cashflowJournalPendingStreaks = &cashflowJournalPendingTracker{}
+	defer func() { cashflowJournalPendingStreaks = prevPending }()
+
+	okxKey := SharedWalletKey{Platform: "okx", Account: "shadow"}
+	res := []sharedWalletDriftResult{{Key: okxKey, Drift: 1.23, Balance: 500, MemberSum: 498.77}}
+	rec := &cashflowJournalReconcile{Key: okxKey, Usable: true, Drift: -2.5, ExpectedEquity: 497.5, AccountValue: 500}
+	applyCashflowJournalDriftBasis(res, okxKey, rec, true)
+
+	if res[0].Basis != "" || res[0].Drift != 1.23 || res[0].JournalPending {
+		t.Errorf("non-HL key must be refused (entry unchanged): %+v", res[0])
+	}
+	// The guard must also not have touched the pending-streak tracker.
+	if got := cashflowJournalPendingStreaks.mark(sharedWalletKeyLabel(okxKey)); got != 1 {
+		t.Errorf("guard must not mutate the pending tracker: next mark = %d, want 1", got)
+	}
+}
+
+// An event settled EXACTLY at the watermark (Time == FillsSinceMs) is booked —
+// the skip is strict `<` at cashflow_journal.go:348 — and the cursor advances
+// one past it. Covered for HL, OKX, and TopStep (all three share the strict-<
+// boundary via advanceCashflowCursor).
+func TestCashflowJournalIngestBooksEventAtWatermark(t *testing.T) {
+	t.Run("hyperliquid", func(t *testing.T) {
+		db := newCashflowJournalTestDB(t)
+		key := SharedWalletKey{Platform: "hyperliquid", Account: "0xwm"}
+		base := CashflowJournalState{FillsSinceMs: 150, BaselineSet: true}
+		res := cashflowJournalFetchResult{
+			Key: key, State: base, StateFound: true, FillsFetched: true,
+			Fills: []hlFillRecord{
+				{Coin: "BTC", Time: 150, Tid: json.Number("1"), ClosedPnl: "10", Fee: "0.2"}, // == watermark: booked
+			},
+		}
+		st := ingestCashflowJournalEvents(db, res, cashflowCutoffAll)
+		sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+		if err != nil {
+			t.Fatalf("sum: %v", err)
+		}
+		if math.Abs(sum-9.8) > 1e-9 {
+			t.Errorf("fill at exact watermark not booked: sum = %v, want 9.8", sum)
+		}
+		if st.FillsSinceMs != 151 {
+			t.Errorf("cursor = %d, want 151", st.FillsSinceMs)
+		}
+	})
+
+	t.Run("okx", func(t *testing.T) {
+		db := newCashflowJournalTestDB(t)
+		key := newOKXJournalKey()
+		base := CashflowJournalState{FillsSinceMs: 150, BaselineSet: true}
+		res := okxCashflowJournalFetchResult{
+			Key: key, State: base, StateFound: true, BillsFetched: true,
+			Bills: []okxBillRecord{
+				{BillID: "wm", TimeMs: 150, Ccy: "USDT", Type: "2", BalChg: 9.8}, // == watermark: booked
+			},
+		}
+		st := ingestOKXCashflowJournalEvents(db, res, cashflowCutoffAll)
+		sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+		if err != nil {
+			t.Fatalf("sum: %v", err)
+		}
+		if math.Abs(sum-9.8) > 1e-9 {
+			t.Errorf("bill at exact watermark not booked: sum = %v, want 9.8", sum)
+		}
+		if st.FillsSinceMs != 151 {
+			t.Errorf("cursor = %d, want 151", st.FillsSinceMs)
+		}
+	})
+
+	t.Run("topstep", func(t *testing.T) {
+		db := newCashflowJournalTestDB(t)
+		key := newTopStepJournalKey()
+		base := CashflowJournalState{FillsSinceMs: 150, BaselineSet: true}
+		res := topstepCashflowJournalFetchResult{
+			Key: key, State: base, StateFound: true, FillsFetched: true,
+			Fills: []topstepFillRecord{
+				{FillID: "wm", TimeMs: 150, Symbol: "ES", Kind: "trade", RealizedPnL: 10, Fee: 0.2}, // == watermark: booked
+			},
+		}
+		st := ingestTopStepCashflowJournalEvents(db, res, cashflowCutoffAll)
+		sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+		if err != nil {
+			t.Fatalf("sum: %v", err)
+		}
+		if math.Abs(sum-9.8) > 1e-9 {
+			t.Errorf("fill at exact watermark not booked: sum = %v, want 9.8", sum)
+		}
+		if st.FillsSinceMs != 151 {
+			t.Errorf("cursor = %d, want 151", st.FillsSinceMs)
+		}
+	})
+}
+
+// An event settled EXACTLY at the cutoff (Time == cutoffMs) is booked — the
+// defer is strict `>` at cashflow_journal.go:351 — while the next-ms event is
+// deferred, cursor stopping one past the booked fill.
+func TestCashflowJournalIngestBooksEventAtCutoff(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xcut"}
+	base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+	res := cashflowJournalFetchResult{
+		Key: key, State: base, StateFound: true, FillsFetched: true,
+		Fills: []hlFillRecord{
+			{Coin: "BTC", Time: 200, Tid: json.Number("1"), ClosedPnl: "10", Fee: "0.2"}, // == cutoff: booked
+			{Coin: "BTC", Time: 201, Tid: json.Number("2"), ClosedPnl: "30", Fee: "0.5"}, // > cutoff: deferred
+		},
+	}
+	st := ingestCashflowJournalEvents(db, res, 200)
+	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	if math.Abs(sum-9.8) > 1e-9 {
+		t.Errorf("fill at exact cutoff must book: sum = %v, want 9.8", sum)
+	}
+	if st.FillsSinceMs != 201 {
+		t.Errorf("cursor = %d, want 201 (one past the booked fill, not past the deferred one)", st.FillsSinceMs)
+	}
+}
+
+// SumCashflowJournal sums amount_usd ONLY — closed_pnl_gross is attribution
+// metadata and must never leak into the settled-cash total.
+func TestSumCashflowJournalIgnoresClosedPnlGross(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xsum"}
+
+	// Fill: net amount 19.7, gross 20 (gross must be ignored by the sum).
+	if err := db.InsertCashflowJournalEntry(key.Platform, key.Account, 100, "fill", 19.7, "BTC", 20, 0.3, "fill:1"); err != nil {
+		t.Fatalf("insert fill: %v", err)
+	}
+	if err := db.InsertCashflowJournalEntry(key.Platform, key.Account, 110, "deposit", 100, "", 0, 0, "xfer:1"); err != nil {
+		t.Fatalf("insert deposit: %v", err)
+	}
+	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	if math.Abs(sum-119.7) > 1e-9 {
+		t.Errorf("sum = %v, want 119.7 (19.7 net + 100 deposit; closed_pnl_gross excluded)", sum)
+	}
+}
+
+// A mapped fill with a zero settled delta is still booked as a row (visible +
+// deduped), the cursor advances past it, and Incomplete is NOT latched; the
+// sum reflects only the non-zero delta.
+func TestCashflowJournalBooksZeroAmountEvents(t *testing.T) {
+	db := newCashflowJournalTestDB(t)
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xzero"}
+	base := CashflowJournalState{FillsSinceMs: 100, BaselineSet: true}
+	res := cashflowJournalFetchResult{
+		Key: key, State: base, StateFound: true, FillsFetched: true,
+		Fills: []hlFillRecord{
+			{Coin: "BTC", Time: 150, Tid: json.Number("1"), ClosedPnl: "0", Fee: "0"},    // zero delta: still booked
+			{Coin: "BTC", Time: 160, Tid: json.Number("2"), ClosedPnl: "10", Fee: "0.2"}, // non-zero
+		},
+	}
+	st := ingestCashflowJournalEvents(db, res, cashflowCutoffAll)
+
+	sum, err := db.SumCashflowJournal(key.Platform, key.Account)
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	if math.Abs(sum-9.8) > 1e-9 {
+		t.Errorf("sum = %v, want 9.8 (zero-delta fill contributes 0)", sum)
+	}
+	var rows int
+	if err := db.db.QueryRow(
+		`SELECT COUNT(*) FROM cashflow_journal WHERE platform = ? AND account = ?`,
+		key.Platform, key.Account).Scan(&rows); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if rows != 2 {
+		t.Errorf("zero-amount row must persist: rows = %d, want 2", rows)
+	}
+	if st.FillsSinceMs != 161 {
+		t.Errorf("cursor must advance past the zero-amount fill: %d, want 161", st.FillsSinceMs)
+	}
+	if st.Incomplete {
+		t.Error("a mapped zero-amount fill must NOT latch Incomplete")
+	}
+}

--- a/scheduler/shared_wallet_audit_test.go
+++ b/scheduler/shared_wallet_audit_test.go
@@ -1,0 +1,203 @@
+package main
+
+// Audit-gap regression tests for the shared-wallet drift alarm, shared-wallet
+// membership, trade-ledger migration, and the kill-switch fill splitter.
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// Below the cent tolerance, reportSharedWalletDrift must never record a
+// tracker entry (the within-tolerance path Clears instead of Records) and,
+// with no entry, no alert can ever fire.
+func TestReportSharedWalletDrift_BelowToleranceRecordsNothing(t *testing.T) {
+	prev := sharedWalletDriftTracker
+	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
+	defer func() { sharedWalletDriftTracker = prev }()
+
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	results := []sharedWalletDriftResult{
+		{Key: key, Drift: 0.004, Balance: 1000, MemberSum: 1000.004},
+	}
+	reportSharedWalletDrift(nil, results)
+	reportSharedWalletDrift(nil, results)
+
+	if n := len(sharedWalletDriftTracker.entries); n != 0 {
+		t.Fatalf("below-tolerance drift recorded %d tracker entries, want 0: %+v",
+			n, sharedWalletDriftTracker.entries)
+	}
+}
+
+// The over-tolerance guard is strict `>`: drift of exactly the $0.01 tolerance
+// must not trip. A $0.02 control wallet confirms on cycle 2, proving the
+// harness would have caught a trip.
+func TestReportSharedWalletDrift_ExactToleranceDoesNotTrip(t *testing.T) {
+	prev := sharedWalletDriftTracker
+	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
+	defer func() { sharedWalletDriftTracker = prev }()
+
+	exactKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xexact"}
+	ctrlKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xctrl"}
+	results := []sharedWalletDriftResult{
+		{Key: exactKey, Drift: sharedWalletDriftTolerance, Balance: 1000, MemberSum: 1000.01},
+		{Key: ctrlKey, Drift: 0.02, Balance: 1000, MemberSum: 1000.02},
+	}
+	reportSharedWalletDrift(nil, results)
+	reportSharedWalletDrift(nil, results)
+
+	if e := sharedWalletDriftTracker.entries[sharedWalletKeyLabel(exactKey)]; e != nil {
+		t.Fatalf("drift exactly at tolerance must not record/trip (guard is strict >): %+v", e)
+	}
+	ctrl := sharedWalletDriftTracker.entries[sharedWalletKeyLabel(ctrlKey)]
+	if ctrl == nil || ctrl.cycles != 2 || !ctrl.alerted {
+		t.Fatalf("control wallet at $0.02 must confirm and alert on cycle 2: %+v", ctrl)
+	}
+}
+
+// A sign-flipping drift is a materially changed drift: after alerting at +$5
+// (anchor +500 cents), a -$5 reading moves 1000 cents against the anchor and
+// must re-alert immediately; a follow-up -$5.05 (5 cents vs the new -500
+// anchor, under the 10% ratio) must stay throttled.
+func TestSharedWalletDriftTracker_SignFlipReAlerts(t *testing.T) {
+	tr := &SharedWalletDriftTracker{}
+	now := time.Now().UTC()
+
+	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now); notify {
+		t.Fatal("cycle 1 is inside the confirmation window; must not notify")
+	}
+	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now.Add(time.Second)); !notify {
+		t.Fatal("cycle 2 must fire the confirmation alert (anchor +500 cents)")
+	}
+	if notify, _, _ := tr.Record("hyperliquid/0xabc", -5.00, []string{"BTC"}, now.Add(2*time.Second)); !notify {
+		t.Fatal("sign flip +$5 → -$5 is a 1000-cent move against the anchor; must re-alert")
+	}
+	if notify, _, _ := tr.Record("hyperliquid/0xabc", -5.05, []string{"BTC"}, now.Add(3*time.Second)); notify {
+		t.Fatal("-$5.05 vs the -$5.00 anchor is a 5-cent move (< 10%% ratio); must stay throttled")
+	}
+}
+
+// sameAccountLiveManualMembers folds in live HL manual strategies ONLY when
+// the wallet key's account matches this process's HYPERLIQUID_ACCOUNT_ADDRESS
+// — a key for a different account must return nothing.
+func TestSameAccountLiveManualMembers_ExcludesDifferentAccount(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xAAA")
+
+	strategies := []StrategyConfig{
+		{ID: "hl-manual-1", Platform: "hyperliquid", Type: "manual", Symbol: "BTC",
+			Args: []string{"hold", "BTC", "--mode=live"}},
+	}
+
+	other := SharedWalletKey{Platform: "hyperliquid", Account: "0xBBB"}
+	if got := sameAccountLiveManualMembers(other, strategies); len(got) != 0 {
+		t.Fatalf("different-account key must yield no members, got %v", got)
+	}
+
+	same := SharedWalletKey{Platform: "hyperliquid", Account: "0xAAA"}
+	got := sameAccountLiveManualMembers(same, strategies)
+	if len(got) != 1 || got[0] != "hl-manual-1" {
+		t.Fatalf("same-account key must include the live manual strategy, got %v", got)
+	}
+}
+
+// Migration-only pass (empty userFills map): a legacy net close row migrates
+// to gross with a modeled fee, matches nothing, and — critically — the net
+// ledger effect (NewPnL − NewFee) and NewCash are IDENTICAL to the legacy net
+// replay. Migration must never move money.
+func TestPlanTradeLedgerForStrategy_MigrationOnlyPreservesNetSum(t *testing.T) {
+	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	trades := []TradeBackfillRow{
+		{RowID: 1, Timestamp: base, Symbol: "BTC", Side: "sell", Quantity: 0.1,
+			Price: 61000, Value: 6100, IsClose: true, RealizedPnL: 95,
+			ExchangeOrderID: "200"}, // legacy: PnLGross=false, ExchangeFee=0
+	}
+
+	plan := planTradeLedgerForStrategy("hl-x", trades, map[string]HLFillSummary{}, 1000, 0)
+
+	if plan.MigratedCount != 1 || plan.MatchedCount != 0 {
+		t.Fatalf("migrated=%d matched=%d, want 1/0 (no fills to true-up)", plan.MigratedCount, plan.MatchedCount)
+	}
+	if plan.UnmatchedOIDCount != 1 {
+		t.Fatalf("UnmatchedOIDCount = %d, want 1", plan.UnmatchedOIDCount)
+	}
+	if len(plan.Changes) != 1 {
+		t.Fatalf("want exactly 1 change, got %d", len(plan.Changes))
+	}
+	c := plan.Changes[0]
+	modeledFee := 6100 * HyperliquidTakerFeePct
+	if c.WasGross { // row was legacy net
+		t.Fatalf("WasGross = %v, want false", c.WasGross)
+	}
+	if math.Abs(c.NewFee-modeledFee) > 1e-9 {
+		t.Errorf("NewFee = %v, want modeled %v", c.NewFee, modeledFee)
+	}
+	// Gross migration: PnL becomes net + fee; net effect unchanged.
+	if math.Abs((c.NewPnL-c.NewFee)-95) > 1e-9 {
+		t.Errorf("net effect NewPnL-NewFee = %v, want 95 (migration must not move money)", c.NewPnL-c.NewFee)
+	}
+	if math.Abs(plan.NewCash-1095) > 1e-9 {
+		t.Errorf("NewCash = %v, want 1095 (initial 1000 + net 95, identical to legacy replay)", plan.NewCash)
+	}
+	if math.Abs(plan.ReplayedCash-plan.NewCash) > 1e-9 {
+		t.Errorf("pre-migration replay %v != post-migration cash %v; migration moved money", plan.ReplayedCash, plan.NewCash)
+	}
+}
+
+// A caller passing an sc that is not among the coin's live peers, or a peer
+// with zero virtual quantity, must get (0,0) — never the whole portfolio fill.
+func TestHyperliquidKillSwitchFillShare_NonPeerFailsClosed(t *testing.T) {
+	peers := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", Args: []string{"chk", "BTC", "--mode=live"}},
+		{ID: "hl-b", Platform: "hyperliquid", Type: "perps", Args: []string{"chk", "BTC", "--mode=live"}},
+	}
+	vq := hlVirtualQuantitySnapshot{"BTC": {"hl-a": 1.0, "hl-b": 1.0}}
+
+	// sc not in the peer set at all (different ID, absent from snapshot).
+	outsider := StrategyConfig{ID: "hl-c", Platform: "hyperliquid", Type: "perps",
+		Args: []string{"chk", "ETH", "--mode=live"}}
+	if sz, fee := hyperliquidKillSwitchFillShare(outsider, "BTC", 2.0, 0.2, peers, vq); sz != 0 || fee != 0 {
+		t.Fatalf("non-peer sc must fail closed to (0,0), got (%v,%v)", sz, fee)
+	}
+
+	// sc is a peer but has zero virtual quantity in the snapshot.
+	vqZero := hlVirtualQuantitySnapshot{"BTC": {"hl-a": 0.0, "hl-b": 1.0}}
+	if sz, fee := hyperliquidKillSwitchFillShare(peers[0], "BTC", 2.0, 0.2, peers, vqZero); sz != 0 || fee != 0 {
+		t.Fatalf("zero-virtual-qty peer must fail closed to (0,0), got (%v,%v)", sz, fee)
+	}
+}
+
+// A single live strategy on the coin owns the entire fill unchanged.
+func TestHyperliquidKillSwitchFillShare_SinglePeerGetsFullFill(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
+		Args: []string{"chk", "BTC", "--mode=live"}}
+	sz, fee := hyperliquidKillSwitchFillShare(sc, "BTC", 1.5, 0.3,
+		[]StrategyConfig{sc}, hlVirtualQuantitySnapshot{})
+	if sz != 1.5 || fee != 0.3 {
+		t.Fatalf("single peer must receive the full fill unchanged, got (%v,%v)", sz, fee)
+	}
+}
+
+// Uneven virtual quantities split proportionally and the shares sum exactly
+// to the portfolio fill totals.
+func TestHyperliquidKillSwitchFillShare_UnevenSplitSumsToTotal(t *testing.T) {
+	a := StrategyConfig{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
+		Args: []string{"chk", "BTC", "--mode=live"}}
+	b := StrategyConfig{ID: "hl-b", Platform: "hyperliquid", Type: "perps",
+		Args: []string{"chk", "BTC", "--mode=live"}}
+	peers := []StrategyConfig{a, b}
+	vq := hlVirtualQuantitySnapshot{"BTC": {"hl-a": 1.0, "hl-b": 2.0}}
+
+	szA, feeA := hyperliquidKillSwitchFillShare(a, "BTC", 1.0, 0.1, peers, vq)
+	szB, feeB := hyperliquidKillSwitchFillShare(b, "BTC", 1.0, 0.1, peers, vq)
+
+	if math.Abs(szA-1.0/3.0) > 1e-9 || math.Abs(szB-2.0/3.0) > 1e-9 {
+		t.Errorf("size shares = %v/%v, want 1/3 and 2/3", szA, szB)
+	}
+	if math.Abs(feeA-0.1/3.0) > 1e-9 || math.Abs(feeB-0.2/3.0) > 1e-9 {
+		t.Errorf("fee shares = %v/%v, want 0.1/3 and 0.2/3", feeA, feeB)
+	}
+	if math.Abs((szA+szB)-1.0) > 1e-9 || math.Abs((feeA+feeB)-0.1) > 1e-9 {
+		t.Errorf("shares must sum to the fill totals: sz %v fee %v", szA+szB, feeA+feeB)
+	}
+}

--- a/scheduler/trade_pnl_test.go
+++ b/scheduler/trade_pnl_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// TestLifetimeTradeStatsAll_GrossConventionRowsNetOfFee verifies W/L counting
+// reads NET PnL through tradeNetPnLSQL on gross-convention (#954) rows: a
+// small gross win whose fee exceeds it must count as a loss, not a win.
+func TestLifetimeTradeStatsAll_GrossConventionRowsNetOfFee(t *testing.T) {
+	sdb := openTestDB(t)
+	now := time.Now().UTC()
+	trades := []Trade{
+		{StrategyID: "s1", Timestamp: now, Symbol: "BTC", PositionID: "p1", Side: "sell", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps", Details: "Close long", IsClose: true, PnLGross: true, RealizedPnL: 100, ExchangeFee: 0.7},
+		{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", PositionID: "p2", Side: "sell", Quantity: 0.1, Price: 50000, Value: 5000, TradeType: "perps", Details: "Close long", IsClose: true, PnLGross: true, RealizedPnL: 0.05, ExchangeFee: 0.10},
+	}
+	for _, tr := range trades {
+		if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
+			t.Fatalf("InsertTrade: %v", err)
+		}
+	}
+
+	stats, err := sdb.LifetimeTradeStatsAll()
+	if err != nil {
+		t.Fatalf("LifetimeTradeStatsAll: %v", err)
+	}
+	if got := stats["s1"]; got.Wins != 1 || got.Losses != 1 {
+		t.Errorf("s1 stats = %+v, want Wins=1 Losses=1 (raw realized_pnl summing would give Wins=2)", got)
+	}
+}
+
+// TestTradeNetPnLSQL_MirrorsGoHelper verifies the SQL expressions
+// tradeNetPnLSQL / tradeLedgerDeltaSQL agree with their Go mirrors
+// tradeNetPnL / tradeLedgerDelta on every row convention.
+func TestTradeNetPnLSQL_MirrorsGoHelper(t *testing.T) {
+	sdb := openTestDB(t)
+	now := time.Now().UTC()
+	trades := []Trade{
+		{PositionID: "gross-close", TradeType: "perps", IsClose: true, PnLGross: true, RealizedPnL: 100, ExchangeFee: 0.7},
+		{PositionID: "legacy-close", TradeType: "perps", IsClose: true, PnLGross: false, RealizedPnL: 99.3, ExchangeFee: 0.7},
+		{PositionID: "gross-open", TradeType: "perps", IsClose: false, PnLGross: true, RealizedPnL: 0, ExchangeFee: 0.5},
+		{PositionID: "legacy-open", TradeType: "perps", IsClose: false, PnLGross: false, RealizedPnL: 0, ExchangeFee: 0.5},
+		{PositionID: "funding", TradeType: TradeTypeFunding, IsClose: false, PnLGross: true, RealizedPnL: 1.25, ExchangeFee: 0},
+		{PositionID: "rebate", TradeType: "perps", IsClose: true, PnLGross: true, RealizedPnL: 10, ExchangeFee: -0.02},
+		{PositionID: "gross-neg-close", TradeType: "perps", IsClose: true, PnLGross: true, RealizedPnL: -42.20, ExchangeFee: 0.08},
+		{PositionID: "gross-zero-fee", TradeType: "perps", IsClose: true, PnLGross: true, RealizedPnL: 33, ExchangeFee: 0},
+	}
+	for i, tr := range trades {
+		tr.StrategyID = "s1"
+		tr.Timestamp = now.Add(time.Duration(i) * time.Second)
+		tr.Symbol = "BTC"
+		tr.Side = "sell"
+		if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
+			t.Fatalf("InsertTrade %s: %v", tr.PositionID, err)
+		}
+	}
+
+	for _, tr := range trades {
+		var sqlNet, sqlDelta float64
+		if err := sdb.db.QueryRow(
+			`SELECT `+tradeNetPnLSQL+`, `+tradeLedgerDeltaSQL+` FROM trades WHERE position_id = ?`,
+			tr.PositionID).Scan(&sqlNet, &sqlDelta); err != nil {
+			t.Fatalf("query %s: %v", tr.PositionID, err)
+		}
+		if goNet := tradeNetPnL(tr); math.Abs(sqlNet-goNet) > 1e-9 {
+			t.Errorf("%s: tradeNetPnLSQL = %v, tradeNetPnL = %v", tr.PositionID, sqlNet, goNet)
+		}
+		if goDelta := tradeLedgerDelta(tr); math.Abs(sqlDelta-goDelta) > 1e-9 {
+			t.Errorf("%s: tradeLedgerDeltaSQL = %v, tradeLedgerDelta = %v", tr.PositionID, sqlDelta, goDelta)
+		}
+	}
+}
+
+func TestHasTradeWithExchangeOrderID(t *testing.T) {
+	sdb := openTestDB(t)
+	tr := Trade{StrategyID: "hl-a", Timestamp: time.Now().UTC(), Symbol: "BTC", Side: "buy", Quantity: 0.1, Price: 50000, Value: 5000, TradeType: "perps", PositionID: "p1", ExchangeOrderID: "OID1"}
+	if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
+		t.Fatalf("InsertTrade: %v", err)
+	}
+
+	cases := []struct {
+		strategyID, oid string
+		want            bool
+	}{
+		{"hl-a", "OID1", true},
+		{"hl-a", "OID2", false},
+		{"hl-b", "OID1", false},
+		{"hl-a", "", false},
+	}
+	for _, c := range cases {
+		got, err := sdb.HasTradeWithExchangeOrderID(c.strategyID, c.oid)
+		if err != nil {
+			t.Fatalf("HasTradeWithExchangeOrderID(%q,%q): %v", c.strategyID, c.oid, err)
+		}
+		if got != c.want {
+			t.Errorf("HasTradeWithExchangeOrderID(%q,%q) = %v, want %v", c.strategyID, c.oid, got, c.want)
+		}
+	}
+}
+
+func TestTradeBackfillRowNetPnL(t *testing.T) {
+	cases := []struct {
+		name string
+		row  TradeBackfillRow
+		want float64
+	}{
+		{"gross subtracts fee", TradeBackfillRow{PnLGross: true, RealizedPnL: 100, ExchangeFee: 0.7}, 99.3},
+		{"legacy returns raw", TradeBackfillRow{PnLGross: false, RealizedPnL: 99.3, ExchangeFee: 0.7}, 99.3},
+		{"gross zero fee", TradeBackfillRow{PnLGross: true, RealizedPnL: 33, ExchangeFee: 0}, 33},
+		{"gross negative pnl", TradeBackfillRow{PnLGross: true, RealizedPnL: -42.20, ExchangeFee: 0.08}, -42.28},
+	}
+	for _, c := range cases {
+		if got := tradeBackfillRowNetPnL(c.row); math.Abs(got-c.want) > 1e-9 {
+			t.Errorf("%s: tradeBackfillRowNetPnL = %v, want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1233

One-pass assertion-quality audit of the money/PnL/fee accounting test surface, per the issue: inventoried every test guarding these paths, checked each against its named invariant (mutation spot-checks where cheap), and added class-level tests (inverse/compound/boundary) for every confirmed gap.

## Per-file audit verdicts

| Surface | Existing coverage verdict | Confirmed gaps -> action |
|---|---|---|
| `trade_pnl.go` (net/gross helpers, `LedgerNetByStrategy`) | Consumers tested indirectly (portfolio/risk/ledger tests) with concrete values; the helpers and SQL constants themselves had no direct tests and no SQL-vs-Go parity check | Added `trade_pnl_test.go`: gross rows counted net-of-fee in W/L (a marginal 0.05 gross / 0.10 fee row is a LOSS); row-for-row `tradeNetPnLSQL`/`tradeLedgerDeltaSQL` vs Go-mirror parity across gross/legacy/open/funding/rebate/negative-PnL/zero-fee rows; `HasTradeWithExchangeOrderID` dedup matrix; `tradeBackfillRowNetPnL` table |
| `shared_wallet_drift_alerts.go` | Tracker confirm/throttle paths well asserted; tolerance boundary and sign-flip class untested | Added: at/below $0.01 never records or alerts (strict `>` guard), $0.02 control confirms on cycle 2; +$5→−$5 sign flip re-alerts and re-anchors, then small move throttled |
| `shared_wallet_reconcile.go` | Non-destructive ambiguous-gap and OID-confirmed-fill paths covered with concrete state asserts | Added: `sameAccountLiveManualMembers` account-mismatch gate (env vs key account) |
| `cashflow_journal.go` (HL, live basis) | Strong concrete-value coverage of ingest/dedup/cursor/fail-closed; the *positive* live path only ever exercised at drift≈0; ingest boundaries untested | Added: usable journal with nonzero drift (50.0) overrides ledger basis and resets pending streak, and the mirror (journal 0.0 silences ledger 0.40 false positive); event exactly at watermark booked, exactly at cutoff booked (regression to `<=`/`>=` would drop/defer settled events); `SumCashflowJournal` ignores `closed_pnl_gross`; zero-amount events booked without latching Incomplete |
| `okx_cashflow_journal.go` / `topstep_cashflow_journal.go` (shadow-only) | Mirrored concrete-value suites; shadow-only rule was call-site convention only — `applyCashflowJournalDriftBasis` matched purely by key | **Safety-class production change:** guard added refusing non-`hyperliquid` keys (matches the two existing HL-only guards in the same file), with regression test asserting an OKX entry is never mutated; OKX/TopStep at-watermark ingest boundary analogs added |
| `backfill_trade_ledger.go` | NOT untested as feared — ~18 planner tests in `shared_wallet_ledger_test.go` with strong idempotence/apportionment/sum-conservation asserts | Gap: every net-sum assert ran with a userFills true-up. Added migration-only (empty fill map) test proving net ledger sum is preserved exactly (`NewPnL−NewFee == legacy net`, `NewCash` unchanged) |
| `backfill_hl_fees.go` | Real-fee-never-overwritten, modeled-fallback-preserved, cash-replay all concretely asserted | No gaps confirmed — no changes |
| Kill-switch fill share (`hyperliquidKillSwitchFillShare`) | Proportional split and peers-sum-to-report covered via `forceCloseKillSwitchPositions` | Added direct tests: non-peer fails closed to (0,0), zero virtual qty fails closed, single peer gets full fill unchanged, uneven 1/3–2/3 split conserves size and fee totals |

## Verification
- `go -C scheduler build .` and `go -C scheduler test ./...` green (full suite, 3 new test files, 577 insertions).
- `gofmt` clean.
- Only production edit is the shadow-only guard above; everything else is test-only.

---
LLM: Fable 5 | medium | Harness: agent