### PR TITLE
test(#1234): audit and strengthen auto-protective test assertions

### DIFF
--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -2022,3 +2022,83 @@ func TestStrategyRestartShape_NotifyRatchetTriggersOnlyChange(t *testing.T) {
 		t.Fatal("notify_ratchet_triggers set-vs-nil should not affect restart shape")
 	}
 }
+
+// TestValidateHotReloadStateCompatible_StopOwnerModeToggles pins the #1234
+// audit invariant class: toggling ANY Hyperliquid stop-loss owner on or off
+// (nil<->positive scalars, nil<->configured regime blocks, scalar<->regime
+// swaps) is blocked while the strategy holds an open position — the resting
+// on-chain trigger was sized for one distance regime — and allowed while flat.
+func TestValidateHotReloadStateCompatible_StopOwnerModeToggles(t *testing.T) {
+	pf := func(v float64) *float64 { return &v }
+	mkCfg := func(mutate func(sc *StrategyConfig)) *Config {
+		sc := StrategyConfig{
+			ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+			Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+			Leverage: 5, MarginMode: "isolated",
+		}
+		if mutate != nil {
+			mutate(&sc)
+		}
+		return minimalReloadConfig([]StrategyConfig{sc})
+	}
+	openState := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
+		}},
+	}}
+	flatState := &AppState{Strategies: map[string]*StrategyState{
+		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{}},
+	}}
+	regimeBlock := func(sc *StrategyConfig, trailing bool) {
+		b := &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{"trending": {ATR: 2}}}
+		if trailing {
+			sc.TrailingStopATRRegime = b
+		} else {
+			sc.StopLossATRRegime = b
+		}
+	}
+
+	cases := []struct {
+		name     string
+		old, new func(sc *StrategyConfig)
+		wantErr  string
+	}{
+		{"trailing_stop_pct removed (positive->nil)",
+			func(sc *StrategyConfig) { sc.TrailingStopPct = pf(3) }, nil,
+			"trailing_stop_pct mode changed"},
+		{"trailing_stop_atr_mult added (nil->positive)",
+			nil, func(sc *StrategyConfig) { sc.TrailingStopATRMult = pf(2) },
+			"trailing_stop_atr_mult mode changed"},
+		{"trailing_stop_atr_mult removed (positive->nil)",
+			func(sc *StrategyConfig) { sc.TrailingStopATRMult = pf(2) }, nil,
+			"trailing_stop_atr_mult mode changed"},
+		{"stop_loss_atr_mult added (nil->positive)",
+			nil, func(sc *StrategyConfig) { sc.StopLossATRMult = pf(2) },
+			"stop_loss_atr_mult mode changed"},
+		{"stop_loss_atr_mult removed (positive->nil)",
+			func(sc *StrategyConfig) { sc.StopLossATRMult = pf(2) }, nil,
+			"stop_loss_atr_mult mode changed"},
+		{"scalar->regime swap (stop_loss_atr_mult -> stop_loss_atr_regime)",
+			func(sc *StrategyConfig) { sc.StopLossATRMult = pf(2) },
+			func(sc *StrategyConfig) { regimeBlock(sc, false) },
+			"stop_loss_atr_regime mode changed"},
+		{"trailing_stop_atr_regime added (nil->configured)",
+			nil, func(sc *StrategyConfig) { regimeBlock(sc, true) },
+			"trailing_stop_atr_regime mode changed"},
+		{"trailing_stop_atr_regime removed (configured->nil)",
+			func(sc *StrategyConfig) { regimeBlock(sc, true) }, nil,
+			"trailing_stop_atr_regime mode changed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateHotReloadStateCompatible(mkCfg(tc.old), mkCfg(tc.new), openState)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("open position: want error containing %q, got: %v", tc.wantErr, err)
+			}
+			// Inverse: the same owner toggle while FLAT must be accepted.
+			if err := validateHotReloadStateCompatible(mkCfg(tc.old), mkCfg(tc.new), flatState); err != nil {
+				t.Fatalf("flat: same toggle must be accepted, got: %v", err)
+			}
+		})
+	}
+}

--- a/scheduler/hyperliquid_protection_test.go
+++ b/scheduler/hyperliquid_protection_test.go
@@ -858,3 +858,60 @@ func TestStrategyTPTiersForRegime_UnifiedBlock(t *testing.T) {
 		t.Fatalf("empty regime tiers = %+v, want nil", got)
 	}
 }
