### PR TITLE
test(#1235): audit look-ahead/liquidation-floor test coverage; pin fee_audit screen_leg liquidated OR

### DIFF
--- a/backtest/tests/test_metrics_liquidation.py
+++ b/backtest/tests/test_metrics_liquidation.py
@@ -254,6 +254,43 @@ def test_format_window_report_silent_when_no_liquidation():
 
 
 # ---------------------------------------------------------------------------
+# fee_audit — screen_leg propagation (#1005/#1235): the leg row must flag
+# liquidation when EITHER the net or the gross (zero-friction) run blew the
+# account; dropping either side of the OR silently hides a blown leg.
+# ---------------------------------------------------------------------------
+
+def _screen_leg_with(monkeypatch, net_liquidated, gross_liquidated):
+    def fake_run_leg(reg, name, params, sym, tf, window, capital=0.0,
+                     direction=None, commission_pct=None, slippage_pct=None,
+                     **kw):
+        # commission_pct=0.0 identifies the gross (zero-friction) re-run.
+        is_gross = commission_pct == 0.0
+        blown = gross_liquidated if is_gross else net_liquidated
+        return {"trades": 3, "span_days": 30.0,
+                "return_pct": -100.0 if blown else 1.0,
+                "sharpe": -100.0 if blown else 0.5,
+                "liquidated": blown}
+
+    monkeypatch.setattr(fa, "run_leg", fake_run_leg, raising=True)
+    leg = fa.screen_leg(object(), "x", "BTC/USDT", "1h",
+                        ("2026-01-01", None), capital=1000.0)
+    assert leg is not None and leg["error"] is None
+    return leg
+
+
+def test_screen_leg_liquidated_when_net_run_busts(monkeypatch):
+    assert _screen_leg_with(monkeypatch, True, False)["liquidated"] is True
+
+
+def test_screen_leg_liquidated_when_only_gross_run_busts(monkeypatch):
+    assert _screen_leg_with(monkeypatch, False, True)["liquidated"] is True
+
+
+def test_screen_leg_not_liquidated_when_neither_run_busts(monkeypatch):
+    assert _screen_leg_with(monkeypatch, False, False)["liquidated"] is False
+
+
+# ---------------------------------------------------------------------------
 # fee_audit — aggregation count + markdown section
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1235 (part of umbrella #1226).

Audit of backtest look-ahead and #1005 liquidation-floor test coverage via mutation spot-checks: each pinned site was mutated locally (shift removed / floor removed / flag dropped), the mapped test confirmed to fail, then reverted. One gap survived — `fee_audit.screen_leg`'s net-OR-gross `liquidated` propagation — now pinned by three new tests. No production changes (no test masked a real bug).

## Coverage map (mutation-verified)

| Site | Mutation | Pinning test | Result |
|---|---|---|---|
| `run_backtest._aligned_regime_columns` `.shift(1)` (#1153) | drop shift | `test_backtester_composite_regime_wiring.py::test_regime_timeframe_override_aligns_without_lookahead` | KILLED |
| `run_backtest._profile_label_series` cross-TF `.shift(1)` (#1153) | drop shift | `test_backtester_composite_regime_wiring.py::test_profile_label_series_cross_timeframe_aligns_without_lookahead` | KILLED |
| `run_backtest._htf_trend_series` `.shift(1)` (#1154) | drop shift | `test_backtest_reporting.py::test_htf_trend_series_uses_last_closed_htf_bar_no_lookahead` | KILLED |
| `backtester._calculate_metrics` sticky equity floor | drop floor | `test_metrics_liquidation.py` (6 tests) | KILLED |
| `backtester._calculate_metrics` Sharpe/Sortino/vol sentinel floor | drop floor | `test_metrics_liquidation.py` (4 tests) | KILLED |
| `backtester._calculate_metrics` `liquidated` flag | force False | `test_metrics_liquidation.py` (9 tests) | KILLED |
| `eval_windows.leg_from_results` `liquidated` propagation | force False | `test_metrics_liquidation.py::test_leg_from_results_propagates_liquidated` (+3) | KILLED |
| `eval_windows.leg_from_results` DDadj floor (#1228) | drop floor | `test_metrics_liquidation.py::test_leg_from_results_floors_ddadj_when_liquidated` | KILLED |
| `fee_audit.screen_leg` `liquidated = net OR gross` | drop either/both sides | none | **SURVIVED → 3 new tests added; all 3 mutants now KILLED** |

Enumeration notes: `grep 'shift(1)\|reindex'` over `backtest/run_backtest.py` confirms the three HTF sites above are the only coarser-timeframe reindex sites (no new series since #1153/#1154). Funding attach uses `merge_asof` backward (rate known at its own timestamp — no shift needed by design). Downstream floor consumers `fee_audit.aggregate_strategy`/`render_markdown` and `eval_windows.score_candidate`/`format_window_report` were already pinned by `test_metrics_liquidation.py`.

Full suite: 2374 passed, 1 skipped.

---
LLM: Fable 5 | medium | Harness: agent
