### PR TITLE
docs: add multi-dimension sweep to the PR review prompt

### DIFF
--- a/.github/prompts/pr-review-format.md
+++ b/.github/prompts/pr-review-format.md
@@ -1,5 +1,7 @@
 PR review output format (this OVERRIDES any final-comment format the code-review skill specifies; keep its multi-agent review process, replace only the shape of the posted comment).
 
+Before writing the comment, sweep the FULL diff once per dimension and collect every finding — do not stop at the first or most salient issue. Dimensions: (1) correctness and logic (including shadowed or dead code and wrong-scope declarations); (2) error paths and failure handling (swallowed errors, fail-open vs fail-closed, error states indistinguishable from empty states); (3) state and lifecycle (stale UI or cache state, residual mutations, ordering); (4) resource cost and scaling (unbounded queries or scans on polled or hot paths, missing indexes, per-call cost growing with history); (5) concurrency and locking; (6) security and input handling (injection, unescaped output, authorization). Report ALL findings that survive the materiality filter in this single comment, not one per review round.
+
 The review comment must contain nothing except the structure that follows — no preamble, summary, intro, header, emoji, or footer outside this structure. Write the entire comment as direct instructions for an agent that will read it and act on it.
 
 Begin with a verdict line that is exactly one of: LGTM, or Needs Updates.


### PR DESCRIPTION
Adds an explicit per-dimension sweep instruction to `.github/prompts/pr-review-format.md`: before writing the comment, the reviewer sweeps the full diff once per dimension (correctness/logic, error paths, state/lifecycle, resource cost and scaling, concurrency/locking, security/input handling) and reports ALL surviving findings in one comment.

Motivation: on PR #1254, five of six findings existed in the original diff but surfaced one to two per round across five review rounds — each pass anchored on the most salient issue. The sweep targets more findings per single pass. No change to the verdict/section contract that fix-pr-review parses, and the file stays clean of the `"` / backtick / `$` injection-guard characters.

---
Created with LLM: Fable 5 | high | Harness: Claude Code
https://claude.ai/code/session_01CcsnwhZjVsaMUhrtkCiBUe