### PR TITLE
fix(#1242): canonical Sortino, None profit factor, half-open M1 windows

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -2859,12 +2859,23 @@ class Backtester:
         else:
             sharpe = 0.0
 
-        # Sortino Ratio (only downside deviation)
-        downside = daily_returns[daily_returns < 0]
-        if len(downside) > 1 and downside.std() > 0:
-            sortino = (daily_returns.mean() / downside.std()) * ann_factor
+        # Sortino Ratio — canonical downside deviation: the root-mean-square of
+        # min(r, 0) about a MAR of 0 (NOT the sample std of negatives about their
+        # own mean), annualized by the same factor as Sharpe. The RMS is taken
+        # over ALL return observations, so a single losing bar still yields a
+        # finite, well-defined denominator. Zero downside (no losing bars, or a
+        # downside deviation that rounds to 0) means Sortino is mathematically
+        # undefined — report None, never a neutral 0.0 that would rank a
+        # flawless leg below a mediocre one.
+        if len(daily_returns) > 0:
+            neg = daily_returns.clip(upper=0.0)
+            downside_dev = float(np.sqrt((neg**2).mean()))
         else:
-            sortino = 0.0
+            downside_dev = 0.0
+        if downside_dev > 0:
+            sortino = (daily_returns.mean() / downside_dev) * ann_factor
+        else:
+            sortino = None
 
         # Max Drawdown — floor the running peak at initial_capital so the
         # baseline is always the true starting balance, not a seeded
@@ -2883,7 +2894,11 @@ class Backtester:
 
             gross_profit = sum(t.pnl for t in winning) if winning else 0
             gross_loss = abs(sum(t.pnl for t in losing)) if losing else 0
-            profit_factor = gross_profit / gross_loss if gross_loss > 0 else float("inf")
+            # All-win legs (no losing trades → gross_loss == 0) have an
+            # undefined profit factor. Report None, never float("inf"): a NaN/inf
+            # would serialize as the nonstandard JSON `Infinity` token that strict
+            # parsers (incl. Go json.Unmarshal) reject.
+            profit_factor = gross_profit / gross_loss if gross_loss > 0 else None
 
             avg_win = np.mean([t.pnl_pct for t in winning]) if winning else 0
             avg_loss = np.mean([t.pnl_pct for t in losing]) if losing else 0
@@ -2910,6 +2925,9 @@ class Backtester:
         # (not -ann_factor) so two equally-dead legs tie regardless of bust
         # timeframe, and not path-dependent so an earlier bust never out-ranks
         # a later one.
+        # Liquidation forces the sentinel floor regardless of the values above
+        # — a busted account is NOT "zero downside"; the None-Sortino convention
+        # never applies here (#1005 override wins).
         if liquidated:
             sharpe = sortino = -LIQUIDATED_METRIC_FLOOR
             volatility = LIQUIDATED_METRIC_FLOOR
@@ -2918,17 +2936,25 @@ class Backtester:
             "total_return_pct": round(total_return * 100, 2),
             "annual_return_pct": round(annual_return * 100, 2),
             "sharpe_ratio": round(sharpe, 3),
-            "sortino_ratio": round(sortino, 3),
+            "sortino_ratio": round(sortino, 3) if sortino is not None else None,
             "max_drawdown_pct": round(max_drawdown * 100, 2),
             "calmar_ratio": round(calmar, 3),
             "volatility_pct": round(volatility * 100, 2),
             "win_rate": round(win_rate * 100, 2),
-            "profit_factor": round(profit_factor, 3),
+            "profit_factor": round(profit_factor, 3) if profit_factor is not None else None,
             "total_trades": total_trades,
             "avg_win_pct": round(avg_win * 100, 2),
             "avg_loss_pct": round(avg_loss * 100, 2),
             "liquidated": liquidated,
         }
+
+
+def _fmt_opt(value, spec: str = ".3f", none_text: str = "n/a") -> str:
+    """Format an optional numeric metric, rendering None (undefined) as text
+    instead of raising on a format spec that only accepts numbers."""
+    if value is None:
+        return none_text
+    return format(value, spec)
 
 
 def format_results(results: dict) -> str:
@@ -2956,14 +2982,14 @@ def format_results(results: dict) -> str:
         f"{'─'*60}",
         f"  RISK METRICS",
         f"    Sharpe Ratio:    {results['sharpe_ratio']:.3f}",
-        f"    Sortino Ratio:   {results['sortino_ratio']:.3f}",
+        f"    Sortino Ratio:   {_fmt_opt(results['sortino_ratio'])}",
         f"    Max Drawdown:    {results['max_drawdown_pct']:.2f}%",
         f"    Calmar Ratio:    {results.get('calmar_ratio', 0):.3f}",
         f"{'─'*60}",
         f"  TRADE STATS",
         f"    Total Trades:    {results['total_trades']}",
         f"    Win Rate:        {results['win_rate']:.1f}%",
-        f"    Profit Factor:   {results['profit_factor']:.3f}",
+        f"    Profit Factor:   {_fmt_opt(results['profit_factor'])}",
         f"    Avg Win:         {results.get('avg_win_pct', 0):+.2f}%",
         f"    Avg Loss:        {results.get('avg_loss_pct', 0):+.2f}%",
         f"{'='*60}",

--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -334,6 +334,7 @@ def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
     present (the Backtester rejects a policy without regime compute).
     """
     from atr import ensure_atr_indicator
+    import pandas as pd
     from data_fetcher import load_cached_data
     from backtester import Backtester
     from run_backtest import (FUNDING_COLUMN_STRATEGIES, _attach_funding_if_needed,
@@ -343,6 +344,18 @@ def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
     df = load_cached_data(symbol, timeframe, start_date=start, end_date=end)
     if df.empty:
         return None
+    # load_ohlcv's end bound is INCLUSIVE (timestamp <= end_ts), but M1 windows
+    # share boundaries ("is" ends where "oos" begins, "2023" where "2024"
+    # begins, ...) and gross_edge_noise documents a half-open [start, end)
+    # convention. Slice the end EXCLUSIVELY here — dropping any bar whose OPEN
+    # time equals `end` — so adjacent windows never double-count the boundary
+    # bar. We fix it at this caller rather than in load_ohlcv, whose inclusive
+    # contract other callers rely on. end=None means "latest cached bar" (no
+    # upper bound), so it is left untouched.
+    if end is not None:
+        df = df[df.index < pd.Timestamp(end)]
+        if df.empty:
+            return None
     if name in FUNDING_COLUMN_STRATEGIES:
         df = _attach_funding_if_needed(df, name, symbol, start)
 

--- a/backtest/reporter.py
+++ b/backtest/reporter.py
@@ -4,6 +4,7 @@ Supports single-strategy reports, comparisons, and multi-asset analysis.
 """
 
 import sys
+import re
 import os
 import json
 from typing import List, Dict, Optional
@@ -15,6 +16,17 @@ import numpy as np
 import pandas as pd
 
 from storage import get_backtest_results
+
+
+def _fmt_opt(value, spec: str = ".3f", none_text: str = "n/a") -> str:
+    """Format an optional numeric metric. None (an undefined metric such as a
+    zero-downside Sortino or an all-win profit factor) renders as text instead
+    of raising on a numeric-only format spec; when the spec carries a field
+    width the placeholder is right-justified to keep table columns aligned."""
+    if value is None:
+        m = re.match(r">?(\d+)", spec)
+        return none_text.rjust(int(m.group(1))) if m else none_text
+    return format(value, spec)
 
 
 def format_single_report(results: dict) -> str:
@@ -37,14 +49,14 @@ def format_single_report(results: dict) -> str:
         f"{'─'*70}",
         f"  RISK METRICS",
         f"    Sharpe Ratio:    {results.get('sharpe_ratio', 0):.3f}",
-        f"    Sortino Ratio:   {results.get('sortino_ratio', 0):.3f}",
+        f"    Sortino Ratio:   {_fmt_opt(results.get('sortino_ratio', 0))}",
         f"    Max Drawdown:    {results.get('max_drawdown_pct', 0):.2f}%",
         f"    Calmar Ratio:    {results.get('calmar_ratio', 0):.3f}",
         f"{'─'*70}",
         f"  TRADE STATS",
         f"    Total Trades:    {results.get('total_trades', 0)}",
         f"    Win Rate:        {results.get('win_rate', 0):.1f}%",
