### PR TITLE
feat(#1295): advisory Monte Carlo drawdown columns in the auto-suggest shortlist

### DIFF
--- a/backtest/auto_suggest.py
+++ b/backtest/auto_suggest.py
@@ -851,6 +851,28 @@ def reproduction_command(entry: dict) -> list:
 # Pure — report formatting
 # ===========================================================================
 
+def _mc_column_window(mc: dict):
+    """Which window the advisory column should report, preferring ``oos``.
+
+    ``extract_mc`` buckets EVERY window it sees, including one whose datasets
+    were all ``no_data`` (empty ``worst``). Keying blindly on "oos" would let
+    such a bucket win and blank the column even though another window was
+    resampled — and since the run itself succeeded, no ``mc_run_failed`` flag
+    would explain the absence. So: prefer a window with usable numbers, then a
+    window that was resampled but had nothing to resample (0 trades -> all-None
+    stats, reported as dashes), and only then give up. ``oos`` wins each tier.
+    """
+    def pick(windows):
+        return "oos" if "oos" in windows else (sorted(windows)[0] if windows else None)
+
+    resampled = {w for w, b in mc.items()
+                 if MC_SCHEME_FOR_COLUMNS in (b.get("worst") or {})}
+    usable = {w for w in resampled
+              if any(v is not None for v in
+                     mc[w]["worst"][MC_SCHEME_FOR_COLUMNS].values())}
+    return pick(usable) or pick(resampled)
+
+
 def _mc_segment(mc: dict) -> str:
     """The advisory MC column: worst-dataset sequencing risk, OOS if scored.
 
@@ -859,10 +881,10 @@ def _mc_segment(mc: dict) -> str:
     """
     if not mc:
         return ""
-    window = "oos" if "oos" in mc else sorted(mc)[0]
-    stats = ((mc.get(window) or {}).get("worst") or {}).get(MC_SCHEME_FOR_COLUMNS)
-    if not stats:
+    window = _mc_column_window(mc)
+    if window is None:
         return ""
+    stats = mc[window]["worst"][MC_SCHEME_FOR_COLUMNS]
 
     def _f(key, prec):
         v = stats.get(key)
@@ -1012,13 +1034,20 @@ def run_open_entry(entry: dict, spec: dict, out_dir: str,
     if "m1_noise" in entry["harnesses"]:
         results["m1_noise"] = noise_cache[entry["noise_family_key"]]
 
+    written = []
+
     def candidate_path() -> str:
         # Shared by m1 and mc — both consume the SAME candidate JSON, so the
         # advisory resampler cannot drift onto a narrower view of the candidate.
+        # Written once per RUN, but ALWAYS rewritten: out_dir persists across
+        # runs (main() only makedirs(exist_ok=True)) and keys are stable, so an
+        # existence check would let an edited candidate be scored from the
+        # previous run's file — silently, since the harness outputs regenerate.
         path = os.path.join(out_dir, f"{key}.candidate.json")
-        if not os.path.exists(path):
+        if not written:
             with open(path, "w") as fh:
                 json.dump(cand, fh, indent=2)
+            written.append(path)
         return path
 
     if "m1" in entry["harnesses"]:

--- a/backtest/auto_suggest.py
+++ b/backtest/auto_suggest.py
@@ -25,9 +25,15 @@ Given a declarative spec (see ``backtest/candidates/<study>/suggest.json``) it:
      work; non-replayable M6 closes are excluded, mirroring
      ``_REPLAYABLE_CLOSE_NAMES``),
   3. corrects the family of primary p-values (M1 step-2 permutation + M6 paired
-     Wilcoxon) with Benjamini-Hochberg — M3/M5 emit no p-values and pass through
-     as clearly-labeled uncorrected context,
+     Wilcoxon) with Benjamini-Hochberg — M3/M5/MC emit no p-values and pass
+     through as clearly-labeled uncorrected context,
   4. ranks survivors first and writes a shortlist artifact.
+
+The Monte Carlo columns (#1295, the ``mc`` harness) are ADVISORY in the strong
+sense: they never gate a promotion whether the run succeeds, fails, or is
+skipped. See ``ADVISORY_HARNESSES`` / ``gate_relevant_results`` — "the gate does
+not read the mc key" would NOT have been sufficient, because the failed-run scan
+reads the results dict's VALUES.
 
 Usage:
   uv run --no-sync python backtest/auto_suggest.py \
@@ -69,13 +75,32 @@ HARNESS_REL = {
     "m3": "backtest/exit_diagnostics.py",
     "m5": "backtest/fee_audit.py",
     "m6": "backtest/exit_policy_ab.py",
+    "mc": "backtest/monte_carlo.py",
 }
 HARNESS_ABS = {k: os.path.join(_REPO, v) for k, v in HARNESS_REL.items()}
 
 KNOWN_HARNESSES = set(HARNESS_REL)
-OPEN_HARNESSES = ("m1_noise", "m1", "m3", "m5")  # applied to open-kind candidates
-DEFAULT_HARNESSES = ["m1_noise", "m1", "m3", "m5"]
+OPEN_HARNESSES = ("m1_noise", "m1", "m3", "m5", "mc")  # applied to open candidates
+DEFAULT_HARNESSES = ["m1_noise", "m1", "m3", "m5", "mc"]
 KNOWN_REGISTRIES = ("spot", "futures")
+
+# ADVISORY harnesses (#1295) emit no p-value AND must never influence the
+# promotion gate IN ANY STATE — including a failed run. This is strictly
+# stronger than "candidate_verdict does not read the key": both
+# ``candidate_verdict`` and ``main`` scan ``results.values()`` generically for a
+# failed status, so an advisory harness that merely APPEARS in the results dict
+# would demote a genuine survivor to ``run_failed`` and flip the exit code.
+# Every gate-facing scan goes through ``gate_relevant_results`` instead.
+#
+# M3/M5 are deliberately NOT listed. They are uncorrected CONTEXT for the
+# reader, but a failed M3/M5 run has always marked the candidate run_failed and
+# that pre-#1295 gate behavior is preserved byte-for-byte.
+ADVISORY_HARNESSES = ("mc",)
+
+# monte_carlo.py's own defaults, restated because auto_suggest passes them
+# explicitly into the argv tail.
+MC_DEFAULT_N_PATHS = 10000
+MC_SCHEME_FOR_COLUMNS = "permute"  # pure sequencing risk; block kept in evidence
 
 # Verdict vocabulary (ranked best-to-worst for the shortlist).
 VERDICT_ORDER = [
@@ -157,6 +182,33 @@ def load_spec(raw: dict, spec_dir: str) -> dict:
             "hypothesis": c.get("hypothesis"),
         })
 
+    # ---- mc (#1295): advisory Monte Carlo block -----------------------------
+    # The threshold source mirrors monte_carlo.py's own mutual exclusion: an
+    # explicit percentage, OR a live config + strategy id to resolve the
+    # per-strategy max_drawdown_pct hierarchy — never both. Neither => the
+    # harness default (25, the portfolio kill-switch default).
+    mc = dict(raw.get("mc") or {})
+    if mc:
+        unknown_mc = set(mc) - {"kill_switch_pct", "config", "strategy_id",
+                                "n_paths"}
+        if unknown_mc:
+            raise ValueError(f"unknown mc keys {sorted(unknown_mc)}; known: "
+                             "kill_switch_pct, config, strategy_id, n_paths")
+        if mc.get("kill_switch_pct") is not None and mc.get("config"):
+            raise ValueError("mc block sets both 'kill_switch_pct' and "
+                             "'config'; they are mutually exclusive threshold "
+                             "sources (monte_carlo.py refuses both)")
+        if bool(mc.get("config")) != bool(mc.get("strategy_id")):
+            raise ValueError("mc 'config' and 'strategy_id' go together (the "
+                             "strategy id selects whose max_drawdown_pct "
+                             "hierarchy resolves)")
+        if mc.get("config"):
+            cfg = mc["config"]
+            mc["config"] = (cfg if os.path.isabs(cfg)
+                            else os.path.join(spec_dir, cfg))
+        if mc.get("n_paths") is not None and int(mc["n_paths"]) < 1:
+            raise ValueError("mc 'n_paths' must be >= 1")
+
     m6 = None
     if raw.get("m6") is not None:
         m6 = dict(raw["m6"])
@@ -212,6 +264,7 @@ def load_spec(raw: dict, spec_dir: str) -> dict:
         "sweep": raw.get("sweep"),
         "gate_variants": raw.get("gate_variants"),
         "m6": m6,
+        "mc": mc,
         "spec_dir": spec_dir,
     }
 
@@ -397,6 +450,27 @@ def m5_argv_tail(strategy, registry, direction, windows, datasets, out_json) -> 
     return tail
 
 