+
+// TestRatchetExcludedFromOnChainTPGates pins the #1234 audit invariant that
+// the trailing-TP ratchet evaluators place NO on-chain take-profits: they must
+// stay out of all three on-chain-TP gates. Adding either name to
+// isTieredTPATRCloseName, strategyUsesTieredTPATRClose, or the
+// closeStrategiesSuppressedByOnChainProtection set would suppress the
+// in-process ratchet evaluator (or place unintended on-chain TPs) and defeat
+// the let-it-ride trailing stop.
+func TestRatchetExcludedFromOnChainTPGates(t *testing.T) {
+	for _, name := range []string{"trailing_tp_ratchet", "trailing_tp_ratchet_regime"} {
+		if isTieredTPATRCloseName(name) {
+			t.Errorf("isTieredTPATRCloseName(%q) = true; ratchet must never be treated as a tiered-TP-ATR close", name)
+		}
+		sc := StrategyConfig{CloseStrategy: &StrategyRef{Name: name}}
+		if strategyUsesTieredTPATRClose(sc) {
+			t.Errorf("strategyUsesTieredTPATRClose = true for %q; ratchet must not arm on-chain TP tiers", name)
+		}
+		if _, ok := closeStrategiesSuppressedByOnChainProtection[name]; ok {
+			t.Errorf("closeStrategiesSuppressedByOnChainProtection contains %q; suppressing the ratchet evaluator would disable its exit logic entirely", name)
+		}
+		if !isTrailingTPRatchetCloseName(name) {
+			t.Errorf("isTrailingTPRatchetCloseName(%q) = false; want true", name)
+		}
+	}
+}
+
+// TestBuildHyperliquidProtectionPlanAnchorsToRiskAnchorPrice pins the #873
+// invariant at the protection-plan layer: after a scale-in, SL/TP trigger
+// geometry anchors to the FROZEN RiskAnchorPrice, never the blended AvgCost.
+func TestBuildHyperliquidProtectionPlanAnchorsToRiskAnchorPrice(t *testing.T) {
+	mult := 1.0
+	sc := StrategyConfig{
+		ID:              "hl-eth",
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		StopLossATRMult: &mult,
+		CloseStrategy:   &StrategyRef{Name: "tiered_tp_atr_live"},
+	}
+	pos := &Position{
+		Symbol:          "ETH",
+		Quantity:        3,
+		AvgCost:         3050, // blended by a scale-in add
+		RiskAnchorPrice: 2900, // frozen at the original open
+		EntryATR:        50,
+		Side:            "long",
+	}
+	plan, ok := buildHyperliquidProtectionPlan(sc, pos)
+	if !ok {
+		t.Fatal("buildHyperliquidProtectionPlan returned ok=false")
+	}
+	if plan.AvgCost != 2900 {
+		t.Errorf("plan.AvgCost = %g; want frozen RiskAnchorPrice 2900, not blended AvgCost 3050", plan.AvgCost)
+	}
+	if plan.Size != 3 {
+		t.Errorf("plan.Size = %g; want re-sized total quantity 3", plan.Size)
+	}
+}

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -205,6 +206,14 @@ func TestComputeTrailingStopUpdate(t *testing.T) {
 		{"short ratchets down", "short", 90, 100, 3, 0.5, 103, 90, 92.7, true},
 		{"short never raises trigger", "short", 101, 100, 3, 0.5, 103, 100, 0, false},
 		{"missing current trigger places one", "long", 100, 100, 3, 0.5, 0, 100, 97, true},
+		// #1234 audit: movePct >= minMovePct — a move exactly AT the threshold
+		// must replace (regression guard for >= flipped to >). trailingPct=50
+		// makes the trigger factor an exact binary 0.5 (long) / 1.5 (short),
+		// so movePct computes to an exact 1.0 in float64 (0.5/50*100).
+		{"long replaces at exact min-move boundary", "long", 101, 100, 50, 1.0, 50, 101, 50.5, true},
+		{"short replaces at exact min-move boundary", "short", 33, 100, 50, 1.0, 50, 33, 49.5, true},
+		{"long holds just under min-move boundary", "long", 100.8, 100, 50, 1.0, 50, 100.8, 0, false},
+		{"short holds just under min-move boundary", "short", 33.2, 100, 50, 1.0, 50, 33.2, 0, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -870,6 +879,13 @@ func TestEffectiveStopLossPct(t *testing.T) {
 		{"drawdown fallback at cap boundary", hlPerps(StrategyConfig{MaxDrawdownPct: 50, Leverage: 5}), 50},
 		{"drawdown fallback ignored when explicit set", hlPerps(StrategyConfig{StopLossPct: pf(2), MaxDrawdownPct: 10}), 2},
 		{"margin fallthrough beats drawdown", hlPerps(StrategyConfig{StopLossMarginPct: pf(20), MaxDrawdownPct: 5, Leverage: 20}), 1.0},
+		// #1234 audit: a resolved regime-owned stop DEFERS (returns 0) and
+		// must never fall through to the max-drawdown fallback — the trigger
+		// is armed post-open once EntryATR and Regime are stamped (#733).
+		{"stop_loss_atr_regime defers, no drawdown fallback",
+			hlPerps(StrategyConfig{StopLossATRRegime: &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{"trending": {ATR: 2}}}, MaxDrawdownPct: 5, Leverage: 5}), 0},
+		{"trailing_stop_atr_regime defers, no drawdown fallback",
+			hlPerps(StrategyConfig{TrailingStopATRRegime: &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{"trending": {ATR: 2}}}, MaxDrawdownPct: 5, Leverage: 5}), 0},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -2647,5 +2663,66 @@ func TestATRMultMissingEntryATR_FixedATRMult(t *testing.T) {
 	posOK := &Position{AvgCost: 2000, EntryATR: 40}
 	if atrMultMissingEntryATR(sc, posOK) {
 		t.Error("expected atrMultMissingEntryATR=false when EntryATR is stamped")
+	}
+}
+
+// TestHyperliquidProtectionPositionSnapshot_CarriesFullSurface pins the #1015
+// invariant field-by-field: the lock-free protection walker's snapshot must
+// carry the FULL protection surface (regime label/windows/transition state,
+// the frozen #873 risk anchor, and post-TP/ratchet state). A field added to
+// the protection surface but not propagated here silently unarms paper regime
+// trailing SLs — the original #1015 bug class.
+func TestHyperliquidProtectionPositionSnapshot_CarriesFullSurface(t *testing.T) {
+	postTP := 1.25
+	src := &Position{
+		AvgCost:                         3100,
+		EntryATR:                        42,
+		RiskAnchorPrice:                 3000,
+		Regime:                          "trending",
+		RegimeWindows:                   map[string]string{"daily": "trending", "weekly": "ranging"},
+		RegimeAppliedLabel:              "trending",
+		RegimePendingLabel:              "ranging",
+		RegimePendingCount:              2,
+		SLAdjustedTiersProcessed:        3,
+		RatchetFallbackNormalizePending: true,
+		PostTPTrailingATRMult:           &postTP,
+	}
+	snap := hyperliquidProtectionPositionSnapshot(src)
+	if snap == nil {
+		t.Fatal("snapshot is nil for non-nil position")
+	}
+	if snap.AvgCost != 3100 || snap.EntryATR != 42 || snap.RiskAnchorPrice != 3000 {
+		t.Errorf("price surface = (AvgCost %v, EntryATR %v, RiskAnchorPrice %v); want (3100, 42, 3000)",
+			snap.AvgCost, snap.EntryATR, snap.RiskAnchorPrice)
+	}
+	if snap.Regime != "trending" || snap.RegimeAppliedLabel != "trending" ||
+		snap.RegimePendingLabel != "ranging" || snap.RegimePendingCount != 2 {
+		t.Errorf("regime surface = (%q, %q, %q, %d); want (trending, trending, ranging, 2)",
+			snap.Regime, snap.RegimeAppliedLabel, snap.RegimePendingLabel, snap.RegimePendingCount)
+	}
+	if !reflect.DeepEqual(snap.RegimeWindows, src.RegimeWindows) {
+		t.Errorf("RegimeWindows = %v; want %v", snap.RegimeWindows, src.RegimeWindows)
+	}
+	if snap.SLAdjustedTiersProcessed != 3 || !snap.RatchetFallbackNormalizePending {
+		t.Errorf("ratchet surface = (%d, %v); want (3, true)",
+			snap.SLAdjustedTiersProcessed, snap.RatchetFallbackNormalizePending)
+	}
+	if snap.PostTPTrailingATRMult == nil || *snap.PostTPTrailingATRMult != 1.25 {
+		t.Errorf("PostTPTrailingATRMult = %v; want 1.25", snap.PostTPTrailingATRMult)
+	}
+
+	// Deep-copy guarantees: the walker is lock-free, so mutating the source
+	// after snapshotting must not leak into the snapshot.
+	src.RegimeWindows["daily"] = "ranging"
+	if snap.RegimeWindows["daily"] != "trending" {
+		t.Error("RegimeWindows was shallow-copied; walker snapshot mutated by main loop")
+	}
+	*src.PostTPTrailingATRMult = 9.9
+	if *snap.PostTPTrailingATRMult != 1.25 {
+		t.Error("PostTPTrailingATRMult pointer was shared; walker snapshot mutated by main loop")
+	}
+
+	if hyperliquidProtectionPositionSnapshot(nil) != nil {
+		t.Error("snapshot of nil position must be nil")
 	}
 }

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -2099,3 +2099,64 @@ func TestFormatKillSwitchResetPrompt_OmitsAddressWhenHLNotConfigured(t *testing.
 		t.Errorf("expected instance label present regardless of HL address, got: %s", got)
 	}
 }
