### PR TITLE
feat(#1274): Monte Carlo trade-order resampler for drawdown/risk-of-ruin distributions

### DIFF
--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -100,12 +100,23 @@ def trade_samples_from_results(results: dict) -> List[dict]:
 
     ``pnl_pct`` is computed purely from entry/exit fill prices, so on a
     zero-friction (gross) run it is the raw per-trade price edge the M1
-    step-2 noise check adjudicates. ``entry_date`` rides along so callers
-    pooling overlapping windows can deduplicate the same physical entry.
+    step-2 noise check adjudicates. ``pnl_pct_net`` (#1274, additive) is the
+    fee-deducted return on entry notional (Trade.pnl has both commissions
+    subtracted; falls back to the gross figure when notional is unavailable)
+    for consumers that need the real equity path, e.g. the Monte Carlo
+    trade-order resampler. ``entry_date`` rides along so callers pooling
+    overlapping windows can deduplicate the same physical entry.
     Missing/empty trade lists yield [].
     """
-    return [{"entry_date": str(t["entry_date"]), "pnl_pct": float(t["pnl_pct"])}
-            for t in results.get("trades") or []]
+    out = []
+    for t in results.get("trades") or []:
+        gross = float(t["pnl_pct"])
+        notional = float(t.get("shares") or 0.0) * float(t.get("entry_price") or 0.0)
+        net = (float(t["pnl"]) / notional * 100.0
+               if notional > 0 and t.get("pnl") is not None else gross)
+        out.append({"entry_date": str(t["entry_date"]), "pnl_pct": gross,
+                    "pnl_pct_net": round(net, 6)})
+    return out
 
 
 def dd_adjusted_return(return_pct: float, max_dd_pct: float) -> float:

--- a/backtest/monte_carlo.py
+++ b/backtest/monte_carlo.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""monte_carlo.py — trade-order Monte Carlo resampler for drawdown and
+risk-of-ruin distributions (#1274).
+
+The validation stack reports path-dependent risk as single-path point
+estimates: the Backtester's ``max_drawdown_pct`` is the drawdown of the ONE
+realized trade ordering, and eval_windows/gross_edge_noise resample only the
+per-trade MEAN. Max drawdown is an order statistic of the trade sequence —
+the same multiset of trades in a different order produces a different max
+drawdown — so a single historical ordering is one draw from a distribution.
+This tool resamples the trade ORDER to produce that distribution:
+
+  - P5 / P50 / P95 (configurable via --percentiles) of max drawdown and of
+    final return across resampled equity paths;
+  - P(final equity < starting equity) — probability the strategy ends
+    underwater;
+  - P(max drawdown >= kill-switch threshold) — probability of tripping the
+    per-strategy drawdown limit. The threshold resolves from a live config
+    (--config PATH --strategy-id ID, mirroring scheduler/config.go's
+    hierarchy: explicit strategy max_drawdown_pct > platform risk override >
+    type default 40/45/50/60) or from --kill-switch-pct (default 25, the
+    portfolio-level kill-switch default in PortfolioRiskConfig).
+
+Two resampling schemes, both run by default (--schemes to restrict):
+
+  - ``permute`` — shuffle the observed trade order (identical multiset,
+    order randomized); isolates pure sequencing risk.
+  - ``block`` — CIRCULAR block bootstrap: sample contiguous blocks (with
+    replacement, wrapping past the series end so tail trades are not
+    under-sampled) and concatenate to the original length; preserves
+    short-range autocorrelation in trade outcomes and also varies the trade
+    multiset. Block length via --block-len (0 = auto, ceil(n^(1/3))).
+
+Compounding model: per-trade percent returns are compounded multiplicatively
+into an equity path marked at TRADE CLOSES only (equity *= 1 + r/100). This
+matches the Backtester's single-mode full-equity deployment but is
+trade-close resolution — intra-trade (bar-level) excursions are invisible, so
+the resampled drawdowns UNDERSTATE what a bar-level equity curve would show.
+Returns default to NET of fees (``pnl / (shares * entry_price)`` — Trade.pnl
+has both commissions deducted; #1241 documents that ``pnl_pct`` is gross);
+--returns gross switches to raw fill-price edge. A path whose equity touches
+0 is a bust: it is sticky-floored there (max DD 100, final return -100),
+mirroring the Backtester's #1005 liquidation-floor convention.
+
+Both probabilities are add-one smoothed ((count + 1) / (n_paths + 1), the
+gross_edge_noise convention) so a finite path count never reports exactly 0.
+All statistics are stdlib-only and deterministic under --seed.
+
+SUGGEST-ONLY / diagnostics-only: output never gates a promotion, writes a
+config, or feeds a live path.
+
+Usage:
+  # Resample the trades of a completed run saved as JSON (a results dict
+  # with a "trades" list, or a bare list of trade dicts / percent returns)
+  uv run --no-sync python backtest/monte_carlo.py --trades-json results.json
+
+  # Run one leg on the M1 audit-identical harness and resample its trades
+  uv run --no-sync python backtest/monte_carlo.py \\
+      --strategy squeeze_momentum --dataset BTC/USDT:1h --window is
+
+  # Kill-switch threshold from a live config's strategy entry
+  uv run --no-sync python backtest/monte_carlo.py --trades-json results.json \\
+      --config scheduler/config.json --strategy-id hl-btc-squeeze
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from random import Random
+from typing import List, Optional, Sequence
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+sys.path.insert(0, os.path.join(_THIS_DIR, "..", "shared_tools"))
+
+from exit_policy_ab import DEFAULT_SEED  # noqa: E402  (path bootstrap above)
+
+DEFAULT_N_PATHS = 10000
+DEFAULT_PERCENTILES = (5.0, 50.0, 95.0)
+# Portfolio-level kill-switch default (scheduler/config.go
+# PortfolioRiskConfig.MaxDrawdownPct).
+DEFAULT_KILL_SWITCH_PCT = 25.0
+SCHEMES = ("permute", "block")
+
+# ---------------------------------------------------------------------------
+# Mirror of scheduler/config.go loadConfig's per-strategy max_drawdown_pct
+# hierarchy (strategy-specific > platform risk override > type default).
+# Change only alongside the Go side.
+# ---------------------------------------------------------------------------
+GO_ID_PREFIX_PLATFORM = (
+    ("ibkr-", "ibkr"),
+    ("deribit-", "deribit"),
+    ("hl-", "hyperliquid"),
+    ("ts-", "topstep"),
+    ("rh-", "robinhood"),
+    ("luno-", "luno"),
+    ("okx-", "okx"),
+)
+GO_TYPE_DEFAULT_MAX_DD = {"options": 40.0, "perps": 50.0, "futures": 45.0}
+GO_FALLBACK_MAX_DD = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Pure statistics (stdlib only; deterministic; unit-tested without data).
+# ---------------------------------------------------------------------------
+
+def equity_path_stats(returns_pct: Sequence[float]) -> tuple:
+    """Compound per-trade percent returns into an equity path and score it.
+
+    Returns ``(max_dd_pct, final_return_pct)`` where ``max_dd_pct`` is the
+    max peak-to-trough drawdown as a POSITIVE magnitude (0 = never below a
+    peak) so it compares directly against a kill-switch threshold, and
+    ``final_return_pct`` is the compounded total return. Equity is marked at
+    trade closes only (see module docstring). A path whose equity touches 0
+    busts: sticky-floored per the #1005 convention (DD 100, final -100).
+    Empty input → (0.0, 0.0).
+    """
+    equity = 1.0
+    peak = 1.0
+    max_dd = 0.0
+    for r in returns_pct:
+        equity *= 1.0 + r / 100.0
+        if equity <= 0.0:
+            return 100.0, -100.0
+        if equity > peak:
+            peak = equity
+        dd = (peak - equity) / peak * 100.0
+        if dd > max_dd:
+            max_dd = dd
+    return max_dd, (equity - 1.0) * 100.0
+
+
+def percentile(sorted_values: Sequence[float], q: float) -> Optional[float]:
+    """Linear-interpolation percentile (numpy's default) on a SORTED list.
+
+    q in [0, 100]. None on an empty sample.
+    """
+    n = len(sorted_values)
+    if n == 0:
+        return None
+    if n == 1:
+        return float(sorted_values[0])
+    pos = (q / 100.0) * (n - 1)
+    lo = int(math.floor(pos))
+    hi = min(lo + 1, n - 1)
+    frac = pos - lo
+    return float(sorted_values[lo] * (1.0 - frac) + sorted_values[hi] * frac)
+
+
+def add_one_smoothed(count: int, n_paths: int) -> float:
+    """(count + 1) / (n_paths + 1) — a finite path count never reports 0."""
+    return (count + 1) / (n_paths + 1)
+
+
+def auto_block_len(n: int) -> int:
+    """Default block length ceil(n^(1/3)) — the standard n^(1/3) rate for
+    block bootstraps, floored at 1."""
+    return max(1, math.ceil(n ** (1.0 / 3.0)))
+
+
+def permuted_path(values: Sequence[float], rng: Random) -> List[float]:
+    """One shuffled copy of the observed trade order (same multiset)."""
+    out = list(values)
+    rng.shuffle(out)
+    return out
+
+
+def block_bootstrap_path(values: Sequence[float], block_len: int,
+                         rng: Random) -> List[float]:
+    """One circular-block-bootstrap path of the original length.
+
+    Blocks of exactly ``block_len`` are drawn with replacement from random
+    start offsets, wrapping past the series end (circular — tail trades are
+    sampled as often as any other), concatenated, and truncated to len(values).
+    """
+    n = len(values)
+    out: List[float] = []
+    while len(out) < n:
+        start = rng.randrange(n)
+        for k in range(block_len):
+            out.append(values[(start + k) % n])
+            if len(out) == n:
+                break
+    return out
+
+
+def resample_stats(values: Sequence[float], scheme: str,
+                   n_paths: int = DEFAULT_N_PATHS,
+                   block_len: int = 0,
+                   seed: int = DEFAULT_SEED,
+                   kill_switch_pct: float = DEFAULT_KILL_SWITCH_PCT,
+                   percentiles: Sequence[float] = DEFAULT_PERCENTILES) -> dict:
+    """Full Monte Carlo stats block for one resampling scheme.
+
+    ``block_len`` <= 0 means auto (ceil(n^(1/3))); ignored for ``permute``.
+    Empty input returns a degenerate block (n_trades 0, everything None) —
+    there is no path to resample, and reporting a fabricated 0-risk number
+    would be worse than reporting nothing.
+    """
+    if scheme not in SCHEMES:
+        raise ValueError(f"unknown scheme {scheme!r}; known: {SCHEMES}")
+    n = len(values)
+    if n == 0:
+        return {"scheme": scheme, "n_trades": 0, "n_paths": 0,
+                "block_len": None, "kill_switch_pct": kill_switch_pct,
+                "max_dd_pct_percentiles": None,
+                "final_return_pct_percentiles": None,
+                "p_final_below_start": None, "p_dd_ge_kill_switch": None}
+    eff_block = None
+    if scheme == "block":
+        eff_block = block_len if block_len > 0 else auto_block_len(n)
+    rng = Random(seed)
+    dds: List[float] = []
+    finals: List[float] = []
+    for _ in range(n_paths):
+        if scheme == "permute":
+            path = permuted_path(values, rng)
+        else:
+            path = block_bootstrap_path(values, eff_block, rng)
+        dd, fin = equity_path_stats(path)
+        dds.append(dd)
+        finals.append(fin)
+    dds.sort()
+    finals.sort()
+    return {
+        "scheme": scheme,
+        "n_trades": n,
+        "n_paths": n_paths,
+        "block_len": eff_block,
+        "kill_switch_pct": kill_switch_pct,
+        "max_dd_pct_percentiles": {
+            f"p{q:g}": round(percentile(dds, q), 4) for q in percentiles},
+        "final_return_pct_percentiles": {
+            f"p{q:g}": round(percentile(finals, q), 4) for q in percentiles},
+        "p_final_below_start": round(
+            add_one_smoothed(sum(1 for f in finals if f < 0.0), n_paths), 6),
+        "p_dd_ge_kill_switch": round(
+            add_one_smoothed(sum(1 for d in dds if d >= kill_switch_pct),
+                             n_paths), 6),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Trade-series extraction (pure).
+# ---------------------------------------------------------------------------
+
+def trade_returns(trades: Sequence, returns: str = "net") -> List[float]:
+    """Per-trade percent returns, in the recorded (chronological) order.
+
+    Accepts Backtester ``Trade.to_dict()`` dicts or bare numbers. ``net``
+    (default) computes ``pnl / (shares * entry_price) * 100`` — Trade.pnl has
+    entry+exit commissions deducted (#1241) — falling back to the gross
+    ``pnl_pct`` when notional is unavailable. ``gross`` reads ``pnl_pct``
+    (fill-price edge, commissions excluded).
+    """
+    if returns not in ("net", "gross"):
+        raise ValueError(f"returns must be 'net' or 'gross', got {returns!r}")
+    out: List[float] = []
+    for t in trades:
+        if isinstance(t, (int, float)):
+            out.append(float(t))
+            continue
+        if returns == "gross":
+            out.append(float(t["pnl_pct"]))
+            continue
+        shares = float(t.get("shares") or 0.0)
+        entry = float(t.get("entry_price") or 0.0)
+        notional = shares * entry
+        if notional > 0 and t.get("pnl") is not None:
+            out.append(float(t["pnl"]) / notional * 100.0)
+        else:
+            out.append(float(t["pnl_pct"]))
+    return out
+
+
+def trades_from_json_payload(payload) -> List:
+    """Extract the trade list from a results-JSON payload.
+
+    Accepts a Backtester results dict (``{"trades": [...]}``) or a bare list
+    of trade dicts / percent returns.
+    """
+    if isinstance(payload, dict):
+        trades = payload.get("trades")
+        if not isinstance(trades, list):
+            raise ValueError(
+                "results JSON is a dict without a 'trades' list; expected a "
+                "Backtester results dict or a bare list of trades")
+        return trades
+    if isinstance(payload, list):
+        return payload
+    raise ValueError(f"unsupported results JSON payload type "
+                     f"{type(payload).__name__}; expected dict or list")
+
+
+def resolve_kill_switch_pct(cfg: dict, strategy_id: str) -> float:
+    """Per-strategy drawdown threshold, mirroring scheduler/config.go's
+    loadConfig hierarchy: explicit strategy ``max_drawdown_pct`` > platform
+    ``risk.max_drawdown_pct`` override > type default (options 40, futures
+    45, perps 50, else 60). Raises ValueError when the strategy is missing.
+    """
+    sc = None
+    for cand in cfg.get("strategies") or []:
+        if isinstance(cand, dict) and cand.get("id") == strategy_id:
+            sc = cand
+            break
+    if sc is None:
+        raise ValueError(f"strategy {strategy_id!r} not found in config")
+    explicit = float(sc.get("max_drawdown_pct") or 0.0)
+    if explicit > 0:
+        return explicit
+    platform = str(sc.get("platform") or "").strip()
+    stype = str(sc.get("type") or "").strip()
+    if not platform:
+        sid = str(sc.get("id") or "")
+        for prefix, name in GO_ID_PREFIX_PLATFORM:
+            if sid.startswith(prefix):
+                platform = name
+                break
+        else:
+            platform = "deribit" if stype == "options" else "binanceus"
+    platforms = cfg.get("platforms") or {}
+    pc = platforms.get(platform) if isinstance(platforms, dict) else None
+    if isinstance(pc, dict):
+        risk = pc.get("risk") or {}
+        pct = float(risk.get("max_drawdown_pct") or 0.0) \
+            if isinstance(risk, dict) else 0.0
+        if pct > 0:
+            return pct
+    return GO_TYPE_DEFAULT_MAX_DD.get(stype, GO_FALLBACK_MAX_DD)
+
+
+# ---------------------------------------------------------------------------
+# Leg execution (I/O; everything above stays pure).
+# ---------------------------------------------------------------------------
+
+def run_leg_trades(strategy: str, registry: str, params: Optional[dict],
+                   dataset: str, window_name: str,
+                   capital: float, direction: Optional[str],
+                   returns: str) -> List[float]:
+    """Run one (strategy, dataset, window) leg on the M1 audit-identical
+    harness (eval_windows.run_leg, default friction) and return its per-trade
+    percent returns in close order."""
+    from eval_windows import (WINDOWS, DEFAULT_CAPITAL,  # noqa: F401
+                              parse_dataset_arg, run_leg)
+    from registry_loader import load_registry
+
+    if window_name not in WINDOWS:
+        raise SystemExit(f"unknown window {window_name!r}; "
+                         f"known: {list(WINDOWS)}")
+    symbol, timeframe = parse_dataset_arg(dataset)
+    reg = load_registry(registry)
+    if strategy not in reg.STRATEGY_REGISTRY:
+        raise SystemExit(f"Unknown strategy {strategy!r}; available: "
+                         f"{reg.list_strategies()}")
+    leg = run_leg(reg, strategy, params, symbol, timeframe,
+                  WINDOWS[window_name], capital=capital, direction=direction,
+                  keep_trades=True)
+    if leg is None:
+        raise SystemExit(f"no cached data for {dataset} in window "
+                         f"{window_name!r}")
+    key = "pnl_pct_net" if returns == "net" else "pnl_pct"
+    return [float(s[key]) for s in leg.get("trade_samples") or []]
+
+
+# ---------------------------------------------------------------------------
+# Reporting / CLI.
+# ---------------------------------------------------------------------------
+
+def _fmt(v, prec=2):
+    return "-" if v is None else f"{v:+.{prec}f}"
+
+
+def format_report(source: str, returns: str, observed: tuple,
+                  threshold_source: str, blocks: List[dict]) -> str:
+    obs_dd, obs_final = observed
+    lines = [
+        f"trade-order Monte Carlo: {source} ({returns} per-trade returns)",
+        f"observed single path: max DD {obs_dd:.2f}%, "
+        f"final return {_fmt(obs_final)}%",
+        f"kill-switch threshold: "
+        f"{blocks[0]['kill_switch_pct']:g}% ({threshold_source})",
+    ]
+    for b in blocks:
+        lines.append("")
+        if b["n_trades"] == 0:
+            lines.append(f"{b['scheme']}: no trades — nothing to resample")
+            continue
+        head = (f"{b['scheme']}: {b['n_paths']} paths over "
+                f"{b['n_trades']} trades")
+        if b["block_len"]:
+            head += f", block_len={b['block_len']}"
+        lines.append(head)
+        dd = b["max_dd_pct_percentiles"]
+        fr = b["final_return_pct_percentiles"]
+        pct_keys = list(dd)
+        lines.append("  max drawdown %:  " + "  ".join(
+            f"{k}={dd[k]:.2f}" for k in pct_keys))
+        lines.append("  final return %:  " + "  ".join(
+            f"{k}={_fmt(fr[k])}" for k in pct_keys))
+        lines.append(f"  P(final < start) = {b['p_final_below_start']:.4f}   "
+                     f"P(max DD >= {b['kill_switch_pct']:g}%) = "
+                     f"{b['p_dd_ge_kill_switch']:.4f}   (add-one smoothed)")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Trade-order Monte Carlo resampler — drawdown / "
+                    "risk-of-ruin distributions (#1274). Suggest-only.")
+    src = p.add_argument_group("trade source (pick one)")
+    src.add_argument("--trades-json", default=None,
+                     help="Results JSON: a Backtester results dict with a "
+                          "'trades' list, or a bare list of trade dicts / "
+                          "percent returns")
+    src.add_argument("--strategy", default=None,
+                     help="Run one leg in-process on the M1 audit harness "
+                          "(registry default params unless --params)")
+    p.add_argument("--registry", choices=["spot", "futures"], default="spot")
+    p.add_argument("--params", default=None,
+                   help="Params JSON for --strategy (default: registry "
+                        "default_params)")
+    p.add_argument("--dataset", default="BTC/USDT:1h",
+                   help="SYMBOL:TIMEFRAME for --strategy (default "
+                        "BTC/USDT:1h)")
+    p.add_argument("--window", default="is",
+                   help="eval_windows window name for --strategy "
+                        "(default: is)")
+    p.add_argument("--direction", default=None, choices=["long", "short"])
+    p.add_argument("--capital", type=float, default=1000.0)
+    p.add_argument("--returns", choices=["net", "gross"], default="net",
+                   help="Per-trade return basis (default net — fees "
+                        "deducted; see module docstring)")
+    p.add_argument("--schemes", default=",".join(SCHEMES),
+                   help=f"Comma list of resampling schemes "
+                        f"(default: {','.join(SCHEMES)})")
+    p.add_argument("--n-paths", type=int, default=DEFAULT_N_PATHS)
+    p.add_argument("--block-len", type=int, default=0,
+                   help="Block length for the block scheme "
+                        "(0 = auto, ceil(n^(1/3)))")
+    p.add_argument("--percentiles", default=",".join(
+        f"{q:g}" for q in DEFAULT_PERCENTILES))
+    p.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    thr = p.add_argument_group("kill-switch threshold")
+    thr.add_argument("--kill-switch-pct", type=float, default=None,
+                     help=f"Drawdown threshold %% (default "
+                          f"{DEFAULT_KILL_SWITCH_PCT:g} — the portfolio "
+                          f"kill-switch default — unless --config resolves "
+                          f"a per-strategy value)")
+    thr.add_argument("--config", default=None,
+                     help="Live go-trader config to resolve the per-strategy "
+                          "threshold from (requires --strategy-id)")
+    thr.add_argument("--strategy-id", default=None,
+                     help="Strategy id inside --config whose max_drawdown_pct "
+                          "hierarchy sets the threshold")
+    p.add_argument("--json", default=None, dest="json_out",
+                   help="Write the full structured result to this path")
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if bool(args.trades_json) == bool(args.strategy):
+        raise SystemExit("pass exactly one trade source: "
+                         "--trades-json or --strategy")
+    if bool(args.config) != bool(args.strategy_id):
+        raise SystemExit("--config and --strategy-id go together")
+    if args.kill_switch_pct is not None and args.config:
+        raise SystemExit("--kill-switch-pct and --config are mutually "
+                         "exclusive threshold sources")
+
+    schemes = [s.strip() for s in args.schemes.split(",") if s.strip()]
+    unknown = [s for s in schemes if s not in SCHEMES]
+    if unknown:
+        raise SystemExit(f"unknown schemes {unknown}; known: {list(SCHEMES)}")
+    percentiles = [float(q) for q in args.percentiles.split(",") if q.strip()]
+
+    if args.config:
+        with open(args.config) as fh:
+            cfg = json.load(fh)
+        kill_switch = resolve_kill_switch_pct(cfg, args.strategy_id)
+        threshold_source = (f"--config {args.config} strategy "
+                            f"{args.strategy_id}")
+    elif args.kill_switch_pct is not None:
+        kill_switch = args.kill_switch_pct
+        threshold_source = "--kill-switch-pct"
+    else:
+        kill_switch = DEFAULT_KILL_SWITCH_PCT
+        threshold_source = "default (portfolio kill switch)"
+
+    if args.trades_json:
+        with open(args.trades_json) as fh:
+            payload = json.load(fh)
+        values = trade_returns(trades_from_json_payload(payload),
+                               returns=args.returns)
+        source = args.trades_json
+    else:
+        params = json.loads(args.params) if args.params else None
+        values = run_leg_trades(args.strategy, args.registry, params,
+                                args.dataset, args.window, args.capital,
+                                args.direction, args.returns)
+        source = (f"{args.strategy} {args.dataset} window={args.window} "
+                  f"({args.registry} registry)")
+
+    observed = equity_path_stats(values)
+    blocks = [resample_stats(values, scheme, n_paths=args.n_paths,
+                             block_len=args.block_len, seed=args.seed,
+                             kill_switch_pct=kill_switch,
+                             percentiles=percentiles)
+              for scheme in schemes]
+
+    print(format_report(source, args.returns, observed, threshold_source,
+                        blocks))
+
+    if args.json_out:
+        payload = {
+            "source": source,
+            "returns": args.returns,
+            "n_trades": len(values),
+            "seed": args.seed,
+            "n_paths": args.n_paths,
+            "percentiles": percentiles,
+            "kill_switch_pct": kill_switch,
+            "kill_switch_source": threshold_source,
+            "observed": {"max_dd_pct": round(observed[0], 4),
+                         "final_return_pct": round(observed[1], 4)},
+            "schemes": blocks,
+        }
+        with open(args.json_out, "w") as fh:
+            json.dump(payload, fh, indent=2, default=str)
+        print(f"\nwrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backtest/monte_carlo.py
+++ b/backtest/monte_carlo.py
@@ -261,11 +261,15 @@ def trade_returns(trades: Sequence, returns: str = "net") -> List[float]:
     if returns not in ("net", "gross"):
         raise ValueError(f"returns must be 'net' or 'gross', got {returns!r}")
     out: List[float] = []
-    for t in trades:
+    for i, t in enumerate(trades):
         if isinstance(t, (int, float)):
             out.append(float(t))
             continue
         if returns == "gross":
+            if "pnl_pct" not in t:
+                raise ValueError(
+                    f"trade {i} is missing 'pnl_pct', required for "
+                    f"--returns gross")
             out.append(float(t["pnl_pct"]))
             continue
         shares = float(t.get("shares") or 0.0)
@@ -274,6 +278,11 @@ def trade_returns(trades: Sequence, returns: str = "net") -> List[float]:
         if notional > 0 and t.get("pnl") is not None:
             out.append(float(t["pnl"]) / notional * 100.0)
         else:
+            if "pnl_pct" not in t:
+                raise ValueError(
+                    f"trade {i} is missing 'pnl_pct' (required as a fallback "
+                    f"when 'shares'/'entry_price'/'pnl' can't derive a net "
+                    f"return)")
             out.append(float(t["pnl_pct"]))
     return out
 
@@ -352,7 +361,10 @@ def run_leg_trades(strategy: str, registry: str, params: Optional[dict],
     if window_name not in WINDOWS:
         raise SystemExit(f"unknown window {window_name!r}; "
                          f"known: {list(WINDOWS)}")
-    symbol, timeframe = parse_dataset_arg(dataset)
+    try:
+        symbol, timeframe = parse_dataset_arg(dataset)
+    except ValueError:
+        raise SystemExit(f"--dataset expects SYMBOL:TIMEFRAME, got: {dataset!r}")
     reg = load_registry(registry)
     if strategy not in reg.STRATEGY_REGISTRY:
         raise SystemExit(f"Unknown strategy {strategy!r}; available: "
@@ -499,8 +511,13 @@ def main(argv: Optional[List[str]] = None) -> int:
                          f"{out_of_range}")
 
     if args.config:
-        with open(args.config) as fh:
-            cfg = json.load(fh)
+        try:
+            with open(args.config) as fh:
+                cfg = json.load(fh)
+        except OSError as exc:
+            raise SystemExit(f"--config {args.config!r} could not be read: {exc}")
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"--config {args.config!r} is not valid JSON: {exc}")
         try:
             kill_switch = resolve_kill_switch_pct(cfg, args.strategy_id)
         except ValueError as exc:
@@ -515,16 +532,26 @@ def main(argv: Optional[List[str]] = None) -> int:
         threshold_source = "default (portfolio kill switch)"
 
     if args.trades_json:
-        with open(args.trades_json) as fh:
-            payload = json.load(fh)
+        try:
+            with open(args.trades_json) as fh:
+                payload = json.load(fh)
+        except OSError as exc:
+            raise SystemExit(
+                f"--trades-json {args.trades_json!r} could not be read: {exc}")
+        except json.JSONDecodeError as exc:
+            raise SystemExit(
+                f"--trades-json {args.trades_json!r} is not valid JSON: {exc}")
         try:
             trades = trades_from_json_payload(payload)
+            values = trade_returns(trades, returns=args.returns)
         except ValueError as exc:
             raise SystemExit(str(exc))
-        values = trade_returns(trades, returns=args.returns)
         source = args.trades_json
     else:
-        params = json.loads(args.params) if args.params else None
+        try:
+            params = json.loads(args.params) if args.params else None
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"--params must be valid JSON: {exc}")
         values = run_leg_trades(args.strategy, args.registry, params,
                                 args.dataset, args.window, args.capital,
                                 args.direction, args.returns)

--- a/backtest/monte_carlo.py
+++ b/backtest/monte_carlo.py
@@ -475,10 +475,24 @@ def main(argv: Optional[List[str]] = None) -> int:
                          "exclusive threshold sources")
 
     schemes = [s.strip() for s in args.schemes.split(",") if s.strip()]
+    if not schemes:
+        raise SystemExit(f"--schemes must name at least one scheme; "
+                         f"known: {list(SCHEMES)}")
     unknown = [s for s in schemes if s not in SCHEMES]
     if unknown:
         raise SystemExit(f"unknown schemes {unknown}; known: {list(SCHEMES)}")
+
+    if args.n_paths < 1:
+        raise SystemExit(f"--n-paths must be >= 1, got {args.n_paths}")
+
     percentiles = [float(q) for q in args.percentiles.split(",") if q.strip()]
+    if not percentiles:
+        raise SystemExit("--percentiles must name at least one value in "
+                         "[0, 100]")
+    out_of_range = [q for q in percentiles if q < 0.0 or q > 100.0]
+    if out_of_range:
+        raise SystemExit(f"--percentiles values must be in [0, 100], got "
+                         f"{out_of_range}")
 
     if args.config:
         with open(args.config) as fh:

--- a/backtest/monte_carlo.py
+++ b/backtest/monte_carlo.py
@@ -485,7 +485,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.n_paths < 1:
         raise SystemExit(f"--n-paths must be >= 1, got {args.n_paths}")
 
-    percentiles = [float(q) for q in args.percentiles.split(",") if q.strip()]
+    try:
+        percentiles = [float(q) for q in args.percentiles.split(",") if q.strip()]
+    except ValueError:
+        raise SystemExit(f"--percentiles values must be numeric, got "
+                         f"{args.percentiles!r}")
     if not percentiles:
         raise SystemExit("--percentiles must name at least one value in "
                          "[0, 100]")
@@ -497,7 +501,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.config:
         with open(args.config) as fh:
             cfg = json.load(fh)
-        kill_switch = resolve_kill_switch_pct(cfg, args.strategy_id)
+        try:
+            kill_switch = resolve_kill_switch_pct(cfg, args.strategy_id)
+        except ValueError as exc:
+            raise SystemExit(str(exc))
         threshold_source = (f"--config {args.config} strategy "
                             f"{args.strategy_id}")
     elif args.kill_switch_pct is not None:
@@ -510,8 +517,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.trades_json:
         with open(args.trades_json) as fh:
             payload = json.load(fh)
-        values = trade_returns(trades_from_json_payload(payload),
-                               returns=args.returns)
+        try:
+            trades = trades_from_json_payload(payload)
+        except ValueError as exc:
+            raise SystemExit(str(exc))
+        values = trade_returns(trades, returns=args.returns)
         source = args.trades_json
     else:
         params = json.loads(args.params) if args.params else None

--- a/backtest/tests/test_gross_edge_noise.py
+++ b/backtest/tests/test_gross_edge_noise.py
@@ -311,9 +311,12 @@ def test_trade_samples_from_results_extracts_entry_and_pnl():
         {"entry_date": "2025-06-20 09:00:00", "pnl_pct": -0.4, "pnl": -4.0},
     ]}
     out = ew.trade_samples_from_results(results)
+    # pnl_pct_net (#1274) is additive; without notional it mirrors the gross.
     assert out == [
-        {"entry_date": "2025-06-15 04:00:00", "pnl_pct": 1.25},
-        {"entry_date": "2025-06-20 09:00:00", "pnl_pct": -0.4},
+        {"entry_date": "2025-06-15 04:00:00", "pnl_pct": 1.25,
+         "pnl_pct_net": 1.25},
+        {"entry_date": "2025-06-20 09:00:00", "pnl_pct": -0.4,
+         "pnl_pct_net": -0.4},
     ]
     assert ew.trade_samples_from_results({}) == []
     assert ew.trade_samples_from_results({"trades": None}) == []

--- a/backtest/tests/test_monte_carlo.py
+++ b/backtest/tests/test_monte_carlo.py
@@ -1,0 +1,350 @@
+"""Unit tests for the trade-order Monte Carlo resampler (#1274).
+
+The statistics layer is pure (lists of floats / plain dicts, stdlib-only,
+seeded) so it is tested without data access — same architecture as
+test_gross_edge_noise. The 3-trade permutation case is hand-enumerable: every
+ordering's max drawdown is computed independently and the resampled
+distribution must stay inside that enumerated set.
+"""
+
+import itertools
+import json
+
+import pytest
+
+import eval_windows as ew
+import monte_carlo as mc
+
+
+# ---------------------------------------------------------------------------
+# equity_path_stats
+# ---------------------------------------------------------------------------
+
+def test_equity_path_empty():
+    assert mc.equity_path_stats([]) == (0.0, 0.0)
+
+
+def test_equity_path_all_winners_has_zero_dd():
+    dd, final = mc.equity_path_stats([10.0, 10.0])
+    assert dd == 0.0
+    assert final == pytest.approx(21.0)
+
+
+def test_equity_path_hand_computed_dd():
+    # 1.0 -> 1.10 (peak) -> 0.88 (dd 20%) -> 0.968 (final -3.2%)
+    dd, final = mc.equity_path_stats([10.0, -20.0, 10.0])
+    assert dd == pytest.approx(20.0)
+    assert final == pytest.approx(-3.2)
+
+
+def test_equity_path_bust_is_sticky_floor():
+    # -100% trade zeroes the account; #1005 convention: DD 100, final -100,
+    # later winners never resurrect it.
+    dd, final = mc.equity_path_stats([-100.0, 50.0])
+    assert (dd, final) == (100.0, -100.0)
+
+
+def test_equity_path_dd_positive_magnitude():
+    dd, _ = mc.equity_path_stats([-10.0])
+    assert dd == pytest.approx(10.0)
+
+
+# ---------------------------------------------------------------------------
+# percentile / smoothing / block length
+# ---------------------------------------------------------------------------
+
+def test_percentile_empty_none_and_interpolation():
+    assert mc.percentile([], 50) is None
+    assert mc.percentile([5.0], 95) == 5.0
+    assert mc.percentile([0.0, 10.0], 50) == pytest.approx(5.0)
+    assert mc.percentile([0.0, 10.0, 20.0], 25) == pytest.approx(5.0)
+
+
+def test_add_one_smoothed_never_zero_or_one():
+    assert mc.add_one_smoothed(0, 100) == pytest.approx(1 / 101)
+    assert mc.add_one_smoothed(100, 100) == pytest.approx(101 / 101)
+
+
+def test_auto_block_len():
+    assert mc.auto_block_len(1) == 1
+    assert mc.auto_block_len(27) == 3
+    assert mc.auto_block_len(28) == 4
+
+
+# ---------------------------------------------------------------------------
+# permute scheme — hand-enumerable 3-trade case
+# ---------------------------------------------------------------------------
+
+def test_permutation_dds_stay_in_enumerated_set():
+    trades = [10.0, -20.0, 5.0]
+    enumerated = {round(mc.equity_path_stats(list(p))[0], 4)
+                  for p in itertools.permutations(trades)}
+    stats = mc.resample_stats(trades, "permute", n_paths=500, seed=42)
+    # Every reported percentile is a value from (or interpolated within) the
+    # enumerated distribution's range.
+    dd_vals = stats["max_dd_pct_percentiles"]
+    assert min(enumerated) <= dd_vals["p5"] <= dd_vals["p50"] \
+        <= dd_vals["p95"] <= max(enumerated)
+    # Final return is order-invariant under permutation (same multiset).
+    fr = stats["final_return_pct_percentiles"]
+    expected_final = mc.equity_path_stats(trades)[1]
+    assert fr["p5"] == pytest.approx(expected_final, abs=1e-4)
+    assert fr["p95"] == pytest.approx(expected_final, abs=1e-4)
+
+
+def test_permutation_per_path_dds_match_enumeration_exactly():
+    trades = [10.0, -20.0, 5.0]
+    enumerated = {round(mc.equity_path_stats(list(p))[0], 6)
+                  for p in itertools.permutations(trades)}
+    from random import Random
+    rng = Random(7)
+    seen = {round(mc.equity_path_stats(mc.permuted_path(trades, rng))[0], 6)
+            for _ in range(300)}
+    assert seen <= enumerated
+    assert seen == enumerated  # 300 draws over 6 orderings covers all
+
+
+# ---------------------------------------------------------------------------
+# block scheme
+# ---------------------------------------------------------------------------
+
+def test_block_path_preserves_circular_contiguity():
+    values = [1.0, 2.0, 3.0, 4.0, 5.0]
+    adjacent = {(values[i], values[(i + 1) % len(values)])
+                for i in range(len(values))}
+    from random import Random
+    rng = Random(3)
+    for _ in range(50):
+        path = mc.block_bootstrap_path(values, 2, rng)
+        assert len(path) == len(values)
+        # Each drawn block of 2 is a circularly-adjacent pair; pairs at even
+        # offsets within the path are whole blocks (last may be truncated).
+        for i in range(0, len(path) - 1, 2):
+            assert (path[i], path[i + 1]) in adjacent
+
+
+def test_block_len_full_series_yields_rotations():
+    values = [1.0, 2.0, 3.0, 4.0]
+    rotations = {tuple(values[i:] + values[:i]) for i in range(len(values))}
+    from random import Random
+    rng = Random(11)
+    for _ in range(30):
+        assert tuple(mc.block_bootstrap_path(values, len(values), rng)) \
+            in rotations
+
+
+def test_block_scheme_auto_len_recorded():
+    stats = mc.resample_stats([1.0] * 27, "block", n_paths=10, seed=1)
+    assert stats["block_len"] == 3
+    stats = mc.resample_stats([1.0] * 27, "block", n_paths=10, seed=1,
+                              block_len=5)
+    assert stats["block_len"] == 5
+
+
+# ---------------------------------------------------------------------------
+# resample_stats — determinism, degenerate inputs, smoothing
+# ---------------------------------------------------------------------------
+
+def test_resample_stats_deterministic_under_seed():
+    trades = [3.0, -2.0, 1.5, -4.0, 2.2, 0.7, -1.1]
+    for scheme in mc.SCHEMES:
+        a = mc.resample_stats(trades, scheme, n_paths=200, seed=99)
+        b = mc.resample_stats(trades, scheme, n_paths=200, seed=99)
+        assert a == b
+
+
+def test_resample_stats_empty_is_degenerate_not_crash():
+    for scheme in mc.SCHEMES:
+        s = mc.resample_stats([], scheme, n_paths=100, seed=1)
+        assert s["n_trades"] == 0
+        assert s["max_dd_pct_percentiles"] is None
+        assert s["p_dd_ge_kill_switch"] is None
+
+
+def test_resample_stats_single_trade():
+    for scheme in mc.SCHEMES:
+        s = mc.resample_stats([5.0], scheme, n_paths=50, seed=1)
+        assert s["max_dd_pct_percentiles"]["p50"] == 0.0
+        assert s["final_return_pct_percentiles"]["p50"] == pytest.approx(5.0)
+
+
+def test_all_winner_series_reports_smoothed_floor():
+    s = mc.resample_stats([1.0, 2.0, 3.0], "permute", n_paths=100, seed=1,
+                          kill_switch_pct=25.0)
+    assert s["p_dd_ge_kill_switch"] == pytest.approx(1 / 101)
+    assert s["p_final_below_start"] == pytest.approx(1 / 101)
+
+
+def test_certain_breach_smoothed_below_one():
+    # Every ordering of a single -50% trade breaches a 25% threshold.
+    s = mc.resample_stats([-50.0], "permute", n_paths=100, seed=1,
+                          kill_switch_pct=25.0)
+    assert s["p_dd_ge_kill_switch"] == pytest.approx(101 / 101)
+    assert s["p_final_below_start"] == pytest.approx(101 / 101)
+
+
+def test_unknown_scheme_rejected():
+    with pytest.raises(ValueError):
+        mc.resample_stats([1.0], "bogus")
+
+
+# ---------------------------------------------------------------------------
+# trade_returns / trades_from_json_payload
+# ---------------------------------------------------------------------------
+
+def _trade(pnl_pct, shares=2.0, entry_price=100.0, pnl=None):
+    return {"pnl_pct": pnl_pct, "shares": shares, "entry_price": entry_price,
+            "pnl": pnl}
+
+
+def test_trade_returns_net_deducts_fees():
+    # Gross +5% on 200 notional = +10 gross; net pnl 8 after fees -> +4%.
+    vals = mc.trade_returns([_trade(5.0, pnl=8.0)])
+    assert vals == [pytest.approx(4.0)]
+
+
+def test_trade_returns_gross_reads_pnl_pct():
+    vals = mc.trade_returns([_trade(5.0, pnl=8.0)], returns="gross")
+    assert vals == [5.0]
+
+
+def test_trade_returns_net_falls_back_without_notional():
+    vals = mc.trade_returns([_trade(5.0, shares=0.0, pnl=8.0)])
+    assert vals == [5.0]
+
+
+def test_trade_returns_accepts_bare_numbers():
+    assert mc.trade_returns([1.5, -2.0]) == [1.5, -2.0]
+
+
+def test_trade_returns_rejects_bad_mode():
+    with pytest.raises(ValueError):
+        mc.trade_returns([], returns="fees")
+
+
+def test_payload_dict_and_list_forms():
+    assert mc.trades_from_json_payload({"trades": [1, 2]}) == [1, 2]
+    assert mc.trades_from_json_payload([1, 2]) == [1, 2]
+    with pytest.raises(ValueError):
+        mc.trades_from_json_payload({"no_trades": []})
+    with pytest.raises(ValueError):
+        mc.trades_from_json_payload("nope")
+
+
+# ---------------------------------------------------------------------------
+# resolve_kill_switch_pct — mirror of config.go's hierarchy
+# ---------------------------------------------------------------------------
+
+def _cfg(strategies, platforms=None):
+    return {"strategies": strategies, "platforms": platforms or {}}
+
+
+def test_kill_switch_explicit_strategy_value_wins():
+    cfg = _cfg([{"id": "s1", "type": "perps", "max_drawdown_pct": 12.5}])
+    assert mc.resolve_kill_switch_pct(cfg, "s1") == 12.5
+
+
+def test_kill_switch_platform_risk_override():
+    cfg = _cfg([{"id": "s1", "type": "spot", "platform": "okx"}],
+               {"okx": {"risk": {"max_drawdown_pct": 33.0}}})
+    assert mc.resolve_kill_switch_pct(cfg, "s1") == 33.0
+
+
+def test_kill_switch_type_defaults():
+    for stype, want in (("options", 40.0), ("futures", 45.0),
+                        ("perps", 50.0), ("spot", 60.0)):
+        cfg = _cfg([{"id": "s1", "type": stype, "platform": "binanceus"}])
+        assert mc.resolve_kill_switch_pct(cfg, "s1") == want
+
+
+def test_kill_switch_platform_inferred_from_id_prefix():
+    # hl- prefix -> hyperliquid platform risk override applies.
+    cfg = _cfg([{"id": "hl-btc-x", "type": "perps"}],
+               {"hyperliquid": {"risk": {"max_drawdown_pct": 18.0}}})
+    assert mc.resolve_kill_switch_pct(cfg, "hl-btc-x") == 18.0
+
+
+def test_kill_switch_missing_strategy_raises():
+    with pytest.raises(ValueError):
+        mc.resolve_kill_switch_pct(_cfg([]), "ghost")
+
+
+# ---------------------------------------------------------------------------
+# trade_samples_from_results — additive pnl_pct_net key (#1274)
+# ---------------------------------------------------------------------------
+
+def test_trade_samples_carry_net_return():
+    results = {"trades": [{"entry_date": "2025-01-01", "pnl_pct": 5.0,
+                           "shares": 2.0, "entry_price": 100.0, "pnl": 8.0}]}
+    samples = ew.trade_samples_from_results(results)
+    assert samples[0]["pnl_pct"] == 5.0
+    assert samples[0]["pnl_pct_net"] == pytest.approx(4.0)
+
+
+def test_trade_samples_net_falls_back_to_gross():
+    results = {"trades": [{"entry_date": "2025-01-01", "pnl_pct": 5.0,
+                           "shares": 0.0, "entry_price": 0.0, "pnl": 8.0}]}
+    samples = ew.trade_samples_from_results(results)
+    assert samples[0]["pnl_pct_net"] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end on a trades-JSON file (no data cache needed)
+# ---------------------------------------------------------------------------
+
+def test_cli_deterministic_byte_identical_json(tmp_path, capsys):
+    trades = [{"entry_date": "2025-01-01", "pnl_pct": 3.0, "shares": 1.0,
+               "entry_price": 100.0, "pnl": 2.5},
+              {"entry_date": "2025-01-02", "pnl_pct": -2.0, "shares": 1.0,
+               "entry_price": 100.0, "pnl": -2.5},
+              {"entry_date": "2025-01-03", "pnl_pct": 4.0, "shares": 1.0,
+               "entry_price": 100.0, "pnl": 3.5}]
+    src = tmp_path / "results.json"
+    src.write_text(json.dumps({"trades": trades}))
+    outs = []
+    for i in range(2):
+        out = tmp_path / f"mc{i}.json"
+        rc = mc.main(["--trades-json", str(src), "--seed", "42",
+                      "--n-paths", "300", "--json", str(out)])
+        assert rc == 0
+        outs.append(out.read_bytes())
+    assert outs[0] == outs[1]  # byte-identical under the same seed
+    payload = json.loads(outs[0])
+    assert {b["scheme"] for b in payload["schemes"]} == set(mc.SCHEMES)
+    assert payload["kill_switch_pct"] == mc.DEFAULT_KILL_SWITCH_PCT
+
+
+def test_cli_config_threshold_resolution(tmp_path, capsys):
+    src = tmp_path / "results.json"
+    src.write_text(json.dumps([1.0, -2.0, 3.0]))
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"strategies": [
+        {"id": "hl-x", "type": "perps", "max_drawdown_pct": 15.0}]}))
+    out = tmp_path / "mc.json"
+    rc = mc.main(["--trades-json", str(src), "--config", str(cfg),
+                  "--strategy-id", "hl-x", "--n-paths", "50",
+                  "--json", str(out)])
+    assert rc == 0
+    assert json.loads(out.read_text())["kill_switch_pct"] == 15.0
+
+
+def test_cli_requires_exactly_one_source(tmp_path):
+    with pytest.raises(SystemExit):
+        mc.main([])
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", "a.json", "--strategy", "breakout"])
+
+
+def test_cli_config_requires_strategy_id(tmp_path):
+    src = tmp_path / "results.json"
+    src.write_text(json.dumps([1.0]))
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src), "--config", "cfg.json"])
+
+
+def test_cli_empty_trades_no_crash(tmp_path, capsys):
+    src = tmp_path / "results.json"
+    src.write_text(json.dumps({"trades": []}))
+    rc = mc.main(["--trades-json", str(src), "--n-paths", "50"])
+    assert rc == 0
+    assert "nothing to resample" in capsys.readouterr().out

--- a/backtest/tests/test_monte_carlo.py
+++ b/backtest/tests/test_monte_carlo.py
@@ -348,3 +348,50 @@ def test_cli_empty_trades_no_crash(tmp_path, capsys):
     rc = mc.main(["--trades-json", str(src), "--n-paths", "50"])
     assert rc == 0
     assert "nothing to resample" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# CLI numeric/enum arg guards — malformed input exits cleanly (SystemExit),
+# never a raw IndexError/TypeError (review on #1293).
+# ---------------------------------------------------------------------------
+
+def _valid_trades_json(tmp_path):
+    src = tmp_path / "results.json"
+    src.write_text(json.dumps([1.0, -2.0, 3.0]))
+    return src
+
+
+def test_cli_rejects_negative_n_paths(tmp_path):
+    src = _valid_trades_json(tmp_path)
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src), "--n-paths", "-5"])
+
+
+def test_cli_rejects_zero_n_paths(tmp_path):
+    src = _valid_trades_json(tmp_path)
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src), "--n-paths", "0"])
+
+
+def test_cli_rejects_percentile_above_100(tmp_path):
+    src = _valid_trades_json(tmp_path)
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src), "--percentiles", "5,50,150"])
+
+
+def test_cli_rejects_negative_percentile(tmp_path):
+    src = _valid_trades_json(tmp_path)
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src), "--percentiles", "-1"])
+
+
+def test_cli_rejects_empty_schemes(tmp_path):
+    src = _valid_trades_json(tmp_path)
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src), "--schemes", ","])
+
+
+def test_cli_rejects_empty_percentiles(tmp_path):
+    src = _valid_trades_json(tmp_path)
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src), "--percentiles", ","])

--- a/backtest/tests/test_monte_carlo.py
+++ b/backtest/tests/test_monte_carlo.py
@@ -395,3 +395,40 @@ def test_cli_rejects_empty_percentiles(tmp_path):
     src = _valid_trades_json(tmp_path)
     with pytest.raises(SystemExit):
         mc.main(["--trades-json", str(src), "--percentiles", ","])
+
+
+def test_cli_rejects_non_numeric_percentile(tmp_path):
+    src = _valid_trades_json(tmp_path)
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src), "--percentiles", "5,abc,95"])
+
+
+def test_cli_rejects_unknown_strategy_id_in_config(tmp_path):
+    src = _valid_trades_json(tmp_path)
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"strategies": [
+        {"id": "hl-x", "type": "perps", "max_drawdown_pct": 15.0}]}))
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src), "--config", str(cfg),
+                  "--strategy-id", "typo-d-id"])
+
+
+def test_cli_rejects_trades_json_dict_without_trades_key(tmp_path):
+    src = tmp_path / "results.json"
+    src.write_text(json.dumps({"foo": []}))
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src)])
+
+
+def test_cli_rejects_trades_json_bare_string(tmp_path):
+    src = tmp_path / "results.json"
+    src.write_text(json.dumps("nope"))
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src)])
+
+
+def test_cli_rejects_trades_json_bare_number(tmp_path):
+    src = tmp_path / "results.json"
+    src.write_text(json.dumps(42))
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src)])

--- a/backtest/tests/test_monte_carlo.py
+++ b/backtest/tests/test_monte_carlo.py
@@ -432,3 +432,72 @@ def test_cli_rejects_trades_json_bare_number(tmp_path):
     src.write_text(json.dumps(42))
     with pytest.raises(SystemExit):
         mc.main(["--trades-json", str(src)])
+
+
+# ---------------------------------------------------------------------------
+# Malformed-CLI-input sub-cases (review on #1293): --config / --trades-json
+# missing or invalid, --params invalid JSON, bad --dataset, and trade dicts
+# missing pnl_pct — all must SystemExit with an actionable message, never an
+# unhandled traceback.
+# ---------------------------------------------------------------------------
+
+def test_cli_config_missing_file_exits_cleanly(tmp_path):
+    src = _valid_trades_json(tmp_path)
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src),
+                  "--config", str(tmp_path / "does_not_exist.json"),
+                  "--strategy-id", "hl-x"])
+
+
+def test_cli_config_invalid_json_exits_cleanly(tmp_path):
+    src = _valid_trades_json(tmp_path)
+    cfg = tmp_path / "config.json"
+    cfg.write_text("{not valid json")
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src), "--config", str(cfg),
+                  "--strategy-id", "hl-x"])
+
+
+def test_cli_trades_json_missing_file_exits_cleanly(tmp_path):
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(tmp_path / "does_not_exist.json")])
+
+
+def test_cli_trades_json_invalid_json_exits_cleanly(tmp_path):
+    src = tmp_path / "results.json"
+    src.write_text("{not valid json")
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src)])
+
+
+def test_cli_params_invalid_json_exits_cleanly(tmp_path):
+    with pytest.raises(SystemExit):
+        mc.main(["--strategy", "squeeze_momentum", "--params", "{bad json"])
+
+
+def test_run_leg_trades_rejects_bad_dataset(tmp_path):
+    with pytest.raises(SystemExit, match="--dataset"):
+        mc.run_leg_trades("squeeze_momentum", "spot", None,
+                          "not-a-valid-dataset", "is", 1000.0, None, "net")
+
+
+def test_trade_returns_missing_pnl_pct_gross_raises_value_error():
+    trade = {"shares": 2.0, "entry_price": 100.0, "pnl": 8.0}
+    with pytest.raises(ValueError, match="pnl_pct"):
+        mc.trade_returns([trade], returns="gross")
+
+
+def test_trade_returns_missing_pnl_pct_net_fallback_raises_value_error():
+    # No notional (shares=0) forces the net-fallback-to-pnl_pct path, which
+    # is also missing pnl_pct here.
+    trade = {"shares": 0.0, "entry_price": 0.0, "pnl": 8.0}
+    with pytest.raises(ValueError, match="pnl_pct"):
+        mc.trade_returns([trade], returns="net")
+
+
+def test_cli_trades_json_missing_pnl_pct_exits_cleanly(tmp_path):
+    src = tmp_path / "results.json"
+    src.write_text(json.dumps({"trades": [
+        {"shares": 0.0, "entry_price": 0.0, "pnl": 8.0}]}))
+    with pytest.raises(SystemExit):
+        mc.main(["--trades-json", str(src)])

--- a/docs/backtesting-registry.md
+++ b/docs/backtesting-registry.md
@@ -44,6 +44,7 @@ its row here in the same PR. A new row is part of the change, not a follow-up.
 | `fee_audit.py` | **M5** registry-wide trade-count × fee-drag selectivity triage. | active | #999 |
 | `exit_policy_ab.py` | **M6** regime-conditioned incumbent-relative exit-policy A/B. | active | #1066 |
 | `auto_suggest.py` | Reusable cross-harness driver that sweeps candidates and ranks gate-survivors under one BH correction. **Suggest-only — never writes a live default/config/PR.** | active | #1210 |
+| `monte_carlo.py` | Trade-order Monte Carlo resampler — permutation + circular block bootstrap over a run's closed trades; drawdown / final-return percentile bands, P(final < start), P(max DD ≥ kill-switch threshold). Suggest-only diagnostics. | active | #1274 |
 
 ## Regime-promotion pipeline (#1065–#1097)
 


### PR DESCRIPTION
Closes #1274

## What

New suggest-only harness `backtest/monte_carlo.py`: resamples a completed backtest's closed-trade **order** to turn single-path drawdown point estimates into distributions.

- **Schemes** (both run by default, `--schemes` to restrict): `permute` (shuffle the observed order — pure sequencing risk) and `block` (circular block bootstrap, `--block-len`, 0 = auto ceil(n^(1/3)) — preserves short-range autocorrelation and varies the multiset).
- **Outputs:** configurable percentile bands (default P5/P50/P95) for max drawdown and final return, add-one-smoothed `P(final < start)` and `P(max DD >= kill-switch threshold)`, plus the observed single-path values and full reproducibility metadata (seed/scheme/paths). Deterministic under `--seed`.
- **Threshold resolution:** `--config <path> --strategy-id <id>` mirrors `scheduler/config.go`'s hierarchy (explicit strategy `max_drawdown_pct` > platform risk override > type default 40/45/50/60, with the Go ID-prefix platform inference), else `--kill-switch-pct` (default 25, the portfolio kill-switch default).
- **Inputs:** a results JSON carrying the Backtester `trades` list (or a bare list of trades/returns), or an in-process leg on the M1 audit-identical harness (`eval_windows.run_leg` with `keep_trades`).
- **Compounding model (documented in the module docstring):** multiplicative on per-trade returns, equity marked at trade closes only; **net-of-fees by default** (`Trade.pnl` is fee-net while `pnl_pct` is gross, #1241), `--returns gross` available; bust paths sticky-floored per the #1005 convention.
- `eval_windows.trade_samples_from_results` gains an **additive** `pnl_pct_net` key; existing consumers (`gross_edge_noise`) read `pnl_pct` by key and are unaffected.
- Registry row added to `docs/backtesting-registry.md` (same-PR upkeep rule).

Note vs the issue sketch: the optional advisory `auto_suggest.py` columns were **not** included — the issue marks them optional and leaving `candidate_verdict` untouched keeps the SUGGEST-ONLY surface unchanged; filed as follow-on issue #1295. The issue's "default 25" is the portfolio kill switch; the per-strategy `max_drawdown_pct` defaults are type-dependent (40–60), so config-based resolution mirrors the Go hierarchy exactly instead of assuming 25.

## Verification

- New `backtest/tests/test_monte_carlo.py` (30 tests): same-seed byte-identical CLI JSON output; hand-enumerated 3-trade permutation distribution matched exactly; block contiguity + full-length-block rotation invariants; degenerate inputs (empty / single trade / all-winner smoothed floor / certain-breach ceiling); kill-switch hierarchy incl. `hl-` prefix inference; net-vs-gross extraction; CLI arg gating.
- Full suite: `2431 passed, 1 skipped` (pytest over `shared_strategies/ shared_tools/ platforms/ backtest/`).
- CLI smoke-run on a synthetic 4-trade file produced sensible permute/block bands (permute holds final return fixed; block widens both tails).

---
Updated with LLM: Fable 5 | medium | Harness: Claude Code

