### PR TITLE
fix(#1264): refuse Discord /paper-to-live while strategy holds open position

### DIFF
--- a/scheduler/discord_mutating_commands.go
+++ b/scheduler/discord_mutating_commands.go
@@ -824,8 +824,7 @@ func (d *DiscordNotifier) handleAddPlatform(s *discordgo.Session, i *discordgo.I
 // it switches a strategy to placing real orders with real funds.
 func (d *DiscordNotifier) handlePaperToLive(s *discordgo.Session, i *discordgo.InteractionCreate, opts []*discordgo.ApplicationCommandInteractionDataOption) {
 	deferAck(s, i)
-	path, err := d.configOpsReady()
-	if err != nil {
+	if _, err := d.configOpsReady(); err != nil {
 		followupText(s, i, err.Error())
 		return
 	}
@@ -834,21 +833,20 @@ func (d *DiscordNotifier) handlePaperToLive(s *discordgo.Session, i *discordgo.I
 		followupText(s, i, "usage: /go-trader-paper-to-live <strategy>")
 		return
 	}
+	if reason := d.ss.paperToLiveBlockedReason(id, false); reason != "" {
+		followupText(s, i, "Refused: "+reason)
+		return
+	}
 	if !d.confirmDestructive(interactionUserID(i), fmt.Sprintf("⚠️ Switch strategy `%s` from PAPER to LIVE? After restart it places **real orders with real funds**.", id)) {
 		followupText(s, i, "Cancelled — no confirmation received.")
 		return
 	}
-	var after []string
-	wErr := d.mutateConfig(path, func(root map[string]json.RawMessage) error {
-		_, a, e := flipStrategyToLive(root, id)
-		after = a
-		return e
-	})
-	if wErr != nil {
-		followupText(s, i, "paper-to-live failed: "+wErr.Error())
+	msg, err := d.ss.executePaperToLive(id)
+	if err != nil {
+		followupText(s, i, "paper-to-live failed: "+err.Error())
 		return
 	}
-	d.applyConfigChange(s, i, true, fmt.Sprintf("Strategy `%s` switched to **LIVE** (args: %s).", id, strings.Join(after, " ")))
+	d.applyConfigChange(s, i, true, msg)
 }
 
 // subcommandOptions extracts the chosen subcommand name and its options from a

--- a/scheduler/discord_mutating_commands_test.go
+++ b/scheduler/discord_mutating_commands_test.go
@@ -422,3 +422,41 @@ func TestWriteValidatedConfigRootRejectsInvalid(t *testing.T) {
 		t.Errorf("original config was modified despite validation failure:\n%s", after)
 	}
 }
+
+// paperToLiveFlatChecks exercises the shared StatusServer seam the Discord
+// /paper-to-live handler delegates to (paperToLiveBlockedReason +
+// executePaperToLive) without a live discordgo session.
+func TestPaperToLiveFlatChecks(t *testing.T) {
+	openPos := &StrategyState{Positions: map[string]*Position{"ETH": {Quantity: 1, AvgCost: 2000}}}
+
+	// Open at pre-confirm → blocked before any write.
+	ss, path, _ := newStructuralTestServer(t)
+	ss.state.Strategies["hl-momentum-eth"] = openPos
+	if reason := ss.paperToLiveBlockedReason("hl-momentum-eth", false); reason == "" || !strings.Contains(reason, "OPEN position") {
+		t.Fatalf("pre-confirm blocked reason = %q, want OPEN-position refusal", reason)
+	}
+
+	// Flat → flips to live.
+	delete(ss.state.Strategies, "hl-momentum-eth")
+	msg, err := ss.executePaperToLive("hl-momentum-eth")
+	if err != nil {
+		t.Fatalf("flat executePaperToLive: %v", err)
+	}
+	if !strings.Contains(msg, "LIVE") {
+		t.Fatalf("success message = %q", msg)
+	}
+	if raw := string(mustReadFile(t, path)); !strings.Contains(raw, "--mode=live") {
+		t.Fatalf("config not flipped:\n%s", raw)
+	}
+
+	// Flat at execute start, opens before write → refused, args untouched.
+	ssOpen, pathOpen, _ := newStructuralTestServer(t)
+	ssOpen.state.Strategies["hl-momentum-eth"] = openPos
+	_, err = ssOpen.executePaperToLive("hl-momentum-eth")
+	if err == nil || !strings.Contains(err.Error(), "opened a position") {
+		t.Fatalf("execute while open err = %v, want opened-a-position refusal", err)
+	}
+	if raw := string(mustReadFile(t, pathOpen)); strings.Contains(raw, "--mode=live") {
+		t.Fatalf("refused execute must not flip args:\n%s", raw)
+	}
+}

--- a/scheduler/ui_structural.go
+++ b/scheduler/ui_structural.go
@@ -220,8 +220,8 @@ func (ss *StatusServer) confirmStructuralAction(action, strategyID string, param
 		// against a position that does not exist on-chain). Refuse rather than
 		// merely warn — there is no coherent live semantics for a carried-over
 		// paper position; flatten first.
-		if ss.strategyHasOpenPosition(strategyID) {
-			return "", "", "", fmt.Errorf("strategy %q holds an OPEN position — paper→live can only run while flat: a simulated paper position has no on-chain backing, so carried into a real-funds live strategy it becomes a phantom the account reconcile flags as a gap and the strategy would mismanage; flatten it first", strategyID)
+		if reason := ss.paperToLiveBlockedReason(strategyID, false); reason != "" {
+			return "", "", "", fmt.Errorf("%s", reason)
 		}
 		desc := fmt.Sprintf("paper-to-live: ⚠️ switch %s from PAPER to LIVE — after restart it places REAL ORDERS WITH REAL FUNDS. %s", sc.ID, structuralApplyMessage(p.Restart))
 		return sc.ID, desc, "", nil
@@ -387,6 +387,18 @@ func (ss *StatusServer) handleAPIStrategyStructural(w http.ResponseWriter, r *ht
 	ss.maybeRestart(p.Restart)
 }
 
+// paperToLiveBlockedReason returns refusal text when id holds an open position.
+// afterConfirm selects execute-time wording (a position opened during confirm).
+func (ss *StatusServer) paperToLiveBlockedReason(id string, afterConfirm bool) string {
+	if !ss.strategyHasOpenPosition(id) {
+		return ""
+	}
+	if afterConfirm {
+		return fmt.Sprintf("strategy %q opened a position after the confirmation was issued — paper→live can only run while flat; nothing changed", id)
+	}
+	return fmt.Sprintf("strategy %q holds an OPEN position — paper→live can only run while flat: a simulated paper position has no on-chain backing, so carried into a real-funds live strategy it becomes a phantom the account reconcile flags as a gap and the strategy would mismanage; flatten it first", id)
+}
+
 // executePaperToLive re-checks the flat precondition at execute time (a
 // position can open between confirm and execute) before flipping the
 // strategy's --mode=paper arg to --mode=live. Refused while open for the same
@@ -407,8 +419,8 @@ func (ss *StatusServer) executePaperToLive(id string) (string, error) {
 	// configWriteMu), so holding configWriteMu can't block a fill, and the
 	// dominant carried-position window is the restart-required
 	// write→restart→reload gap, not this micro check→write one.
-	if ss.strategyHasOpenPosition(id) {
-		return "", fmt.Errorf("strategy %q opened a position after the confirmation was issued — paper→live can only run while flat; nothing changed", id)
+	if reason := ss.paperToLiveBlockedReason(id, true); reason != "" {
+		return "", fmt.Errorf("%s", reason)
 	}
 	var after []string
 	err := ss.mutateConfigRoot(func(root map[string]json.RawMessage) error {


### PR DESCRIPTION
## Summary
- Add `paperToLiveBlockedReason` as the shared flat-only refusal helper used by dashboard confirm, execute, and Discord.
- Discord `/paper-to-live` now pre-checks before the DM confirm and delegates the write to `executePaperToLive` (same path as the dashboard).
- Add `TestPaperToLiveFlatChecks` covering pre-confirm refusal, flat success, and execute-time refusal without a discordgo session.

Closes #1264

## Test plan
- [x] `go test ./scheduler -run 'TestPaperToLiveFlatChecks|TestUIPaperToLiveFlatChecks'`

---
Created with LLM: Composer 2.5 | high | Harness: Cursor