+
+// TestHyperliquidKillSwitchFillShare_FailsClosedWhenNotAPeer pins the #1234
+// audit invariant that hyperliquidKillSwitchFillShare fails closed: an sc that
+// is not among the coin's live peers, or whose virtual quantity is zero, must
+// receive (0, 0) rather than claiming any share of the portfolio-level fill.
+func TestHyperliquidKillSwitchFillShare_FailsClosedWhenNotAPeer(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", Leverage: 5,
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-b", Platform: "hyperliquid", Type: "perps", Leverage: 5,
+			Args: []string{"ema", "ETH", "1h", "--mode=live"}},
+	}
+	virtualQty := hlVirtualQuantitySnapshot{
+		"ETH": {"hl-a": 1.5, "hl-b": 0.5},
+	}
+
+	t.Run("non-peer strategy gets zero share", func(t *testing.T) {
+		outsider := StrategyConfig{ID: "hl-c", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"rsi", "ETH", "1h", "--mode=live"}}
+		sz, fee := hyperliquidKillSwitchFillShare(outsider, "ETH", 2.0, 4.0, hlLive, virtualQty)
+		if sz != 0 || fee != 0 {
+			t.Errorf("fill share for non-peer = (%v, %v); want (0, 0) fail-closed", sz, fee)
+		}
+	})
+
+	t.Run("peer with zero virtual quantity gets zero share", func(t *testing.T) {
+		zeroQty := hlVirtualQuantitySnapshot{
+			"ETH": {"hl-a": 0, "hl-b": 0.5},
+		}
+		sz, fee := hyperliquidKillSwitchFillShare(hlLive[0], "ETH", 2.0, 4.0, hlLive, zeroQty)
+		if sz != 0 || fee != 0 {
+			t.Errorf("fill share for zero-qty peer = (%v, %v); want (0, 0) fail-closed", sz, fee)
+		}
+	})
+
+	t.Run("all peers zero quantity gets zero share", func(t *testing.T) {
+		allZero := hlVirtualQuantitySnapshot{
+			"ETH": {"hl-a": 0, "hl-b": 0},
+		}
+		sz, fee := hyperliquidKillSwitchFillShare(hlLive[0], "ETH", 2.0, 4.0, hlLive, allZero)
+		if sz != 0 || fee != 0 {
+			t.Errorf("fill share with all-zero peers = (%v, %v); want (0, 0) fail-closed", sz, fee)
+		}
+	})
+
+	t.Run("sole peer receives full fill", func(t *testing.T) {
+		solo := hlLive[:1]
+		sz, fee := hyperliquidKillSwitchFillShare(hlLive[0], "ETH", 2.0, 4.0, solo, virtualQty)
+		if sz != 2.0 || fee != 4.0 {
+			t.Errorf("sole-peer fill share = (%v, %v); want full (2.0, 4.0)", sz, fee)
+		}
+	})
+
+	t.Run("peer shares sum to the reported fill", func(t *testing.T) {
+		szA, feeA := hyperliquidKillSwitchFillShare(hlLive[0], "ETH", 2.0, 4.0, hlLive, virtualQty)
+		szB, feeB := hyperliquidKillSwitchFillShare(hlLive[1], "ETH", 2.0, 4.0, hlLive, virtualQty)
+		if math.Abs(szA+szB-2.0) > 1e-9 || math.Abs(feeA+feeB-4.0) > 1e-9 {
+			t.Errorf("peer shares sum to (%v, %v); want (2.0, 4.0)", szA+szB, feeA+feeB)
+		}
+	})
+}