+def mc_argv_tail(candidate_path, registry, windows, datasets, n_paths, seed,
+                 mc: dict, out_json) -> list:
+    """Advisory Monte Carlo (#1295), multi-leg mode.
+
+    Threads the CANDIDATE JSON — not a bare --strategy/--params pair — so the
+    resampled trade series carries the candidate's close stack, entry gate and
+    stops. A bare-strategy tail would resample a strategy nobody is ranking.
+    """
+    tail = ["--candidate-json", candidate_path, "--registry", registry,
+            "--windows", _csv(windows), "--n-paths", str(n_paths),
+            "--seed", str(seed), "--json", out_json]
+    if datasets:
+        tail += ["--datasets", _csv(datasets)]
+    mc = mc or {}
+    if mc.get("config"):
+        tail += ["--config", mc["config"], "--strategy-id", mc["strategy_id"]]
+    elif mc.get("kill_switch_pct") is not None:
+        tail += ["--kill-switch-pct", str(mc["kill_switch_pct"])]
+    return tail
+
+
 def m6_argv_tail(m6_candidate, registry, windows, datasets, resamples, seed, out_json) -> list:
     tail = ["--strategy", m6_candidate["strategy_id"],
             "--registry", registry,
@@ -499,6 +573,58 @@ def extract_m3(payload: dict) -> dict:
     return out
 
 
+def _p95_max_dd(block: dict):
+    """P95 max drawdown from a monte_carlo scheme block, when the run used the
+    default percentile set. None — never a fabricated number — otherwise."""
+    return (block.get("max_dd_pct_percentiles") or {}).get("p95")
+
+
+def _worst(values: list):
+    """Max over the non-None values; None when every leg is unusable. A risk
+    column aggregates across datasets by WORST case — averaging would let one
+    benign dataset mask a fragile one."""
+    present = [v for v in values if v is not None]
+    return max(present) if present else None
+
+
+def extract_mc(payload: dict) -> dict:
+    """monte_carlo multi-leg payload -> {window: {per_dataset, worst}}.
+
+    ADVISORY ONLY (#1295): emits no p-value, and is never read by
+    ``candidate_verdict`` or ``collect_family_pvalues``. ``worst`` carries the
+    across-dataset worst case per scheme, which is what the shortlist prints.
+    """
+    out = {}
+    for leg in (payload.get("legs") or []):
+        w = leg.get("window")
+        if w is None:
+            continue
+        bucket = out.setdefault(w, {"per_dataset": {}, "worst": {}})
+        schemes = {}
+        for b in (leg.get("schemes") or []):
+            schemes[b.get("scheme")] = {
+                "p_dd_ge_kill_switch": b.get("p_dd_ge_kill_switch"),
+                "p95_max_dd": _p95_max_dd(b),
+                "p_final_below_start": b.get("p_final_below_start"),
+            }
+        bucket["per_dataset"][leg.get("dataset")] = {
+            "status": leg.get("status"),
+            "n_trades": leg.get("n_trades"),
+            "schemes": schemes,
+        }
+    for bucket in out.values():
+        per_ds = list(bucket["per_dataset"].values())
+        scheme_names = {s for d in per_ds for s in (d["schemes"] or {})}
+        for scheme in sorted(scheme_names):
+            rows = [d["schemes"].get(scheme) or {} for d in per_ds]
+            bucket["worst"][scheme] = {
+                k: _worst([r.get(k) for r in rows])
+                for k in ("p_dd_ge_kill_switch", "p95_max_dd",
+                          "p_final_below_start")
+            }
+    return out
+
+
 def extract_m5(payload: dict, strategy: str) -> dict:
     """fee_audit rows -> the salvage screen for one strategy (no p)."""
     for row in (payload.get("rows") or []):
@@ -581,6 +707,33 @@ def _tests_for(entry, tests: list) -> list:
     return [t for t in tests if t["candidate_key"] == entry["key"]]
 
 
+def gate_relevant_results(entry: dict) -> dict:
+    """The entry's harness runs MINUS the advisory ones (#1295).
+
+    The only place the promotion gate is allowed to look at ``entry["results"]``.
+    An advisory harness must not change a verdict by succeeding, by failing, or
+    by being absent — filtering here is what makes that true, since the
+    failed-run scan below keys on the dict's VALUES, not on any harness name.
+    """
+    return {h: r for h, r in (entry.get("results") or {}).items()
+            if h not in ADVISORY_HARNESSES}
+
+
+def any_gate_failure(entries: list) -> bool:
+    """Did any GATE-relevant harness run fail? Drives the process exit code."""
+    return any((v or {}).get("status") == "failed"
+               for e in entries for v in gate_relevant_results(e).values())
+
+
+def advisory_failures(entry: dict) -> list:
+    """Advisory harnesses whose run failed — surfaced as a limitation, never as
+    a verdict. Silence would be worse: an operator reads a blank MC column as
+    "low risk" rather than "not measured"."""
+    return sorted(h for h, r in (entry.get("results") or {}).items()
+                  if h in ADVISORY_HARNESSES
+                  and (r or {}).get("status") == "failed")
+
+
 def candidate_verdict(entry: dict, tests: list) -> str:
     """Pre-registered promotion gate, generalized from ``regime_1152._verdict``
     with the BH layer added. A candidate is only a ``survivor`` when its positive
@@ -588,7 +741,9 @@ def candidate_verdict(entry: dict, tests: list) -> str:
     reported as its own verdict, never as a survivor."""
     if entry.get("precondition_errors"):
         return "excluded_not_replayable"
-    r = entry.get("results") or {}
+    # Advisory harnesses are filtered OUT before the failed-run scan, and are
+    # never read below — the gate is byte-for-byte what it was pre-#1295.
+    r = gate_relevant_results(entry)
     if any((v or {}).get("status") == "failed" for v in r.values()):
         return "run_failed"
 
@@ -696,6 +851,28 @@ def reproduction_command(entry: dict) -> list:
 # Pure — report formatting
 # ===========================================================================
 
+def _mc_segment(mc: dict) -> str:
+    """The advisory MC column: worst-dataset sequencing risk, OOS if scored.
+
+    Deliberately labeled ``(adv)`` and printed with the window it came from —
+    an unlabeled probability next to a promotion verdict reads as evidence.
+    """
+    if not mc:
+        return ""
+    window = "oos" if "oos" in mc else sorted(mc)[0]
+    stats = ((mc.get(window) or {}).get("worst") or {}).get(MC_SCHEME_FOR_COLUMNS)
+    if not stats:
+        return ""
+
+    def _f(key, prec):
+        v = stats.get(key)
+        return "-" if v is None else format(v, f".{prec}f")
+
+    return (f"  MC(adv,{window})=p95DD {_f('p95_max_dd', 1)}% "
+            f"pKS {_f('p_dd_ge_kill_switch', 3)} "
+            f"pDown {_f('p_final_below_start', 3)}")
+
+
 def format_shortlist(report: dict) -> str:
     corr = report["correction"]
     lines = [f"== auto-suggest shortlist: {report['study']} =="]
@@ -726,11 +903,19 @@ def format_shortlist(report: dict) -> str:
         m5 = (r.get("m5") or {}).get("data")
         if m5:
             extra += f"  M5(ctx)={m5.get('salvage_verdict')}"
+        extra += _mc_segment((r.get("mc") or {}).get("data"))
         limn = (" [" + ",".join(e["limitations"]) + "]") if e.get("limitations") else ""
         lines.append(f"{i:>2}  {e['key']:<40} {e['verdict']:<26}{extra}{limn}")
     lines.append("")
-    lines.append("M3/M5 figures are UNCORRECTED CONTEXT (no p-values), never "
+    lines.append("M3/M5/MC figures are UNCORRECTED CONTEXT (no p-values), never "
                  "counted as significance evidence.")
+    lines.append(f"MC(adv) = trade-order Monte Carlo (#1274), "
+                 f"{MC_SCHEME_FOR_COLUMNS} scheme, WORST dataset in the window: "
+                 "p95DD = P95 max drawdown, pKS = P(max DD >= kill switch), "
+                 "pDown = P(final < start). Advisory only — it does not gate "
+                 "promotion, and a failed MC run leaves the verdict untouched "
+                 "(flagged 'mc_run_failed'). Open candidates only; M6 exit-A/B "
+                 "entries carry no MC column.")
     lines.append(FOOTER)
     return "\n".join(lines)
 
@@ -827,10 +1012,17 @@ def run_open_entry(entry: dict, spec: dict, out_dir: str,
     if "m1_noise" in entry["harnesses"]:
         results["m1_noise"] = noise_cache[entry["noise_family_key"]]
 
+    def candidate_path() -> str:
+        # Shared by m1 and mc — both consume the SAME candidate JSON, so the
+        # advisory resampler cannot drift onto a narrower view of the candidate.
+        path = os.path.join(out_dir, f"{key}.candidate.json")
+        if not os.path.exists(path):
+            with open(path, "w") as fh:
+                json.dump(cand, fh, indent=2)
+        return path
+
     if "m1" in entry["harnesses"]:
-        cand_path = os.path.join(out_dir, f"{key}.candidate.json")
-        with open(cand_path, "w") as fh:
-            json.dump(cand, fh, indent=2)
+        cand_path = candidate_path()
         out = os.path.join(out_dir, f"{key}.m1.json")
         run = _run_harness("m1", m1_argv_tail(cand_path, reg, windows, datasets, out), out)
         if run["status"] == "ok":
@@ -858,7 +1050,24 @@ def run_open_entry(entry: dict, spec: dict, out_dir: str,
         # and abort the whole suggester. By this point the cache is populated.
         results["m5"] = m5_cache[_m5_family_key(cand)]
 
+    if "mc" in entry["harnesses"]:
+        # ADVISORY (#1295) — per-candidate, unlike the family-keyed noise/m5
+        # runs: the resampled trade series depends on this candidate's entry
+        # gate, close stack and params, so two siblings sharing a noise family
+        # still need their own Monte Carlo.
+        out = os.path.join(out_dir, f"{key}.mc.json")
+        mc = spec.get("mc") or {}
+        tail = mc_argv_tail(candidate_path(), reg, windows, datasets,
+                            mc.get("n_paths") or MC_DEFAULT_N_PATHS,
+                            spec["seed"], mc, out)
+        run = _run_harness("mc", tail, out)
+        if run["status"] == "ok":
+            run["data"] = extract_mc(run.pop("payload"))
+        results["mc"] = run
+
     entry["results"] = results
+    for h in advisory_failures(entry):
+        entry["limitations"].append(f"{h}_run_failed")
     return entry
 
 
@@ -876,8 +1085,18 @@ def run_exit_ab_entry(entry: dict, spec: dict, out_dir: str) -> dict:
     return entry
 
 
+def _cmd(harness: str, tail: list) -> str:
+    return ("uv run --no-sync python " + HARNESS_REL[harness] + " "
+            + " ".join(shlex.quote(str(a)) for a in tail))
+
+
 def _dry_run_commands(entries: list, spec: dict, out_dir: str) -> list:
-    """Every planned command, without running anything."""
+    """Every planned command, without running anything.
+
+    EVERY enabled harness appears here. A dry run that omits a harness it will
+    actually spawn under-reports the plan — the one thing a dry run exists to
+    prevent.
+    """
     cmds = []
     for e in entries:
         reg, windows, datasets = spec["registry"], spec["windows"], spec["datasets"]
@@ -886,23 +1105,40 @@ def _dry_run_commands(entries: list, spec: dict, out_dir: str) -> list:
             continue
         if e["kind"] == "open":
             cand = e["candidate"]
+            key, direction = e["key"], _direction_for(cand)
+            params_json = json.dumps(cand["params"]) if cand.get("params") else None
+            cand_path = os.path.join(out_dir, f"{key}.candidate.json")
             if "m1_noise" in e["harnesses"]:
-                cmds.append("uv run --no-sync python " + HARNESS_REL["m1_noise"] + " " + " ".join(
-                    shlex.quote(str(a)) for a in noise_argv_tail(
-                        cand["name"], json.dumps(cand["params"]) if cand.get("params") else None,
-                        reg, _direction_for(cand), windows, datasets,
-                        spec["resamples"], spec["seed"], spec["correction"]["alpha"],
-                        os.path.join(out_dir, f"{e['key']}.noise.json"))))
+                cmds.append(_cmd("m1_noise", noise_argv_tail(
+                    cand["name"], params_json, reg, direction, windows, datasets,
+                    spec["resamples"], spec["seed"], spec["correction"]["alpha"],
+                    os.path.join(out_dir, f"{key}.noise.json"))))
             if "m1" in e["harnesses"]:
-                cmds.append("uv run --no-sync python " + HARNESS_REL["m1"] + " " + " ".join(
-                    shlex.quote(str(a)) for a in m1_argv_tail(
-                        os.path.join(out_dir, f"{e['key']}.candidate.json"),
-                        reg, windows, datasets, os.path.join(out_dir, f"{e['key']}.m1.json"))))
+                cmds.append(_cmd("m1", m1_argv_tail(
+                    cand_path, reg, windows, datasets,
+                    os.path.join(out_dir, f"{key}.m1.json"))))
+            if "m3" in e["harnesses"]:
+                close_json = (json.dumps(cand["close_strategies"])
+                              if cand.get("close_strategies") else None)
+                cmds.append(_cmd("m3", m3_argv_tail(
+                    cand["name"], params_json, reg, direction, close_json,
+                    windows, datasets, os.path.join(out_dir, f"{key}.m3.json"))))
+            if "m5" in e["harnesses"]:
+                cmds.append(_cmd("m5", m5_argv_tail(
+                    cand["name"], reg, direction, windows, datasets,
+                    os.path.join(out_dir,
+                                 f"m5.{cand['name']}.{direction or 'long'}.json"))))
+            if "mc" in e["harnesses"]:
+                mc = spec.get("mc") or {}
+                cmds.append(_cmd("mc", mc_argv_tail(
+                    cand_path, reg, windows, datasets,
+                    mc.get("n_paths") or MC_DEFAULT_N_PATHS, spec["seed"], mc,
+                    os.path.join(out_dir, f"{key}.mc.json"))))
         else:
-            cmds.append("uv run --no-sync python " + HARNESS_REL["m6"] + " " + " ".join(
-                shlex.quote(str(a)) for a in m6_argv_tail(
-                    e["candidate"], reg, windows, datasets,
-                    spec["resamples"], spec["seed"], os.path.join(out_dir, f"{e['key']}.m6.json"))))
+            cmds.append(_cmd("m6", m6_argv_tail(
+                e["candidate"], reg, windows, datasets,
+                spec["resamples"], spec["seed"],
+                os.path.join(out_dir, f"{e['key']}.m6.json"))))
     return cmds
 
 
@@ -1027,9 +1263,11 @@ def main(argv=None) -> int:
             fh.write("```\n" + text + "\n```\n")
         print(f"wrote {args.markdown_out}")
 
-    failed = any((v or {}).get("status") == "failed"
-                 for e in entries for v in (e.get("results") or {}).values())
-    return 1 if failed else 0
+    # Advisory-harness failures are reported (stderr + a per-entry limitation
+    # flag + a missing MC column) but never fail the run: an unavailable Monte
+    # Carlo column must not change the process's success signal any more than
+    # it changes a verdict (#1295).
+    return 1 if any_gate_failure(entries) else 0
 
 
 if __name__ == "__main__":

--- a/backtest/candidates/suggest.template.jsonc
+++ b/backtest/candidates/suggest.template.jsonc
@@ -46,9 +46,20 @@
   //   "m5"       — M5 fee audit / salvage verdict (context; no p; screens
   //                registry DEFAULT params only — swept candidates get a
   //                "m5_params_unaudited" limitation flag, never audited wrong).
+  //   "mc"       — trade-order Monte Carlo drawdown risk (#1295; ADVISORY
+  //                context; no p). Never gates promotion — not when it passes,
+  //                not when it fails (a failed run only adds an
+  //                "mc_run_failed" limitation flag). Open candidates only.
   // (M6 is NOT listed here — it is driven by the "m6" block below, one entry
-  // per close variant.) Default: ["m1_noise", "m1", "m3", "m5"].
-  "harnesses": ["m1_noise", "m1", "m3", "m5", "m6"],
+  // per close variant.) Default: ["m1_noise", "m1", "m3", "m5", "mc"].
+  "harnesses": ["m1_noise", "m1", "m3", "m5", "mc", "m6"],
+
+  // ---- Advisory Monte Carlo tuning (#1295). Optional; omit for the defaults
+  // (kill-switch threshold 25 = the portfolio kill-switch default; 10000
+  // paths). The threshold has exactly two sources and they are mutually
+  // exclusive: an explicit "kill_switch_pct", OR a live daemon "config" plus
+  // the "strategy_id" whose max_drawdown_pct hierarchy should resolve.
+  "mc": {"kill_switch_pct": 25, "n_paths": 10000},
 
   // Walk-forward windows to score. Any of eval_windows.WINDOWS:
   //   "is", "oos" (the protocol pair the promotion gate keys off),

--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -608,6 +608,40 @@ def validate_candidate(candidate: dict) -> dict:
     return candidate
 
 
+def run_candidate_leg(reg, candidate: dict, symbol: str, timeframe: str,
+                      window: tuple, capital: float = DEFAULT_CAPITAL, *,
+                      keep_trades: bool = False,
+                      intrabar_resolution: str = "ohlc_walk") -> Optional[dict]:
+    """Single source of truth for candidate-dict -> ``run_leg`` kwargs.
+
+    Every field ``validate_candidate`` accepts and the backtester can model is
+    threaded here. Callers that resample or re-score a candidate (M1's
+    ``evaluate_window``, monte_carlo's per-leg trade series) MUST go through
+    this rather than hand-picking a subset: a caller that quietly drops
+    ``close_strategies`` / ``allowed_regimes`` reports numbers for a DIFFERENT
+    strategy than the one under test, while looking correct.
+    """
+    return run_leg(
+        reg, candidate["name"], candidate.get("params"),
+        symbol, timeframe, window, capital=capital,
+        close_strategies=candidate.get("close_strategies"),
+        # The validated default ("long") must also be the EXECUTED
+        # default: with close refs and direction=None the engine path
+        # would open shorts on raw signal=-1, silently scoring a
+        # different entry universe than the long-leg harness (#996).
+        direction=candidate.get("direction") or "long",
+        invert_signal=bool(candidate.get("invert_signal")),
+        stop_loss_atr_mult=candidate.get("stop_loss_atr_mult"),
+        trailing_stop_atr_mult=candidate.get("trailing_stop_atr_mult"),
+        profile_allocation=candidate.get("profile_allocation"),
+        allowed_regimes=candidate.get("allowed_regimes"),
+        regime_windows_spec=candidate.get("regime_windows_spec"),
+        regime_directional_policy=candidate.get("regime_directional_policy"),
+        keep_trades=keep_trades,
+        intrabar_resolution=intrabar_resolution,
+    )
+
+
 def evaluate_window(reg, candidate: dict, datasets: List[tuple],
                     window_name: str, capital: float,
                     bars_memo: dict, *,
@@ -631,25 +665,9 @@ def evaluate_window(reg, candidate: dict, datasets: List[tuple],
     candidate_legs = {}
     for symbol, timeframe in datasets:
         ds = dataset_key(symbol, timeframe)
-        candidate_legs[ds] = run_leg(
-            reg, candidate["name"], candidate.get("params"),
-            symbol, timeframe, window, capital=capital,
-            close_strategies=candidate.get("close_strategies"),
-            # The validated default ("long") must also be the EXECUTED
-            # default: with close refs and direction=None the engine path
-            # would open shorts on raw signal=-1, silently scoring a
-            # different entry universe than the long-leg harness (#996).
-            direction=candidate.get("direction") or "long",
-            invert_signal=bool(candidate.get("invert_signal")),
-            stop_loss_atr_mult=candidate.get("stop_loss_atr_mult"),
-            trailing_stop_atr_mult=candidate.get("trailing_stop_atr_mult"),
-            profile_allocation=candidate.get("profile_allocation"),
-            allowed_regimes=candidate.get("allowed_regimes"),
-            regime_windows_spec=candidate.get("regime_windows_spec"),
-            regime_directional_policy=candidate.get(
-                "regime_directional_policy"),
-            intrabar_resolution=intrabar_resolution,
-        )
+        candidate_legs[ds] = run_candidate_leg(
+            reg, candidate, symbol, timeframe, window, capital=capital,
+            intrabar_resolution=intrabar_resolution)
     score = score_candidate(candidate_legs, bars)
     score["window"] = window_name
     score["window_range"] = list(window)

--- a/backtest/monte_carlo.py
+++ b/backtest/monte_carlo.py
@@ -49,6 +49,21 @@ All statistics are stdlib-only and deterministic under --seed.
 SUGGEST-ONLY / diagnostics-only: output never gates a promotion, writes a
 config, or feeds a live path.
 
+Three trade sources, exactly one per invocation: ``--trades-json`` (a saved
+run), ``--strategy`` (one bare registry strategy on the M1 harness), or
+``--candidate-json`` (a full eval_windows candidate — name, params, direction,
+close_strategies, allowed_regimes, regime_windows_spec, stops — resampled
+exactly as M1 scores it). The candidate source is what auto_suggest shells:
+resampling a gate-carrying candidate as if it were the bare strategy would
+report drawdowns for a strategy nobody is considering.
+
+MULTI-LEG MODE (#1295): pass ``--windows`` and/or ``--datasets`` (comma lists)
+instead of the singular ``--window``/``--dataset`` to fan one invocation across
+every (window, dataset) pair, emitting one stats block per leg under a ``legs``
+key — the same fan shape as the other M-harness payloads. ``--datasets``
+defaults to the six audit datasets. The singular flags keep their original
+single-leg payload shape (``observed`` + ``schemes`` at the top level).
+
 Usage:
   # Resample the trades of a completed run saved as JSON (a results dict
   # with a "trades" list, or a bare list of trade dicts / percent returns)
@@ -57,6 +72,10 @@ Usage:
   # Run one leg on the M1 audit-identical harness and resample its trades
   uv run --no-sync python backtest/monte_carlo.py \\
       --strategy squeeze_momentum --dataset BTC/USDT:1h --window is
+
+  # Resample a full candidate across the protocol windows and audit datasets
+  uv run --no-sync python backtest/monte_carlo.py \\
+      --candidate-json cand.json --windows is,oos
 
   # Kill-switch threshold from a live config's strategy entry
   uv run --no-sync python backtest/monte_carlo.py --trades-json results.json \\
@@ -347,36 +366,97 @@ def resolve_kill_switch_pct(cfg: dict, strategy_id: str) -> float:
 # Leg execution (I/O; everything above stays pure).
 # ---------------------------------------------------------------------------
 
+def _leg_returns(leg: Optional[dict], returns: str) -> Optional[List[float]]:
+    """Per-trade percent returns from a run_leg result; None when no data."""
+    if leg is None:
+        return None
+    key = "pnl_pct_net" if returns == "net" else "pnl_pct"
+    return [float(s[key]) for s in leg.get("trade_samples") or []]
+
+
+def _load_reg_and_window(registry: str, window_name: str):
+    from eval_windows import WINDOWS
+    from registry_loader import load_registry
+
+    if window_name not in WINDOWS:
+        raise SystemExit(f"unknown window {window_name!r}; "
+                         f"known: {list(WINDOWS)}")
+    return load_registry(registry), WINDOWS[window_name]
+
+
 def run_leg_trades(strategy: str, registry: str, params: Optional[dict],
                    dataset: str, window_name: str,
                    capital: float, direction: Optional[str],
                    returns: str) -> List[float]:
     """Run one (strategy, dataset, window) leg on the M1 audit-identical
     harness (eval_windows.run_leg, default friction) and return its per-trade
-    percent returns in close order."""
-    from eval_windows import (WINDOWS, DEFAULT_CAPITAL,  # noqa: F401
-                              parse_dataset_arg, run_leg)
-    from registry_loader import load_registry
+    percent returns in close order.
 
-    if window_name not in WINDOWS:
-        raise SystemExit(f"unknown window {window_name!r}; "
-                         f"known: {list(WINDOWS)}")
+    The BARE-STRATEGY source: ``direction`` is threaded exactly as given (None
+    = the engine's raw-signal default), matching gross_edge_noise's leg. A full
+    candidate goes through ``run_candidate_leg_trades`` instead, where the
+    validated "long" default applies (#996).
+    """
+    from eval_windows import parse_dataset_arg, run_leg
+
+    reg, window = _load_reg_and_window(registry, window_name)
     try:
         symbol, timeframe = parse_dataset_arg(dataset)
     except ValueError:
         raise SystemExit(f"--dataset expects SYMBOL:TIMEFRAME, got: {dataset!r}")
-    reg = load_registry(registry)
     if strategy not in reg.STRATEGY_REGISTRY:
         raise SystemExit(f"Unknown strategy {strategy!r}; available: "
                          f"{reg.list_strategies()}")
-    leg = run_leg(reg, strategy, params, symbol, timeframe,
-                  WINDOWS[window_name], capital=capital, direction=direction,
-                  keep_trades=True)
-    if leg is None:
+    values = _leg_returns(
+        run_leg(reg, strategy, params, symbol, timeframe, window,
+                capital=capital, direction=direction, keep_trades=True),
+        returns)
+    if values is None:
         raise SystemExit(f"no cached data for {dataset} in window "
                          f"{window_name!r}")
-    key = "pnl_pct_net" if returns == "net" else "pnl_pct"
-    return [float(s[key]) for s in leg.get("trade_samples") or []]
+    return values
+
+
+def run_candidate_leg_trades(candidate: dict, registry: str, dataset: str,
+                             window_name: str, capital: float,
+                             returns: str) -> Optional[List[float]]:
+    """Per-trade returns for ONE candidate leg, resampled exactly as M1 scores
+    it — the full candidate shape (close stack, entry gate, stops, profile
+    allocation) is threaded via ``eval_windows.run_candidate_leg``, never a
+    hand-picked subset. ``None`` when the dataset has no cached bars in the
+    window (a missing dataset must not abort a multi-leg fan)."""
+    from eval_windows import parse_dataset_arg, run_candidate_leg
+
+    reg, window = _load_reg_and_window(registry, window_name)
+    try:
+        symbol, timeframe = parse_dataset_arg(dataset)
+    except ValueError:
+        raise SystemExit(f"--datasets expects SYMBOL:TIMEFRAME, got: {dataset!r}")
+    if candidate["name"] not in reg.STRATEGY_REGISTRY:
+        raise SystemExit(f"Unknown strategy {candidate['name']!r}; available: "
+                         f"{reg.list_strategies()}")
+    return _leg_returns(
+        run_candidate_leg(reg, candidate, symbol, timeframe, window,
+                          capital=capital, keep_trades=True),
+        returns)
+
+
+def default_dataset_args() -> List[str]:
+    """The six audit datasets as SYMBOL:TIMEFRAME strings (eval_windows SSoT)."""
+    from eval_windows import DATASETS
+    return [f"{sym}:{tf}" for sym, tf in DATASETS]
+
+
+def leg_blocks(values: Sequence[float], schemes: Sequence[str], *,
+               n_paths: int, block_len: int, seed: int,
+               kill_switch_pct: float,
+               percentiles: Sequence[float]) -> List[dict]:
+    """One resample_stats block per scheme, for a single leg's trade series."""
+    return [resample_stats(values, scheme, n_paths=n_paths,
+                           block_len=block_len, seed=seed,
+                           kill_switch_pct=kill_switch_pct,
+                           percentiles=percentiles)
+            for scheme in schemes]
 
 
 # ---------------------------------------------------------------------------
@@ -420,6 +500,42 @@ def format_report(source: str, returns: str, observed: tuple,
     return "\n".join(lines)
 
 
+def format_multileg_report(source: str, returns: str, threshold_source: str,
+                           kill_switch_pct: float, legs: List[dict]) -> str:
+    lines = [
+        f"trade-order Monte Carlo: {source} ({returns} per-trade returns)",
+        f"kill-switch threshold: {kill_switch_pct:g}% ({threshold_source})",
+        f"{len(legs)} leg(s)",
+    ]
+    for leg in legs:
+        lines.append("")
+        head = f"-- {leg['window']} / {leg['dataset']}"
+        if leg["status"] != "ok":
+            lines.append(f"{head}: {leg['status']} — nothing to resample")
+            continue
+        obs = leg["observed"]
+        lines.append(f"{head} ({leg['n_trades']} trades)")
+        lines.append(f"  observed single path: max DD "
+                     f"{obs['max_dd_pct']:.2f}%, final return "
+                     f"{_fmt(obs['final_return_pct'])}%")
+        for b in leg["schemes"]:
+            if b["n_trades"] == 0:
+                lines.append(f"  {b['scheme']}: no trades")
+                continue
+            dd = b["max_dd_pct_percentiles"]
+            fr = b["final_return_pct_percentiles"]
+            keys = list(dd)
+            lines.append(f"  {b['scheme']}: maxDD% "
+                         + "  ".join(f"{k}={dd[k]:.2f}" for k in keys)
+                         + " | final% "
+                         + "  ".join(f"{k}={_fmt(fr[k])}" for k in keys))
+            lines.append(f"    P(final < start) = "
+                         f"{b['p_final_below_start']:.4f}   "
+                         f"P(max DD >= {b['kill_switch_pct']:g}%) = "
+                         f"{b['p_dd_ge_kill_switch']:.4f}   (add-one smoothed)")
+    return "\n".join(lines)
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         description="Trade-order Monte Carlo resampler — drawdown / "
@@ -432,16 +548,27 @@ def build_parser() -> argparse.ArgumentParser:
     src.add_argument("--strategy", default=None,
                      help="Run one leg in-process on the M1 audit harness "
                           "(registry default params unless --params)")
+    src.add_argument("--candidate-json", default=None,
+                     help="Path to a full eval_windows candidate JSON (name, "
+                          "params, direction, close_strategies, "
+                          "allowed_regimes, stops, ...). Resampled exactly as "
+                          "M1 scores it")
     p.add_argument("--registry", choices=["spot", "futures"], default="spot")
     p.add_argument("--params", default=None,
                    help="Params JSON for --strategy (default: registry "
                         "default_params)")
-    p.add_argument("--dataset", default="BTC/USDT:1h",
-                   help="SYMBOL:TIMEFRAME for --strategy (default "
-                        "BTC/USDT:1h)")
-    p.add_argument("--window", default="is",
-                   help="eval_windows window name for --strategy "
-                        "(default: is)")
+    p.add_argument("--dataset", default=None,
+                   help="SYMBOL:TIMEFRAME single-leg source (default "
+                        "BTC/USDT:1h); mutually exclusive with --datasets")
+    p.add_argument("--window", default=None,
+                   help="eval_windows window name, single-leg "
+                        "(default: is); mutually exclusive with --windows")
+    p.add_argument("--windows", default=None,
+                   help="Comma list of eval_windows window names — multi-leg "
+                        "mode (#1295); one stats block per (window, dataset)")
+    p.add_argument("--datasets", default=None,
+                   help="Comma list of SYMBOL:TIMEFRAME — multi-leg mode "
+                        "(#1295). Default in multi-leg: the six audit datasets")
     p.add_argument("--direction", default=None, choices=["long", "short"])
     p.add_argument("--capital", type=float, default=1000.0)
     p.add_argument("--returns", choices=["net", "gross"], default="net",
@@ -477,9 +604,26 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Optional[List[str]] = None) -> int:
     args = build_parser().parse_args(argv)
 
-    if bool(args.trades_json) == bool(args.strategy):
-        raise SystemExit("pass exactly one trade source: "
-                         "--trades-json or --strategy")
+    sources = [bool(args.trades_json), bool(args.strategy),
+               bool(args.candidate_json)]
+    if sum(sources) != 1:
+        raise SystemExit("pass exactly one trade source: --trades-json, "
+                         "--strategy or --candidate-json")
+
+    if args.candidate_json and (args.params or args.direction):
+        raise SystemExit("--params/--direction are --strategy flags; a "
+                         "candidate JSON carries its own params and direction")
+
+    multileg = bool(args.windows) or bool(args.datasets)
+    if multileg:
+        if args.trades_json:
+            raise SystemExit("--windows/--datasets are leg-fan flags; they do "
+                             "not apply to --trades-json (a saved run is one "
+                             "already-realized leg)")
+        if args.window or args.dataset:
+            raise SystemExit("--windows/--datasets (multi-leg) are mutually "
+                             "exclusive with --window/--dataset (single-leg)")
+
     if bool(args.config) != bool(args.strategy_id):
         raise SystemExit("--config and --strategy-id go together")
     if args.kill_switch_pct is not None and args.config:
@@ -531,6 +675,109 @@ def main(argv: Optional[List[str]] = None) -> int:
         kill_switch = DEFAULT_KILL_SWITCH_PCT
         threshold_source = "default (portfolio kill switch)"
 
+    candidate = None
+    if args.candidate_json:
+        from eval_windows import validate_candidate
+        try:
+            with open(args.candidate_json) as fh:
+                candidate = json.load(fh)
+        except OSError as exc:
+            raise SystemExit(f"--candidate-json {args.candidate_json!r} could "
+                             f"not be read: {exc}")
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"--candidate-json {args.candidate_json!r} is not "
+                             f"valid JSON: {exc}")
+        try:
+            validate_candidate(candidate)
+        except ValueError as exc:
+            raise SystemExit(f"--candidate-json is not a valid candidate: {exc}")
+
+    common = dict(n_paths=args.n_paths, block_len=args.block_len,
+                  seed=args.seed, kill_switch_pct=kill_switch,
+                  percentiles=percentiles)
+
+    if multileg:
+        from eval_windows import dataset_key, parse_dataset_arg, run_leg
+
+        window_names = ([w.strip() for w in args.windows.split(",") if w.strip()]
+                        if args.windows else ["is", "oos"])
+        dataset_args = ([d.strip() for d in args.datasets.split(",") if d.strip()]
+                        if args.datasets else default_dataset_args())
+        if not window_names or not dataset_args:
+            raise SystemExit("--windows/--datasets must each name at least "
+                             "one value")
+        try:
+            params = json.loads(args.params) if args.params else None
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"--params must be valid JSON: {exc}")
+
+        legs = []
+        for wname in window_names:
+            for ds in dataset_args:
+                try:
+                    symbol, timeframe = parse_dataset_arg(ds)
+                except ValueError:
+                    raise SystemExit(f"--datasets expects SYMBOL:TIMEFRAME, "
+                                     f"got: {ds!r}")
+                if candidate is not None:
+                    values = run_candidate_leg_trades(
+                        candidate, args.registry, ds, wname, args.capital,
+                        args.returns)
+                else:
+                    # Bare strategy: the gross_edge_noise leg (direction
+                    # threaded as given), fanned across windows/datasets.
+                    reg, window = _load_reg_and_window(args.registry, wname)
+                    if args.strategy not in reg.STRATEGY_REGISTRY:
+                        raise SystemExit(
+                            f"Unknown strategy {args.strategy!r}; available: "
+                            f"{reg.list_strategies()}")
+                    values = _leg_returns(
+                        run_leg(reg, args.strategy, params, symbol, timeframe,
+                                window, capital=args.capital,
+                                direction=args.direction, keep_trades=True),
+                        args.returns)
+                leg = {"window": wname, "dataset": dataset_key(symbol, timeframe)}
+                if values is None:
+                    # A dataset with no cached bars in this window must not
+                    # abort the fan — record it and keep going.
+                    leg.update({"status": "no_data", "n_trades": 0,
+                                "observed": None, "schemes": []})
+                else:
+                    obs = equity_path_stats(values)
+                    leg.update({
+                        "status": "ok", "n_trades": len(values),
+                        "observed": {"max_dd_pct": round(obs[0], 4),
+                                     "final_return_pct": round(obs[1], 4)},
+                        "schemes": leg_blocks(values, schemes, **common)})
+                legs.append(leg)
+
+        name = candidate["name"] if candidate is not None else args.strategy
+        source = (f"{name} windows={','.join(window_names)} "
+                  f"({args.registry} registry)")
+        print(format_multileg_report(source, args.returns, threshold_source,
+                                     kill_switch, legs))
+
+        if not any(leg["status"] == "ok" for leg in legs):
+            sys.stderr.write("no cached data for any (window, dataset) leg\n")
+            return 1
+
+        if args.json_out:
+            payload = {
+                "source": source, "returns": args.returns, "seed": args.seed,
+                "n_paths": args.n_paths, "percentiles": percentiles,
+                "kill_switch_pct": kill_switch,
+                "kill_switch_source": threshold_source,
+                "candidate": candidate,
+                "legs": legs,
+            }
+            with open(args.json_out, "w") as fh:
+                json.dump(payload, fh, indent=2, default=str)
+            print(f"\nwrote {args.json_out}")
+        return 0
+
+    window = args.window or "is"
+    dataset = args.dataset or "BTC/USDT:1h"
+
     if args.trades_json:
         try:
             with open(args.trades_json) as fh:
@@ -547,23 +794,27 @@ def main(argv: Optional[List[str]] = None) -> int:
         except ValueError as exc:
             raise SystemExit(str(exc))
         source = args.trades_json
+    elif candidate is not None:
+        values = run_candidate_leg_trades(candidate, args.registry, dataset,
+                                          window, args.capital, args.returns)
+        if values is None:
+            raise SystemExit(f"no cached data for {dataset} in window "
+                             f"{window!r}")
+        source = (f"{candidate['name']} {dataset} window={window} "
+                  f"({args.registry} registry, candidate-json)")
     else:
         try:
             params = json.loads(args.params) if args.params else None
         except json.JSONDecodeError as exc:
             raise SystemExit(f"--params must be valid JSON: {exc}")
         values = run_leg_trades(args.strategy, args.registry, params,
-                                args.dataset, args.window, args.capital,
+                                dataset, window, args.capital,
                                 args.direction, args.returns)
-        source = (f"{args.strategy} {args.dataset} window={args.window} "
+        source = (f"{args.strategy} {dataset} window={window} "
                   f"({args.registry} registry)")
 
     observed = equity_path_stats(values)
-    blocks = [resample_stats(values, scheme, n_paths=args.n_paths,
-                             block_len=args.block_len, seed=args.seed,
-                             kill_switch_pct=kill_switch,
-                             percentiles=percentiles)
-              for scheme in schemes]
+    blocks = leg_blocks(values, schemes, **common)
 
     print(format_report(source, args.returns, observed, threshold_source,
                         blocks))

--- a/backtest/tests/test_auto_suggest.py
+++ b/backtest/tests/test_auto_suggest.py
@@ -859,3 +859,129 @@ def test_dry_run_omits_the_mc_command_when_mc_is_not_enabled():
     spec["seed"], spec["resamples"], spec["datasets"] = 1066, 10, None
     cmds = asug._dry_run_commands(asug.expand_candidates(spec), spec, "/tmp/out")
     assert not any("monte_carlo.py" in c for c in cmds)
+
+
+# --------------------------------------------------------------------------
+# 10. #1312 review — candidate JSON freshness + MC column window selection
+# --------------------------------------------------------------------------
+
+def _open_spec(harnesses):
+    spec = asug.load_spec(_base_spec(harnesses=harnesses), _STUDY_DIR)
+    spec["seed"], spec["resamples"], spec["datasets"] = 1066, 10, None
+    return spec
+
+
+def _capture_candidate(monkeypatch, harness_flag):
+    """Run one open entry, returning the candidate dict the harness actually
+    read off disk at subprocess-spawn time."""
+    seen = {}
+
+    def fake_run_harness(harness, tail, out_json):
+        path = tail[tail.index(harness_flag) + 1]
+        with open(path) as fh:
+            seen[harness] = json.load(fh)
+        return {"harness": harness, "argv_tail": tail, "status": "failed"}
+
+    monkeypatch.setattr(asug, "_run_harness", fake_run_harness)
+    return seen
+
+
+def test_candidate_json_is_rewritten_over_a_stale_file_from_a_prior_run(monkeypatch, tmp_path):
+    # out_dir persists between runs (main only makedirs(exist_ok=True)) and keys
+    # are stable, so an existence-check write lets M1 — the PROMOTION GATE —
+    # score last run's candidate while the shortlist looks current.
+    spec = _open_spec(["m1"])
+    entry = asug.expand_candidates(spec)[0]
+    stale = tmp_path / f"{entry['key']}.candidate.json"
+    stale.write_text(json.dumps({"name": "STALE_STRATEGY",
+                                 "allowed_regimes": ["stale_gate"]}))
+
+    seen = _capture_candidate(monkeypatch, "--candidate-json")
+    asug.run_open_entry(entry, spec, str(tmp_path), {}, {})
+    assert seen["m1"]["name"] == "squeeze_momentum"
+    assert "allowed_regimes" not in seen["m1"]
+    assert json.loads(stale.read_text())["name"] == "squeeze_momentum"
+
+
+def test_mc_also_reads_a_freshly_written_candidate_not_a_stale_one(monkeypatch, tmp_path):
+    spec = _open_spec(["mc"])
+    entry = asug.expand_candidates(spec)[0]
+    (tmp_path / f"{entry['key']}.candidate.json").write_text(
+        json.dumps({"name": "STALE_STRATEGY"}))
+
+    seen = _capture_candidate(monkeypatch, "--candidate-json")
+    asug.run_open_entry(entry, spec, str(tmp_path), {}, {})
+    assert seen["mc"]["name"] == "squeeze_momentum"
+
+
+def test_candidate_json_is_written_once_per_run_and_shared_by_m1_and_mc(monkeypatch, tmp_path):
+    spec = _open_spec(["m1", "mc"])
+    entry = asug.expand_candidates(spec)[0]
+    paths, writes = [], []
+
+    real_dump = json.dump
+
+    def counting_dump(obj, fh, **kw):
+        if getattr(fh, "name", "").endswith(".candidate.json"):
+            writes.append(fh.name)
+        return real_dump(obj, fh, **kw)
+
+    monkeypatch.setattr(asug.json, "dump", counting_dump)
+    monkeypatch.setattr(asug, "_run_harness", lambda h, tail, out: (
+        paths.append(tail[tail.index("--candidate-json") + 1])
+        or {"harness": h, "argv_tail": tail, "status": "failed"}))
+
+    asug.run_open_entry(entry, spec, str(tmp_path), {}, {})
+    assert len(paths) == 2 and paths[0] == paths[1]   # one file, both harnesses
+    assert len(writes) == 1                           # written exactly once
+
+
+# ---- MC column window selection -------------------------------------------
+
+def _mc_data(**windows):
+    """windows: name -> dict of permute stats, or None for an all-no_data bucket."""
+    out = {}
+    for w, stats in windows.items():
+        out[w] = {"per_dataset": {},
+                  "worst": {} if stats is None else {"permute": stats}}
+    return out
+
+
+_SCORED = {"p_dd_ge_kill_switch": 0.30, "p95_max_dd": 40.0,
+           "p_final_below_start": 0.20}
+_SCORED_OOS = {"p_dd_ge_kill_switch": 0.55, "p95_max_dd": 70.0,
+               "p_final_below_start": 0.40}
+_NO_TRADES = {"p_dd_ge_kill_switch": None, "p95_max_dd": None,
+              "p_final_below_start": None}
+
+
+def test_mc_column_falls_back_to_a_scored_window_when_oos_is_all_no_data():
+    mc = _mc_data(**{"is": _SCORED, "oos": None})
+    assert asug._mc_column_window(mc) == "is"
+    seg = asug._mc_segment(mc)
+    assert "MC(adv,is)=p95DD 40.0%" in seg   # not blanked
+
+
+def test_mc_column_still_prefers_oos_when_both_windows_are_scored():
+    mc = _mc_data(**{"is": _SCORED, "oos": _SCORED_OOS})
+    assert asug._mc_column_window(mc) == "oos"
+    assert "MC(adv,oos)=p95DD 70.0%" in asug._mc_segment(mc)
+
+
+def test_mc_column_prefers_a_scored_window_over_a_zero_trade_one():
+    mc = _mc_data(**{"is": _SCORED, "oos": _NO_TRADES})
+    assert asug._mc_column_window(mc) == "is"
+    assert "MC(adv,is)" in asug._mc_segment(mc)
+
+
+def test_mc_column_reports_dashes_when_every_window_was_resampled_but_empty():
+    # 0 trades everywhere: measured, nothing to resample — say so, don't hide.
+    mc = _mc_data(**{"is": _NO_TRADES, "oos": _NO_TRADES})
+    assert asug._mc_column_window(mc) == "oos"
+    assert "MC(adv,oos)=p95DD -% pKS - pDown -" in asug._mc_segment(mc)
+
+
+def test_mc_column_absent_when_no_window_was_resampled_at_all():
+    assert asug._mc_column_window(_mc_data(**{"is": None, "oos": None})) is None
+    assert asug._mc_segment(_mc_data(**{"is": None, "oos": None})) == ""
+    assert asug._mc_segment({}) == ""

--- a/backtest/tests/test_auto_suggest.py
+++ b/backtest/tests/test_auto_suggest.py
@@ -607,3 +607,255 @@ def test_reproduction_command_uses_relative_harness_paths():
     cmds = asug.reproduction_command(entry)
     assert cmds and cmds[0].startswith("uv run --no-sync python backtest/eval_windows.py")
     assert "--candidate-json" in cmds[0]
+
+
+# --------------------------------------------------------------------------
+# 9. #1295 — advisory Monte Carlo columns must never touch the promotion gate
+# --------------------------------------------------------------------------
+
+def _survivor_entry(**results_over):
+    """An entry whose GATE evidence is a clean pass: noise distinguishable,
+    M1 pass on both protocol windows."""
+    results = {
+        "m1_noise": {"status": "ok",
+                     "data": {"verdict": "distinguishable_positive",
+                              "permutation_p": 0.001, "mean": 0.5, "n": 80}},
+        "m1": {"status": "ok", "data": {"is": {"verdict": "pass"},
+                                        "oos": {"verdict": "pass"}}},
+    }
+    results.update(results_over)
+    return {"key": "c1", "kind": "open", "limitations": [],
+            "precondition_errors": [], "noise_family_key": "fam",
+            "results": results}
+
+
+def _mc_ok_run():
+    return {"status": "ok", "data": {"oos": {"per_dataset": {}, "worst": {
+        "permute": {"p_dd_ge_kill_switch": 0.42, "p95_max_dd": 61.0,
+                    "p_final_below_start": 0.3}}}}}
+
+
+def _family_tests(entry):
+    tests = asug.collect_family_pvalues([entry])
+    asug.apply_family_correction(tests, 0.05)
+    return tests
+
+
+def test_mc_absent_present_and_failed_all_yield_the_same_verdict():
+    # The #1274 pre-registered criterion, strengthened per #1295: a FAILED mc
+    # run is the case the naive "no mc key is read" invariant misses, because
+    # candidate_verdict's failed-run scan reads results.values() generically.
+    absent = _survivor_entry()
+    present = _survivor_entry(mc=_mc_ok_run())
+    failed = _survivor_entry(mc={"status": "failed", "argv_tail": ["--json", "x"]})
+
+    verdicts = {name: asug.candidate_verdict(e, _family_tests(e))
+                for name, e in (("absent", absent), ("present", present),
+                                ("failed", failed))}
+    assert verdicts == {"absent": "survivor", "present": "survivor",
+                        "failed": "survivor"}
+
+
+def test_gate_relevant_results_drops_only_advisory_harnesses():
+    entry = _survivor_entry(mc={"status": "failed"},
+                            m5={"status": "ok", "data": {}})
+    gate = asug.gate_relevant_results(entry)
+    assert set(gate) == {"m1_noise", "m1", "m5"}
+    assert "mc" not in gate
+    # M5 stays gate-relevant: a failed M5 still means run_failed (pre-#1295).
+    assert asug.candidate_verdict(
+        _survivor_entry(m5={"status": "failed"}), []) == "run_failed"
+
+
+def test_failed_gate_harness_still_yields_run_failed():
+    entry = _survivor_entry(m1={"status": "failed"})
+    assert asug.candidate_verdict(entry, []) == "run_failed"
+
+
+def test_mc_only_failure_does_not_flip_the_process_exit_code():
+    mc_failed = _survivor_entry(mc={"status": "failed"})
+    assert asug.any_gate_failure([mc_failed]) is False
+    gate_failed = _survivor_entry(m3={"status": "failed"})
+    assert asug.any_gate_failure([gate_failed]) is True
+
+
+def test_mc_failure_surfaces_as_a_limitation_not_a_verdict():
+    entry = _survivor_entry(mc={"status": "failed"})
+    assert asug.advisory_failures(entry) == ["mc"]
+    assert asug.advisory_failures(_survivor_entry(mc=_mc_ok_run())) == []
+    # a failed GATE harness is not an "advisory failure"
+    assert asug.advisory_failures(_survivor_entry(m1={"status": "failed"})) == []
+
+
+def test_mc_contributes_no_pvalue_and_leaves_bh_family_size_unchanged():
+    without = asug.collect_family_pvalues([_survivor_entry()])
+    with_mc = asug.collect_family_pvalues([_survivor_entry(mc=_mc_ok_run())])
+    assert [t["p"] for t in without] == [t["p"] for t in with_mc]
+    assert asug.apply_family_correction(with_mc, 0.05)["m"] == \
+        asug.apply_family_correction(without, 0.05)["m"]
+    assert all(t["harness"] != "mc" for t in with_mc)
+
+
+# ---- mc argv tail ---------------------------------------------------------
+
+def test_mc_argv_tail_threads_the_candidate_json_not_a_bare_strategy():
+    tail = asug.mc_argv_tail("/t/c.json", "spot", ["is", "oos"],
+                             ["BTC/USDT:1h"], 500, 7, {}, "/t/o.json")
+    assert tail[:2] == ["--candidate-json", "/t/c.json"]
+    assert "--strategy" not in tail          # fidelity: never the bare strategy
+    assert "--windows" in tail and tail[tail.index("--windows") + 1] == "is,oos"
+    assert tail[tail.index("--datasets") + 1] == "BTC/USDT:1h"
+    assert tail[tail.index("--n-paths") + 1] == "500"
+    assert tail[tail.index("--seed") + 1] == "7"
+
+
+def test_mc_argv_tail_omits_datasets_when_none_and_threshold_when_default():
+    tail = asug.mc_argv_tail("/t/c.json", "spot", ["is"], None, 10, 1, {}, "/o")
+    assert "--datasets" not in tail
+    assert "--kill-switch-pct" not in tail and "--config" not in tail
+
+
+def test_mc_argv_tail_threshold_sources_are_exclusive():
+    explicit = asug.mc_argv_tail("/c", "spot", ["is"], None, 10, 1,
+                                 {"kill_switch_pct": 30}, "/o")
+    assert explicit[explicit.index("--kill-switch-pct") + 1] == "30"
+    assert "--config" not in explicit
+
+    from_cfg = asug.mc_argv_tail("/c", "spot", ["is"], None, 10, 1,
+                                 {"config": "/cfg.json", "strategy_id": "hl-x"},
+                                 "/o")
+    assert from_cfg[from_cfg.index("--config") + 1] == "/cfg.json"
+    assert from_cfg[from_cfg.index("--strategy-id") + 1] == "hl-x"
+    assert "--kill-switch-pct" not in from_cfg   # monte_carlo.py refuses both
+
+
+# ---- mc spec block --------------------------------------------------------
+
+def test_load_spec_rejects_both_mc_threshold_sources():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        asug.load_spec(_base_spec(mc={"kill_switch_pct": 30,
+                                      "config": "c.json",
+                                      "strategy_id": "x"}), _STUDY_DIR)
+
+
+def test_load_spec_rejects_mc_config_without_strategy_id():
+    with pytest.raises(ValueError, match="go together"):
+        asug.load_spec(_base_spec(mc={"config": "c.json"}), _STUDY_DIR)
+    with pytest.raises(ValueError, match="go together"):
+        asug.load_spec(_base_spec(mc={"strategy_id": "x"}), _STUDY_DIR)
+
+
+def test_load_spec_rejects_unknown_mc_key_and_bad_n_paths():
+    with pytest.raises(ValueError, match="unknown mc keys"):
+        asug.load_spec(_base_spec(mc={"schemes": ["permute"]}), _STUDY_DIR)
+    with pytest.raises(ValueError, match="n_paths"):
+        asug.load_spec(_base_spec(mc={"n_paths": 0}), _STUDY_DIR)
+
+
+def test_load_spec_resolves_mc_config_against_the_spec_dir():
+    spec = asug.load_spec(_base_spec(mc={"config": "cfg.json",
+                                         "strategy_id": "hl-x"}), _STUDY_DIR)
+    assert spec["mc"]["config"] == os.path.join(_STUDY_DIR, "cfg.json")
+
+
+def test_mc_is_a_default_open_harness_but_never_an_m6_one():
+    assert "mc" in asug.DEFAULT_HARNESSES and "mc" in asug.OPEN_HARNESSES
+    spec = asug.load_spec(_base_spec(harnesses=None), _STUDY_DIR)
+    entry = asug.expand_candidates(spec)[0]
+    assert "mc" in entry["harnesses"]
+    # explicit harness list without mc skips it cleanly
+    spec = asug.load_spec(_base_spec(harnesses=["m1"]), _STUDY_DIR)
+    assert "mc" not in asug.expand_candidates(spec)[0]["harnesses"]
+
+
+# ---- extract_mc -----------------------------------------------------------
+
+def _mc_payload():
+    def leg(window, ds, p_ks, p95, p_down, status="ok"):
+        return {"window": window, "dataset": ds, "status": status, "n_trades": 20,
+                "schemes": [{"scheme": "permute", "p_dd_ge_kill_switch": p_ks,
+                             "max_dd_pct_percentiles": {"p5": 1.0, "p50": 10.0,
+                                                        "p95": p95},
+                             "p_final_below_start": p_down}]}
+    return {"legs": [leg("is", "BTC/USDT 1h", 0.10, 30.0, 0.20),
+                     leg("oos", "BTC/USDT 1h", 0.30, 45.0, 0.25),
+                     leg("oos", "ETH/USDT 4h", 0.55, 70.0, 0.40)]}
+
+
+def test_extract_mc_keys_by_window_and_takes_the_worst_dataset():
+    out = asug.extract_mc(_mc_payload())
+    assert set(out) == {"is", "oos"}
+    worst = out["oos"]["worst"]["permute"]
+    # worst-case, not mean: the fragile ETH leg must not be averaged away
+    assert worst == {"p_dd_ge_kill_switch": 0.55, "p95_max_dd": 70.0,
+                     "p_final_below_start": 0.40}
+    assert set(out["oos"]["per_dataset"]) == {"BTC/USDT 1h", "ETH/USDT 4h"}
+
+
+def test_extract_mc_tolerates_no_data_legs_and_missing_percentiles():
+    payload = {"legs": [
+        {"window": "oos", "dataset": "BTC/USDT 1h", "status": "no_data",
+         "n_trades": 0, "schemes": []},
+        {"window": "oos", "dataset": "ETH/USDT 1h", "status": "ok", "n_trades": 3,
+         "schemes": [{"scheme": "permute", "p_dd_ge_kill_switch": 0.2,
+                      "max_dd_pct_percentiles": {"p50": 5.0},  # no p95 configured
+                      "p_final_below_start": 0.1}]}]}
+    out = asug.extract_mc(payload)
+    worst = out["oos"]["worst"]["permute"]
+    assert worst["p_dd_ge_kill_switch"] == 0.2
+    assert worst["p95_max_dd"] is None      # never fabricated
+    assert asug.extract_mc({}) == {}
+
+
+# ---- report ---------------------------------------------------------------
+
+def test_format_shortlist_labels_mc_advisory_and_prints_the_oos_worst_case():
+    report = {
+        "study": "t", "exploratory": False,
+        "correction": {"method": "benjamini_hochberg", "alpha": 0.05, "m": 1,
+                       "effective_threshold": 0.01, "bonferroni_threshold": 0.05,
+                       "n_survivors": 1},
+        "ranked": [{"key": "win", "verdict": "survivor", "limitations": [],
+                    "results": {"mc": {"data": asug.extract_mc(_mc_payload())}}}],
+    }
+    text = asug.format_shortlist(report)
+    assert "MC(adv,oos)" in text
+    assert "p95DD 70.0%" in text and "pKS 0.550" in text
+    assert "does not gate" in text
+    assert "M3/M5/MC figures are UNCORRECTED CONTEXT" in text
+
+
+def test_format_shortlist_omits_the_mc_segment_when_the_run_failed():
+    report = {
+        "study": "t", "exploratory": False,
+        "correction": {"method": "benjamini_hochberg", "alpha": 0.05, "m": 1,
+                       "effective_threshold": None, "bonferroni_threshold": None,
+                       "n_survivors": 0},
+        "ranked": [{"key": "win", "verdict": "survivor",
+                    "limitations": ["mc_run_failed"],
+                    "results": {"mc": {"status": "failed"}}}],
+    }
+    text = asug.format_shortlist(report)
+    row = next(ln for ln in text.splitlines() if ln.strip().startswith("1 "))
+    assert "MC(adv," not in row       # no column, rather than a fake 0
+    assert "mc_run_failed" in row     # but the absence is visible
+    assert "survivor" in row          # and the verdict is untouched
+
+
+# ---- dry run --------------------------------------------------------------
+
+def test_dry_run_prints_a_command_for_every_enabled_harness():
+    spec = asug.load_spec(_base_spec(harnesses=None), _STUDY_DIR)
+    spec["seed"], spec["resamples"], spec["datasets"] = 1066, 10, None
+    entries = asug.expand_candidates(spec)
+    cmds = asug._dry_run_commands(entries, spec, "/tmp/out")
+    for harness in ("m1_noise", "m1", "m3", "m5", "mc"):
+        assert any(asug.HARNESS_REL[harness] in c for c in cmds), \
+            f"dry-run omits {harness} — it would spawn it anyway"
+
+
+def test_dry_run_omits_the_mc_command_when_mc_is_not_enabled():
+    spec = asug.load_spec(_base_spec(harnesses=["m1"]), _STUDY_DIR)
+    spec["seed"], spec["resamples"], spec["datasets"] = 1066, 10, None
+    cmds = asug._dry_run_commands(asug.expand_candidates(spec), spec, "/tmp/out")
+    assert not any("monte_carlo.py" in c for c in cmds)

--- a/backtest/tests/test_monte_carlo.py
+++ b/backtest/tests/test_monte_carlo.py
@@ -501,3 +501,255 @@ def test_cli_trades_json_missing_pnl_pct_exits_cleanly(tmp_path):
         {"shares": 0.0, "entry_price": 0.0, "pnl": 8.0}]}))
     with pytest.raises(SystemExit):
         mc.main(["--trades-json", str(src)])
+
+
+# ---------------------------------------------------------------------------
+# #1295 — candidate fidelity: resample the candidate, not the bare strategy
+# ---------------------------------------------------------------------------
+
+class _FakeReg:
+    STRATEGY_REGISTRY = {"squeeze_momentum": {"default_params": {}}}
+
+    @staticmethod
+    def list_strategies():
+        return ["squeeze_momentum"]
+
+
+_SAMPLES = [{"entry_date": "2025-01-01", "pnl_pct": 2.0, "pnl_pct_net": 1.5},
+            {"entry_date": "2025-01-02", "pnl_pct": -1.0, "pnl_pct_net": -1.4}]
+
+
+def _rich_candidate():
+    return {"name": "squeeze_momentum", "direction": "long",
+            "params": {"kc_mult": 1.5},
+            "close_strategies": [{"name": "atr_stop", "params": {"atr_mult": 2.0}}],
+            "allowed_regimes": ["trending_up_clean"],
+            "regime_windows_spec": {"medium": {"classifier": "composite",
+                                               "period": 14}},
+            "trailing_stop_atr_mult": 2.5}
+
+
+def test_run_candidate_leg_threads_the_whole_candidate_into_run_leg(monkeypatch):
+    # The #1295 regression: a resampler that hand-picks name/params/direction
+    # silently scores an UNGATED, default-close strategy — different numbers,
+    # same-looking column. Every modelable field must reach run_leg.
+    seen = {}
+
+    def fake_run_leg(reg, name, params, symbol, timeframe, window, **kw):
+        seen.update(name=name, params=params, kw=kw)
+        return {"trade_samples": list(_SAMPLES)}
+
+    monkeypatch.setattr(ew, "run_leg", fake_run_leg)
+    cand = _rich_candidate()
+    ew.run_candidate_leg(_FakeReg, cand, "BTC/USDT", "1h",
+                         ("2025-06-10", "2026-01-01"), keep_trades=True)
+
+    assert seen["name"] == "squeeze_momentum"
+    assert seen["params"] == {"kc_mult": 1.5}
+    kw = seen["kw"]
+    assert kw["close_strategies"] == cand["close_strategies"]
+    assert kw["allowed_regimes"] == ["trending_up_clean"]
+    assert kw["regime_windows_spec"] == cand["regime_windows_spec"]
+    assert kw["trailing_stop_atr_mult"] == 2.5
+    assert kw["keep_trades"] is True
+
+
+def test_run_candidate_leg_applies_the_validated_long_direction_default(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(ew, "run_leg",
+                        lambda *a, **kw: seen.update(kw) or {"trade_samples": []})
+    ew.run_candidate_leg(_FakeReg, {"name": "squeeze_momentum"}, "BTC/USDT",
+                         "1h", ("2025-06-10", None))
+    assert seen["direction"] == "long"      # #996: validated default = executed
+
+
+def _patch_leg(monkeypatch, leg):
+    import registry_loader
+    monkeypatch.setattr(registry_loader, "load_registry", lambda r: _FakeReg)
+    monkeypatch.setattr(ew, "run_candidate_leg", lambda *a, **kw: leg)
+
+
+def test_run_candidate_leg_trades_delegates_and_returns_net_series(monkeypatch):
+    captured = {}
+
+    def fake(reg, cand, symbol, timeframe, window, **kw):
+        captured.update(cand=cand, symbol=symbol, timeframe=timeframe, kw=kw)
+        return {"trade_samples": list(_SAMPLES)}
+
+    import registry_loader
+    monkeypatch.setattr(registry_loader, "load_registry", lambda r: _FakeReg)
+    monkeypatch.setattr(ew, "run_candidate_leg", fake)
+
+    vals = mc.run_candidate_leg_trades(_rich_candidate(), "spot",
+                                       "BTC/USDT:1h", "is", 1000.0, "net")
+    assert vals == [1.5, -1.4]                       # pnl_pct_net
+    assert captured["cand"]["allowed_regimes"] == ["trending_up_clean"]
+    assert (captured["symbol"], captured["timeframe"]) == ("BTC/USDT", "1h")
+    assert captured["kw"]["keep_trades"] is True
+
+    monkeypatch.setattr(ew, "run_candidate_leg", fake)
+    assert mc.run_candidate_leg_trades(_rich_candidate(), "spot",
+                                       "BTC/USDT:1h", "is", 1000.0,
+                                       "gross") == [2.0, -1.0]
+
+
+def test_run_candidate_leg_trades_returns_none_on_missing_data(monkeypatch):
+    _patch_leg(monkeypatch, None)
+    assert mc.run_candidate_leg_trades({"name": "squeeze_momentum"}, "spot",
+                                       "BTC/USDT:1h", "is", 1000.0, "net") is None
+
+
+def test_default_dataset_args_matches_the_eval_windows_audit_six():
+    assert mc.default_dataset_args() == [f"{s}:{t}" for s, t in ew.DATASETS]
+    assert len(mc.default_dataset_args()) == 6
+
+
+# ---------------------------------------------------------------------------
+# #1295 — multi-leg mode
+# ---------------------------------------------------------------------------
+
+def _write_candidate(tmp_path, **over):
+    cand = {"name": "squeeze_momentum", "direction": "long"}
+    cand.update(over)
+    p = tmp_path / "cand.json"
+    p.write_text(json.dumps(cand))
+    return p
+
+
+def test_multileg_payload_has_one_block_per_window_dataset_pair(monkeypatch, tmp_path):
+    _patch_leg(monkeypatch, {"trade_samples": list(_SAMPLES)})
+    cand = _write_candidate(tmp_path)
+    out = tmp_path / "mc.json"
+    rc = mc.main(["--candidate-json", str(cand), "--windows", "is,oos",
+                  "--datasets", "BTC/USDT:1h,ETH/USDT:4h", "--n-paths", "50",
+                  "--json", str(out)])
+    assert rc == 0
+    payload = json.loads(out.read_text())
+    assert "legs" in payload and "observed" not in payload   # fan shape
+    assert len(payload["legs"]) == 4
+    assert {(l["window"], l["dataset"]) for l in payload["legs"]} == {
+        ("is", "BTC/USDT 1h"), ("is", "ETH/USDT 4h"),
+        ("oos", "BTC/USDT 1h"), ("oos", "ETH/USDT 4h")}
+    leg = payload["legs"][0]
+    assert leg["status"] == "ok" and leg["n_trades"] == 2
+    assert {b["scheme"] for b in leg["schemes"]} == set(mc.SCHEMES)
+    assert payload["candidate"]["name"] == "squeeze_momentum"
+
+
+def test_multileg_is_deterministic_under_seed(monkeypatch, tmp_path):
+    _patch_leg(monkeypatch, {"trade_samples": list(_SAMPLES)})
+    cand = _write_candidate(tmp_path)
+    outs = []
+    for i in range(2):
+        out = tmp_path / f"mc{i}.json"
+        assert mc.main(["--candidate-json", str(cand), "--windows", "is",
+                        "--datasets", "BTC/USDT:1h", "--seed", "42",
+                        "--n-paths", "200", "--json", str(out)]) == 0
+        outs.append(out.read_bytes())
+    assert outs[0] == outs[1]
+
+
+def test_multileg_defaults_to_the_audit_six_datasets(monkeypatch, tmp_path):
+    _patch_leg(monkeypatch, {"trade_samples": list(_SAMPLES)})
+    out = tmp_path / "mc.json"
+    assert mc.main(["--candidate-json", str(_write_candidate(tmp_path)),
+                    "--windows", "oos", "--n-paths", "20",
+                    "--json", str(out)]) == 0
+    assert len(json.loads(out.read_text())["legs"]) == 6
+
+
+def test_multileg_records_a_no_data_leg_without_aborting_the_fan(monkeypatch, tmp_path):
+    import registry_loader
+    monkeypatch.setattr(registry_loader, "load_registry", lambda r: _FakeReg)
+    calls = {"n": 0}
+
+    def fake(*a, **kw):
+        calls["n"] += 1
+        return None if calls["n"] == 1 else {"trade_samples": list(_SAMPLES)}
+
+    monkeypatch.setattr(ew, "run_candidate_leg", fake)
+    out = tmp_path / "mc.json"
+    rc = mc.main(["--candidate-json", str(_write_candidate(tmp_path)),
+                  "--windows", "is", "--datasets", "BTC/USDT:1h,ETH/USDT:4h",
+                  "--n-paths", "20", "--json", str(out)])
+    assert rc == 0                                   # one bad leg != a failure
+    legs = json.loads(out.read_text())["legs"]
+    assert [l["status"] for l in legs] == ["no_data", "ok"]
+    assert legs[0]["schemes"] == [] and legs[0]["observed"] is None
+
+
+def test_multileg_fails_when_no_leg_has_data(monkeypatch, tmp_path):
+    _patch_leg(monkeypatch, None)
+    assert mc.main(["--candidate-json", str(_write_candidate(tmp_path)),
+                    "--windows", "is", "--datasets", "BTC/USDT:1h"]) == 1
+
+
+def test_multileg_bare_strategy_source_also_fans(monkeypatch, tmp_path):
+    import registry_loader
+    monkeypatch.setattr(registry_loader, "load_registry", lambda r: _FakeReg)
+    monkeypatch.setattr(ew, "run_leg",
+                        lambda *a, **kw: {"trade_samples": list(_SAMPLES)})
+    out = tmp_path / "mc.json"
+    assert mc.main(["--strategy", "squeeze_momentum", "--windows", "is",
+                    "--datasets", "BTC/USDT:1h", "--n-paths", "20",
+                    "--json", str(out)]) == 0
+    assert len(json.loads(out.read_text())["legs"]) == 1
+
+
+# ---- CLI guards -----------------------------------------------------------
+
+def test_cli_rejects_three_way_source_ambiguity(tmp_path):
+    with pytest.raises(SystemExit, match="exactly one trade source"):
+        mc.main(["--strategy", "x", "--candidate-json", "c.json"])
+    with pytest.raises(SystemExit, match="exactly one trade source"):
+        mc.main(["--trades-json", "a.json", "--candidate-json", "c.json"])
+
+
+def test_cli_rejects_multileg_flags_on_a_saved_run(tmp_path):
+    with pytest.raises(SystemExit, match="do not apply to --trades-json"):
+        mc.main(["--trades-json", "a.json", "--windows", "is"])
+
+
+def test_cli_rejects_mixing_singular_and_plural_leg_flags(tmp_path):
+    with pytest.raises(SystemExit, match="mutually exclusive"):
+        mc.main(["--strategy", "x", "--windows", "is", "--window", "oos"])
+    with pytest.raises(SystemExit, match="mutually exclusive"):
+        mc.main(["--strategy", "x", "--datasets", "BTC/USDT:1h",
+                 "--dataset", "ETH/USDT:1h"])
+
+
+def test_cli_rejects_strategy_flags_alongside_a_candidate_json():
+    with pytest.raises(SystemExit, match="candidate JSON carries its own"):
+        mc.main(["--candidate-json", "c.json", "--params", "{}"])
+    with pytest.raises(SystemExit, match="candidate JSON carries its own"):
+        mc.main(["--candidate-json", "c.json", "--direction", "short"])
+
+
+def test_cli_rejects_an_invalid_candidate_json(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"name": "squeeze_momentum", "direction": "both"}))
+    with pytest.raises(SystemExit, match="not a valid candidate"):
+        mc.main(["--candidate-json", str(bad), "--window", "is"])
+
+
+def test_single_leg_payload_shape_is_unchanged_by_1295(monkeypatch, tmp_path):
+    # Regression guard: the pre-#1295 single-dataset CLI keeps its flat payload
+    # (observed + schemes at the top level, no "legs" key) and its defaults.
+    import registry_loader
+    monkeypatch.setattr(registry_loader, "load_registry", lambda r: _FakeReg)
+    seen = {}
+
+    def fake_run_leg(reg, name, params, symbol, timeframe, window, **kw):
+        seen.update(direction=kw.get("direction"), symbol=symbol)
+        return {"trade_samples": list(_SAMPLES)}
+
+    monkeypatch.setattr(ew, "run_leg", fake_run_leg)
+    out = tmp_path / "mc.json"
+    assert mc.main(["--strategy", "squeeze_momentum", "--n-paths", "20",
+                    "--json", str(out)]) == 0
+    payload = json.loads(out.read_text())
+    assert "legs" not in payload
+    assert set(payload["observed"]) == {"max_dd_pct", "final_return_pct"}
+    assert payload["n_trades"] == 2
+    assert seen["symbol"] == "BTC/USDT"      # --dataset default preserved
+    assert seen["direction"] is None         # bare strategy: unchanged, not "long"

--- a/docs/backtesting-registry.md
+++ b/docs/backtesting-registry.md
@@ -43,8 +43,8 @@ its row here in the same PR. A new row is part of the change, not a follow-up.
 | `exit_diagnostics.py` | **M3** holding-time / excursion diagnostics — where a strategy's PnL dies. | active | #997 |
 | `fee_audit.py` | **M5** registry-wide trade-count × fee-drag selectivity triage. Sweeps the FULL registry incl. discovery-hidden/quarantined names (#1275) — re-screening is the recovery path out of quarantine. | active | #999 #1275 |
 | `exit_policy_ab.py` | **M6** regime-conditioned incumbent-relative exit-policy A/B. | active | #1066 |
-| `auto_suggest.py` | Reusable cross-harness driver that sweeps candidates and ranks gate-survivors under one BH correction. **Suggest-only — never writes a live default/config/PR.** | active | #1210 |
-| `monte_carlo.py` | Trade-order Monte Carlo resampler — permutation + circular block bootstrap over a run's closed trades; drawdown / final-return percentile bands, P(final < start), P(max DD ≥ kill-switch threshold). Suggest-only diagnostics. | active | #1274 |
+| `auto_suggest.py` | Reusable cross-harness driver that sweeps candidates and ranks gate-survivors under one BH correction. Carries advisory Monte Carlo drawdown-risk columns (`mc` harness, #1295) that never influence the gate in any state — including a failed MC run. **Suggest-only — never writes a live default/config/PR.** | active | #1210, #1295 |
+| `monte_carlo.py` | Trade-order Monte Carlo resampler — permutation + circular block bootstrap over a run's closed trades; drawdown / final-return percentile bands, P(final < start), P(max DD ≥ kill-switch threshold). Sources: `--trades-json`, `--strategy`, or `--candidate-json` (full candidate shape); `--windows`/`--datasets` fan one run across legs (#1295). Suggest-only diagnostics. | active | #1274, #1295 |
 
 ## Regime-promotion pipeline (#1065–#1097)
 


### PR DESCRIPTION
Surfaces per-candidate trade-order Monte Carlo risk in the `auto_suggest.py` shortlist — P95 max drawdown, `P(max DD >= kill switch)`, `P(final < start)` — so a candidate that clears the promotion gate with a fragile equity path no longer looks identical to a robust one at the moment a human is comparing them. The columns are advisory: they never influence the gate.

## The two traps

The issue's original sketch would have shipped both of these; validation caught them and they're closed here.

**1. "The gate doesn't read the `mc` key" is not failure isolation.** `candidate_verdict` (`auto_suggest.py:592`) and `main()` (`:1030`) scan `results.values()` generically for a failed status. An `mc` entry that merely *appears* in the results dict would demote a genuine survivor to `run_failed` and flip the process exit code — without either site ever reading an `mc` key. A test asserting "identical verdict with and without MC fields" passes while this is broken, because it injects a *successful* MC block.

Closed with `ADVISORY_HARNESSES` + `gate_relevant_results()`, the only place the gate may touch `entry["results"]`. A failed MC run surfaces as an `mc_run_failed` limitation and a missing column, never as a verdict. **M3/M5 are deliberately not advisory** — a failed M3/M5 has always meant `run_failed`, and that pre-#1295 behavior is preserved byte-for-byte.

**2. The resampler was measuring a different strategy.** `monte_carlo.run_leg_trades` threaded only name/params/direction into `eval_windows.run_leg`, which also accepts `close_strategies`, `allowed_regimes`, `regime_windows_spec` and the stop fields. A `gate_variants` entry or a close-carrying candidate would have been resampled as the **ungated, default-close** strategy — a plausible-looking drawdown number sitting next to, and misdescribing, the candidate it characterizes. Worse than an absent column.

Closed by making `eval_windows.run_candidate_leg` the single source of truth for candidate-dict → `run_leg` kwargs, shared by M1's `evaluate_window` and a new `--candidate-json` Monte Carlo source.

## Also in this PR

- **`monte_carlo.py` multi-leg mode** — `--windows`/`--datasets` fan one invocation across every (window, dataset) pair under a `legs` key, matching the other M-harness payload shapes. `--datasets` defaults to the audit six; a leg with no cached bars records `no_data` instead of aborting the fan. The singular `--window`/`--dataset` CLI keeps its original flat payload *and* its `direction=None` bare-strategy semantics — both regression-covered unchanged.
- **`_dry_run_commands` now prints every enabled harness.** It previously omitted m3 and m5 as well as mc. A dry run that hides harnesses it will actually spawn under-reports the plan, which is the one thing a dry run exists to prevent. (Slightly beyond the issue's letter; same defect class, and adding `mc` beside two existing gaps would have been odd.)
- Spec `mc` block (`kill_switch_pct` XOR `config`+`strategy_id`, plus `n_paths`), template documentation, and the `docs/backtesting-registry.md` rows for both harnesses.
- MC attaches to `OPEN_HARNESSES` only, so M6 exit-A/B entries carry no MC column — stated in the report footer rather than left implicit.

## Verification

Full Python suite: **2605 passed, 1 skipped**.

Both regression tests were confirmed red on the unfixed code:

1. Reverting `ADVISORY_HARNESSES` to `()` — i.e. the naive "don't read the key" fix — fails all four isolation tests, including `test_mc_absent_present_and_failed_all_yield_the_same_verdict`.
1. Dropping the gate/close fields back out of `run_candidate_leg` fails `test_run_candidate_leg_threads_the_whole_candidate_into_run_leg`.

End-to-end on cached BTC/USDT 1h data, `squeeze_momentum` resamples **26 trades** ungated and **0 trades** under a `trending_up_clean` gate — direct evidence the entry gate now reaches the resampler. Real shortlist segment from that run:

```
MC(adv,is)=p95DD 19.0% pKS 0.001 pDown 0.001
```

A `--dry-run` on a defaults spec emits the `mc` command with the gate-carrying `--candidate-json`; the shipped `squeeze_momentum_1198` spec pins its harness list, so `mc` is correctly skipped there with no subprocess.

Closes #1295

---
Created with LLM: Opus 4.8 | high | Harness: Claude Code
