### PR TITLE
docs(#1243): re-run documented backtest studies under corrected #1228 geometry

### DIFF
--- a/backtest/candidates/breakout_984/README.md
+++ b/backtest/candidates/breakout_984/README.md
@@ -257,3 +257,55 @@ burns 24.8pp; `tp_tight` cuts trades but cuts gross return even faster.
    sweep.
 
 A negative result is a valid M1 finding — documented, not deleted (#995 step 4).
+
+## Addendum 2026-07-05 — re-run under the corrected simulation geometry (#1243)
+
+Re-ran the headline drivers (`audit_headline.py` continuous-window;
+`validate_shortlist.py` M1 protocol; `fee_drag.py`) on current `main` (the
+#1238 audit fixes plus #1250 fee-net-per-trade and #1251 canonical Sortino /
+`None` profit-factor / half-open windows), identical cache snapshot. **The
+keep-baseline verdict holds** — but one candidate, `tp_tight`, shifted
+materially, so read the detail before reusing the step-5 numbers.
+
+**Verdict unchanged, and why.** The decision rests on the M1 protocol: baseline
+is the only shortlist member passing judged IS+OOS, and every non-baseline
+candidate still FAILS the judged OOS (2026 crash) window — the window
+breakout's keep verdict lives in. That table is unchanged: baseline OOS PASS
+(held-out 0/3); `trail_atr_3.0` FAIL 0/3; `tp_tight` FAIL 2/3;
+`tp_tight_trail3` FAIL 0/3; `time_stop_250` FAIL 3/3. `tp_tight`'s OOS mean
+Sharpe is if anything slightly worse (-1.67 vs the documented -1.63), so the
+decisive crash-window failure is intact. **No promotion guidance changes.**
+
+**But the step-5 continuous-collapse claim for `tp_tight` does NOT reproduce.**
+Under the corrected closed-bar EntryATR geometry, the tiered-TP ladder's fills
+move and the stitched-frame collapse the doc headlines is gone:
+
+| run | metric | documented | re-run | status |
+|---|---|---:|---:|---|
+| baseline | Sharpe / ret / vsB&H / worstDD / #T | +0.02 / -1.1% / +43.7 / -52.2% / 260 | +0.02 / -1.08% / +43.74 / -52.17% / 260 | identical |
+| `trail_atr_3.0` | " | -0.33 / -9.4% / +35.5 / -52.3% / 364 | -0.495 / -14.86% / +29.97 / -51.62% / 371 | shifted worse |
+| `tp_tight` | " | -0.26 / -10.5% / +34.4 / **-69.0%** / 148 | **+0.150 / +0.86% / +45.69 / -34.28%** / 148 | **shifted much better** |
+| `tp_tight_trail3` | " | -0.57 / -11.9% / +32.9 / -48.6% / 961 | -0.720 / -15.62% / +29.21 / -47.89% / 963 | shifted worse |
+| `time_stop_250` | " | -0.39 / -25.3% / +19.6 / -68.4% / 109 | -0.386 / -25.27% / +19.56 / -68.36% / 109 | identical |
+
+`tp_tight` keeps the same 148 entries (the entry set is frozen), so the whole
+move is exit-geometry: on the stitched continuous frame it goes from a -69.0%
+worst-DD, -10.5%-return collapse to a **-34.28% worst DD, +0.86% return, +45.69
+vs-B&H** profile essentially level with baseline. `fee_drag.py` corroborates —
+its net flips from a documented -10.5% to +0.86% with drag collapsing 13.6pp →
+1.5pp — while `trail_atr_3.0`'s gross edge instead erodes (8.4% → 1.47%). So the
+specific documented narrative "`tp_tight` deepens the worst DD to -69.0%,
+amputating the fat-tail trends" is **refuted under corrected geometry**; the
+generic step-5 methodology lesson (per-window PASS can hide a stitched-frame
+problem) is unaffected — it still holds for other candidates and studies.
+
+**Net:** the promotion decision (keep baseline; do not ship `tp_tight`) is
+unchanged because it is driven by the judged-OOS crash-window failure, not by
+the stitched frame. `tp_tight` is now the candidate to revisit **if and only
+if** breakout's keep rationale is ever reweighted away from crash-window
+outperformance — but that is a hypothetical, not a flip today, so no follow-up
+decision issue is filed. The corrected `tp_tight` continuous numbers above
+supersede the step-5 table for any future comparison.
+
+---
+Updated with LLM: Opus 4.8 | high | Harness: Claude Code

--- a/backtest/candidates/squeeze_983/README.md
+++ b/backtest/candidates/squeeze_983/README.md
@@ -192,3 +192,36 @@ flip sign on the stitched frame.
    sweep.
 
 A negative result is a valid M1 finding — documented, not deleted (#995 step 4).
+
+## Addendum 2026-07-05 — re-run under the corrected simulation geometry (#1243)
+
+Re-ran the headline drivers (`audit_headline.py` continuous-window;
+`validate_shortlist.py` M1 protocol, default shortlist + time-stop shortlist)
+on current `main` (the #1238 audit fixes plus #1250 fee-net-per-trade and #1251
+canonical Sortino / `None` profit-factor / half-open windows), identical cache
+snapshot. **Verdict holds: no close stack ships; keep the baseline stack.** The
+baseline (open-signal-as-close, no ATR geometry) is byte-identical; the
+ATR-geometry candidate (`tp_default` tiered-TP ladder) shifted slightly, all in
+the conservative direction, and stays a collapse.
+
+Step-5 continuous audit window (2025-06-10 → latest):
+
+| run | metric | documented | re-run | status |
+|---|---|---:|---:|---|
+| baseline | mean Sharpe / ret / vsB&H / worstDD / #T | +0.07 / +1.1% / +45.9 / -58.5% / 130 | +0.07 / +1.07% / +45.90 / -58.46% / 130 | identical |
+| `tp_default` | mean Sharpe / ret / vsB&H / worstDD / #T | -0.51 / -23.8% / +21.1 / -72.4% / 168 | **-0.532 / -24.07% / +20.76 / -72.38% / 158** | shifted, still collapses |
+
+`tp_default` runs 158 trades vs the documented 168 — the #1238 closed-bar
+EntryATR moved a handful of tiered-TP fills — and its stitched worst DD stays
+-72% with a negative return, so the step-5 conclusion ("do not deploy the
+ladder on this entry") is unchanged.
+
+M1 protocol PASS/FAIL table — **every verdict identical to the documented run**
+(baseline OOS PASS, held-out 1/3; `tp_default` OOS PASS, held-out 2/3;
+`sl_atr_1.5` / `trail_atr_3.0` / `tp_runner_trail3` FAIL 0/3;
+`time_stop_200/225/250` OOS FAIL, held-out 1/3). No PASS↔FAIL flipped despite
+the #1251 DDadj-floor and half-open-window changes. The keep-baseline verdict
+and the "-58.5% DD is regime exposure, not exit quality → M4" disposition stand.
+
+---
+Updated with LLM: Opus 4.8 | high | Harness: Claude Code

--- a/backtest/research/regime_1211_incumbent_baseline.py
+++ b/backtest/research/regime_1211_incumbent_baseline.py
@@ -43,6 +43,24 @@ Run (needs the OHLCV cache reachable from shared_tools/):
 
 Read-only research layer. No live path, no Go path, no config, no gate threshold is touched by
 running this. The gate stays fail-closed (abstaining) until a follow-up PR lands one outcome.
+
+Addendum 2026-07-05 -- re-run under the corrected simulation geometry (#1243):
+Re-ran this harness on current main (the #1238 audit fixes plus #1250
+fee-net-per-trade and #1251 canonical Sortino / None profit-factor / half-open
+windows). The pre-registered decision reproduces UNCHANGED: replicates=False
+(primary_met=True, breadth_met=False, symbols_met=True), 11/24 held-out cells
+significant, Phase-2 branch 2b (drop the incumbent veto). All 24 per-cell
+significance flags match the committed regime_1211_baseline_remeasure.json
+exactly. The corrections provably do not reach this study: it measures
+forward-realized-volatility regime separation via block-permutation Kruskal-
+Wallis, using none of the corrected backtester / fee-accounting / Sortino code
+paths (no trades, no PnL, no ATR-stop geometry). The one per-cell p that moved
+-- BTC/USDT 1h OOS 0.005 -> 0.105 (both sig=False) -- is a data artifact, not a
+code artifact: the committed run's OOS window resolved to 2026-07-02 (4344
+bars) whereas this re-run used the #1228 audit cache snapshot (OOS ends
+2026-06-04, 3649 bars), so the shorter OOS window shifts that borderline
+permutation p without changing its non-significant verdict or the fixed-date
+held-out cells that carry breadth_met. Verdict holds; no follow-up needed.
 """
 from __future__ import annotations
 import os, sys

--- a/docs/research/1054-regime-adaptive-htf-m1.md
+++ b/docs/research/1054-regime-adaptive-htf-m1.md
@@ -168,5 +168,32 @@ exactly); statistics deterministic at seed 1066, 10000 resamples.
 
 Generated: 2026-07-01
 
+## Addendum 2026-07-05 — re-run under the corrected simulation geometry (#1243)
+
+Re-ran the full #1054 evidence set on current `main` (the #1238 audit fixes
+plus #1250 fee-net-per-trade and #1251 canonical Sortino / `None`
+profit-factor / half-open windows) against the identical cache snapshot
+(audit-dataset last bars 2026-06-04 → 2026-06-12). **Every figure reproduces
+bit-for-bit; the deprecate recommendation stands unchanged.**
+
+| harness | documented | re-run | status |
+|---|---|---|---|
+| M5 fee-audit row | 37 trades, gross +0.27, net -0.66, drag 0.94pp, `graduate_m1` | 37, +0.27, -0.66, 0.94, `graduate_m1` | identical |
+| M1 baseline | IS/OOS PASS (relative bar), held-out 0/3; means IS +0.23/+0.75, OOS -0.32/-0.20 | IS/OOS PASS, held-out 0/3; IS +0.23/+0.75, OOS -0.32/-0.20 | identical |
+| noise (M5 slices) | n=37, mean +0.082%/trade, permutation p=0.3913, `INDISTINGUISHABLE_FROM_ZERO` | n=37, +0.082%, p=0.3913, `INDISTINGUISHABLE_FROM_ZERO` | identical |
+| noise (all windows) | n=173, mean -0.022%/trade, permutation p=0.5516, sign 110/173 p=0.0004, `NO_POSITIVE_EDGE` | n=173, -0.022%, p=0.5516, 110/173 p=0.0004, `NO_POSITIVE_EDGE` | identical |
+
+Why nothing moved: the corrections do not reach this study. The noise gate
+scores **zero-friction gross legs**, and every per-trade gross return
+reproduces to the digit (e.g. IS BTC/USDT 1h +3.05%), so the trade set is
+unchanged — `regime_adaptive_htf` enters on regime labels and exits
+open-signal-as-close with no ATR-stop/tiered-TP geometry, the only surface the
+#1238 EntryATR / unified-SL fixes touch. #1250's per-trade fee-net change also
+leaves the M5 net -0.66%/leg untouched (`fee_audit` already computed net legs
+from the fee-inclusive cash path, not the per-trade `pnl` field #1250 revised).
+The pre-registered `NO_POSITIVE_EDGE` verdict and the deprecate recommendation
+(scoped to the fade-only default, pending the M4 adjudication) are unchanged.
+
 ---
 Created with LLM: Fable 5 | high | Harness: Claude Code + live M1 runs
+Updated with LLM: Opus 4.8 | high | Harness: Claude Code

--- a/docs/research/1152-ranging-exit-geometry-m6.md
+++ b/docs/research/1152-ranging-exit-geometry-m6.md
@@ -155,5 +155,47 @@ uv run --no-sync python backtest/research/regime_1152_exit_retune.py --only mr.b
 
 Deterministic given the cache snapshot (harness seed 1066, fixed windows).
 
+## Addendum 2026-07-05 — re-run under the corrected simulation geometry (#1243)
+
+Re-ran the full M6 matrix (`regime_1152_exit_retune.py --jobs 6`, 18 A/B runs)
+on current `main` (the #1238 audit fixes plus #1250 fee-net-per-trade and #1251
+canonical Sortino / `None` profit-factor / half-open windows), identical cache
+snapshot. **Verdict holds: every incumbent stands; no ratchet or B2 geometry
+ships.** This study exercises exactly the surface the corrections touch —
+per-entry ΔPnL on ratchet / tiered-TP ladders with ATR geometry — so several
+per-run labels moved, but none crosses the promotion line and the decisive
+cross-entry-style gate is unchanged.
+
+**The gate outcome is intact.** The pre-registered gate needs a candidate to
+clear BOTH entry styles. The only run that passes under either style,
+`mr.b2_rv_wider`, reproduces essentially to the digit (IS +0.005 sig+2 → +0.005
+sig+2; OOS +0.050 sig+2 → +0.048 sig+2; still `candidate_beats_incumbent`), and
+its squeeze counterpart `sq.b2_rv_wider` still fails out-of-sample (OOS -0.050 →
+-0.054, `incumbent_stands`) — if anything the corrected geometry weakened the
+squeeze side (its lone IS sig-positive dataset dropped, sig+1 → sig+0). The
+cross-style contradiction that blocks the `ranging_volatile` B2 split therefore
+persists. **No promotion guidance changes.**
+
+**Three per-run labels shifted, all within the non-promoting band**
+(`incumbent_stands` ↔ `positive_but_not_significant`, never reaching
+`candidate_beats_incumbent`):
+
+| run | documented | re-run | Δnet/entry shift (is / oos) |
+|---|---|---|---|
+| `mr.rv_wider` | positive_but_not_significant | incumbent_stands | +0.012 → **-0.004** / +0.023 → +0.016 |
+| `mr.rv_quiet_geometry` | incumbent_stands | positive_but_not_significant | -0.012 → +0.007 / +0.011 → +0.005 |
+| `mr.b2_rv_patient3` | incumbent_stands | positive_but_not_significant | +0.065 (sig+1) → +0.026 (sig 0) / -0.002 → +0.007 |
+
+All three stay non-significant (0 individually-significant datasets after the
+shift), so none is a gate pass; two moved more conservative, one slightly less,
+consistent with the audit's "generally more conservative" closed-bar geometry
+plus small paired-N changes (n 333 → 334 from the #1251 half-open boundary bar).
+Every other run's verdict label is unchanged. The `ranging_quiet` evidence gap
+(zero gated entries) is structural and likewise unchanged. **Bottom line: the
+#1152 "every incumbent stands" verdict, and the standing recommendation to
+re-run `b2_rv_wider` cross-style once the OOS window accumulates more squeeze
+entries, both stand under the corrected engine.**
+
 ---
 Created with LLM: Fable 5 | high | Harness: Claude Code
+Updated with LLM: Opus 4.8 | high | Harness: Claude Code

--- a/docs/research/1181-htf-filter-baseline-revalidation.md
+++ b/docs/research/1181-htf-filter-baseline-revalidation.md
@@ -105,5 +105,49 @@ uv run --no-sync python backtest/run_backtest.py --strategy sma_crossover \
 (`git show e002a3f:backtest/run_backtest.py`). Results depend on the OHLCV
 cache state; the tables above were produced on the 2026-07-01 20:58 snapshot.
 
+## Addendum 2026-07-05 — re-run under the corrected simulation geometry (#1243)
+
+Re-ran both `sma_crossover --htf-filter` baselines on current `main` (which
+carries the #1238 audit fixes plus #1250 fee-net-per-trade and #1251 canonical
+Sortino / `None` profit-factor / half-open windows) against the **identical
+cache snapshot** these baselines were built on (`shared_tools/trading_bot.db`,
+audit-dataset last bars 2026-06-04 → 2026-06-12, byte-for-byte the range the
+tables above pin). Result: **unchanged except Sortino, exactly as the #1242
+re-baseline note above anticipated.** Every return / Sharpe / max-DD / trade /
+win-rate figure reproduces to the digit; only the Sortino column moves, and it
+moves because #1251 redefined the metric, not because any trade changed.
+
+`sma_crossover BTC/USDT 1h --htf-filter`:
+
+| metric | documented (pre-#1251) | re-run (current main) | status |
+|---|---:|---:|---|
+| Total return | +147.80% | +147.80% | unchanged |
+| Sharpe | 0.998 | 0.998 | unchanged |
+| Sortino | 0.932 | **1.415** | shifted (metric redefinition #1251) |
+| Max DD | -36.85% | -36.85% | unchanged |
+| Trades | 75 | 75 | unchanged |
+| Win rate | 32.0% | 32.0% | unchanged |
+
+`sma_crossover ETH/USDT 4h --htf-filter`:
+
+| metric | documented (pre-#1251) | re-run (current main) | status |
+|---|---:|---:|---:|
+| Total return | +7.94% | +7.94% | unchanged |
+| Sharpe | 0.248 | 0.248 | unchanged |
+| Sortino | 0.222 | **0.354** | shifted (metric redefinition #1251) |
+| Max DD | -51.79% | -51.79% | unchanged |
+| Trades | 13 | 13 | unchanged |
+| Win rate | 38.5% | 38.5% | unchanged |
+
+**Canonical Sortino baselines are now 1.415 (BTC 1h) and 0.354 (ETH 4h);** they
+supersede the pre-#1251 0.932 / 0.222 wherever a future comparison needs the
+Sortino column. **No verdict flips.** The EntryATR / unified-SL corrections do
+not reach these runs — `sma_crossover --htf-filter` exits open-signal-as-close
+with no ATR-stop/tiered-TP geometry, so the trade set is identical; and #1250's
+fee-net change left win-rate and every equity figure untouched here (no trade
+crossed zero PnL as a result). The #1181 "no decision rested on a leak-inflated
+number" disposition stands.
+
 ---
 Created with LLM: Fable 5 | high | Harness: Claude Code
+Updated with LLM: Opus 4.8 | high | Harness: Claude Code


### PR DESCRIPTION
## What & why

Closes #1243. Re-runs the six documented backtest studies whose verdicts rest on ATR-stop / tiered-TP geometry against **current `main`**, which combines three merged corrections — #1238 (the #1228 audit: closed-bar EntryATR, unified #841 per-regime SL, DDadj liquidation floor), #1250 (per-trade `Trade.pnl` now nets both entry and exit fees at every close), and #1251 (canonical downside-deviation Sortino, `None` profit-factor on all-win legs, half-open `[start, end)` eval windows). Each study is re-run on the **identical #1228 audit cache snapshot** (audit-dataset last bars 2026-06-04 → 2026-06-12) so any move is attributable to the engine, not cache drift. Every study gets a **dated 2026-07-05 addendum** stating unchanged-vs-shifted with numbers.

This is an investigation + docs deliverable — no code paths change (the one `.py` edit is an addendum in the #1211 harness module docstring, its study note).

## Result: no verdict flips — every promotion decision holds

| Study | Harness | Outcome |
|---|---|---|
| #1181 | `run_backtest.py --htf-filter` | **Held**, except Sortino re-baselines under #1251 (BTC 1h 0.932→1.415, ETH 4h 0.222→0.354). Every return/Sharpe/DD/trade/win-rate reproduces exactly. Fulfils the Sortino regeneration the doc deferred to #1243. |
| #1054 | `fee_audit` + `eval_windows` + `gross_edge_noise` | **Bit-identical**; deprecate recommendation stands. Corrections don't reach it (gross legs unchanged, no ATR geometry). |
| #983 | `squeeze_983` drivers | Baseline byte-identical; `tp_default` continuous headline shifted slightly (168→158 trades, more conservative) but still collapses; M1 protocol table unchanged. **Keep-baseline holds.** |
| #984 | `breakout_984` drivers | Baseline byte-identical; `tp_tight`'s step-5 continuous-collapse is **refuted** (worst DD -69.0%→-34.28%, ret -10.5%→+0.86%, same 148 entries) — but its judged-OOS crash-window failure, the decisive axis, is unchanged, so **promotion guidance does not flip.** |
| #1152 | `regime_1152_exit_retune.py` (M6) | Three per-run labels shifted, all within the non-promoting band; the sole gate-passer `mr.b2_rv_wider` is unchanged and its squeeze counterpart still fails OOS → cross-style gate and "every incumbent stands" **hold.** |
| #1211 | `regime_1211_incumbent_baseline.py` | Pre-registered `replicates=False → branch 2b` reproduces; all 24 cell significance flags match. Corrections provably don't reach it (regime-separation permutation stats). The one moving OOS p is cache-tail drift vs the fresher cache the committed artifact used, not a code change. |

## Notable shift (documented, not a flip)

#984 `tp_tight`: under corrected closed-bar EntryATR the tiered-TP ladder's stitched-frame collapse disappears — it goes from a -69% worst-DD / -10.5%-return collapse to a -34% worst-DD / +0.86%-return profile level with baseline (`fee_drag` net flips -10.5%→+0.86%, drag 13.6pp→1.5pp). The specific documented narrative ("`tp_tight` deepens worst DD to -69%") is refuted. But the keep-baseline decision rests on `tp_tight` failing the **judged-OOS crash window** (OOS mean Sharpe -1.67, if anything slightly worse), which is intact — so no promotion guidance changes. Revisiting `tp_tight` is deliberately left unfiled: it would only matter if breakout's keep rationale were reweighted away from crash-window outperformance, a hypothetical, not a flip.

## Method notes

- Committed run artifacts are left as **historical**; current-engine numbers live in the dated addenda with full provenance (regenerated to scratchpad and diffed, committed JSONs untouched — the #1152 aggregate write was captured then `git checkout`-restored).
- No harness added / deprecated / repurposed, so **no `docs/backtesting-registry.md` row changes** are part of this PR.

## Acceptance criteria (#1243)

- [x] Each listed study re-run on the corrected engine (none N/A — all reproduced deterministically on the audit snapshot).
- [x] Per-study addendum: unchanged vs shifted, with numbers.
- [x] Flipped verdicts escalated — **none found**; the one material shift (#984 `tp_tight`) does not flip promotion guidance and is documented in place.

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code
https://claude.ai/code/session_01TMQ1ic25DvfW2pBkVYbKvu