### PR TITLE
fix(#1316): restore opt-in Monte Carlo — drop "mc" from DEFAULT_HARNESSES

### DIFF
--- a/backtest/auto_suggest.py
+++ b/backtest/auto_suggest.py
@@ -81,7 +81,7 @@ HARNESS_ABS = {k: os.path.join(_REPO, v) for k, v in HARNESS_REL.items()}
 
 KNOWN_HARNESSES = set(HARNESS_REL)
 OPEN_HARNESSES = ("m1_noise", "m1", "m3", "m5", "mc")  # applied to open candidates
-DEFAULT_HARNESSES = ["m1_noise", "m1", "m3", "m5", "mc"]
+DEFAULT_HARNESSES = ["m1_noise", "m1", "m3", "m5"]  # "mc" is opt-in only, see ADVISORY_HARNESSES below
 KNOWN_REGISTRIES = ("spot", "futures")
 
 # ADVISORY harnesses (#1295) emit no p-value AND must never influence the

--- a/backtest/candidates/suggest.template.jsonc
+++ b/backtest/candidates/suggest.template.jsonc
@@ -50,8 +50,9 @@
   //                context; no p). Never gates promotion — not when it passes,
   //                not when it fails (a failed run only adds an
   //                "mc_run_failed" limitation flag). Open candidates only.
+  //                NOT run by default (#1316) — must be named explicitly.
   // (M6 is NOT listed here — it is driven by the "m6" block below, one entry
-  // per close variant.) Default: ["m1_noise", "m1", "m3", "m5", "mc"].
+  // per close variant.) Default: ["m1_noise", "m1", "m3", "m5"].
   "harnesses": ["m1_noise", "m1", "m3", "m5", "mc", "m6"],
 
   // ---- Advisory Monte Carlo tuning (#1295). Optional; omit for the defaults

--- a/backtest/tests/test_auto_suggest.py
+++ b/backtest/tests/test_auto_suggest.py
@@ -758,14 +758,17 @@ def test_load_spec_resolves_mc_config_against_the_spec_dir():
     assert spec["mc"]["config"] == os.path.join(_STUDY_DIR, "cfg.json")
 
 
-def test_mc_is_a_default_open_harness_but_never_an_m6_one():
-    assert "mc" in asug.DEFAULT_HARNESSES and "mc" in asug.OPEN_HARNESSES
+def test_mc_is_opt_in_not_a_default_harness():
+    assert "mc" not in asug.DEFAULT_HARNESSES and "mc" in asug.OPEN_HARNESSES
+    # a spec that doesn't name its own harnesses list gets the defaults, and
+    # those must not include mc
     spec = asug.load_spec(_base_spec(harnesses=None), _STUDY_DIR)
     entry = asug.expand_candidates(spec)[0]
-    assert "mc" in entry["harnesses"]
-    # explicit harness list without mc skips it cleanly
-    spec = asug.load_spec(_base_spec(harnesses=["m1"]), _STUDY_DIR)
-    assert "mc" not in asug.expand_candidates(spec)[0]["harnesses"]
+    assert "mc" not in entry["harnesses"]
+    # a spec that explicitly opts in still gets mc, since it's a valid
+    # selectable open-kind harness
+    spec = asug.load_spec(_base_spec(harnesses=["m1", "mc"]), _STUDY_DIR)
+    assert "mc" in asug.expand_candidates(spec)[0]["harnesses"]
 
 
 # ---- extract_mc -----------------------------------------------------------
@@ -845,13 +848,26 @@ def test_format_shortlist_omits_the_mc_segment_when_the_run_failed():
 # ---- dry run --------------------------------------------------------------
 
 def test_dry_run_prints_a_command_for_every_enabled_harness():
-    spec = asug.load_spec(_base_spec(harnesses=None), _STUDY_DIR)
+    spec = asug.load_spec(_base_spec(harnesses=["m1_noise", "m1", "m3", "m5", "mc"]),
+                           _STUDY_DIR)
     spec["seed"], spec["resamples"], spec["datasets"] = 1066, 10, None
     entries = asug.expand_candidates(spec)
     cmds = asug._dry_run_commands(entries, spec, "/tmp/out")
     for harness in ("m1_noise", "m1", "m3", "m5", "mc"):
         assert any(asug.HARNESS_REL[harness] in c for c in cmds), \
             f"dry-run omits {harness} — it would spawn it anyway"
+
+
+def test_dry_run_with_default_harnesses_omits_mc():
+    spec = asug.load_spec(_base_spec(harnesses=None), _STUDY_DIR)
+    spec["seed"], spec["resamples"], spec["datasets"] = 1066, 10, None
+    entries = asug.expand_candidates(spec)
+    cmds = asug._dry_run_commands(entries, spec, "/tmp/out")
+    for harness in ("m1_noise", "m1", "m3", "m5"):
+        assert any(asug.HARNESS_REL[harness] in c for c in cmds), \
+            f"dry-run omits {harness} — it would spawn it anyway"
+    assert not any("monte_carlo.py" in c for c in cmds), \
+        "mc must not run when a spec doesn't opt into it (#1316)"
 
 
 def test_dry_run_omits_the_mc_command_when_mc_is_not_enabled():


### PR DESCRIPTION
## Summary

`#1295` (landed via `#1312`, commit `9ccd431`) added the advisory Monte Carlo (`mc`) harness to `auto_suggest.py` and enabled it by default, contradicting the originating issue's explicit "opt-in, not default" requirement and its own acceptance criteria ("`DEFAULT_HARNESSES` is unchanged"). Every study spec that didn't pin its own `harnesses` list was silently running a 10k-path Monte Carlo fan (2 schemes × N legs per candidate) it never asked for.

- Drop `"mc"` from `DEFAULT_HARNESSES` (`backtest/auto_suggest.py:84`). `OPEN_HARNESSES`/`KNOWN_HARNESSES` are unchanged — `mc` stays a valid, explicitly selectable open-kind harness.
- Invert the regression pin in `test_auto_suggest.py`: now asserts `mc` is opt-in (`not in DEFAULT_HARNESSES`, still `in OPEN_HARNESSES`), and that a `harnesses=None` spec's expanded candidate omits `mc` while an explicit `["m1", "mc"]` spec keeps it.
- Split the old `test_dry_run_prints_a_command_for_every_enabled_harness` (which assumed defaults included `mc`) into one test with an explicit `mc`-including harness list, plus a new `test_dry_run_with_default_harnesses_omits_mc` proving no `monte_carlo.py` line appears under `--dry-run` for a default-harnesses spec.
- Corrected the `Default:` comment in `backtest/candidates/suggest.template.jsonc:54`.
- Checked `docs/backtesting-registry.md` and `docs/ARCHITECTURE.md` — neither claims `mc` is a default harness, so no doc fix was needed there.

## Test plan

- [x] `uv run --no-sync python -m pytest backtest/tests/test_auto_suggest.py -q` — 81 passed.
- [x] Full suite: `uv run --no-sync python -m pytest shared_tools/ shared_strategies/ platforms/ backtest/ -n auto` — 2614 passed, 1 skipped.

Closes #1316

---
Created with LLM: Sonnet 5 | high | Harness: Claude Code
