### PR TITLE
Add FXMacroData integration

### DIFF
--- a/scheduler/agent_info.go
+++ b/scheduler/agent_info.go
@@ -88,6 +88,8 @@ var agentInfoEnvVars = []agentEnvVar{
 	{Name: "ANTHROPIC_API_KEY", Purpose: "Anthropic API key for the #1137 LLM entry-analysis pipeline (shared_scripts/llm_review.py); Go only checks presence to warn when analysis is enabled without it.", Secret: true},
 	{Name: "DISCORD_BOT_TOKEN", Purpose: "Discord bot token for notifications.", Secret: true},
 	{Name: "DISCORD_OWNER_ID", Purpose: "Discord user ID that receives owner-only DMs and mutating commands.", Secret: false},
+	{Name: "FXMACRODATA_API_KEY", Purpose: "FXMacroData API key for scheduler macro, FX, COT, commodity, and session context.", Secret: true},
+	{Name: "FXMD_API_KEY", Purpose: "Fallback FXMacroData API key env var used when FXMACRODATA_API_KEY is unset.", Secret: true},
 	{Name: "GITHUB_TOKEN", Purpose: "GitHub token for the self-updater (fallback to GO_TRADER_GITHUB_TOKEN).", Secret: true},
 	{Name: "GO_TRADER_ALLOW_MISSING_STATE", Purpose: "Set to 1 to allow startup with no existing state DB (CheckStatePresence bypass).", Secret: false},
 	{Name: "GO_TRADER_CASHFLOW_JOURNAL_ALARM", Purpose: "Set to 0/off/false/no to force the legacy trade-ledger drift basis for HL shared wallets instead of the #1100 exchange-sourced cash-flow journal (default on).", Secret: false},

--- a/scheduler/fxmacrodata.go
+++ b/scheduler/fxmacrodata.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const fxMacroDataDefaultBaseURL = "https://fxmacrodata.com/api/v1/"
+
+// FXMacroDataClient adds macro, FX, COT, commodity, and session context to
+// scheduler workflows without adding third-party dependencies.
+type FXMacroDataClient struct {
+	APIKey     string
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+func NewFXMacroDataClient(apiKey string) *FXMacroDataClient {
+	return &FXMacroDataClient{
+		APIKey:  strings.TrimSpace(apiKey),
+		BaseURL: fxMacroDataDefaultBaseURL,
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+func NewFXMacroDataClientFromEnv() *FXMacroDataClient {
+	apiKey := os.Getenv("FXMACRODATA_API_KEY")
+	if apiKey == "" {
+		apiKey = os.Getenv("FXMD_API_KEY")
+	}
+	return NewFXMacroDataClient(apiKey)
+}
+
+func (c *FXMacroDataClient) Request(
+	ctx context.Context,
+	path string,
+	params url.Values,
+	result any,
+) error {
+	requestURL, err := c.buildURL(path, params)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("fxmacrodata http %d for %s", resp.StatusCode, path)
+	}
+	return json.NewDecoder(resp.Body).Decode(result)
+}
+
+func (c *FXMacroDataClient) DataCatalogue(
+	ctx context.Context,
+	currency string,
+) (map[string]any, error) {
+	return c.getMap(ctx, "data_catalogue/"+normaliseFXMacroDataCurrency(currency), nil)
+}
+
+func (c *FXMacroDataClient) Announcements(
+	ctx context.Context,
+	currency string,
+	indicator string,
+	params url.Values,
+) (map[string]any, error) {
+	path := fmt.Sprintf(
+		"announcements/%s/%s",
+		normaliseFXMacroDataCurrency(currency),
+		indicator,
+	)
+	return c.getMap(ctx, path, params)
+}
+
+func (c *FXMacroDataClient) Calendar(
+	ctx context.Context,
+	currency string,
+	params url.Values,
+) (map[string]any, error) {
+	return c.getMap(ctx, "calendar/"+normaliseFXMacroDataCurrency(currency), params)
+}
+
+func (c *FXMacroDataClient) Forex(
+	ctx context.Context,
+	base string,
+	quote string,
+	params url.Values,
+) (map[string]any, error) {
+	path := fmt.Sprintf(
+		"forex/%s/%s",
+		normaliseFXMacroDataCurrency(base),
+		normaliseFXMacroDataCurrency(quote),
+	)
+	return c.getMap(ctx, path, params)
+}
+
+func (c *FXMacroDataClient) COT(
+	ctx context.Context,
+	currency string,
+	params url.Values,
+) (map[string]any, error) {
+	return c.getMap(ctx, "cot/"+normaliseFXMacroDataCurrency(currency), params)
+}
+
+func (c *FXMacroDataClient) Commodity(
+	ctx context.Context,
+	indicator string,
+	params url.Values,
+) (map[string]any, error) {
+	return c.getMap(ctx, "commodities/"+indicator, params)
+}
+
+func (c *FXMacroDataClient) MarketSessions(
+	ctx context.Context,
+	params url.Values,
+) (map[string]any, error) {
+	return c.getMap(ctx, "market_sessions", params)
+}
+
+func (c *FXMacroDataClient) RiskSentiment(
+	ctx context.Context,
+	params url.Values,
+) (map[string]any, error) {
+	return c.getMap(ctx, "risk_sentiment", params)
+}
+
+func (c *FXMacroDataClient) getMap(
+	ctx context.Context,
+	path string,
+	params url.Values,
+) (map[string]any, error) {
+	var result map[string]any
+	err := c.Request(ctx, path, params, &result)
+	return result, err
+}
+
+func (c *FXMacroDataClient) buildURL(path string, params url.Values) (string, error) {
+	baseURL := strings.TrimRight(c.BaseURL, "/") + "/"
+	u, err := url.Parse(baseURL + strings.TrimLeft(path, "/"))
+	if err != nil {
+		return "", err
+	}
+	query := u.Query()
+	for key, values := range params {
+		for _, value := range values {
+			query.Add(key, value)
+		}
+	}
+	if c.APIKey != "" {
+		query.Set("api_key", c.APIKey)
+	}
+	u.RawQuery = query.Encode()
+	return u.String(), nil
+}
+
+func normaliseFXMacroDataCurrency(currency string) string {
+	return strings.ToLower(strings.TrimSpace(currency))
+}

--- a/scheduler/fxmacrodata_test.go
+++ b/scheduler/fxmacrodata_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestFXMacroDataBuildURL(t *testing.T) {
+	client := NewFXMacroDataClient("test-key")
+	client.BaseURL = "https://example.com/api/v1/"
+
+	params := url.Values{}
+	params.Set("limit", "1")
+
+	got, err := client.buildURL("forex/eur/usd", params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "https://example.com/api/v1/forex/eur/usd?api_key=test-key&limit=1"
+	if got != want {
+		t.Fatalf("buildURL() = %q, want %q", got, want)
+	}
+}
+
+func TestNormaliseFXMacroDataCurrency(t *testing.T) {
+	if got := normaliseFXMacroDataCurrency(" USD "); got != "usd" {
+		t.Fatalf("normaliseFXMacroDataCurrency() = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a dependency-free FXMacroData Go client for macro, FX, COT, commodity, market-session, and risk-sentiment data
- support API keys from FXMACRODATA_API_KEY or FXMD_API_KEY
- include URL-construction tests for the scheduler package

## Validation
- git diff --check

Not run locally: Go is not installed in this environment.