-        f"    Profit Factor:   {results.get('profit_factor', 0):.3f}",
+        f"    Profit Factor:   {_fmt_opt(results.get('profit_factor', 0))}",
         f"    Avg Win:         {results.get('avg_win_pct', 0):+.2f}%",
         f"    Avg Loss:        {results.get('avg_loss_pct', 0):+.2f}%",
     ]
@@ -92,10 +104,10 @@ def format_comparison_report(results_list: List[dict], title: str = "STRATEGY CO
             f"{r.get('symbol','?'):<10} "
             f"{r.get('total_return_pct',0):>+7.1f}% "
             f"{r.get('sharpe_ratio',0):>7.2f} "
-            f"{r.get('sortino_ratio',0):>7.2f} "
+            f"{_fmt_opt(r.get('sortino_ratio',0), '>7.2f'):} "
             f"{r.get('max_drawdown_pct',0):>+7.1f}% "
             f"{r.get('win_rate',0):>6.1f}% "
-            f"{r.get('profit_factor',0):>5.2f} "
+            f"{_fmt_opt(r.get('profit_factor',0), '>5.2f'):} "
             f"{r.get('total_trades',0):>6}"
         )
 

--- a/backtest/tests/test_metric_degenerates.py
+++ b/backtest/tests/test_metric_degenerates.py
@@ -1,0 +1,246 @@
+"""#1242: degenerate-safe backtest metric definitions and window bounds.
+
+Three independent fixes, one home:
+
+1. Sortino uses the CANONICAL downside deviation — root-mean-square of
+   ``min(r, 0)`` about MAR=0 over all observations — not the sample std of
+   negatives about their own mean. A leg with zero downside (no losing bars)
+   has an UNDEFINED Sortino and reports ``None``, never a neutral 0.0 that
+   would rank a flawless leg below a mediocre one. A single losing bar now
+   yields a finite value instead of the old ``len>1`` neutral 0.0.
+2. ``profit_factor`` on an all-win leg (gross_loss == 0) is ``None``, never
+   ``float("inf")`` — so ``json.dump`` never emits the nonstandard ``Infinity``
+   token that strict parsers (incl. Go ``json.Unmarshal``) reject.
+3. eval_windows slices ``[start, end)`` exclusively, so adjacent M1 windows —
+   which share calendar boundaries — never double-count the boundary bar.
+"""
+import json
+import os
+import sys
+import types
+
+import numpy as np
+import pandas as pd
+import pytest
+
+_BT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BT_DIR not in sys.path:
+    sys.path.insert(0, _BT_DIR)
+
+import eval_windows as ew  # noqa: E402
+from backtester import Backtester, format_results  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _metrics(equities, trades=None, timeframe="1d", initial_capital=1000.0):
+    idx = pd.date_range("2024-01-01", periods=len(equities), freq="D")
+    equity_df = pd.DataFrame({"equity": np.asarray(equities, dtype=float)},
+                             index=idx)
+    df = pd.DataFrame({"close": np.full(len(equities), 100.0)}, index=idx)
+    bt = Backtester(initial_capital=initial_capital)
+    return bt._calculate_metrics(equity_df, trades or [], df, timeframe=timeframe)
+
+
+def _trade(pnl, pnl_pct=0.0):
+    """Minimal stand-in — _calculate_metrics only reads .pnl / .pnl_pct."""
+    return types.SimpleNamespace(pnl=pnl, pnl_pct=pnl_pct)
+
+
+def _ann_factor(timeframe="1d"):
+    # Mirror the Backtester's periods-per-year annualization for 1d.
+    return np.sqrt(365)
+
+
+# ---------------------------------------------------------------------------
+# Sortino — canonical downside deviation about MAR=0
+# ---------------------------------------------------------------------------
+
+def test_sortino_zero_losing_bars_is_none_not_zero():
+    # Monotonically rising equity: every return is >= 0, so downside deviation
+    # is 0 and Sortino is mathematically undefined. Must be None, NOT 0.0 —
+    # a neutral 0.0 would rank this near-perfect leg below a mediocre one.
+    m = _metrics([1000, 1100, 1200, 1300, 1400])
+    assert m["liquidated"] is False
+    assert m["sortino_ratio"] is None
+    # Sanity: the leg genuinely has upside (Sharpe is finite and positive).
+    assert m["sharpe_ratio"] > 0
+
+
+def test_sortino_one_losing_bar_is_finite_canonical_value():
+    # A single down bar. The OLD code (len(downside) > 1) collapsed this to a
+    # neutral 0.0; the canonical RMS-about-0 denominator is well-defined from
+    # one observation, so Sortino is finite. Recompute the canonical value
+    # independently and assert equality.
+    equities = [1000, 1100, 1050, 1200, 1300]
+    m = _metrics(equities)
+    rets = pd.Series(equities, dtype=float).pct_change().dropna()
+    downside_dev = float(np.sqrt((rets.clip(upper=0.0) ** 2).mean()))
+    expected = (rets.mean() / downside_dev) * _ann_factor()
+    assert m["sortino_ratio"] is not None
+    assert m["sortino_ratio"] == pytest.approx(round(expected, 3))
+    # The old sample-std-of-negatives denominator needs >=2 negatives and would
+    # have returned 0.0 here — guard against a regression to that behavior.
+    assert m["sortino_ratio"] != 0.0
+
+
+def test_sortino_all_loss_is_finite_negative():
+    # Every bar loses: downside deviation is well-defined and the numerator
+    # (mean return) is negative, so Sortino is a finite negative number.
+    equities = [1000, 950, 900, 850, 800]
+    m = _metrics(equities)
+    rets = pd.Series(equities, dtype=float).pct_change().dropna()
+    downside_dev = float(np.sqrt((rets.clip(upper=0.0) ** 2).mean()))
+    expected = (rets.mean() / downside_dev) * _ann_factor()
+    assert m["liquidated"] is False
+    assert m["sortino_ratio"] is not None
+    assert m["sortino_ratio"] < 0
+    assert m["sortino_ratio"] == pytest.approx(round(expected, 3))
+
+
+def test_sortino_liquidated_forces_floor_not_none():
+    # #1005 override wins: a liquidated leg is NOT "zero downside" — it forces
+    # the sentinel floor regardless of the canonical None convention.
+    m = _metrics([1000, -500, 800, 900])  # bust idx 1
+    assert m["liquidated"] is True
+    assert m["sortino_ratio"] is not None
+    assert m["sortino_ratio"] < 0
+
+
+def test_sortino_uptrend_with_no_trades_still_none():
+    # No trades AND no down bars — the profit_factor path takes its no-trade
+    # branch (0) while Sortino remains None; the two conventions are independent.
+    m = _metrics([1000, 1010, 1020], trades=[])
+    assert m["sortino_ratio"] is None
+    assert m["profit_factor"] == 0  # no-trade branch, unchanged
+
+
+# ---------------------------------------------------------------------------
+# profit_factor — all-win legs report None, never Infinity
+# ---------------------------------------------------------------------------
+
+def test_profit_factor_all_win_is_none():
+    trades = [_trade(50.0, 0.05), _trade(30.0, 0.03)]
+    m = _metrics([1000, 1050, 1080], trades=trades)
+    assert m["profit_factor"] is None
+
+
+def test_profit_factor_mixed_is_finite():
+    trades = [_trade(80.0, 0.08), _trade(-20.0, -0.02)]
+    m = _metrics([1000, 1080, 1060], trades=trades)
+    assert m["profit_factor"] == pytest.approx(round(80.0 / 20.0, 3))
+
+
+def test_profit_factor_none_never_serializes_as_infinity():
+    # The whole point of None over inf: json.dump must never emit `Infinity`.
+    trades = [_trade(50.0, 0.05), _trade(30.0, 0.03)]
+    m = _metrics([1000, 1050, 1080], trades=trades)
+    # Zero-downside equity here also makes Sortino None — serialize both.
+    dumped = json.dumps(m)
+    assert "Infinity" not in dumped
+    assert "-Infinity" not in dumped
+    assert "NaN" not in dumped
+    # Round-trips through a strict parser (allow_nan=False mirrors Go's reject).
+    reparsed = json.loads(dumped)
+    assert reparsed["profit_factor"] is None
+    assert reparsed["sortino_ratio"] is None
+    # allow_nan=False raises on any inf/nan token — the strict-parser contract.
+    json.dumps(m, allow_nan=False)
+
+
+def test_format_results_tolerates_none_metrics():
+    # The pretty-printer must not raise on a None Sortino / profit_factor.
+    trades = [_trade(50.0, 0.05)]
+    m = _metrics([1000, 1050], trades=trades)
+    results = {
+        "strategy_name": "x", "symbol": "BTC/USDT", "timeframe": "1d",
+        "start_date": "2024-01-01T00:00:00", "end_date": "2024-01-02T00:00:00",
+        "initial_capital": 1000.0, "final_capital": 1050.0,
+        **m,
+    }
+    text = format_results(results)
+    assert "n/a" in text  # None rendered as text, not crashed
+
+
+# ---------------------------------------------------------------------------
+# Window boundary — adjacent M1 windows share no bar ([start, end) slicing)
+# ---------------------------------------------------------------------------
+
+class _FakeRegistry:
+    STRATEGY_REGISTRY = {"noop": {"default_params": {}, "description": "t"}}
+
+    @staticmethod
+    def list_strategies():
+        return ["noop"]
+
+    @staticmethod
+    def apply_strategy(name, df, params):
+        out = df.copy()
+        out["signal"] = np.zeros(len(out), dtype=int)
+        return out
+
+
+def _master_frame():
+    # Hourly bars straddling the 2024-01-01 boundary shared by the "2023" and
+    # "2024" M1 windows.
+    idx = pd.date_range("2023-12-31 00:00", "2024-01-02 00:00", freq="1h")
+    base = 100.0 + np.arange(len(idx))
+    return pd.DataFrame({
+        "open": base, "high": base * 1.01, "low": base * 0.99,
+        "close": base, "volume": np.full(len(idx), 1000.0),
+    }, index=idx)
+
+
+def _inclusive_loader(master):
+    """Mimic load_ohlcv's INCLUSIVE end bound (timestamp <= end_ts) so the test
+    proves eval_windows' own exclusive slice — not a loader quirk — drops the
+    boundary bar."""
+    def _load(symbol, timeframe, start_date=None, end_date=None, **kw):
+        df = master
+        if start_date is not None:
+            df = df[df.index >= pd.Timestamp(start_date)]
+        if end_date is not None:
+            df = df[df.index <= pd.Timestamp(end_date)]  # INCLUSIVE, like real DB
+        return df.copy()
+    return _load
+
+
+def _captured_index(monkeypatch, window):
+    """Run one leg and capture the DataFrame index that reaches apply_strategy
+    (i.e. the post-slice frame the Backtester actually trades)."""
+    import data_fetcher
+    monkeypatch.setattr(data_fetcher, "load_cached_data",
+                        _inclusive_loader(_master_frame()), raising=True)
+    seen = {}
+    orig = _FakeRegistry.apply_strategy
+
+    reg = _FakeRegistry()
+
+    def _spy(name, df, params):
+        seen["index"] = df.index
+        return orig(name, df, params)
+
+    monkeypatch.setattr(reg, "apply_strategy", _spy)
+    ew.run_leg(reg, "noop", None, "BTC/USDT", "1h", window)
+    return seen["index"]
+
+
+def test_adjacent_windows_share_no_bar(monkeypatch):
+    boundary = pd.Timestamp("2024-01-01 00:00")
+    idx_2023 = _captured_index(monkeypatch, ("2023-12-31", "2024-01-01"))
+    idx_2024 = _captured_index(monkeypatch, ("2024-01-01", "2024-01-02"))
+    # No overlap at all between the two adjacent windows.
+    assert set(idx_2023) & set(idx_2024) == set()
+    # Specifically, the shared boundary bar belongs ONLY to the later window.
+    assert boundary not in idx_2023
+    assert boundary in idx_2024
+    # And the first window is non-empty right up to (but excluding) the boundary.
+    assert idx_2023.max() < boundary
+
+
+def test_open_ended_window_keeps_last_bar(monkeypatch):
+    # end=None means "latest cached bar" — no upper slice applied.
+    idx = _captured_index(monkeypatch, ("2023-12-31", None))
+    assert idx.max() == pd.Timestamp("2024-01-02 00:00")

