### PR TITLE
fix(#1272): enforce startup-only kill-switch clear with phase guard

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -284,6 +284,10 @@ func main() {
 	statusPort := resolveStatusPort(*statusPortFlag, cfg.StatusPort)
 	server := NewStatusServer(state, &mu, cfg.StatusToken, cfg.Strategies, stateDB)
 	server.SetConfigContext(*configPath, cfg)
+	// #1272: end single-threaded startup before the first state-reading
+	// goroutine (http.Serve). ClearLatchedKillSwitchSharedWallet above must
+	// stay before this call.
+	markSchedulerStarted()
 	server.Start(statusPort)
 
 	// Graceful shutdown — two-phase drain (see scheduler/shutdown.go).

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -6,8 +6,21 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
+
+// schedulerStarted is set once in main immediately before server.Start — the
+// first spawn that can read PortfolioRisk under mu. ClearLatchedKillSwitchSharedWallet
+// may only run while this is false (#1272).
+var schedulerStarted atomic.Bool
+
+// markSchedulerStarted ends the single-threaded startup phase. Call exactly
+// once immediately before server.Start (or any other goroutine that reads
+// AppState under mu).
+func markSchedulerStarted() {
+	schedulerStarted.Store(true)
+}
 
 // collectPriceSymbols returns the list of BinanceUS-format symbols to fetch
 // for spot strategy valuation/notional. Only "spot" strategy types are
@@ -282,11 +295,15 @@ func detectSharedWalletPlatforms(strategies []StrategyConfig) []string {
 // peak — the original root cause from #244.
 //
 // CONCURRENCY: This function mutates state.PortfolioRisk without holding any
-// lock. It is only safe to call during startup, before the state mutex is
-// created and before any goroutines are spawned. See main.go:109.
+// lock. It is only safe during the single-threaded startup phase — before
+// markSchedulerStarted(). Calling it after that panics (#1272); do not hold
+// mu across the balance fetcher I/O inside this helper.
 //
 // Returns true iff the kill switch was cleared.
 func ClearLatchedKillSwitchSharedWallet(state *AppState, strategies []StrategyConfig, fetcher SharedWalletBalanceFetcher) bool {
+	if schedulerStarted.Load() {
+		panic("ClearLatchedKillSwitchSharedWallet called after scheduler started")
+	}
 	if state == nil || !state.PortfolioRisk.KillSwitchActive {
 		return false
 	}
@@ -346,6 +363,10 @@ func ClearLatchedKillSwitchSharedWallet(state *AppState, strategies []StrategyCo
 // operator-required gaps such as OKX spot or Robinhood options. Those venues do
 // not block OnChainConfirmedFlat because there is no safe automated close path,
 // but resuming trading without a human reset would hide remaining live exposure.
+//
+// CONCURRENCY: lock-free body — the caller must hold mu while invoking this
+// (hot-loop site in main does). Unlike ClearLatchedKillSwitchSharedWallet,
+// this helper is intended for post-startup use under the state lock.
 func AutoResetConfirmedFlatKillSwitch(prs *PortfolioRiskState, rebaselineValue float64, details string) bool {
 	if prs == nil || !prs.KillSwitchActive {
 		return false

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -1142,10 +1142,13 @@ func TestCheckPortfolioRisk_EventLoggedOnTrigger(t *testing.T) {
 // --- ClearLatchedKillSwitchSharedWallet (#244) ---
 
 // resetSchedulerStarted clears the #1272 startup-phase guard between tests.
-// The package-level flag persists across the test binary.
+// The package-level flag persists across the test binary. t.Cleanup restores
+// false after the test so a markSchedulerStarted() call (e.g. the panic-path
+// test) cannot leak into a later Clear-calling test that forgets to reset.
 func resetSchedulerStarted(t *testing.T) {
 	t.Helper()
 	schedulerStarted.Store(false)
+	t.Cleanup(func() { schedulerStarted.Store(false) })
 }
 
 // latchedSharedWalletState builds an AppState with a latched kill switch and

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -1141,6 +1141,13 @@ func TestCheckPortfolioRisk_EventLoggedOnTrigger(t *testing.T) {
 
 // --- ClearLatchedKillSwitchSharedWallet (#244) ---
 
+// resetSchedulerStarted clears the #1272 startup-phase guard between tests.
+// The package-level flag persists across the test binary.
+func resetSchedulerStarted(t *testing.T) {
+	t.Helper()
+	schedulerStarted.Store(false)
+}
+
 // latchedSharedWalletState builds an AppState with a latched kill switch and
 // shared-wallet strategies for use in #244 regression tests.
 func latchedSharedWalletState() *AppState {
@@ -1168,6 +1175,7 @@ func sharedHLStrategies() []StrategyConfig {
 // that PeakValue is re-baselined so the next CheckPortfolioRisk call does
 // not immediately re-latch the switch (#244 regression).
 func TestClearLatchedKillSwitchSharedWallet_Success(t *testing.T) {
+	resetSchedulerStarted(t)
 	state := latchedSharedWalletState()
 	strategies := sharedHLStrategies()
 
@@ -1227,6 +1235,7 @@ func TestClearLatchedKillSwitchSharedWallet_Success(t *testing.T) {
 // This reproduces the exact scenario from the issue — a $20K peak from
 // shared-wallet double-counting against a real $5K balance.
 func TestClearLatchedKillSwitchSharedWallet_NoRelatchOnNextTick(t *testing.T) {
+	resetSchedulerStarted(t)
 	state := &AppState{
 		Strategies: map[string]*StrategyState{},
 		PortfolioRisk: PortfolioRiskState{
@@ -1265,6 +1274,7 @@ func TestClearLatchedKillSwitchSharedWallet_NoRelatchOnNextTick(t *testing.T) {
 // that a network/config failure on the balance fetch leaves the kill switch
 // latched (acceptance criterion #2).
 func TestClearLatchedKillSwitchSharedWallet_FetchFailurePreservesLatch(t *testing.T) {
+	resetSchedulerStarted(t)
 	state := latchedSharedWalletState()
 	strategies := sharedHLStrategies()
 	originalLatchedAt := state.PortfolioRisk.KillSwitchAt
@@ -1291,6 +1301,7 @@ func TestClearLatchedKillSwitchSharedWallet_FetchFailurePreservesLatch(t *testin
 // TestClearLatchedKillSwitchSharedWallet_NoSharedWalletNoOp verifies that
 // non-shared-wallet setups are unaffected (acceptance criterion #3).
 func TestClearLatchedKillSwitchSharedWallet_NoSharedWalletNoOp(t *testing.T) {
+	resetSchedulerStarted(t)
 	state := latchedSharedWalletState()
 	// Strategies without capital_pct (or only one strategy on a wallet) are
 	// not "shared" — there is no double-counting risk to recover from.
@@ -1322,6 +1333,7 @@ func TestClearLatchedKillSwitchSharedWallet_NoSharedWalletNoOp(t *testing.T) {
 // helper is a no-op (and skips the network fetch entirely) when the kill
 // switch is not active.
 func TestClearLatchedKillSwitchSharedWallet_InactiveSwitchNoOp(t *testing.T) {
+	resetSchedulerStarted(t)
 	state := &AppState{
 		PortfolioRisk: PortfolioRiskState{PeakValue: 10000, KillSwitchActive: false},
 	}
@@ -1346,6 +1358,7 @@ func TestClearLatchedKillSwitchSharedWallet_InactiveSwitchNoOp(t *testing.T) {
 // switch is cleared and PeakValue is re-baselined to the SUM of all
 // fetched balances (not just the first).
 func TestClearLatchedKillSwitchSharedWallet_MultiPlatformAllSuccess(t *testing.T) {
+	resetSchedulerStarted(t)
 	state := latchedSharedWalletState()
 	strategies := []StrategyConfig{
 		{ID: "hl-a", Platform: "hyperliquid", CapitalPct: 0.5, Capital: 1000},
@@ -1390,6 +1403,7 @@ func TestClearLatchedKillSwitchSharedWallet_MultiPlatformAllSuccess(t *testing.T
 // re-baselining peak — a partial slice would under-baseline and still be
 // unsafe.
 func TestClearLatchedKillSwitchSharedWallet_MultiPlatformAnyFailPreservesLatch(t *testing.T) {
+	resetSchedulerStarted(t)
 	state := latchedSharedWalletState()
 	originalLatchedAt := state.PortfolioRisk.KillSwitchAt
 	originalPeak := state.PortfolioRisk.PeakValue
@@ -1424,6 +1438,53 @@ func TestClearLatchedKillSwitchSharedWallet_MultiPlatformAnyFailPreservesLatch(t
 	if len(state.PortfolioRisk.Events) != 0 {
 		t.Errorf("expected no audit event on partial failure; got %d", len(state.PortfolioRisk.Events))
 	}
+}
+
+// TestClearLatchedKillSwitchSharedWallet_PanicsAfterSchedulerStarted is the
+// #1272 regression: post-startup misuse must panic before any mutation so a
+// future refactor cannot silently race the kill-switch latch.
+func TestClearLatchedKillSwitchSharedWallet_PanicsAfterSchedulerStarted(t *testing.T) {
+	resetSchedulerStarted(t)
+	state := latchedSharedWalletState()
+	originalPeak := state.PortfolioRisk.PeakValue
+	originalLatchedAt := state.PortfolioRisk.KillSwitchAt
+	strategies := sharedHLStrategies()
+
+	markSchedulerStarted()
+
+	fetcherCalls := 0
+	fetcher := func(platform string) (float64, error) {
+		fetcherCalls++
+		return 4500, nil
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when ClearLatchedKillSwitchSharedWallet runs after markSchedulerStarted")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "after scheduler started") {
+			t.Errorf("unexpected panic value: %#v", r)
+		}
+		if fetcherCalls != 0 {
+			t.Errorf("expected fetcher not called on panic path; got %d calls", fetcherCalls)
+		}
+		if !state.PortfolioRisk.KillSwitchActive {
+			t.Error("expected latch untouched after panic")
+		}
+		if state.PortfolioRisk.PeakValue != originalPeak {
+			t.Errorf("expected PeakValue untouched; got %.2f", state.PortfolioRisk.PeakValue)
+		}
+		if !state.PortfolioRisk.KillSwitchAt.Equal(originalLatchedAt) {
+			t.Error("expected KillSwitchAt untouched after panic")
+		}
+		if len(state.PortfolioRisk.Events) != 0 {
+			t.Errorf("expected no audit event on panic path; got %d", len(state.PortfolioRisk.Events))
+		}
+	}()
+
+	ClearLatchedKillSwitchSharedWallet(state, strategies, fetcher)
 }
 
 func TestAutoResetConfirmedFlatKillSwitch_Success(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add a package-level `schedulerStarted` atomic flag; `ClearLatchedKillSwitchSharedWallet` panics if called after it is set.
- Set the flag in `main` immediately before `server.Start` (first state-reading goroutine).
- Document CONCURRENCY on both clear helpers; add panic regression test and reset existing ClearLatched tests.

Closes #1272

## Test plan
- [x] `go test -C scheduler -race -count=1 -run 'TestClearLatchedKillSwitchSharedWallet_|TestAutoResetConfirmedFlatKillSwitch_' .`
- [ ] Confirm sole production clear still runs before `markSchedulerStarted()` / `server.Start`

LLM: Cursor Grok 4.5 | high | Harness: Cursor