### PR TITLE
feat(#1266): configurable alert throttle interval with 6h default

### DIFF
--- a/scheduler/alert_throttle.go
+++ b/scheduler/alert_throttle.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DefaultAlertThrottleInterval is the fleet-wide re-alert back-off when
+// alert_throttle_interval is omitted from config.json.
+const DefaultAlertThrottleInterval = 6 * time.Hour
+
+// alertThrottleInterval is the active re-alert back-off for all operator alert
+// throttles. Set from config at load and on SIGHUP hot-reload.
+var alertThrottleInterval = DefaultAlertThrottleInterval
+
+func effectiveAlertThrottleInterval() time.Duration {
+	return alertThrottleInterval
+}
+
+func applyAlertThrottleInterval(d time.Duration) {
+	alertThrottleInterval = d
+}
+
+// ParseAlertThrottleInterval converts alert_throttle_interval config text to a
+// duration. Empty/missing → DefaultAlertThrottleInterval (6h).
+func ParseAlertThrottleInterval(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return DefaultAlertThrottleInterval, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid alert_throttle_interval %q: %w", s, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("alert_throttle_interval must be > 0, got %s", s)
+	}
+	return d, nil
+}

--- a/scheduler/alert_throttle.go
+++ b/scheduler/alert_throttle.go
@@ -22,6 +22,21 @@ func applyAlertThrottleInterval(d time.Duration) {
 	alertThrottleInterval = d
 }
 