--- a/docs/research/1181-htf-filter-baseline-revalidation.md
+++ b/docs/research/1181-htf-filter-baseline-revalidation.md
@@ -71,6 +71,14 @@ strategy/symbol/timeframe combinations; any future comparison uses these, not
 the PR's "before" column. The ETH 4h/1d collapse (+180.51% → +7.94%) confirms
 the leak's severity scales with the LTF→HTF ratio's candle span.
 
+> **Sortino re-baseline (#1242):** the Sortino column above was computed under
+> the pre-#1242 nonstandard definition (sample std of negative returns about
+> their own mean, neutral 0.0 for <2 down bars). #1242 switched to the canonical
+> downside deviation (root-mean-square of `min(r, 0)` about MAR=0, `None` when
+> there is zero downside), so every Sortino figure in this document shifts.
+> Sharpe, return, drawdown, trades, and win-rate are unaffected. Regenerating
+> these Sortino baselines is tracked in #1243.
+
 ## Dispositions (acceptance criterion 3)
 
 | Decision surface | Disposition | Why |


### PR DESCRIPTION
## Summary
Fixes the three backtest metric/convention degenerates from the #1228 audit (§4-5), each real but re-baselining and deferred from PR #1238. One PR, three independent sub-fixes.

1. **Sortino** (`backtest/backtester.py` `_calculate_metrics`): replaced the sample std of negative returns about their own mean — which gated on `len(downside) > 1` and scored a leg with 0-1 losing bars a neutral `0.0` (a near-perfect leg could rank below a mediocre one) — with the **canonical downside deviation**: root-mean-square of `min(r, 0)` about MAR=0 over all return observations, annualized by the same factor as Sharpe. **Zero downside** (no losing bars / downside deviation == 0) is a mathematically undefined Sortino and now reports **`None`**, never `0.0` and never a cap. The #1005 liquidation override still forces `sortino = -LIQUIDATED_METRIC_FLOOR` (a busted account is not "zero downside"). The return dict and both pretty-printers (`format_results`, `reporter.py`) tolerate `None`.

