### PR TITLE
docs: fix stale starter comment left behind by the #1314 starter flip

### DIFF
--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -298,7 +298,8 @@ func hasAnyEnabledStrategyType(opts InitOptions) bool {
 }
 
 // applyMinimalStarterDefaults turns the empty/default init path into one safe,
-// easy-to-understand starter strategy: BTC spot tema_cross on BinanceUS.
+// easy-to-understand starter strategy: BTC spot starterSpotStrategyID
+// (currently chart_pattern) on BinanceUS.
 func applyMinimalStarterDefaults(opts *InitOptions) {
 	if !opts.EnableSpot && hasAnyEnabledStrategyType(*opts) {
 		return


### PR DESCRIPTION
Addresses the Recommended Optional from the #1314 review: the doc comment on `applyMinimalStarterDefaults` (scheduler/init.go:301) still named `tema_cross` after `starterSpotStrategyID` was flipped to `chart_pattern`. The comment now references the constant (with the current value in parentheses) so it survives future flips.

Comment-only change; `go -C scheduler build .` passes, gofmt clean.

---
Created with LLM: Fable 5 | medium | Harness: Claude Code