+// applyAlertThrottleFromConfig adopts cfg's alert_throttle_interval into the
+// live runtime. Call only when a config is actually adopted (daemon startup or
+// an accepted SIGHUP reload) — never from loadConfig/LoadConfigForProbe.
+func applyAlertThrottleFromConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	d, err := ParseAlertThrottleInterval(cfg.AlertThrottleInterval)
+	if err != nil {
+		return err
+	}
+	applyAlertThrottleInterval(d)
+	return nil
+}
+
 // ParseAlertThrottleInterval converts alert_throttle_interval config text to a
 // duration. Empty/missing → DefaultAlertThrottleInterval (6h).
 func ParseAlertThrottleInterval(s string) (time.Duration, error) {

--- a/scheduler/alert_throttle_test.go
+++ b/scheduler/alert_throttle_test.go
@@ -77,6 +77,9 @@ func TestLoadConfig_AppliesAlertThrottleInterval(t *testing.T) {
 	if cfg.AlertThrottleInterval != "45m" {
 		t.Fatalf("AlertThrottleInterval = %q, want 45m", cfg.AlertThrottleInterval)
 	}
+	if err := applyAlertThrottleFromConfig(cfg); err != nil {
+		t.Fatalf("applyAlertThrottleFromConfig: %v", err)
+	}
 	if effectiveAlertThrottleInterval() != 45*time.Minute {
 		t.Fatalf("runtime interval = %s, want 45m", effectiveAlertThrottleInterval())
 	}
@@ -106,6 +109,9 @@ func TestLoadConfig_AlertThrottleIntervalDefaultsToSixHours(t *testing.T) {
 	if _, err := LoadConfigForProbe(path); err != nil {
 		t.Fatalf("LoadConfigForProbe: %v", err)
 	}
+	if err := applyAlertThrottleFromConfig(&Config{}); err != nil {
+		t.Fatalf("applyAlertThrottleFromConfig: %v", err)
+	}
 	if effectiveAlertThrottleInterval() != DefaultAlertThrottleInterval {
 		t.Fatalf("runtime interval = %s, want %s", effectiveAlertThrottleInterval(), DefaultAlertThrottleInterval)
 	}
@@ -129,5 +135,78 @@ func TestApplyHotReloadConfig_UpdatesAlertThrottleInterval(t *testing.T) {
 	}
 	if effectiveAlertThrottleInterval() != 2*time.Hour {
 		t.Fatalf("runtime interval = %s, want 2h", effectiveAlertThrottleInterval())
+	}
+}
+
+func TestLoadConfigForProbe_DoesNotMutateAdoptedAlertThrottleInterval(t *testing.T) {
+	prev := alertThrottleInterval
+	t.Cleanup(func() { alertThrottleInterval = prev })
+	applyAlertThrottleInterval(90 * time.Minute)
+
+	dir := t.TempDir()
+	path := dir + "/config.json"
+	cfgJSON := `{
+		"alert_throttle_interval": "15m",
+		"strategies": [{
+			"id": "hl-sole",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 10,
+			"leverage": 5
+		}]
+	}`
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := LoadConfigForProbe(path); err != nil {
+		t.Fatalf("LoadConfigForProbe: %v", err)
+	}
+	if effectiveAlertThrottleInterval() != 90*time.Minute {
+		t.Fatalf("probe load mutated runtime interval to %s, want 90m", effectiveAlertThrottleInterval())
+	}
+}
+
+func TestAlertThrottleInterval_ConcurrentProbeDoesNotRace(t *testing.T) {
+	prev := alertThrottleInterval
+	t.Cleanup(func() { alertThrottleInterval = prev })
+	applyAlertThrottleInterval(time.Hour)
+
+	dir := t.TempDir()
+	path := dir + "/config.json"
+	cfgJSON := `{
+		"alert_throttle_interval": "30m",
+		"strategies": [{
+			"id": "hl-sole",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 10,
+			"leverage": 5
+		}]
+	}`
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 200; i++ {
+			_ = effectiveAlertThrottleInterval()
+		}
+	}()
+	for i := 0; i < 20; i++ {
+		if _, err := LoadConfigForProbe(path); err != nil {
+			t.Fatalf("LoadConfigForProbe: %v", err)
+		}
+	}
+	<-done
+	if effectiveAlertThrottleInterval() != time.Hour {
+		t.Fatalf("runtime interval = %s, want 1h", effectiveAlertThrottleInterval())
 	}
 }

--- a/scheduler/alert_throttle_test.go
+++ b/scheduler/alert_throttle_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseAlertThrottleInterval_DefaultsToSixHours(t *testing.T) {
+	d, err := ParseAlertThrottleInterval("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != DefaultAlertThrottleInterval {
+		t.Fatalf("got %s, want %s", d, DefaultAlertThrottleInterval)
+	}
+}
+
+func TestParseAlertThrottleInterval_ParsesGoDuration(t *testing.T) {
+	d, err := ParseAlertThrottleInterval("30m")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != 30*time.Minute {
+		t.Fatalf("got %s, want 30m", d)
+	}
+}
+
+func TestParseAlertThrottleInterval_RejectsInvalid(t *testing.T) {
+	if _, err := ParseAlertThrottleInterval("nonsense"); err == nil {
+		t.Fatal("expected error for invalid duration")
+	}
+}
+
+func TestParseAlertThrottleInterval_RejectsNonPositive(t *testing.T) {
+	for _, raw := range []string{"0", "-1h"} {
+		if _, err := ParseAlertThrottleInterval(raw); err == nil {
+			t.Fatalf("expected error for %q", raw)
+		}
+	}
+}
+
+func withAlertThrottleInterval(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := alertThrottleInterval
+	alertThrottleInterval = d
+	t.Cleanup(func() { alertThrottleInterval = prev })
+}
+
+func TestLoadConfig_AppliesAlertThrottleInterval(t *testing.T) {
+	prev := alertThrottleInterval
+	t.Cleanup(func() { alertThrottleInterval = prev })
+
+	dir := t.TempDir()
+	path := dir + "/config.json"
+	cfgJSON := `{
+		"alert_throttle_interval": "45m",
+		"strategies": [{
+			"id": "hl-sole",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 10,
+			"leverage": 5
+		}]
+	}`
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := LoadConfigForProbe(path)
+	if err != nil {
+		t.Fatalf("LoadConfigForProbe: %v", err)
+	}
+	if cfg.AlertThrottleInterval != "45m" {
+		t.Fatalf("AlertThrottleInterval = %q, want 45m", cfg.AlertThrottleInterval)
+	}
+	if effectiveAlertThrottleInterval() != 45*time.Minute {
+		t.Fatalf("runtime interval = %s, want 45m", effectiveAlertThrottleInterval())
+	}
+}
+
+func TestLoadConfig_AlertThrottleIntervalDefaultsToSixHours(t *testing.T) {
+	prev := alertThrottleInterval
+	t.Cleanup(func() { alertThrottleInterval = prev })
+
+	dir := t.TempDir()
+	path := dir + "/config.json"
+	cfgJSON := `{
+		"strategies": [{
+			"id": "hl-sole",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 10,
+			"leverage": 5
+		}]
+	}`
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := LoadConfigForProbe(path); err != nil {
+		t.Fatalf("LoadConfigForProbe: %v", err)
+	}
+	if effectiveAlertThrottleInterval() != DefaultAlertThrottleInterval {
+		t.Fatalf("runtime interval = %s, want %s", effectiveAlertThrottleInterval(), DefaultAlertThrottleInterval)
+	}
+}
+
+func TestApplyHotReloadConfig_UpdatesAlertThrottleInterval(t *testing.T) {
+	prev := alertThrottleInterval
+	t.Cleanup(func() { alertThrottleInterval = prev })
+	applyAlertThrottleInterval(time.Hour)
+
+	cfg := minimalReloadConfig(nil)
+	next := minimalReloadConfig(nil)
+	next.AlertThrottleInterval = "2h"
+
+	changes, err := applyHotReloadConfig(cfg, next, NewAppState(), nil, nil)
+	if err != nil {
+		t.Fatalf("applyHotReloadConfig: %v", err)
+	}
+	if !strings.Contains(strings.Join(changes, "\n"), "alert_throttle_interval") {
+		t.Fatalf("expected alert_throttle_interval change, got %v", changes)
+	}
+	if effectiveAlertThrottleInterval() != 2*time.Hour {
+		t.Fatalf("runtime interval = %s, want 2h", effectiveAlertThrottleInterval())
+	}
+}

--- a/scheduler/config.example.json
+++ b/scheduler/config.example.json
@@ -4,6 +4,7 @@
   "db_file": "scheduler/state.db",
   "status_port": 8099,
   "default_stop_loss_atr_mult": 1.0,
+  "alert_throttle_interval": "6h",
   "user_defaults": {
     "close": {
       "trailing_tp_ratchet": {

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -1316,11 +1316,6 @@ func loadConfig(path string, skipLiveCredentialChecks bool) (*Config, error) {
 	if err := validateConfig(&cfg, skipLiveCredentialChecks); err != nil {
 		return nil, err
 	}
-	throttle, err := ParseAlertThrottleInterval(cfg.AlertThrottleInterval)
-	if err != nil {
-		return nil, err
-	}
-	applyAlertThrottleInterval(throttle)
 	return &cfg, nil
 }
 

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -185,6 +185,7 @@ type Config struct {
 	DefaultStopLossATRMult *float64                   `json:"default_stop_loss_atr_mult,omitempty"` // #605 — top-level default applied to HL perps/manual strategies that omit all stop_loss_* / trailing_stop_* fields. Nil/missing falls back to 1.0; explicit values let operators tune the ATR stop without recompiling.
 	NotifyTPSLFills        *bool                      `json:"notify_tp_sl_fills,omitempty"`         // #661 — owner DM when HL on-chain TP/SL fills are detected by the reconciler. Nil/missing → enabled; explicit false disables.
 	NotifyRatchetTriggers  *bool                      `json:"notify_ratchet_triggers,omitempty"`    // #1110 — owner DM when a trailing_tp_ratchet* tier clears and tightens the trail. Nil/missing → enabled; explicit false disables.
+	AlertThrottleInterval  string                     `json:"alert_throttle_interval,omitempty"`    // #1266 — fleet-wide re-alert back-off for throttled operator alerts. Go duration ("6h", "30m"); empty → 6h.
 	TradingViewExport      TradingViewExportConfig    `json:"tradingview_export,omitempty"`         // #3 — optional symbol overrides for TradingView portfolio CSV exports
 	UserDefaults           *UserDefaultsConfig        `json:"user_defaults,omitempty"`              // #1135 — canonical operator override layer for defaults. close → close-evaluator tier ladders; regime_atr → standalone use_defaults-only *_atr_regime owners; manual → manual-open/type=manual defaults. Legacy user_close_defaults/manual_defaults are migrated to this tree at load.
 }
@@ -1315,6 +1316,11 @@ func loadConfig(path string, skipLiveCredentialChecks bool) (*Config, error) {
 	if err := validateConfig(&cfg, skipLiveCredentialChecks); err != nil {
 		return nil, err
 	}
+	throttle, err := ParseAlertThrottleInterval(cfg.AlertThrottleInterval)
+	if err != nil {
+		return nil, err
+	}
+	applyAlertThrottleInterval(throttle)
 	return &cfg, nil
 }
 
@@ -2203,6 +2209,10 @@ func validateConfig(cfg *Config, skipLiveCredentialChecks bool) error {
 		if _, err := ParseSummaryFrequency(v); err != nil {
 			errs = append(errs, fmt.Sprintf("summary_frequency[%q]: %v", k, err))
 		}
+	}
+
+	if _, err := ParseAlertThrottleInterval(cfg.AlertThrottleInterval); err != nil {
+		errs = append(errs, err.Error())
 	}
 
 	for k, v := range cfg.TradingViewExport.SymbolOverrides {

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -43,6 +43,13 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 		addChange("default_stop_loss_atr_mult: %s -> %s (applies to strategies opened after restart; existing StopLossATRMult on currently-loaded strategies is unchanged)", formatFloatPtr(cfg.DefaultStopLossATRMult), formatFloatPtr(next.DefaultStopLossATRMult))
 		cfg.DefaultStopLossATRMult = next.DefaultStopLossATRMult
 	}
+	if cfg.AlertThrottleInterval != next.AlertThrottleInterval {
+		addChange("alert_throttle_interval: %q -> %q", cfg.AlertThrottleInterval, next.AlertThrottleInterval)
+		cfg.AlertThrottleInterval = next.AlertThrottleInterval
+		if d, err := ParseAlertThrottleInterval(cfg.AlertThrottleInterval); err == nil {
+			applyAlertThrottleInterval(d)
+		}
+	}
 	// #1135: user_defaults flows through hot-reload so SIGHUP edits to the
 	// operator-default layer shape subsequent manual-open invocations, new
 	// type=manual defaults, and close-default injection. The CLI loads fresh

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -46,8 +46,8 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 	if cfg.AlertThrottleInterval != next.AlertThrottleInterval {
 		addChange("alert_throttle_interval: %q -> %q", cfg.AlertThrottleInterval, next.AlertThrottleInterval)
 		cfg.AlertThrottleInterval = next.AlertThrottleInterval
-		if d, err := ParseAlertThrottleInterval(cfg.AlertThrottleInterval); err == nil {
-			applyAlertThrottleInterval(d)
+		if err := applyAlertThrottleFromConfig(cfg); err != nil {
+			return nil, fmt.Errorf("alert_throttle_interval: %w", err)
 		}
 	}
 	// #1135: user_defaults flows through hot-reload so SIGHUP edits to the

--- a/scheduler/failure_alerts.go
+++ b/scheduler/failure_alerts.go
@@ -30,7 +30,7 @@ func shouldNotifyDrainFailure(failureCount int, lastNotifiedAt, now time.Time) b
 	if failureCount%10 == 0 {
 		return true
 	}
-	if !lastNotifiedAt.IsZero() && now.Sub(lastNotifiedAt) >= time.Hour {
+	if !lastNotifiedAt.IsZero() && now.Sub(lastNotifiedAt) >= effectiveAlertThrottleInterval() {
 		return true
 	}
 	return false

--- a/scheduler/failure_alerts_test.go
+++ b/scheduler/failure_alerts_test.go
@@ -33,6 +33,7 @@ func TestShouldNotifyDrainFailure_EveryTenthNotifies(t *testing.T) {
 }
 
 func TestShouldNotifyDrainFailure_HourlyEvenIfNotMod10(t *testing.T) {
+	withAlertThrottleInterval(t, time.Hour)
 	notifiedAt := time.Now()
 	// count=5, not mod 10, but >1 hour since last notify
 	if !shouldNotifyDrainFailure(5, notifiedAt, notifiedAt.Add(61*time.Minute)) {
@@ -131,6 +132,7 @@ func TestLiveExecFailureThrottle_ClearResetsCount(t *testing.T) {
 }
 
 func TestLiveExecFailureThrottle_HourlyAlert(t *testing.T) {
+	withAlertThrottleInterval(t, time.Hour)
 	th := &LiveExecFailureThrottle{}
 	now := time.Now()
 	th.Record("k1", "err", now)                                  // notified

--- a/scheduler/hl_reconcile_gap_alerts.go
+++ b/scheduler/hl_reconcile_gap_alerts.go
@@ -47,16 +47,13 @@ const hlReconcileGapAlertThreshold = 3
 // same ratio (anchored to the last LOGGED residual) gates the stdout log.
 const hlReconcileGapRealertRatio = 0.10
 
-// hlReconcileGapLogInterval is the heartbeat ceiling for the stdout [WARN] gap
-// line per coin (#1088 sibling fix): once a gap is persisting, a STABLE,
-// unchanging residual re-logs at most once per this interval. The stdout line
-// previously fired every reconcile cycle a gap persisted (unconditionally,
-// outside the alert gate) — the identical per-cycle log spam #1088 fixed in the
-// drift reporter. Aligned to the hourly notification back-off so a persistent
-// stable gap's stdout cadence matches its alert cadence; a materially-changed
-// residual (hlReconcileGapRealertRatio) or any cycle that fires an alert logs
-// immediately regardless, preserving onset, worsening, and alert visibility.
-const hlReconcileGapLogInterval = time.Hour
+// hlReconcileGapLogInterval returns the heartbeat ceiling for the stdout
+// [WARN] gap line per coin (#1088 sibling fix). Aligned to the configured
+// notification back-off so a persistent stable gap's stdout cadence matches
+// its alert cadence.
+func hlReconcileGapLogInterval() time.Duration {
+	return effectiveAlertThrottleInterval()
+}
 
 // hlReconcileGapEntry is one slot in the per-coin gap tracker.
 type hlReconcileGapEntry struct {
@@ -129,7 +126,7 @@ func (t *HLReconcileGapTracker) Record(coin string, delta float64, now time.Time
 		logMove > hlReconcileGapRealertRatio*math.Abs(e.lastLoggedDelta)
 	shouldLog = e.lastLoggedAt.IsZero() ||
 		logSigChanged ||
-		now.Sub(e.lastLoggedAt) >= hlReconcileGapLogInterval
+		now.Sub(e.lastLoggedAt) >= hlReconcileGapLogInterval()
 
 	// Confirmation window: a transient one- or two-cycle gap (indexer lag that
 	// resolves once the fill is indexed) never reaches the threshold — it
@@ -155,7 +152,7 @@ func (t *HLReconcileGapTracker) Record(coin string, delta float64, now time.Time
 		shouldNotify = true // first crossing of the confirmation window
 	case sigChanged:
 		shouldNotify = true
-	case !e.lastNotifiedAt.IsZero() && now.Sub(e.lastNotifiedAt) >= time.Hour:
+	case !e.lastNotifiedAt.IsZero() && now.Sub(e.lastNotifiedAt) >= effectiveAlertThrottleInterval():
 		shouldNotify = true
 	}
 	if shouldNotify {

--- a/scheduler/hl_reconcile_gap_alerts_test.go
+++ b/scheduler/hl_reconcile_gap_alerts_test.go
@@ -97,6 +97,7 @@ func TestHLReconcileGapTracker_ThrottleAndRealert(t *testing.T) {
 // re-DM'd the operator roughly every 6 minutes and the hourly case was never
 // reached.
 func TestHLReconcileGapTracker_StableGapRealertsHourlyNotEveryTenth(t *testing.T) {
+	withAlertThrottleInterval(t, time.Hour)
 	tr := &HLReconcileGapTracker{}
 	now := time.Now().UTC()
 	// Cross the confirmation window → first alert.

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -110,6 +110,10 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Failed to load config: %v\n", err)
 		os.Exit(1)
 	}
+	if err := applyAlertThrottleFromConfig(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to apply alert throttle interval: %v\n", err)
+		os.Exit(1)
+	}
 	fmt.Printf("Loaded config: %d strategies, interval=%ds\n", len(cfg.Strategies), cfg.IntervalSeconds)
 
 	// #1085: load the directional-certification artifact (SSoT for the

--- a/scheduler/script_failure_alerts.go
+++ b/scheduler/script_failure_alerts.go
@@ -180,7 +180,7 @@ func recordScriptFailureAtThreshold(t *ScriptFailureTracker, strategyID, errSig 
 		shouldNotify = true
 	case e.count%10 == 0:
 		shouldNotify = true
-	case !e.lastNotifiedAt.IsZero() && now.Sub(e.lastNotifiedAt) >= time.Hour:
+	case !e.lastNotifiedAt.IsZero() && now.Sub(e.lastNotifiedAt) >= effectiveAlertThrottleInterval():
 		shouldNotify = true
 	}
 	if shouldNotify {

--- a/scheduler/script_failure_alerts_test.go
+++ b/scheduler/script_failure_alerts_test.go
@@ -59,6 +59,7 @@ func TestScriptFailureTracker_ThrottlesAfterThreshold(t *testing.T) {
 }
 
 func TestScriptFailureTracker_HourlyReAlert(t *testing.T) {
+	withAlertThrottleInterval(t, time.Hour)
 	tr := &ScriptFailureTracker{}
 	now := time.Unix(1700000000, 0).UTC()
 	for i := 0; i < scriptFailureAlertThreshold; i++ {

--- a/scheduler/shared_wallet_drift_alerts.go
+++ b/scheduler/shared_wallet_drift_alerts.go
@@ -40,18 +40,12 @@ const sharedWalletDriftAlertThreshold = 2
 // continuously and defeat the hourly back-off.
 const sharedWalletDriftRealertRatio = 0.10
 
-// sharedWalletDriftLogInterval is the heartbeat ceiling for the stdout [WARN]
-// drift line per wallet (#1088): once an over-tolerance episode is underway, a
-// STABLE, unchanging drift re-logs at most once per this interval. It is aligned
-// to the hourly notification back-off (time.Hour) so a persistent stable drift's
-// stdout cadence matches its alert cadence instead of spamming the log — a flat
-// per-cycle log produced 620 lines in 6h, and even a 1-minute interval still
-// logged ~once/70s ≈ 310. A drift that materially CHANGES
-// (sharedWalletDriftRealertRatio, anchored to the last logged line) logs
-// immediately regardless of this interval, and so does any cycle that fires an
-// operator alert, so onset, worsening, and alert visibility are all preserved
-// while a stable drift collapses to onset + the hourly heartbeat + alert cycles.
-const sharedWalletDriftLogInterval = time.Hour
+// sharedWalletDriftLogInterval returns the heartbeat ceiling for the stdout
+// [WARN] drift line per wallet (#1088), aligned to the configured notification
+// back-off so a persistent stable drift's stdout cadence matches its alert cadence.
+func sharedWalletDriftLogInterval() time.Duration {
+	return effectiveAlertThrottleInterval()
+}
 
 // sharedWalletDriftEntry is one slot in the per-wallet drift tracker.
 type sharedWalletDriftEntry struct {
@@ -204,7 +198,7 @@ func (t *SharedWalletDriftTracker) Record(walletKey string, drift float64, orpha
 		float64(logDeltaCents) > sharedWalletDriftRealertRatio*float64(absInt64(e.lastLoggedDriftCents))
 	shouldLog = e.lastLoggedAt.IsZero() ||
 		logSigChanged ||
-		now.Sub(e.lastLoggedAt) >= sharedWalletDriftLogInterval
+		now.Sub(e.lastLoggedAt) >= sharedWalletDriftLogInterval()
 
 	// Confirmation window: no coin has stayed unowned long enough yet — a
 	// transient one-cycle orphan never reaches the threshold (it clears next
@@ -222,7 +216,7 @@ func (t *SharedWalletDriftTracker) Record(walletKey string, drift float64, orpha
 		shouldNotify = true // a coin crossed its confirmation window
 	case e.alerted && sigChanged:
 		shouldNotify = true
-	case !e.lastNotifiedAt.IsZero() && now.Sub(e.lastNotifiedAt) >= time.Hour:
+	case !e.lastNotifiedAt.IsZero() && now.Sub(e.lastNotifiedAt) >= effectiveAlertThrottleInterval():
 		shouldNotify = true
 	}
 	if shouldNotify {

--- a/scheduler/shared_wallet_reconcile_cycle_test.go
+++ b/scheduler/shared_wallet_reconcile_cycle_test.go
@@ -548,6 +548,7 @@ func TestSharedWalletDriftTracker_RecoveryCountSurvivesChurn(t *testing.T) {
 // 620-lines-in-6h spam the issue reported; a 1-minute interval only halved it,
 // so the heartbeat is aligned to the hourly notification cadence.
 func TestSharedWalletDriftTracker_LogThrottledPerInterval(t *testing.T) {
+	withAlertThrottleInterval(t, time.Hour)
 	tr := &SharedWalletDriftTracker{}
 	now := time.Now().UTC()
 	// Cycle 1: onset. In the confirmation window (no alert) but MUST log once.
@@ -608,6 +609,7 @@ func TestSharedWalletDriftTracker_WorseningDriftLogsWithinInterval(t *testing.T)
 // short reconcile cadence the old %10 rule fired a Discord/DM alert roughly
 // every few minutes; the hourly case was preempted and never reached.
 func TestSharedWalletDriftTracker_StableDriftRealertsHourlyNotEveryTenth(t *testing.T) {
+	withAlertThrottleInterval(t, time.Hour)
 	tr := &SharedWalletDriftTracker{}
 	now := time.Now().UTC()
 	tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now) // onset


### PR DESCRIPTION
## Summary
- Add top-level `alert_throttle_interval` config (Go duration string; default `6h` when omitted).
- Wire all four operator alert throttle paths: CB drain/live-exec (`shouldNotifyDrainFailure`), script failures, HL reconcile gaps, and shared-wallet drift (notification + aligned log heartbeats).
- Hot-reload the interval via SIGHUP without restart.

Closes #1266

## Test plan
- [x] `go test . -run 'AlertThrottle|ShouldNotifyDrainFailure|ScriptFailureTracker_Hourly|HLReconcileGapTracker_Stable|SharedWalletDriftTracker_(LogThrottled|StableDrift)|ApplyHotReloadConfig_UpdatesAlert'`
- [x] `go build` in `scheduler/`

LLM: Composer 2.5 | high | Harness: Cursor