### PR TITLE
fix(#1315): correct Hyperliquid fee model — 0.045% taker, maker constant, hyperliquid audit fees, roster re-screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Built-in mappings cover known OKX/BinanceUS pairs; add `tradingview_export.symbo
 | Binance US Spot | 0.1% taker | ±0.05% |
 | Deribit Options | 0.03% of premium | — |
 | IBKR/CME Options | $0.25/contract | — |
-| Hyperliquid Perps | 0.035% taker | ±0.05% |
+| Hyperliquid Perps | 0.045% taker / 0.015% maker (base tier) | ±0.05% |
 | TopStep Futures | Per-contract (configurable) | ±0.05% |
 | Robinhood Crypto | No commission (spread embedded) | ±0.05% |
 | Robinhood Options | $0.03/contract (regulatory fee) | — |

--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -452,12 +452,19 @@ LIQUIDATED_METRIC_FLOOR = 100.0
 # and related constants. test_platform_fees.py scrapes fees.go to enforce parity.
 PLATFORM_FEE_PCT = {
     "binanceus":   0.001,    # BinanceSpotFeePct
-    "hyperliquid": 0.00035,  # HyperliquidTakerFeePct
+    "hyperliquid": 0.00045,  # HyperliquidTakerFeePct (base tier, #1315)
     "robinhood":   0.0,      # RobinhoodCryptoFeePct (no commission)
     "luno":        0.01,     # LunoTakerFeePct
     "okx":         0.001,    # OKXSpotTakerFeePct
     "okx-perps":   0.0005,   # OKXPerpsTakerFeePct
 }
+
+# Hyperliquid base-tier maker rate — parity pair with
+# scheduler/fees.go:HyperliquidMakerFeePct (#1315). The bar-level simulator
+# has no maker-priced fills (all fills are market/trigger at next open;
+# resting manual limit orders are an unmodeled #906 parity limitation), so
+# this constant exists for parity and for future consumers, not the fill loop.
+HYPERLIQUID_MAKER_FEE_PCT = 0.00015
 
 
 def fee_pct_for_platform(platform: str) -> float:

--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -9,7 +9,7 @@ per-dataset Sharpe / return / max-DD / DD-adjusted-return / trades, pass/fail
 verdicts, and optional plateau sweeps.
 
 Harness is audit-identical (#956/#963/#976): registry default or supplied
-params, single mode, binanceus fee model, long-leg signal path unless the
+params, single mode, hyperliquid fee model (#1315), long-leg signal path unless the
 candidate config supplies close refs / direction. Sharpe uses the Backtester's
 timeframe-annualized scale, the same scale on both sides of the bar.
 
@@ -87,7 +87,13 @@ PROTOCOL_WINDOWS = ("is", "oos")
 HELD_OUT_WINDOWS = ("2023", "2024", "2025H1")
 
 DEFAULT_CAPITAL = 1000.0
-PLATFORM = "binanceus"  # audit fee model; fixed, not a knob
+# Audit fee model; fixed, not a knob. #1315: hyperliquid base-tier taker
+# (0.045%/side + the Backtester's 5 bps slippage) — live deployment is
+# Hyperliquid perps, so audits price the fees we actually pay. This encodes
+# an explicit perps-deployment assumption even for spot-audited strategies.
+# Verdicts recorded before #1315 were graded under "binanceus" (0.1%/side,
+# ~0.3% round-trip) — see the dated annotations in docs/research/.
+PLATFORM = "hyperliquid"
 
 
 # ---------------------------------------------------------------------------

--- a/backtest/eval_windows.py
+++ b/backtest/eval_windows.py
@@ -87,13 +87,31 @@ PROTOCOL_WINDOWS = ("is", "oos")
 HELD_OUT_WINDOWS = ("2023", "2024", "2025H1")
 
 DEFAULT_CAPITAL = 1000.0
-# Audit fee model; fixed, not a knob. #1315: hyperliquid base-tier taker
-# (0.045%/side + the Backtester's 5 bps slippage) — live deployment is
-# Hyperliquid perps, so audits price the fees we actually pay. This encodes
-# an explicit perps-deployment assumption even for spot-audited strategies.
-# Verdicts recorded before #1315 were graded under "binanceus" (0.1%/side,
-# ~0.3% round-trip) — see the dated annotations in docs/research/.
-PLATFORM = "hyperliquid"
+# Two independent platform axes (#1315 review): the fee model a harness prices
+# and the exchange whose cached OHLCV it loads must never be coupled — changing
+# one must not silently repoint the other.
+#
+# PLATFORM — the DATA-SOURCE exchange_id for cached OHLCV. Imported by the
+# regime research/promotion pipeline (regime_bounded_window_validate,
+# regime_diagnostics, regime_calibrate, regime_vol_model, the regime_10xx /
+# regime_1211 research one-shots) and passed to load_cached_data(exchange_id=…).
+# Stays "binanceus": every committed regime baseline (incl. the #1211 incumbent
+# baseline) was computed on this series. NOT the fee model.
+PLATFORM = "binanceus"
+
+# FEE_PLATFORM — the audit fee model; fixed, not a knob. Used only at the
+# Backtester platform= sites of the active M harnesses (eval_windows,
+# exit_policy_ab, exit_diagnostics; fee_audit/gross_edge_noise/auto_suggest
+# inherit). #1315: hyperliquid base-tier taker (0.045%/side + the Backtester's
+# 5 bps slippage) — live deployment is Hyperliquid perps, so audits price the
+# fees we actually pay. This encodes an explicit perps-deployment assumption
+# even for spot-audited strategies. Verdicts recorded before #1315 were graded
+# under "binanceus" (0.1%/side, ~0.3% round-trip) — see the dated annotations
+# in docs/research/. The frozen research one-shots (regime_1081/regime_1083)
+# deliberately keep their Backtester fee model on the data-source constant so
+# their committed negative-result artifacts stay reproducible under the fee
+# model they were graded with.
+FEE_PLATFORM = "hyperliquid"
 
 
 # ---------------------------------------------------------------------------
@@ -415,7 +433,7 @@ def run_leg(reg, name: str, params: Optional[dict], symbol: str, timeframe: str,
                   or bool(regime_windows_spec)
                   or bool(regime_directional_policy))
     bt_kwargs = dict(
-        initial_capital=capital, platform=PLATFORM,
+        initial_capital=capital, platform=FEE_PLATFORM,
         open_strategy={"name": name, "params": dict(strat_params or {})},
         close_strategies=close_strategies,
         direction=direction, invert_signal=invert_signal,

--- a/backtest/exit_diagnostics.py
+++ b/backtest/exit_diagnostics.py
@@ -8,7 +8,7 @@ mechanism to try next (atr_stop / time_stop / zscore_target), instead of a
 blind close-param sweep.
 
 It runs the SAME audit-identical harness as the M1 scorer: it imports the
-versioned ``WINDOWS`` / ``DATASETS`` / ``PLATFORM`` from ``eval_windows.py`` so
+versioned ``WINDOWS`` / ``DATASETS`` / ``FEE_PLATFORM`` from ``eval_windows.py`` so
 diagnosis and scoring see byte-identical data slices, then reads the per-trade
 hold telemetry the backtester stamps (#997: ``bars_held``, ``mfe_pct`` /
 ``mae_pct`` excursions, ``entry_fee`` / ``exit_fee``, ``exit_reason``).
@@ -44,7 +44,7 @@ if _THIS_DIR not in sys.path:
 from eval_windows import (  # noqa: E402  (path bootstrap above)
     DATASETS,
     DEFAULT_CAPITAL,
-    PLATFORM,
+    FEE_PLATFORM,
     WINDOWS,
     dataset_key,
     parse_dataset_arg,
@@ -330,7 +330,7 @@ def run_leg_trades(reg, name: str, params: Optional[dict], symbol: str,
     df_signals = ensure_atr_indicator(df_signals)
 
     bt = Backtester(
-        initial_capital=capital, platform=PLATFORM,
+        initial_capital=capital, platform=FEE_PLATFORM,
         open_strategy={"name": name, "params": dict(strat_params or {})},
         close_strategies=close_strategies,
         direction=direction, invert_signal=invert_signal,

--- a/backtest/exit_policy_ab.py
+++ b/backtest/exit_policy_ab.py
@@ -53,7 +53,7 @@ fabricating a paired number.
 All scoring/aggregation/statistics below the I/O line are pure (operate on lists
 of plain dicts), unit-tested without data access — same architecture as
 ``eval_windows.py`` / ``exit_diagnostics.py``. The audit-identical data slices
-(``WINDOWS`` / ``DATASETS`` / ``PLATFORM`` / fees) are imported from
+(``WINDOWS`` / ``DATASETS`` / ``FEE_PLATFORM`` / fees) are imported from
 ``eval_windows.py`` so M6 sees byte-identical data to the rest of the suite.
 
 Usage:
@@ -92,7 +92,7 @@ sys.path.insert(0, os.path.join(_THIS_DIR, "..", "shared_tools"))
 from eval_windows import (  # noqa: E402  (path bootstrap above)
     DATASETS,
     DEFAULT_CAPITAL,
-    PLATFORM,
+    FEE_PLATFORM,
     WINDOWS,
     dataset_key,
     parse_dataset_arg,
@@ -607,7 +607,7 @@ def _backtester_kwargs(open_name: str, params: Optional[dict],
     """
     use_regime = bool(gate.get("allowed_regimes"))
     kw = dict(
-        initial_capital=capital, platform=PLATFORM,
+        initial_capital=capital, platform=FEE_PLATFORM,
         open_strategy={"name": open_name, "params": dict(params or {})},
         close_strategies=(list(close_refs) if close_refs else None),
         direction=direction,

--- a/backtest/fee_audit.py
+++ b/backtest/fee_audit.py
@@ -71,7 +71,7 @@ if _THIS_DIR not in sys.path:
 from eval_windows import (  # noqa: E402  (path bootstrap above)
     DATASETS,
     DEFAULT_CAPITAL,
-    PLATFORM,
+    FEE_PLATFORM,
     WINDOWS,
     dataset_key,
     parse_dataset_arg,
@@ -286,7 +286,7 @@ def render_markdown(ranked: List[dict], meta: dict) -> str:
         f"- Datasets: {meta['datasets_desc']}",
         f"- Direction: {meta.get('direction', 'long')}",
         f"- Capital: {meta['capital']}",
-        f"- Fee model: {PLATFORM} platform taker fee + 5 bps slippage (net); "
+        f"- Fee model: {FEE_PLATFORM} platform taker fee + 5 bps slippage (net); "
         "commission=0 and slippage=0 (gross). Fee drag = mean per-leg "
         "(gross - net) return.",
         "",

--- a/backtest/fee_audit.py
+++ b/backtest/fee_audit.py
@@ -2,11 +2,12 @@
 """fee_audit.py — registry-wide trade-count x fee-drag selectivity screen (#999 M5).
 
 The cheapest possible triage before any M1 effort is spent on a strategy: does
-its edge survive its own churn? At the binanceus audit fee model (0.1% taker
-per side, ~0.3% round-trip once spread is counted), a strategy that fires
-350-800 times/year pays 100%+ of capital in fees, while passing incumbents
-trade 0-8 times per window. This screen makes that arithmetic explicit and
-reproducible.
+its edge survive its own churn? At the hyperliquid audit fee model (#1315:
+base-tier 0.045% taker per side + 5 bps slippage, ~0.19% round-trip), a
+strategy that fires hundreds of times/year still pays tens of percent of
+capital in fees, while passing incumbents trade 0-8 times per window. This
+screen makes that arithmetic explicit and reproducible. (Verdicts recorded
+before #1315 used the binanceus model — 0.1%/side, ~0.3% round-trip.)
 
 For every registered strategy on the audit datasets/windows it runs each leg
 TWICE on the eval_windows.py harness (#994):

--- a/backtest/tests/test_platform_fees.py
+++ b/backtest/tests/test_platform_fees.py
@@ -7,7 +7,12 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from backtester import Backtester, PLATFORM_FEE_PCT, fee_pct_for_platform
+from backtester import (
+    Backtester,
+    HYPERLIQUID_MAKER_FEE_PCT,
+    PLATFORM_FEE_PCT,
+    fee_pct_for_platform,
+)
 
 
 FEES_GO = Path(__file__).resolve().parents[2] / "scheduler" / "fees.go"
@@ -16,7 +21,7 @@ FEES_GO = Path(__file__).resolve().parents[2] / "scheduler" / "fees.go"
 # the Go source the scraper below catches it.
 EXPECTED_RATES = {
     "binanceus":   0.001,
-    "hyperliquid": 0.00035,
+    "hyperliquid": 0.00045,
     "robinhood":   0.0,
     "luno":        0.01,
     "okx":         0.001,
@@ -30,8 +35,8 @@ def _scrape_fees_go_constants() -> dict:
     silently drifting from the Go source."""
     text = FEES_GO.read_text()
     const_pattern = re.compile(
-        r"^\s*(BinanceSpotFeePct|HyperliquidTakerFeePct|LunoTakerFeePct|"
-        r"OKXSpotTakerFeePct|OKXPerpsTakerFeePct)\s*=\s*([0-9.]+)",
+        r"^\s*(BinanceSpotFeePct|HyperliquidTakerFeePct|HyperliquidMakerFeePct|"
+        r"LunoTakerFeePct|OKXSpotTakerFeePct|OKXPerpsTakerFeePct)\s*=\s*([0-9.]+)",
         re.MULTILINE,
     )
     return {m.group(1): float(m.group(2)) for m in const_pattern.finditer(text)}
@@ -54,6 +59,15 @@ def test_platform_fee_table_matches_fees_go():
     assert go_rates["OKXPerpsTakerFeePct"] == PLATFORM_FEE_PCT["okx-perps"]
 
 
+def test_hyperliquid_maker_rate_matches_fees_go():
+    """The maker constant is a Go↔Python parity pair like the taker table
+    (#1315) — scrape fees.go so the two can't silently drift."""
+    go_rates = _scrape_fees_go_constants()
+    assert go_rates["HyperliquidMakerFeePct"] == HYPERLIQUID_MAKER_FEE_PCT
+    # Base-tier sanity: maker is strictly cheaper than taker.
+    assert HYPERLIQUID_MAKER_FEE_PCT < PLATFORM_FEE_PCT["hyperliquid"]
+
+
 def test_unknown_platform_falls_back_to_binanceus():
     """Matches the ``default:`` branch in CalculatePlatformSpotFee."""
     assert fee_pct_for_platform("mystery-exchange") == PLATFORM_FEE_PCT["binanceus"]
@@ -61,7 +75,7 @@ def test_unknown_platform_falls_back_to_binanceus():
 
 def test_backtester_uses_platform_fee_by_default():
     bt = Backtester(platform="hyperliquid")
-    assert bt.commission_pct == pytest.approx(0.00035)
+    assert bt.commission_pct == pytest.approx(0.00045)
 
     bt = Backtester(platform="robinhood")
     assert bt.commission_pct == 0.0
@@ -95,7 +109,7 @@ def _one_trade_df():
     "platform,expected_rate",
     [
         ("binanceus",   0.001),
-        ("hyperliquid", 0.00035),
+        ("hyperliquid", 0.00045),
         ("robinhood",   0.0),
         ("luno",        0.01),
         ("okx",         0.001),

--- a/backtest/tests/test_platform_fees.py
+++ b/backtest/tests/test_platform_fees.py
@@ -68,6 +68,40 @@ def test_hyperliquid_maker_rate_matches_fees_go():
     assert HYPERLIQUID_MAKER_FEE_PCT < PLATFORM_FEE_PCT["hyperliquid"]
 
 
+def test_audit_fee_axis_decoupled_from_data_axis():
+    """#1315 review: the audit fee model and the OHLCV data source are
+    independent axes. eval_windows.PLATFORM is the data exchange_id the regime
+    research/promotion pipeline loads cached candles under — it must stay
+    binanceus (every committed regime baseline, incl. the #1211 incumbent
+    baseline, was computed on that series). FEE_PLATFORM carries the #1315
+    hyperliquid audit fee model and is the only constant fed to Backtester
+    platform= in the active M harnesses."""
+    import eval_windows
+
+    assert eval_windows.PLATFORM == "binanceus"
+    assert eval_windows.FEE_PLATFORM == "hyperliquid"
+
+    backtest_dir = Path(__file__).resolve().parents[1]
+    # Fee-axis sites: Backtester platform= must read FEE_PLATFORM, never the
+    # data-source constant.
+    for harness in ("eval_windows.py", "exit_policy_ab.py",
+                    "exit_diagnostics.py"):
+        text = (backtest_dir / harness).read_text()
+        assert "platform=FEE_PLATFORM" in text, harness
+        assert re.search(r"platform=PLATFORM\b", text) is None, (
+            f"{harness} feeds the data-source constant into a Backtester "
+            "fee model — use FEE_PLATFORM"
+        )
+    # Data-axis sites: the regime harnesses load cached OHLCV under the
+    # data-source constant, never the fee constant.
+    for harness in ("regime_bounded_window_validate.py",
+                    "regime_diagnostics.py", "regime_calibrate.py",
+                    "regime_vol_model.py"):
+        text = (backtest_dir / harness).read_text()
+        assert "exchange_id=PLATFORM" in text, harness
+        assert "exchange_id=FEE_PLATFORM" not in text, harness
+
+
 def test_unknown_platform_falls_back_to_binanceus():
     """Matches the ``default:`` branch in CalculatePlatformSpotFee."""
     assert fee_pct_for_platform("mystery-exchange") == PLATFORM_FEE_PCT["binanceus"]

--- a/docs/research/1315-fee-rescreen-m5.md
+++ b/docs/research/1315-fee-rescreen-m5.md
@@ -108,7 +108,10 @@ Context: this run re-screens the quarantine roster after #1315 switched the
 audit fee model from binanceus (0.1% taker/side + 5 bps slippage, ~0.3%
 round-trip) to hyperliquid base tier (0.045% taker/side + 5 bps slippage,
 ~0.19% round-trip). Baseline verdicts are the `docs/research/fee-audit-m5.md`
-table (generated 2026-06-12, binanceus model). Two caveats when comparing:
+table (generated 2026-06-12, binanceus model). Only the *fee* axis changed:
+the OHLCV data source is unchanged from the baseline (binanceus cached
+candles — `eval_windows._load_data` loads under the default `exchange_id`,
+independent of the audit fee model). Two caveats when comparing:
 
 - The `oos` window ends at the latest cached bar, so this run carries ~1 month
   more data than the baseline. **Gross** legs are fee-free — any gross change

--- a/docs/research/1315-fee-rescreen-m5.md
+++ b/docs/research/1315-fee-rescreen-m5.md
@@ -1,0 +1,175 @@
+# Fee-aware selectivity audit (#999 M5)
+
+Registry-wide trade-count x fee-drag screen. Each strategy leg is run twice on the eval_windows.py harness — once with the audit fee model, once with commission and slippage zeroed — to isolate fee drag and apply the salvage test (does a positive *gross* edge exist under the churn?).
+
+## Reproduce
+
+```
+uv run --no-sync python backtest/fee_audit.py --registry both --strategies adx_trend,amd_ifvg,atr_breakout,bollinger_bands,ema_crossover,heikin_ashi_ema,ichimoku_cloud,macd,mean_reversion,momentum,mtf_confluence,order_blocks,pairs_spread,parabolic_sar,range_scalper,rsi,rsi_macd_combo,sma_crossover,squeeze_momentum,stoch_rsi,supertrend,sweep_squeeze_combo,triple_ema,volume_weighted,vol_momentum,vwap_reversion,tema_cross,regime_adaptive,triple_ema_bidir,tema_cross_bd,funding_skew,consolidation_range --markdown docs/research/1315-fee-rescreen-m5.md
+```
+
+- Generated: 2026-07-10
+- Registries: both
+- Windows: is (2025-06-10 → 2026-01-01), oos (2026-01-01 → latest)
+- Datasets: BTC/USDT 1h, BTC/USDT 4h, ETH/USDT 1h, ETH/USDT 4h, SOL/USDT 1h, SOL/USDT 4h
+- Direction: long
+- Capital: 1000.0
+- Fee model: hyperliquid platform taker fee + 5 bps slippage (net); commission=0 and slippage=0 (gross). Fee drag = mean per-leg (gross - net) return.
+
+Returns are mean per-leg total-return %; trades are summed across all scored legs; trades/yr is annualized over the summed calendar span. **Verdicts:** `deprecate` (gross <= 0, no edge to salvage), `graduate_m1` (gross > 0, net <= 0 — raise selectivity), `healthy` (net > 0), `unscreened_short` (emitted short entries the long/flat harness drops — long leg alone can't justify deprecate/no_trades), `no_trades` (never fired). A † flags a row whose short half was unmeasured (verdict reflects the long leg only).
+
+| rank | strategy | reg | trades | trades/yr | gross %/leg | net %/leg | fee drag (pp) | drag/trade (pp) | net Sharpe | verdict |
+|-----:|----------|-----|-------:|----------:|------------:|----------:|--------------:|----------------:|-----------:|---------|
+| 1 | vwap_reversion | spot | 1496 | 251.5 | -6.54 | -26.05 | 19.51 | 0.1565 | -1.29 | `deprecate` |
+| 2 | parabolic_sar | spot | 1325 | 222.8 | -8.80 | -26.06 | 17.26 | 0.1563 | -1.33 | `deprecate` |
+| 3 | macd | spot | 1258 | 211.5 | -10.14 | -25.60 | 15.47 | 0.1475 | -1.40 | `deprecate` |
+| 4 | tema_cross_bd † | futures | 807 | 135.7 | -6.08 | -17.11 | 11.03 | 0.1640 | -0.73 | `unscreened_short` |
+| 5 | triple_ema_bidir † | futures | 801 | 134.7 | -9.50 | -20.49 | 10.99 | 0.1646 | -1.13 | `unscreened_short` |
+| 6 | heikin_ashi_ema | spot | 805 | 135.3 | -13.84 | -23.91 | 10.07 | 0.1501 | -1.24 | `deprecate` |
+| 7 | regime_adaptive † | futures | 747 | 125.6 | -12.13 | -21.90 | 9.77 | 0.1570 | -1.02 | `unscreened_short` |
+| 8 | stoch_rsi | spot | 662 | 111.3 | -13.30 | -21.76 | 8.46 | 0.1534 | -1.17 | `deprecate` |
+| 9 | regime_adaptive | spot | 505 | 84.9 | 3.92 | -4.33 | 8.24 | 0.1959 | -0.56 | `graduate_m1` |
+| 10 | ema_crossover | spot | 564 | 94.8 | -11.12 | -18.78 | 7.67 | 0.1631 | -1.16 | `deprecate` |
+| 11 | consolidation_range † | futures | 625 | 105.1 | -22.86 | -30.25 | 7.38 | 0.1418 | -1.67 | `unscreened_short` |
+| 12 | triple_ema | spot | 516 | 86.8 | -6.71 | -13.87 | 7.16 | 0.1666 | -0.83 | `deprecate` |
+| 13 | tema_cross | spot | 454 | 76.3 | -0.08 | -6.88 | 6.80 | 0.1798 | -0.68 | `deprecate` |
+| 14 | supertrend | spot | 476 | 80.0 | -10.31 | -17.00 | 6.69 | 0.1686 | -1.00 | `deprecate` |
+| 15 | mean_reversion | spot | 496 | 83.4 | -18.19 | -24.30 | 6.11 | 0.1478 | -1.30 | `deprecate` |
+| 16 | atr_breakout | spot | 389 | 65.4 | -4.08 | -9.83 | 5.74 | 0.1771 | -0.85 | `deprecate` |
+| 17 | sma_crossover | spot | 364 | 61.2 | -7.38 | -12.23 | 4.84 | 0.1597 | -0.72 | `deprecate` |
+| 18 | bollinger_bands | spot | 344 | 57.8 | -12.90 | -17.72 | 4.82 | 0.1680 | -0.99 | `deprecate` |
+| 19 | pairs_spread | spot | 375 | 63.0 | -19.14 | -23.61 | 4.48 | 0.1434 | -1.32 | `deprecate` |
+| 20 | order_blocks | spot | 294 | 49.4 | -2.75 | -7.10 | 4.35 | 0.1776 | -0.48 | `deprecate` |
+| 21 | momentum | futures | 288 | 48.4 | -8.52 | -12.70 | 4.18 | 0.1744 | -1.04 | `deprecate` |
+| 22 | volume_weighted | spot | 282 | 47.4 | -8.53 | -12.22 | 3.69 | 0.1569 | -0.66 | `deprecate` |
+| 23 | adx_trend | spot | 203 | 34.1 | -19.35 | -22.01 | 2.66 | 0.1571 | -1.11 | `deprecate` |
+| 24 | ichimoku_cloud | spot | 174 | 29.3 | -2.17 | -4.46 | 2.30 | 0.1584 | -0.53 | `deprecate` |
+| 25 | squeeze_momentum | spot | 135 | 22.7 | -0.57 | -2.81 | 2.24 | 0.1994 | -0.06 | `deprecate` |
+| 26 | vol_momentum † | futures | 149 | 25.1 | -2.13 | -4.37 | 2.23 | 0.1799 | -0.11 | `unscreened_short` |
+| 27 | rsi_macd_combo | spot | 178 | 29.9 | -21.71 | -23.84 | 2.13 | 0.1433 | -1.13 | `deprecate` |
+| 28 | funding_skew † | futures | 147 | 24.7 | -9.47 | -11.58 | 2.11 | 0.1720 | -0.81 | `unscreened_short` |
+| 29 | momentum | spot | 128 | 21.5 | -9.33 | -11.03 | 1.70 | 0.1589 | -0.72 | `deprecate` |
+| 30 | amd_ifvg | spot | 111 | 18.7 | -4.25 | -5.77 | 1.52 | 0.1642 | -0.15 | `deprecate` |
+| 31 | rsi | spot | 117 | 19.7 | -21.00 | -22.39 | 1.39 | 0.1423 | -1.18 | `deprecate` |
+| 32 | vol_momentum | spot | 87 | 14.6 | -0.52 | -1.89 | 1.37 | 0.1894 | -0.44 | `deprecate` |
+| 33 | mtf_confluence † | futures | 77 | 12.9 | -4.55 | -5.65 | 1.10 | 0.1713 | -0.53 | `unscreened_short` |
+| 34 | mtf_confluence | spot | 63 | 10.6 | -1.18 | -2.10 | 0.92 | 0.1756 | -0.20 | `deprecate` |
+| 35 | sweep_squeeze_combo | spot | 26 | 4.4 | -8.21 | -8.54 | 0.33 | 0.1542 | -0.61 | `deprecate` |
+| 36 | range_scalper | spot | 11 | 1.8 | -8.35 | -8.46 | 0.11 | 0.1191 | -0.46 | `deprecate` |
+
+## Deprecation list (gross edge <= 0 — fee filter cannot save)
+
+- **vwap_reversion** (spot): gross -6.54%, net -26.05%, 1496 trades (251.5/yr)
+- **parabolic_sar** (spot): gross -8.80%, net -26.06%, 1325 trades (222.8/yr)
+- **macd** (spot): gross -10.14%, net -25.60%, 1258 trades (211.5/yr)
+- **heikin_ashi_ema** (spot): gross -13.84%, net -23.91%, 805 trades (135.3/yr)
+- **stoch_rsi** (spot): gross -13.30%, net -21.76%, 662 trades (111.3/yr)
+- **ema_crossover** (spot): gross -11.12%, net -18.78%, 564 trades (94.8/yr)
+- **triple_ema** (spot): gross -6.71%, net -13.87%, 516 trades (86.8/yr)
+- **tema_cross** (spot): gross -0.08%, net -6.88%, 454 trades (76.3/yr)
+- **supertrend** (spot): gross -10.31%, net -17.00%, 476 trades (80.0/yr)
+- **mean_reversion** (spot): gross -18.19%, net -24.30%, 496 trades (83.4/yr)
+- **atr_breakout** (spot): gross -4.08%, net -9.83%, 389 trades (65.4/yr)
+- **sma_crossover** (spot): gross -7.38%, net -12.23%, 364 trades (61.2/yr)
+- **bollinger_bands** (spot): gross -12.90%, net -17.72%, 344 trades (57.8/yr)
+- **pairs_spread** (spot): gross -19.14%, net -23.61%, 375 trades (63.0/yr)
+- **order_blocks** (spot): gross -2.75%, net -7.10%, 294 trades (49.4/yr)
+- **momentum** (futures): gross -8.52%, net -12.70%, 288 trades (48.4/yr)
+- **volume_weighted** (spot): gross -8.53%, net -12.22%, 282 trades (47.4/yr)
+- **adx_trend** (spot): gross -19.35%, net -22.01%, 203 trades (34.1/yr)
+- **ichimoku_cloud** (spot): gross -2.17%, net -4.46%, 174 trades (29.3/yr)
+- **squeeze_momentum** (spot): gross -0.57%, net -2.81%, 135 trades (22.7/yr)
+- **rsi_macd_combo** (spot): gross -21.71%, net -23.84%, 178 trades (29.9/yr)
+- **momentum** (spot): gross -9.33%, net -11.03%, 128 trades (21.5/yr)
+- **amd_ifvg** (spot): gross -4.25%, net -5.77%, 111 trades (18.7/yr)
+- **rsi** (spot): gross -21.00%, net -22.39%, 117 trades (19.7/yr)
+- **vol_momentum** (spot): gross -0.52%, net -1.89%, 87 trades (14.6/yr)
+- **mtf_confluence** (spot): gross -1.18%, net -2.10%, 63 trades (10.6/yr)
+- **sweep_squeeze_combo** (spot): gross -8.21%, net -8.54%, 26 trades (4.4/yr)
+- **range_scalper** (spot): gross -8.35%, net -8.46%, 11 trades (1.8/yr)
+
+## M1 graduations (gross > 0, net <= 0 — mechanism: raise selectivity)
+
+- **regime_adaptive** (spot): gross 3.92%, net -4.33%, fee drag 8.24pp over 505 trades (84.9/yr) — raise selectivity
+
+## Unscreened short legs (long/flat harness drops short entries — verdict withheld)
+
+- **tema_cross_bd** (futures): short-capable (bidirectional / allow_short); the long/flat harness measured only its long leg (gross -6.08%, net -17.11% over 807 long trades). Re-screen via the open/close engine (models both sides) before any deprecate/graduate call.
+- **triple_ema_bidir** (futures): short-capable (bidirectional / allow_short); the long/flat harness measured only its long leg (gross -9.50%, net -20.49% over 801 long trades). Re-screen via the open/close engine (models both sides) before any deprecate/graduate call.
+- **regime_adaptive** (futures): short-capable (bidirectional / allow_short); the long/flat harness measured only its long leg (gross -12.13%, net -21.90% over 747 long trades). Re-screen via the open/close engine (models both sides) before any deprecate/graduate call.
+- **consolidation_range** (futures): short-capable (bidirectional / allow_short); the long/flat harness measured only its long leg (gross -22.86%, net -30.25% over 625 long trades). Re-screen via the open/close engine (models both sides) before any deprecate/graduate call.
+- **vol_momentum** (futures): short-capable (bidirectional / allow_short); the long/flat harness measured only its long leg (gross -2.13%, net -4.37% over 149 long trades). Re-screen via the open/close engine (models both sides) before any deprecate/graduate call.
+- **funding_skew** (futures): short-capable (bidirectional / allow_short); the long/flat harness measured only its long leg (gross -9.47%, net -11.58% over 147 long trades). Re-screen via the open/close engine (models both sides) before any deprecate/graduate call.
+- **mtf_confluence** (futures): short-capable (bidirectional / allow_short); the long/flat harness measured only its long leg (gross -4.55%, net -5.65% over 77 long trades). Re-screen via the open/close engine (models both sides) before any deprecate/graduate call.
+
+## Verdict comparison vs the binanceus-model baseline (#1315)
+
+Context: this run re-screens the quarantine roster after #1315 switched the
+audit fee model from binanceus (0.1% taker/side + 5 bps slippage, ~0.3%
+round-trip) to hyperliquid base tier (0.045% taker/side + 5 bps slippage,
+~0.19% round-trip). Baseline verdicts are the `docs/research/fee-audit-m5.md`
+table (generated 2026-06-12, binanceus model). Two caveats when comparing:
+
+- The `oos` window ends at the latest cached bar, so this run carries ~1 month
+  more data than the baseline. **Gross** legs are fee-free — any gross change
+  between the two reports is data drift, not the fee model.
+- Six names (`tema_cross`, `regime_adaptive`, `triple_ema_bidir`,
+  `tema_cross_bd`, `funding_skew`, `consolidation_range`) are quarantined only
+  by the #1282 adjudication, in flight on PR #1314 at generation time; they are
+  included here so the corrected-model evidence is on record either way.
+
+Result: **no strategy's verdict improves under the corrected (cheaper) fee
+model.** Fee drag per row drops by roughly a third (e.g. vwap_reversion 28.39
+→ 19.51 pp), but every roster member's net stays negative — at these churn
+rates the fee model was not the deciding margin, the missing gross edge was.
+
+| strategy | reg | binanceus verdict (2026-06-12) | hyperliquid verdict (this run) | flip? |
+|----------|-----|-------------------------------|--------------------------------|-------|
+| vwap_reversion | spot | `deprecate` | `deprecate` | no |
+| parabolic_sar | spot | `deprecate` | `deprecate` | no |
+| macd | spot | `deprecate` | `deprecate` | no |
+| triple_ema_bidir † | futures | `unscreened_short` | `unscreened_short` | no |
+| tema_cross_bd † | futures | `unscreened_short` | `unscreened_short` | no |
+| heikin_ashi_ema | spot | `deprecate` | `deprecate` | no |
+| regime_adaptive † | futures | `unscreened_short` | `unscreened_short` | no |
+| stoch_rsi | spot | `deprecate` | `deprecate` | no |
+| regime_adaptive | spot | `graduate_m1` | `graduate_m1` | no |
+| ema_crossover | spot | `deprecate` | `deprecate` | no |
+| consolidation_range † | futures | `unscreened_short` | `unscreened_short` | no |
+| triple_ema | spot | `deprecate` | `deprecate` | no |
+| tema_cross | spot | `graduate_m1` | `deprecate` | **yes — worse, data drift** (gross +0.59 → -0.08%/leg as the oos window extended 444 → 454 trades; gross legs are fee-free, so the fee model can't have moved this) |
+| supertrend | spot | `deprecate` | `deprecate` | no |
+| mean_reversion | spot | `deprecate` | `deprecate` | no |
+| atr_breakout | spot | `deprecate` | `deprecate` | no |
+| sma_crossover | spot | `deprecate` | `deprecate` | no |
+| bollinger_bands | spot | `deprecate` | `deprecate` | no |
+| pairs_spread | spot | `deprecate` | `deprecate` | no |
+| order_blocks | spot | `deprecate` | `deprecate` | no |
+| momentum | futures | `deprecate` | `deprecate` | no |
+| volume_weighted | spot | `deprecate` | `deprecate` | no |
+| adx_trend | spot | `deprecate` | `deprecate` | no |
+| ichimoku_cloud | spot | `deprecate` | `deprecate` | no |
+| squeeze_momentum | spot | `deprecate` | `deprecate` | no |
+| vol_momentum † | futures | `unscreened_short` | `unscreened_short` | no |
+| rsi_macd_combo | spot | `deprecate` | `deprecate` | no |
+| funding_skew † | futures | `unscreened_short` | `unscreened_short` | no |
+| momentum | spot | `deprecate` | `deprecate` | no |
+| amd_ifvg | spot | `deprecate` | `deprecate` | no |
+| rsi | spot | `deprecate` | `deprecate` | no |
+| vol_momentum | spot | `deprecate` | `deprecate` | no |
+| mtf_confluence † | futures | `unscreened_short` | `unscreened_short` | no |
+| mtf_confluence | spot | `deprecate` | `deprecate` | no |
+| sweep_squeeze_combo | spot | `deprecate` | `deprecate` | no |
+| range_scalper | spot | `deprecate` | `deprecate` | no |
+
+**Conclusion: no roster change.** The #1282 deprecations of `tema_cross` and
+`regime_adaptive` (spot longs with real gross edges) also stand — their M5
+nets remain negative under hyperliquid fees (tema_cross -6.88%/leg,
+regime_adaptive -4.33%/leg on the protocol windows), and the #1282 verdicts
+additionally rested on M1 protocol failures vs the incumbent bar, which the
+fee change moves on both sides. `regime_adaptive` spot stays `graduate_m1` on
+the M5 screen exactly as it was pre-change; its quarantine (PR #1314) came
+from the deeper M1/noise protocol, not this screen.
+
+---
+Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/docs/research/fee-audit-m5.md
+++ b/docs/research/fee-audit-m5.md
@@ -1,5 +1,13 @@
 # Fee-aware selectivity audit (#999 M5)
 
+> **Fee-model note (2026-07-10, #1315):** every net number and verdict in this
+> report was graded under the **binanceus** audit fee model (0.1% taker/side +
+> 5 bps slippage, ~0.3% round-trip). #1315 switched the audit fee model to
+> **hyperliquid** base tier (0.045% taker/side + 5 bps slippage, ~0.19%
+> round-trip) — the fees live deployment actually pays. This report is kept
+> as-is for provenance; the corrected-model re-screen of the quarantine roster
+> is `docs/research/1315-fee-rescreen-m5.md`.
+
 Registry-wide trade-count x fee-drag screen. Each strategy leg is run twice on the eval_windows.py harness — once with the audit fee model, once with commission and slippage zeroed — to isolate fee drag and apply the salvage test (does a positive *gross* edge exist under the churn?).
 
 ## Reproduce

--- a/scheduler/fees.go
+++ b/scheduler/fees.go
@@ -13,8 +13,15 @@ const (
 	// IBKR options fees (per contract, CME Micro)
 	IBKROptionFeeFixed = 0.25 // $0.25 per contract (CME Micro fee)
 
-	// Hyperliquid perps taker fee
-	HyperliquidTakerFeePct = 0.00035 // 0.035% taker fee
+	// Hyperliquid perps fees, base tier (no volume-tier or staking discount —
+	// the conservative bound), per the official schedule:
+	// https://hyperliquid.gitbook.io/hyperliquid-docs/trading/fees (#1315).
+	// Taker is the modeled-fee fallback wherever the real userFills fee is
+	// unavailable. Maker exists for surfaces that knowingly model a
+	// maker-priced fill; the TP-fill fallback in bookPerpsCloseWithFillFee
+	// deliberately stays on taker (see the comment there).
+	HyperliquidTakerFeePct = 0.00045 // 0.045% taker fee
+	HyperliquidMakerFeePct = 0.00015 // 0.015% maker fee
 
 	// Luno spot taker fee (base rate; volume-tiered down to 0.03%)
 	LunoTakerFeePct = 0.01 // 1.00% taker fee

--- a/scheduler/fees_test.go
+++ b/scheduler/fees_test.go
@@ -25,6 +25,25 @@ func TestCalculateFuturesFee(t *testing.T) {
 	}
 }
 
+func TestHyperliquidFeeConstants(t *testing.T) {
+	// Base-tier rates per the official schedule (#1315). The Python side
+	// (backtest/tests/test_platform_fees.py) scrapes this file to enforce
+	// Go↔Python parity; this pin catches a Go-side edit that forgets the pair.
+	if HyperliquidTakerFeePct != 0.00045 {
+		t.Errorf("HyperliquidTakerFeePct = %v, want 0.00045", HyperliquidTakerFeePct)
+	}
+	if HyperliquidMakerFeePct != 0.00015 {
+		t.Errorf("HyperliquidMakerFeePct = %v, want 0.00015", HyperliquidMakerFeePct)
+	}
+	if HyperliquidMakerFeePct >= HyperliquidTakerFeePct {
+		t.Errorf("maker rate %v must be below taker rate %v", HyperliquidMakerFeePct, HyperliquidTakerFeePct)
+	}
+	// The modeled-fee helper charges taker — the conservative fallback.
+	if got := CalculateHyperliquidFee(1000.0); got != 1000.0*HyperliquidTakerFeePct {
+		t.Errorf("CalculateHyperliquidFee(1000) = %v, want %v", got, 1000.0*HyperliquidTakerFeePct)
+	}
+}
+
 func TestCalculatePlatformSpotFeeOKX(t *testing.T) {
 	// OKX spot: 0.1%
 	fee := CalculatePlatformSpotFee("okx", 1000.0)

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -419,8 +419,10 @@ func bookPerpsPartialCloseWithFillFee(s *StrategyState, symbol string, closeQty,
 	if s.Platform == "okx" && s.Type == "perps" {
 		feePlatform = "okx-perps"
 	}
-	// TP fills are typically maker-priced; use the taker rate as a conservative
-	// fallback when userFills misses so virtual cash is not overstated.
+	// TP fills are typically maker-priced (HyperliquidMakerFeePct exists for
+	// that), but this fallback fires only when userFills misses and the true
+	// fill type is unknown — deliberately keep the taker rate (#1315 decision)
+	// so virtual cash is never overstated by an optimistic maker assumption.
 	fee := CalculatePlatformSpotFee(feePlatform, qty*closePx)
 	feeSource := FeeSourceModeled
 	if useFillFee {


### PR DESCRIPTION
Closes #1315

## What changed

- **Taker constant corrected + maker added** — `scheduler/fees.go` `HyperliquidTakerFeePct` 0.00035 → **0.00045** and new `HyperliquidMakerFeePct = 0.00015` (base tier per the [official schedule](https://hyperliquid.gitbook.io/hyperliquid-docs/trading/fees)); `backtest/backtester.py` mirrors both. This corrects the live modeled-fee fallback (`hyperliquid_fills.go` miss path, `backfill_hl_fees.go`, `backfill_trade_ledger.go` — all read the constant symbolically) and every hyperliquid-platform backtest.
- **Audit fee model switched, on its own axis** — new `backtest/eval_windows.py` `FEE_PLATFORM = "hyperliquid"` carries the audit fee model at the Backtester `platform=` sites (`eval_windows`/`exit_policy_ab`/`exit_diagnostics`, inherited by M1/M5 `fee_audit.py`/noise-gate/`auto_suggest.py`); audits now price ~0.19% round-trip instead of ~0.3%. `PLATFORM` stays `"binanceus"` as the OHLCV data-source `exchange_id` the regime research/promotion pipeline loads under — the fee model change never repoints the data axis (review finding, cycle 1), guarded by `test_audit_fee_axis_decoupled_from_data_axis`. The header documents the explicit perps-deployment assumption this encodes, including for spot-audited strategies.
- **Maker-vs-taker decision recorded** — the modeled fallback for TP fills (`portfolio.go` `bookPerpsCloseWithFillFee`) **deliberately stays on taker**: it only fires when `userFills` misses and the true fill type is unknown, and virtual cash must never be overstated. No backtester maker routing was added — the bar-level simulator has no maker fills (resting limit orders are an unmodeled #906 parity limitation), and live #883 limit fills book real `userFills` fees.
- **Quarantine roster re-screened** — `docs/research/1315-fee-rescreen-m5.md`: M5 fee audit over the 32 quarantine-relevant names (26 on main + the six #1282 additions in flight on PR #1314) under the corrected model. **Result: no verdict improves.** Fee drag drops ~⅓ per row but every net stays negative — the missing gross edge, not the fee model, was the deciding margin. The one verdict change (`tema_cross` `graduate_m1` → `deprecate`) is data drift on the fee-free gross leg (oos window extended a month), not fees. No roster change.
- **History annotated, not rewritten** — `docs/research/fee-audit-m5.md` gets a dated fee-model provenance note; `README.md` fee table updated.

## Parity guards

- `backtest/tests/test_platform_fees.py` scrapes `fees.go` for the maker constant too, and asserts maker < taker; end-to-end fee-deduction test pinned at 0.00045.
- New Go `TestHyperliquidFeeConstants` pins both rates and the taker-based `CalculateHyperliquidFee`.

## Verification

- `go -C scheduler build .` and `go test ./...` pass (all packages, 33.9s).
- Full pytest suite: **2612 passed, 3 skipped** (`-n auto`).
- Red → green: the extended parity test failed against the old constants (ImportError on the maker constant / 0.00045 mismatch) before the source change.

## Notes

- Verdicts recorded before this PR were graded under the binanceus model; comparisons across the boundary must use the annotations.
- The re-screen includes the six #1282 names whose quarantine lands with PR #1314 — evidence is on record whichever order the PRs merge; no conflict (this PR touches no roster).

---
Updated with LLM: Fable 5 | high | Harness: Claude Code