2. **profit_factor** (~2886): all-win legs (`gross_loss == 0`) now emit **`None`** instead of `float("inf")`, before any serialization, so `json.dump` never emits the nonstandard `Infinity` token that strict parsers (incl. Go `json.Unmarshal`) reject. No-trade legs keep their `0` branch.

3. **Window boundary** (`backtest/eval_windows.py` `run_leg`): slices `[start, end)` **exclusively** at the caller — `load_ohlcv`'s inclusive-end contract is deliberately left untouched for its other callers. Adjacent M1 windows that share calendar boundaries (`is`/`oos`, `2023`/`2024`, ...) no longer double-count the boundary bar; `gross_edge_noise` already documents and dedupes `[start, end)`, so the two now agree.

## Tests
New `backtest/tests/test_metric_degenerates.py` (11 tests): Sortino with 0 losing bars → `None`, 1 losing bar → finite canonical value (recomputed independently), all-loss → finite negative, liquidated → floor; profit_factor all-win → `None` and `json.dumps(..., allow_nan=False)` succeeds (never `Infinity`); `format_results` tolerates `None`; adjacent windows disjoint with the boundary bar in the later window only; open-ended (`end=None`) window keeps its last bar.

Ran red against `origin/main` first (8 of 11 fail there), green here. Full suite: **2377 passed, 1 skipped** (`backtest/tests shared_strategies shared_tools platforms`).

## Baseline impact
Every non-liquidated Sortino value shifts under the new canonical definition. The Sortino column in `docs/research/1181-htf-filter-baseline-revalidation.md` is annotated as pre-#1242; regenerating those Sortino baselines is tracked in **#1243**. Sharpe, return, drawdown, trades, and win-rate are unaffected. The exclusive-window slice drops one boundary bar from the `is`/`2023`/`2024`/`2025H1` windows' equity curves (nil trade-level effect by the N→N+1 fill construction).

Closes #1242

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code