--- a/scheduler/regime_atr_test.go
+++ b/scheduler/regime_atr_test.go
@@ -487,3 +487,71 @@ func TestParseRegimeATRBlock_AtrMultipleCanonical(t *testing.T) {
 		t.Fatal("expected error when both atr_multiple and atr are set")
 	}
 }
+
+// TestValidateRegimeATRConfig_RegimeOwnerMutexAllPairs pins the #1234 audit
+// invariant that each regime stop block is mutually exclusive with EVERY other
+// stop-loss owner — all nine regime-involving pairs, not just the two that had
+// bespoke regression tests. Losing any pair silently allows two owners to arm
+// competing stops on the same position.
+func TestValidateRegimeATRConfig_RegimeOwnerMutexAllPairs(t *testing.T) {
+	pf := func(v float64) *float64 { return &v }
+	regimeBlock := func() *RegimeATRBlock { return &RegimeATRBlock{raw: adx3StateATR(2.0)} }
+	cases := []struct {
+		name    string
+		mutate  func(sc *StrategyConfig)
+		wantErr string
+	}{
+		{"stop_loss_atr_regime x stop_loss_pct",
+			func(sc *StrategyConfig) { sc.StopLossATRRegime = regimeBlock(); sc.StopLossPct = pf(1.5) },
+			"stop_loss_atr_regime is mutually exclusive with stop_loss_pct"},
+		{"stop_loss_atr_regime x stop_loss_margin_pct",
+			func(sc *StrategyConfig) { sc.StopLossATRRegime = regimeBlock(); sc.StopLossMarginPct = pf(20) },
+			"stop_loss_atr_regime is mutually exclusive with stop_loss_margin_pct"},
+		{"stop_loss_atr_regime x trailing_stop_pct",
+			func(sc *StrategyConfig) { sc.StopLossATRRegime = regimeBlock(); sc.TrailingStopPct = pf(2) },
+			"stop_loss_atr_regime is mutually exclusive with trailing_stop_pct"},
+		{"stop_loss_atr_regime x trailing_stop_atr_mult",
+			func(sc *StrategyConfig) { sc.StopLossATRRegime = regimeBlock(); sc.TrailingStopATRMult = pf(2) },
+			"stop_loss_atr_regime is mutually exclusive with trailing_stop_atr_mult"},
+		{"stop_loss_atr_regime x stop_loss_atr_mult",
+			func(sc *StrategyConfig) { sc.StopLossATRRegime = regimeBlock(); sc.StopLossATRMult = pf(2) },
+			"stop_loss_atr_regime is mutually exclusive with stop_loss_atr_mult"},
+		{"trailing_stop_atr_regime x stop_loss_pct",
+			func(sc *StrategyConfig) { sc.TrailingStopATRRegime = regimeBlock(); sc.StopLossPct = pf(1.5) },
+			"trailing_stop_atr_regime is mutually exclusive with stop_loss_pct"},
+		{"trailing_stop_atr_regime x stop_loss_margin_pct",
+			func(sc *StrategyConfig) { sc.TrailingStopATRRegime = regimeBlock(); sc.StopLossMarginPct = pf(20) },
+			"trailing_stop_atr_regime is mutually exclusive with stop_loss_margin_pct"},
+		{"trailing_stop_atr_regime x trailing_stop_pct",
+			func(sc *StrategyConfig) { sc.TrailingStopATRRegime = regimeBlock(); sc.TrailingStopPct = pf(2) },
+			"trailing_stop_atr_regime is mutually exclusive with trailing_stop_pct"},
+		{"trailing_stop_atr_regime x trailing_stop_atr_mult",
+			func(sc *StrategyConfig) { sc.TrailingStopATRRegime = regimeBlock(); sc.TrailingStopATRMult = pf(2) },
+			"trailing_stop_atr_regime is mutually exclusive with trailing_stop_atr_mult"},
+		{"trailing_stop_atr_regime x stop_loss_atr_mult",
+			func(sc *StrategyConfig) { sc.TrailingStopATRRegime = regimeBlock(); sc.StopLossATRMult = pf(2) },
+			"trailing_stop_atr_regime is mutually exclusive with stop_loss_atr_mult"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := StrategyConfig{
+				ID:              "hl-test",
+				Type:            "perps",
+				Platform:        "hyperliquid",
+				RegimeATRWindow: "daily",
+			}
+			tc.mutate(&sc)
+			errs := validateRegimeATRConfig(adxRegimeCfg(sc))
+			found := false
+			for _, e := range errs {
+				if strings.Contains(e, tc.wantErr) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("want error containing %q, got: %v", tc.wantErr, errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1234 (child of umbrella #1226).

Assertion-quality audit of every test guarding the auto-protective surface. Verdicts per mechanism, then the gaps fixed. **No production changes** — no test masked a real bug.

## Per-mechanism audit verdicts

1. **Seven stop-loss owners / EffectiveStopLossPct (config.go)** — scalar×scalar mutex: all 10 pairs strongly tested. All-omitted → DefaultStopLossATRMult=1.0: strong. EffectiveStopLossPct ladder: strong per scalar branch. **Gaps fixed:** 9 of 11 regime-involving mutex pairs untested; the two explicit regime-deferral branches of EffectiveStopLossPct unexercised.
2. **Hot-reload owner guards (config_reload.go)** — regime→scalar while open and trailing_stop_pct nil→positive were tested; **gaps fixed:** scalar→regime direction, positive→nil removals, both scalar ATR mode toggles, trailing_stop_atr_regime mode toggle — now all covered with while-flat inverses.
3. **Trailing SL (hyperliquid_trailing_stop.go)** — cancel+replace args, ratchet monotonicity, breach equality, and all four hlSLEffectiveQty branches (incl. onChain==virtual boundary): strong. **Gaps fixed:** exact min-move threshold boundary (movePct == min must replace; mutation-verified that flipping >= to > fails the new rows); #1015 snapshot had only one behavioral test — added field-by-field completeness plus deep-copy isolation (RegimeWindows map, PostTPTrailingATRMult pointer).
4. **Open-arm (hyperliquid_open_trailing.go)** — strong: happy path, existing-SL no-op, paper no-subprocess, size-cap deferral, immediate-fill booking, regime branch. No gaps.
5. **Protection sync (hyperliquid_protection.go)** — EntryATR<=0 skip, manual inclusion, on-chain TP gate live-true/paper-false, paper-never-suppressed inverse (incl. survival into buildStrategyRefsArg): strong. **Gap fixed:** no test pinned #873 plan geometry to the frozen RiskAnchorPrice when AvgCost had blended after a scale-in.
6. **Trailing-TP ratchet (trailing_tp_ratchet.go)** — tier math, validation, DM idempotency, two-layer notify gating: strong. **Gap fixed:** nothing asserted the ratchet's exclusion from the three on-chain-TP gates — adding it to any of isTieredTPATRCloseName / strategyUsesTieredTPATRClose / closeStrategiesSuppressedByOnChainProtection previously regressed no test.
7. **Circuit breaker (#1046/#1048)** — enabled-nil/true/false × both firing arms (drawdown and loss-streak, separately), latched-drain-while-disabled, warn-once throttle, and the full circuitBreakerPermitsManagement exclusion table: strong. Pending-close drain paths extensively tested across all four platforms. Residual (documented, not testable without refactor): the #1046 main-loop fall-through itself (cbManageOnly, Signal=0 instead of continue) lives inline in main.go's dispatch and has no unit seam; the predicate it keys off is fully tested.
8. **Kill switch (kill_switch_close.go)** — planKillSwitchClose confirmed-flat true/false, per-platform close/fetcher/unwired/unconfigured failure paths all fail-closed, #1190 reset-DM content: strong. **Gap fixed:** hyperliquidKillSwitchFillShare's fail-closed branch (non-peer / zero-qty / all-zero → (0,0)) had zero coverage; also pinned sole-peer full fill and peers-sum-to-report.
9. **Pause (#1150, pause.go)** — 24-case signal table (fresh open/add/flip blocked; closes, pure-close exits pass), options actions, hot-reload while open: strong. Residual (documented): the 7 main.go dispatch-site wirings are not unit-testable without a dispatch refactor; the helper and its allows-args semantics are fully covered.

## Verification
- `go -C scheduler build .` and `go -C scheduler test ./...` green.
- Mutation spot-check: flipping the min-move `>=` to `>` fails the new boundary rows (reverted).

LLM: Fable 5 | medium | Harness: agent