### PR TITLE
feat(#1159): phase-1 per-strategy correlated hedge legs [Grok 4.5, high]

### DIFF
--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -756,6 +756,14 @@ def load_strategy_config(config_path: str, strategy_id: str,
                 f"release (backtester parity deferred — see #907). Use the "
                 f"static `direction` / `invert_signal` fields for backtesting."
             )
+        # #1159 phase 1: correlated hedge execution is live Hyperliquid-only.
+        hedge = sc.get("hedge") or {}
+        if isinstance(hedge, dict) and hedge.get("enabled"):
+            raise ValueError(
+                f"{config_path}: strategy {strategy_id!r} uses enabled hedge "
+                f"configuration, which is HL-live-only in this release "
+                f"(backtester parity deferred — see #1159)."
+            )
         # #842: a strategy has a single close_strategy ref. Still accept the
         # legacy close_strategies array (length <=1 after the collapse) so old
         # configs keep backtesting; the backtester's close_strategies= list

--- a/backtest/tests/test_backtester_scale_in.py
+++ b/backtest/tests/test_backtester_scale_in.py
@@ -536,6 +536,23 @@ def test_loader_defaults_off(tmp_path):
     assert kwargs["scale_in"] is None
 
 
+def test_loader_rejects_enabled_hedge(tmp_path):
+    path = _config(tmp_path, _hl_strategy(
+        hedge={
+            "enabled": True,
+            "symbol": "ETH",
+            "side": "inverse",
+            "ratio": 0.5,
+            "platform": "hyperliquid",
+            "type": "perps",
+            "margin_mode": "cross",
+            "leverage": 2,
+        }
+    ))
+    with pytest.raises(ValueError, match="enabled hedge.*HL-live-only"):
+        run_backtest.load_strategy_config(path, "hl-test")
+
+
 def test_loader_rejects_block_without_flag(tmp_path):
     path = _config(tmp_path, _hl_strategy(scale_in={"max_adds": 3}))
     with pytest.raises(ValueError, match="allow_scale_in"):

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -605,6 +605,20 @@ type StrategyRef struct {
 	Params map[string]interface{} `json:"params,omitempty"`
 }
 
+const HedgeSideInverse = "inverse"
+
+// HedgeConfig declares a strictly-coupled Hyperliquid perps hedge leg.
+type HedgeConfig struct {
+	Enabled    bool    `json:"enabled"`
+	Symbol     string  `json:"symbol"`
+	Side       string  `json:"side"`
+	Ratio      float64 `json:"ratio"`
+	Platform   string  `json:"platform"`
+	Type       string  `json:"type"`
+	MarginMode string  `json:"margin_mode"`
+	Leverage   float64 `json:"leverage"`
+}
+
 // StrategyConfig describes a single strategy job.
 type StrategyConfig struct {
 	ID                          string                   `json:"id"`
@@ -660,6 +674,7 @@ type StrategyConfig struct {
 	RegimeProfileAllocation     *RegimeProfileAllocation `json:"regime_profile_allocation,omitempty"` // HL perps only: slow regime switch between two validated open_strategy param profiles. A long-window regime label (from the #879 store) selects the active profile; switching is hysteretic (confirm_bars closed bars) and flat-only. Requires regime.enabled=true. Backtester replays the switch. (#998)
 	AllowScaleIn                bool                     `json:"allow_scale_in,omitempty"`            // HL perps/manual only: opt in to scale-in / pyramiding — a same-direction signal on an open position ADDS size (blends price+size, freezes EntryATR/regime/TP geometry) instead of being skipped. Default false preserves the legacy skip-on-same-direction behavior for every strategy that does not opt in. Gated by ScaleIn caps + spacing. (#873)
 	ScaleIn                     *ScaleInConfig           `json:"scale_in,omitempty"`                  // scale-in tuning; only consulted when AllowScaleIn is true. Nil = defaults (unlimited adds/notional, no spacing, per-add size = standard open notional). (#873)
+	Hedge                       *HedgeConfig             `json:"hedge,omitempty"`                     // #1159 — live HL-perps correlated hedge, strictly coupled to the primary lifecycle.
 }
 
 // ScaleInConfig tunes the opt-in scale-in / pyramiding path (#873). All fields
@@ -2222,6 +2237,9 @@ func validateConfig(cfg *Config, skipLiveCredentialChecks bool) error {
 	for _, msg := range hyperliquidPeerStrategyErrors(cfg.Strategies) {
 		errs = append(errs, msg)
 	}
+	// #1159: phase-1 hedge ownership is structurally unambiguous. Reject
+	// primary/hedge and hedge/hedge coin collisions before any live order.
+	errs = append(errs, validateHedgeConfigs(cfg.Strategies)...)
 
 	// #42: Validate portfolio risk config.
 	if cfg.PortfolioRisk != nil {

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -350,6 +350,15 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 				sc.ScaleIn = nil
 			}
 		}
+		if !hedgeConfigEqual(sc.Hedge, ns.Hedge) {
+			addChange("strategy[%s].hedge: shape updated", sc.ID)
+			if ns.Hedge == nil {
+				sc.Hedge = nil
+			} else {
+				clone := *ns.Hedge
+				sc.Hedge = &clone
+			}
+		}
 	}
 
 	if portfolioRiskMaxDrawdown(cfg.PortfolioRisk) != portfolioRiskMaxDrawdown(next.PortfolioRisk) {
@@ -637,6 +646,14 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 			errs = append(errs, fmt.Sprintf("strategy[%s] margin_mode changed with open positions (%q -> %q; flatten first or restart after close)",
 				sc.ID, sc.MarginMode, ns.MarginMode))
 		}
+		if !hedgeConfigEqual(sc.Hedge, ns.Hedge) {
+			ss := stateStrategy(state, sc.ID)
+			if strategyHasOpenHedgeLeg(ss) {
+				errs = append(errs, fmt.Sprintf("strategy[%s] hedge changed with an open hedge leg (flatten first or restart after close)", sc.ID))
+			} else if strategyHasOpenPositions(ss) {
+				errs = append(errs, fmt.Sprintf("strategy[%s] hedge changed with open positions (flatten first or restart after close)", sc.ID))
+			}
+		}
 		if hyperliquidManagedStopReloadGuard(sc) && strategyHasOpenPositions(stateStrategy(state, sc.ID)) {
 			oldTrailing := sc.TrailingStopPct != nil && *sc.TrailingStopPct > 0
 			newTrailing := ns.TrailingStopPct != nil && *ns.TrailingStopPct > 0
@@ -810,6 +827,7 @@ func strategyRestartShape(sc StrategyConfig) StrategyConfig {
 	sc.Paused = false                    // #1150: hot-reloadable always, including while open. Pausing only holds position-increasing signals from the next cycle — closes, trailing SL, ratchet, and protection sync keep running — so toggling mid-position never strands protection. Applied in applyHotReloadConfig.
 	sc.LLMEntryAnalysis = nil            // #1137: hot-reloadable always, including while open — advisory-only entry commentary, never touches position/order state. Applied in applyHotReloadConfig.
 	sc.AllowDeprecated = false           // #1275: hot-reloadable always, including while open — acknowledgment flag only, never gates loading, probing, or trading. Applied in applyHotReloadConfig; reloadConfig re-evaluates the deprecated-edge warning after apply, so flipping the ack off re-warns.
+	sc.Hedge = nil                       // #1159: hedge configuration is hot-reloadable while flat; state-compatibility blocks changes with any open position.
 	sc.Capital = 0
 	sc.Leverage = 0
 	sc.SizingLeverage = 0

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -71,6 +71,9 @@ CREATE TABLE IF NOT EXISTS positions (
     side TEXT NOT NULL,
     multiplier REAL NOT NULL DEFAULT 0,
     owner_strategy_id TEXT NOT NULL DEFAULT '',
+    is_hedge INTEGER NOT NULL DEFAULT 0,
+    hedge_primary_symbol TEXT NOT NULL DEFAULT '',
+    hedge_primary_position_id TEXT NOT NULL DEFAULT '',
     opened_at TEXT NOT NULL DEFAULT '',
     stop_loss_oid INTEGER NOT NULL DEFAULT 0,
     stop_loss_trigger_px REAL NOT NULL DEFAULT 0,
@@ -606,6 +609,10 @@ func (sdb *StateDB) migrateSchema() error {
 		// open — a gap the SIGHUP hot-reload guard can't see. "" = pre-#1277
 		// position, never stamped.
 		"ALTER TABLE positions ADD COLUMN atr_method_at_open TEXT NOT NULL DEFAULT ''",
+		// #1159: strategy-owned correlated hedge metadata.
+		"ALTER TABLE positions ADD COLUMN is_hedge INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE positions ADD COLUMN hedge_primary_symbol TEXT NOT NULL DEFAULT ''",
+		"ALTER TABLE positions ADD COLUMN hedge_primary_position_id TEXT NOT NULL DEFAULT ''",
 		// #1277 hardening (review round 2): manual opens resolve atr_method at
 		// queue time (next to the EntryATR fetch in manualOpenCore) and carry
 		// it through the pending queue so the drain stamps the method the ATR
@@ -1223,8 +1230,10 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	}
 	defer stmtStrat.Close()
 
-	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, tp_armed_tiers_json, stop_loss_atr_mult, tp_tiers_json, sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, regime, regime_windows_json, regime_pending_label, regime_pending_count, regime_applied_label, scale_in_count, last_add_price, added_notional_usd, risk_anchor_price, scale_in_resize_pending, ratchet_fallback_normalize_pending, open_profile, direction_certified_at_open, direction_certified_states_json, llm_analysis_requested, llm_verdict, atr_method_at_open)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, is_hedge, hedge_primary_symbol, hedge_primary_position_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, tp_armed_tiers_json, stop_loss_atr_mult, tp_tiers_json, sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, regime, regime_windows_json, regime_pending_label, regime_pending_count, regime_applied_label, scale_in_count, last_add_price, added_notional_usd, risk_anchor_price, scale_in_resize_pending, ratchet_fallback_normalize_pending, open_profile, direction_certified_at_open, direction_certified_states_json, llm_analysis_requested, llm_verdict, atr_method_at_open)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+		        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+		        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare position insert: %w", err)
 	}
@@ -1292,7 +1301,11 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			if pos.LLMAnalysisRequested {
 				llmAnalysisRequested = 1
 			}
-			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), marshalTPArmedTiersJSON(pos.TPArmedTiers), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON, pos.SLAdjustedTiersProcessed, nullableFloat64(pos.PostTPTrailingATRMult), pos.Regime, marshalRegimeWindowsJSON(pos.RegimeWindows), pos.RegimePendingLabel, pos.RegimePendingCount, pos.RegimeAppliedLabel, pos.ScaleInCount, pos.LastAddPrice, pos.AddedNotionalUSD, pos.RiskAnchorPrice, scaleInResizePending, ratchetFallbackNormalizePending, pos.OpenProfile, directionCertifiedAtOpen, marshalStringMapJSON(pos.DirectionCertifiedStatesAtOpen), llmAnalysisRequested, pos.LLMVerdict, pos.ATRMethodAtOpen); err != nil {
+			isHedge := 0
+			if pos.IsHedge {
+				isHedge = 1
+			}
+			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, isHedge, pos.HedgePrimarySymbol, pos.HedgePrimaryPositionID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), marshalTPArmedTiersJSON(pos.TPArmedTiers), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON, pos.SLAdjustedTiersProcessed, nullableFloat64(pos.PostTPTrailingATRMult), pos.Regime, marshalRegimeWindowsJSON(pos.RegimeWindows), pos.RegimePendingLabel, pos.RegimePendingCount, pos.RegimeAppliedLabel, pos.ScaleInCount, pos.LastAddPrice, pos.AddedNotionalUSD, pos.RiskAnchorPrice, scaleInResizePending, ratchetFallbackNormalizePending, pos.OpenProfile, directionCertifiedAtOpen, marshalStringMapJSON(pos.DirectionCertifiedStatesAtOpen), llmAnalysisRequested, pos.LLMVerdict, pos.ATRMethodAtOpen); err != nil {
 				return fmt.Errorf("insert position %s/%s: %w", s.ID, pos.Symbol, err)
 			}
 		}
@@ -1711,7 +1724,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 3. Load positions for each strategy.
-	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(tp_armed_tiers_json, '') AS tp_armed_tiers_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json, COALESCE(sl_adjusted_tiers_processed, 0) AS sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, COALESCE(regime, '') AS regime, COALESCE(regime_windows_json, '') AS regime_windows_json, COALESCE(regime_pending_label, '') AS regime_pending_label, COALESCE(regime_pending_count, 0) AS regime_pending_count, COALESCE(regime_applied_label, '') AS regime_applied_label, COALESCE(scale_in_count, 0) AS scale_in_count, COALESCE(last_add_price, 0) AS last_add_price, COALESCE(added_notional_usd, 0) AS added_notional_usd, COALESCE(risk_anchor_price, 0) AS risk_anchor_price, COALESCE(scale_in_resize_pending, 0) AS scale_in_resize_pending, COALESCE(ratchet_fallback_normalize_pending, 0) AS ratchet_fallback_normalize_pending, COALESCE(open_profile, '') AS open_profile, COALESCE(direction_certified_at_open, 0) AS direction_certified_at_open, COALESCE(direction_certified_states_json, '') AS direction_certified_states_json, COALESCE(llm_analysis_requested, 0) AS llm_analysis_requested, COALESCE(llm_verdict, '') AS llm_verdict, COALESCE(atr_method_at_open, '') AS atr_method_at_open FROM positions")
+	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, COALESCE(is_hedge, 0) AS is_hedge, COALESCE(hedge_primary_symbol, '') AS hedge_primary_symbol, COALESCE(hedge_primary_position_id, '') AS hedge_primary_position_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(tp_armed_tiers_json, '') AS tp_armed_tiers_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json, COALESCE(sl_adjusted_tiers_processed, 0) AS sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, COALESCE(regime, '') AS regime, COALESCE(regime_windows_json, '') AS regime_windows_json, COALESCE(regime_pending_label, '') AS regime_pending_label, COALESCE(regime_pending_count, 0) AS regime_pending_count, COALESCE(regime_applied_label, '') AS regime_applied_label, COALESCE(scale_in_count, 0) AS scale_in_count, COALESCE(last_add_price, 0) AS last_add_price, COALESCE(added_notional_usd, 0) AS added_notional_usd, COALESCE(risk_anchor_price, 0) AS risk_anchor_price, COALESCE(scale_in_resize_pending, 0) AS scale_in_resize_pending, COALESCE(ratchet_fallback_normalize_pending, 0) AS ratchet_fallback_normalize_pending, COALESCE(open_profile, '') AS open_profile, COALESCE(direction_certified_at_open, 0) AS direction_certified_at_open, COALESCE(direction_certified_states_json, '') AS direction_certified_states_json, COALESCE(llm_analysis_requested, 0) AS llm_analysis_requested, COALESCE(llm_verdict, '') AS llm_verdict, COALESCE(atr_method_at_open, '') AS atr_method_at_open FROM positions")
 	if err != nil {
 		return nil, fmt.Errorf("load positions: %w", err)
 	}
@@ -1731,9 +1744,11 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var directionCertifiedAtOpen int
 		var directionCertifiedStatesJSON string
 		var llmAnalysisRequested int
-		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &tpArmedTiersJSON, &slATRMult, &pos.TPTiersJSON, &pos.SLAdjustedTiersProcessed, &postTPTrailingMult, &pos.Regime, &regimeWindowsJSON, &pos.RegimePendingLabel, &pos.RegimePendingCount, &pos.RegimeAppliedLabel, &pos.ScaleInCount, &pos.LastAddPrice, &pos.AddedNotionalUSD, &pos.RiskAnchorPrice, &scaleInResizePending, &ratchetFallbackNormalizePending, &pos.OpenProfile, &directionCertifiedAtOpen, &directionCertifiedStatesJSON, &llmAnalysisRequested, &pos.LLMVerdict, &pos.ATRMethodAtOpen); err != nil {
+		var isHedge int
+		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &isHedge, &pos.HedgePrimarySymbol, &pos.HedgePrimaryPositionID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &tpArmedTiersJSON, &slATRMult, &pos.TPTiersJSON, &pos.SLAdjustedTiersProcessed, &postTPTrailingMult, &pos.Regime, &regimeWindowsJSON, &pos.RegimePendingLabel, &pos.RegimePendingCount, &pos.RegimeAppliedLabel, &pos.ScaleInCount, &pos.LastAddPrice, &pos.AddedNotionalUSD, &pos.RiskAnchorPrice, &scaleInResizePending, &ratchetFallbackNormalizePending, &pos.OpenProfile, &directionCertifiedAtOpen, &directionCertifiedStatesJSON, &llmAnalysisRequested, &pos.LLMVerdict, &pos.ATRMethodAtOpen); err != nil {
 			return nil, fmt.Errorf("scan position: %w", err)
 		}
+		pos.IsHedge = isHedge != 0
 		pos.ScaleInResizePending = scaleInResizePending != 0
 		pos.RatchetFallbackNormalizePending = ratchetFallbackNormalizePending != 0
 		pos.LLMAnalysisRequested = llmAnalysisRequested != 0

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -74,6 +74,7 @@ CREATE TABLE IF NOT EXISTS positions (
     is_hedge INTEGER NOT NULL DEFAULT 0,
     hedge_primary_symbol TEXT NOT NULL DEFAULT '',
     hedge_primary_position_id TEXT NOT NULL DEFAULT '',
+    hedge_qty_per_primary_unit REAL NOT NULL DEFAULT 0,
     opened_at TEXT NOT NULL DEFAULT '',
     stop_loss_oid INTEGER NOT NULL DEFAULT 0,
     stop_loss_trigger_px REAL NOT NULL DEFAULT 0,
@@ -613,6 +614,7 @@ func (sdb *StateDB) migrateSchema() error {
 		"ALTER TABLE positions ADD COLUMN is_hedge INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE positions ADD COLUMN hedge_primary_symbol TEXT NOT NULL DEFAULT ''",
 		"ALTER TABLE positions ADD COLUMN hedge_primary_position_id TEXT NOT NULL DEFAULT ''",
+		"ALTER TABLE positions ADD COLUMN hedge_qty_per_primary_unit REAL NOT NULL DEFAULT 0",
 		// #1277 hardening (review round 2): manual opens resolve atr_method at
 		// queue time (next to the EntryATR fetch in manualOpenCore) and carry
 		// it through the pending queue so the drain stamps the method the ATR
@@ -1230,10 +1232,10 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	}
 	defer stmtStrat.Close()
 
-	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, is_hedge, hedge_primary_symbol, hedge_primary_position_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, tp_armed_tiers_json, stop_loss_atr_mult, tp_tiers_json, sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, regime, regime_windows_json, regime_pending_label, regime_pending_count, regime_applied_label, scale_in_count, last_add_price, added_notional_usd, risk_anchor_price, scale_in_resize_pending, ratchet_fallback_normalize_pending, open_profile, direction_certified_at_open, direction_certified_states_json, llm_analysis_requested, llm_verdict, atr_method_at_open)
+	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, is_hedge, hedge_primary_symbol, hedge_primary_position_id, hedge_qty_per_primary_unit, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, tp_armed_tiers_json, stop_loss_atr_mult, tp_tiers_json, sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, regime, regime_windows_json, regime_pending_label, regime_pending_count, regime_applied_label, scale_in_count, last_add_price, added_notional_usd, risk_anchor_price, scale_in_resize_pending, ratchet_fallback_normalize_pending, open_profile, direction_certified_at_open, direction_certified_states_json, llm_analysis_requested, llm_verdict, atr_method_at_open)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 		        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-		        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare position insert: %w", err)
 	}
@@ -1305,7 +1307,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			if pos.IsHedge {
 				isHedge = 1
 			}
-			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, isHedge, pos.HedgePrimarySymbol, pos.HedgePrimaryPositionID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), marshalTPArmedTiersJSON(pos.TPArmedTiers), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON, pos.SLAdjustedTiersProcessed, nullableFloat64(pos.PostTPTrailingATRMult), pos.Regime, marshalRegimeWindowsJSON(pos.RegimeWindows), pos.RegimePendingLabel, pos.RegimePendingCount, pos.RegimeAppliedLabel, pos.ScaleInCount, pos.LastAddPrice, pos.AddedNotionalUSD, pos.RiskAnchorPrice, scaleInResizePending, ratchetFallbackNormalizePending, pos.OpenProfile, directionCertifiedAtOpen, marshalStringMapJSON(pos.DirectionCertifiedStatesAtOpen), llmAnalysisRequested, pos.LLMVerdict, pos.ATRMethodAtOpen); err != nil {
+			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, isHedge, pos.HedgePrimarySymbol, pos.HedgePrimaryPositionID, pos.HedgeQtyPerPrimaryUnit, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), marshalTPArmedTiersJSON(pos.TPArmedTiers), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON, pos.SLAdjustedTiersProcessed, nullableFloat64(pos.PostTPTrailingATRMult), pos.Regime, marshalRegimeWindowsJSON(pos.RegimeWindows), pos.RegimePendingLabel, pos.RegimePendingCount, pos.RegimeAppliedLabel, pos.ScaleInCount, pos.LastAddPrice, pos.AddedNotionalUSD, pos.RiskAnchorPrice, scaleInResizePending, ratchetFallbackNormalizePending, pos.OpenProfile, directionCertifiedAtOpen, marshalStringMapJSON(pos.DirectionCertifiedStatesAtOpen), llmAnalysisRequested, pos.LLMVerdict, pos.ATRMethodAtOpen); err != nil {
 				return fmt.Errorf("insert position %s/%s: %w", s.ID, pos.Symbol, err)
 			}
 		}
@@ -1724,7 +1726,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 3. Load positions for each strategy.
-	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, COALESCE(is_hedge, 0) AS is_hedge, COALESCE(hedge_primary_symbol, '') AS hedge_primary_symbol, COALESCE(hedge_primary_position_id, '') AS hedge_primary_position_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(tp_armed_tiers_json, '') AS tp_armed_tiers_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json, COALESCE(sl_adjusted_tiers_processed, 0) AS sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, COALESCE(regime, '') AS regime, COALESCE(regime_windows_json, '') AS regime_windows_json, COALESCE(regime_pending_label, '') AS regime_pending_label, COALESCE(regime_pending_count, 0) AS regime_pending_count, COALESCE(regime_applied_label, '') AS regime_applied_label, COALESCE(scale_in_count, 0) AS scale_in_count, COALESCE(last_add_price, 0) AS last_add_price, COALESCE(added_notional_usd, 0) AS added_notional_usd, COALESCE(risk_anchor_price, 0) AS risk_anchor_price, COALESCE(scale_in_resize_pending, 0) AS scale_in_resize_pending, COALESCE(ratchet_fallback_normalize_pending, 0) AS ratchet_fallback_normalize_pending, COALESCE(open_profile, '') AS open_profile, COALESCE(direction_certified_at_open, 0) AS direction_certified_at_open, COALESCE(direction_certified_states_json, '') AS direction_certified_states_json, COALESCE(llm_analysis_requested, 0) AS llm_analysis_requested, COALESCE(llm_verdict, '') AS llm_verdict, COALESCE(atr_method_at_open, '') AS atr_method_at_open FROM positions")
+	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, COALESCE(is_hedge, 0) AS is_hedge, COALESCE(hedge_primary_symbol, '') AS hedge_primary_symbol, COALESCE(hedge_primary_position_id, '') AS hedge_primary_position_id, COALESCE(hedge_qty_per_primary_unit, 0) AS hedge_qty_per_primary_unit, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(tp_armed_tiers_json, '') AS tp_armed_tiers_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json, COALESCE(sl_adjusted_tiers_processed, 0) AS sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, COALESCE(regime, '') AS regime, COALESCE(regime_windows_json, '') AS regime_windows_json, COALESCE(regime_pending_label, '') AS regime_pending_label, COALESCE(regime_pending_count, 0) AS regime_pending_count, COALESCE(regime_applied_label, '') AS regime_applied_label, COALESCE(scale_in_count, 0) AS scale_in_count, COALESCE(last_add_price, 0) AS last_add_price, COALESCE(added_notional_usd, 0) AS added_notional_usd, COALESCE(risk_anchor_price, 0) AS risk_anchor_price, COALESCE(scale_in_resize_pending, 0) AS scale_in_resize_pending, COALESCE(ratchet_fallback_normalize_pending, 0) AS ratchet_fallback_normalize_pending, COALESCE(open_profile, '') AS open_profile, COALESCE(direction_certified_at_open, 0) AS direction_certified_at_open, COALESCE(direction_certified_states_json, '') AS direction_certified_states_json, COALESCE(llm_analysis_requested, 0) AS llm_analysis_requested, COALESCE(llm_verdict, '') AS llm_verdict, COALESCE(atr_method_at_open, '') AS atr_method_at_open FROM positions")
 	if err != nil {
 		return nil, fmt.Errorf("load positions: %w", err)
 	}
@@ -1745,7 +1747,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var directionCertifiedStatesJSON string
 		var llmAnalysisRequested int
 		var isHedge int
-		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &isHedge, &pos.HedgePrimarySymbol, &pos.HedgePrimaryPositionID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &tpArmedTiersJSON, &slATRMult, &pos.TPTiersJSON, &pos.SLAdjustedTiersProcessed, &postTPTrailingMult, &pos.Regime, &regimeWindowsJSON, &pos.RegimePendingLabel, &pos.RegimePendingCount, &pos.RegimeAppliedLabel, &pos.ScaleInCount, &pos.LastAddPrice, &pos.AddedNotionalUSD, &pos.RiskAnchorPrice, &scaleInResizePending, &ratchetFallbackNormalizePending, &pos.OpenProfile, &directionCertifiedAtOpen, &directionCertifiedStatesJSON, &llmAnalysisRequested, &pos.LLMVerdict, &pos.ATRMethodAtOpen); err != nil {
+		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &isHedge, &pos.HedgePrimarySymbol, &pos.HedgePrimaryPositionID, &pos.HedgeQtyPerPrimaryUnit, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &tpArmedTiersJSON, &slATRMult, &pos.TPTiersJSON, &pos.SLAdjustedTiersProcessed, &postTPTrailingMult, &pos.Regime, &regimeWindowsJSON, &pos.RegimePendingLabel, &pos.RegimePendingCount, &pos.RegimeAppliedLabel, &pos.ScaleInCount, &pos.LastAddPrice, &pos.AddedNotionalUSD, &pos.RiskAnchorPrice, &scaleInResizePending, &ratchetFallbackNormalizePending, &pos.OpenProfile, &directionCertifiedAtOpen, &directionCertifiedStatesJSON, &llmAnalysisRequested, &pos.LLMVerdict, &pos.ATRMethodAtOpen); err != nil {
 			return nil, fmt.Errorf("scan position: %w", err)
 		}
 		pos.IsHedge = isHedge != 0

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1117,6 +1117,9 @@ func collectPositions(sc StrategyConfig, ss *StrategyState, prices map[string]fl
 			dateStr = fmt.Sprintf(" [%s]", pos.OpenedAt.Format("Jan 02 15:04"))
 		}
 		extras := ""
+		if pos.IsHedge {
+			extras += fmt.Sprintf(" | HEDGE for %s", pos.HedgePrimarySymbol)
+		}
 		if name := closeStrategySummaryName(sc); name != "" {
 			extras += fmt.Sprintf(" | close: %s", name)
 		}

--- a/scheduler/discord_commands.go
+++ b/scheduler/discord_commands.go
@@ -176,8 +176,12 @@ func formatPositionsResponse(state *AppState, prices map[string]float64) string 
 			if _, ok := lines[plat]; !ok {
 				platforms = append(platforms, plat)
 			}
+			hedgeTag := ""
+			if p.IsHedge {
+				hedgeTag = " [hedge]"
+			}
 			lines[plat] = append(lines[plat], fmt.Sprintf(
-				"  %s %s %.4f @ $%.2f (mv $%.2f) [%s]", sym, p.Side, p.Quantity, p.AvgCost, mv, id))
+				"  %s %s %.4f @ $%.2f (mv $%.2f) [%s]%s", sym, p.Side, p.Quantity, p.AvgCost, mv, id, hedgeTag))
 		}
 	}
 	if len(platforms) == 0 {

--- a/scheduler/hedge.go
+++ b/scheduler/hedge.go
@@ -21,21 +21,72 @@ type hedgeOrder struct {
 	FullClose bool
 }
 
-// hedgeLifecycleDueInterval returns the due-check interval for a hedge-enabled
-// strategy. With open primary/hedge exposure it caps at the global cadence so
-// reconcile+sync bound the naked-hedge window after an on-chain primary SL/TP
-// fill (#1159 review). Flat / non-hedge strategies keep their strategy interval.
-func hedgeLifecycleDueInterval(sc StrategyConfig, ss *StrategyState, strategyInterval, globalInterval int) int {
+// hedgeNeedsLifecycleSync reports whether a hedge-enabled strategy currently
+// holds open primary and/or hedge exposure and therefore needs reconcile+
+// syncStrategyHedge at the global cadence — WITHOUT accelerating the primary's
+// signal-evaluation due interval (#1159 review).
+func hedgeNeedsLifecycleSync(sc StrategyConfig, ss *StrategyState) bool {
 	if !hedgeEnabled(sc) {
-		return strategyInterval
+		return false
 	}
-	primarySym := hyperliquidConfiguredCoin(sc)
-	if strategyHasOpenHedgeLeg(ss) || findPrimaryPosition(ss, primarySym) != nil {
-		if globalInterval > 0 && (strategyInterval <= 0 || globalInterval < strategyInterval) {
-			return globalInterval
+	if strategyHasOpenHedgeLeg(ss) {
+		return true
+	}
+	return findPrimaryPosition(ss, hyperliquidConfiguredCoin(sc)) != nil
+}
+
+// collectHedgeLifecycleCandidates returns hedge-enabled strategies with open
+// primary/hedge exposure. Caller must hold mu (RLock or Lock) while reading state.
+func collectHedgeLifecycleCandidates(strategies []StrategyConfig, state map[string]*StrategyState) []StrategyConfig {
+	out := make([]StrategyConfig, 0)
+	for _, sc := range strategies {
+		if hedgeNeedsLifecycleSync(sc, state[sc.ID]) {
+			out = append(out, sc)
 		}
 	}
-	return strategyInterval
+	return out
+}
+
+// mergeStrategyConfigsByID appends extra strategies whose IDs are not already
+// present in base, preserving base order then extra order.
+func mergeStrategyConfigsByID(base, extra []StrategyConfig) []StrategyConfig {
+	seen := make(map[string]struct{}, len(base)+len(extra))
+	out := make([]StrategyConfig, 0, len(base)+len(extra))
+	for _, sc := range base {
+		if _, ok := seen[sc.ID]; ok {
+			continue
+		}
+		seen[sc.ID] = struct{}{}
+		out = append(out, sc)
+	}
+	for _, sc := range extra {
+		if _, ok := seen[sc.ID]; ok {
+			continue
+		}
+		seen[sc.ID] = struct{}{}
+		out = append(out, sc)
+	}
+	return out
+}
+
+// capDelayForHedgeLifecycle caps the inter-cycle sleep at the global interval
+// while any hedge-enabled strategy still has open exposure, so naked-hedge
+// reconcile+sync stay bounded without collapsing primary dueStrategies.
+// Caller must hold mu (RLock or Lock) while reading state.
+func capDelayForHedgeLifecycle(delay time.Duration, strategies []StrategyConfig, state map[string]*StrategyState, globalIntervalSeconds int) time.Duration {
+	if globalIntervalSeconds <= 0 {
+		return delay
+	}
+	maxDelay := time.Duration(globalIntervalSeconds) * time.Second
+	for _, sc := range strategies {
+		if hedgeNeedsLifecycleSync(sc, state[sc.ID]) {
+			if delay > maxDelay {
+				return maxDelay
+			}
+			return delay
+		}
+	}
+	return delay
 }
 
 func hedgeEnabled(sc StrategyConfig) bool { return sc.Hedge != nil && sc.Hedge.Enabled }

--- a/scheduler/hedge.go
+++ b/scheduler/hedge.go
@@ -21,6 +21,23 @@ type hedgeOrder struct {
 	FullClose bool
 }
 
+// hedgeLifecycleDueInterval returns the due-check interval for a hedge-enabled
+// strategy. With open primary/hedge exposure it caps at the global cadence so
+// reconcile+sync bound the naked-hedge window after an on-chain primary SL/TP
+// fill (#1159 review). Flat / non-hedge strategies keep their strategy interval.
+func hedgeLifecycleDueInterval(sc StrategyConfig, ss *StrategyState, strategyInterval, globalInterval int) int {
+	if !hedgeEnabled(sc) {
+		return strategyInterval
+	}
+	primarySym := hyperliquidConfiguredCoin(sc)
+	if strategyHasOpenHedgeLeg(ss) || findPrimaryPosition(ss, primarySym) != nil {
+		if globalInterval > 0 && (strategyInterval <= 0 || globalInterval < strategyInterval) {
+			return globalInterval
+		}
+	}
+	return strategyInterval
+}
+
 func hedgeEnabled(sc StrategyConfig) bool { return sc.Hedge != nil && sc.Hedge.Enabled }
 
 func hedgeCoin(sc StrategyConfig) string {

--- a/scheduler/hedge.go
+++ b/scheduler/hedge.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)
+
+const hedgeQtyEpsilon = 1e-9
+
+type hedgeTarget struct {
+	Side     string
+	Quantity float64
+}
+
+type hedgeOrder struct {
+	Side      string
+	Quantity  float64
+	Close     bool
+	FullClose bool
+}
+
+func hedgeEnabled(sc StrategyConfig) bool { return sc.Hedge != nil && sc.Hedge.Enabled }
+
+func hedgeCoin(sc StrategyConfig) string {
+	if !hedgeEnabled(sc) {
+		return ""
+	}
+	return hyperliquidCoinFromSymbol(sc.Hedge.Symbol)
+}
+
+func hyperliquidCoinFromSymbol(symbol string) string {
+	s := strings.TrimSpace(symbol)
+	if i := strings.IndexByte(s, '/'); i >= 0 {
+		s = s[:i]
+	}
+	return strings.ToUpper(strings.TrimSpace(s))
+}
+
+func hedgeTargetForPrimary(sc StrategyConfig, primarySide string, primaryQty, primaryPrice, hedgePrice float64) (hedgeTarget, error) {
+	if !hedgeEnabled(sc) || primaryQty <= hedgeQtyEpsilon {
+		return hedgeTarget{}, nil
+	}
+	if primaryPrice <= 0 || hedgePrice <= 0 {
+		return hedgeTarget{}, fmt.Errorf("hedge sizing requires positive primary and hedge prices")
+	}
+	side := ""
+	switch primarySide {
+	case "long":
+		side = "short"
+	case "short":
+		side = "long"
+	default:
+		return hedgeTarget{}, fmt.Errorf("invalid primary side %q", primarySide)
+	}
+	qty := primaryQty * primaryPrice * sc.Hedge.Ratio / hedgePrice
+	if math.IsNaN(qty) || math.IsInf(qty, 0) || qty <= hedgeQtyEpsilon {
+		return hedgeTarget{}, fmt.Errorf("resolved hedge quantity is not positive")
+	}
+	return hedgeTarget{Side: side, Quantity: qty}, nil
+}
+
+func planHedgeTransition(current *Position, target hedgeTarget) ([]hedgeOrder, error) {
+	if current != nil && (!current.IsHedge || current.Quantity <= 0 || (current.Side != "long" && current.Side != "short")) {
+		return nil, fmt.Errorf("ambiguous or corrupt hedge ownership state")
+	}
+	if target.Quantity < 0 || (target.Quantity > hedgeQtyEpsilon && target.Side != "long" && target.Side != "short") {
+		return nil, fmt.Errorf("invalid hedge target")
+	}
+	if current == nil {
+		if target.Quantity <= hedgeQtyEpsilon {
+			return nil, nil
+		}
+		return []hedgeOrder{{Side: openSideForPosition(target.Side), Quantity: target.Quantity}}, nil
+	}
+	if target.Quantity <= hedgeQtyEpsilon {
+		return []hedgeOrder{{Close: true, Quantity: current.Quantity, FullClose: true}}, nil
+	}
+	if current.Side != target.Side {
+		return []hedgeOrder{{Close: true, Quantity: current.Quantity, FullClose: true}, {Side: openSideForPosition(target.Side), Quantity: target.Quantity}}, nil
+	}
+	delta := target.Quantity - current.Quantity
+	if math.Abs(delta) <= hedgeQtyEpsilon {
+		return nil, nil
+	}
+	if delta > 0 {
+		return []hedgeOrder{{Side: openSideForPosition(target.Side), Quantity: delta}}, nil
+	}
+	return []hedgeOrder{{Close: true, Quantity: -delta}}, nil
+}
+
+func openSideForPosition(side string) string {
+	if side == "long" {
+		return "buy"
+	}
+	return "sell"
+}
+
+func validateHedgeConfigs(strategies []StrategyConfig) []string {
+	var errs []string
+	primaryOwners := make(map[string]string)
+	hedgeOwners := make(map[string]string)
+	for _, sc := range strategies {
+		if coin := hyperliquidConfiguredCoin(sc); coin != "" {
+			primaryOwners[coin] = sc.ID
+		}
+	}
+	for _, sc := range strategies {
+		if !hedgeEnabled(sc) {
+			continue
+		}
+		prefix := fmt.Sprintf("strategy[%s].hedge", sc.ID)
+		h := sc.Hedge
+		coin := hedgeCoin(sc)
+		primary := hyperliquidConfiguredCoin(sc)
+		if sc.Platform != "hyperliquid" || sc.Type != "perps" || !hyperliquidIsLive(sc.Args) || h.Platform != "hyperliquid" || h.Type != "perps" {
+			errs = append(errs, prefix+": phase 1 requires live Hyperliquid perps for both primary and hedge")
+		}
+		if coin == "" {
+			errs = append(errs, prefix+".symbol is required")
+		}
+		if h.Side != HedgeSideInverse {
+			errs = append(errs, prefix+".side must be \"inverse\"")
+		}
+		if h.Ratio <= 0 || math.IsNaN(h.Ratio) || math.IsInf(h.Ratio, 0) {
+			errs = append(errs, prefix+".ratio must be > 0")
+		}
+		if h.MarginMode != "isolated" && h.MarginMode != "cross" {
+			errs = append(errs, prefix+".margin_mode must be \"isolated\" or \"cross\"")
+		}
+		if h.Leverage < 1 || h.Leverage > 50 {
+			errs = append(errs, prefix+".leverage must be in [1, 50]")
+		}
+		if coin != "" && coin == primary {
+			errs = append(errs, prefix+".symbol matches its primary coin")
+		}
+		if owner, ok := primaryOwners[coin]; ok && owner != sc.ID {
+			errs = append(errs, fmt.Sprintf("%s.symbol matches configured strategy %s primary coin", prefix, owner))
+		}
+		if owner, ok := hedgeOwners[coin]; ok && owner != sc.ID {
+			errs = append(errs, fmt.Sprintf("%s.symbol is shared by hedge-enabled strategies %s and %s", prefix, owner, sc.ID))
+		} else if coin != "" {
+			hedgeOwners[coin] = sc.ID
+		}
+	}
+	return errs
+}
+
+func hedgeConfigEqual(a, b *HedgeConfig) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+// strategyHasOpenHedgeLeg reports whether s owns a live phase-1 hedge leg.
+func strategyHasOpenHedgeLeg(s *StrategyState) bool {
+	return findHedgePosition(s, StrategyConfig{}) != nil
+}
+
+func findHedgePosition(s *StrategyState, sc StrategyConfig) *Position {
+	if s == nil {
+		return nil
+	}
+	coin := hedgeCoin(sc)
+	for symbol, pos := range s.Positions {
+		if pos == nil || !pos.IsHedge || pos.Quantity <= hedgeQtyEpsilon {
+			continue
+		}
+		if coin == "" || strings.EqualFold(symbol, coin) {
+			return pos
+		}
+	}
+	return nil
+}
+
+func findPrimaryPosition(s *StrategyState, primarySym string) *Position {
+	if s == nil {
+		return nil
+	}
+	pos := s.Positions[primarySym]
+	if pos == nil || pos.IsHedge || pos.Quantity <= hedgeQtyEpsilon {
+		return nil
+	}
+	return pos
+}
+
+func applyHedgeOpen(s *StrategyState, sc StrategyConfig, primary *Position, side string, qty, px, fee float64, oid string, logger *StrategyLogger) *Trade {
+	if s == nil || primary == nil || qty <= 0 || px <= 0 || (side != "long" && side != "short") {
+		return nil
+	}
+	coin := hedgeCoin(sc)
+	if coin == "" {
+		return nil
+	}
+	now := time.Now().UTC()
+	primaryID := ensurePositionTradeID(sc.ID, primary.Symbol, primary)
+	pos := &Position{
+		Symbol: coin, Quantity: qty, InitialQuantity: qty,
+		AvgCost: px, Side: side, Multiplier: 1, Leverage: sc.Hedge.Leverage,
+		OwnerStrategyID: sc.ID, IsHedge: true,
+		HedgePrimarySymbol: primary.Symbol, HedgePrimaryPositionID: primaryID, OpenedAt: now,
+	}
+	pos.TradePositionID = primaryID + ":hedge"
+	s.Positions[coin] = pos
+	trade := Trade{
+		Timestamp: now, StrategyID: sc.ID, Symbol: coin, Side: openTradeSide(side),
+		Quantity: qty, Price: px, Value: qty * px, TradeType: "perps",
+		Details:    fmt.Sprintf("[hedge] open %s %s @ $%.4f", side, coin, px),
+		PositionID: pos.TradePositionID, ExchangeOrderID: oid,
+		ExchangeFee: fee, FeeSource: FeeSourceUserFills, PnLGross: true,
+	}
+	RecordTrade(s, trade)
+	s.Cash -= fee
+	if logger != nil {
+		logger.Info("[hedge] opened %s %.6f %s @ $%.4f", side, qty, coin, px)
+	}
+	return &trade
+}
+
+func applyHedgeScale(pos *Position, addQty, px float64) {
+	if pos == nil || !pos.IsHedge || addQty <= 0 || px <= 0 {
+		return
+	}
+	oldQty := pos.Quantity
+	newQty := oldQty + addQty
+	if newQty <= 0 {
+		return
+	}
+	pos.AvgCost = (oldQty*pos.AvgCost + addQty*px) / newQty
+	pos.Quantity = newQty
+	pos.InitialQuantity += addQty
+}

--- a/scheduler/hedge.go
+++ b/scheduler/hedge.go
@@ -38,6 +38,17 @@ func hyperliquidCoinFromSymbol(symbol string) string {
 	return strings.ToUpper(strings.TrimSpace(s))
 }
 
+func hedgeInverseSide(primarySide string) (string, error) {
+	switch primarySide {
+	case "long":
+		return "short", nil
+	case "short":
+		return "long", nil
+	default:
+		return "", fmt.Errorf("invalid primary side %q", primarySide)
+	}
+}
+
 func hedgeTargetForPrimary(sc StrategyConfig, primarySide string, primaryQty, primaryPrice, hedgePrice float64) (hedgeTarget, error) {
 	if !hedgeEnabled(sc) || primaryQty <= hedgeQtyEpsilon {
 		return hedgeTarget{}, nil
@@ -45,20 +56,49 @@ func hedgeTargetForPrimary(sc StrategyConfig, primarySide string, primaryQty, pr
 	if primaryPrice <= 0 || hedgePrice <= 0 {
 		return hedgeTarget{}, fmt.Errorf("hedge sizing requires positive primary and hedge prices")
 	}
-	side := ""
-	switch primarySide {
-	case "long":
-		side = "short"
-	case "short":
-		side = "long"
-	default:
-		return hedgeTarget{}, fmt.Errorf("invalid primary side %q", primarySide)
+	side, err := hedgeInverseSide(primarySide)
+	if err != nil {
+		return hedgeTarget{}, err
 	}
 	qty := primaryQty * primaryPrice * sc.Hedge.Ratio / hedgePrice
 	if math.IsNaN(qty) || math.IsInf(qty, 0) || qty <= hedgeQtyEpsilon {
 		return hedgeTarget{}, fmt.Errorf("resolved hedge quantity is not positive")
 	}
 	return hedgeTarget{Side: side, Quantity: qty}, nil
+}
+
+// hedgeTargetForLifecycle sizes the hedge from primary quantity only once a
+// frozen qty-per-primary-unit ratio exists. Live marks are used solely for a
+// fresh open (no hedge yet). Mark drift with an unchanged primary qty yields
+// a zero-order plan (#1159 review: no per-cycle rebalance churn).
+func hedgeTargetForLifecycle(sc StrategyConfig, primary, hedge *Position, primaryPrice, hedgePrice float64) (hedgeTarget, error) {
+	if !hedgeEnabled(sc) || primary == nil || primary.Quantity <= hedgeQtyEpsilon {
+		return hedgeTarget{}, nil
+	}
+	if hedge != nil && hedge.HedgeQtyPerPrimaryUnit > hedgeQtyEpsilon {
+		side, err := hedgeInverseSide(primary.Side)
+		if err != nil {
+			return hedgeTarget{}, err
+		}
+		qty := primary.Quantity * hedge.HedgeQtyPerPrimaryUnit
+		if math.IsNaN(qty) || math.IsInf(qty, 0) || qty <= hedgeQtyEpsilon {
+			return hedgeTarget{}, fmt.Errorf("resolved hedge quantity is not positive")
+		}
+		return hedgeTarget{Side: side, Quantity: qty}, nil
+	}
+	return hedgeTargetForPrimary(sc, primary.Side, primary.Quantity, primaryPrice, hedgePrice)
+}
+
+// ensureHedgeQtyPerPrimaryUnit stamps (or self-heals) the frozen qty ratio so
+// upgrades / pre-stamp positions stop mark-driven churn on the next sync.
+func ensureHedgeQtyPerPrimaryUnit(hedge, primary *Position) {
+	if hedge == nil || primary == nil || primary.Quantity <= hedgeQtyEpsilon || hedge.Quantity <= hedgeQtyEpsilon {
+		return
+	}
+	if hedge.HedgeQtyPerPrimaryUnit > hedgeQtyEpsilon {
+		return
+	}
+	hedge.HedgeQtyPerPrimaryUnit = hedge.Quantity / primary.Quantity
 }
 
 func planHedgeTransition(current *Position, target hedgeTarget) ([]hedgeOrder, error) {
@@ -100,10 +140,12 @@ func openSideForPosition(side string) string {
 func validateHedgeConfigs(strategies []StrategyConfig) []string {
 	var errs []string
 	primaryOwners := make(map[string]string)
+	primaryCounts := make(map[string]int)
 	hedgeOwners := make(map[string]string)
 	for _, sc := range strategies {
 		if coin := hyperliquidConfiguredCoin(sc); coin != "" {
 			primaryOwners[coin] = sc.ID
+			primaryCounts[coin]++
 		}
 	}
 	for _, sc := range strategies {
@@ -142,6 +184,12 @@ func validateHedgeConfigs(strategies []StrategyConfig) []string {
 			errs = append(errs, fmt.Sprintf("%s.symbol is shared by hedge-enabled strategies %s and %s", prefix, owner, sc.ID))
 		} else if coin != "" {
 			hedgeOwners[coin] = sc.ID
+		}
+		// Phase 1: hedge reconcile lives on the sole-owner primary path. A
+		// shared primary coin would skip that path and strand the hedge leg —
+		// reject at load so ownership stays structurally unambiguous (#1159 review).
+		if primary != "" && primaryCounts[primary] > 1 {
+			errs = append(errs, prefix+": phase 1 rejects hedge when the primary coin is shared with another strategy")
 		}
 	}
 	return errs
@@ -201,6 +249,9 @@ func applyHedgeOpen(s *StrategyState, sc StrategyConfig, primary *Position, side
 		AvgCost: px, Side: side, Multiplier: 1, Leverage: sc.Hedge.Leverage,
 		OwnerStrategyID: sc.ID, IsHedge: true,
 		HedgePrimarySymbol: primary.Symbol, HedgePrimaryPositionID: primaryID, OpenedAt: now,
+	}
+	if primary.Quantity > hedgeQtyEpsilon {
+		pos.HedgeQtyPerPrimaryUnit = qty / primary.Quantity
 	}
 	pos.TradePositionID = primaryID + ":hedge"
 	s.Positions[coin] = pos

--- a/scheduler/hedge_sync.go
+++ b/scheduler/hedge_sync.go
@@ -138,6 +138,17 @@ func syncStrategyHedge(sc StrategyConfig, s *StrategyState, primarySym string, p
 		return findPrimaryPosition(s, primarySym), findHedgePosition(s, sc)
 	}
 	primary, current := read()
+	if primary != nil && current != nil {
+		if mu != nil {
+			mu.Lock()
+		}
+		ensureHedgeQtyPerPrimaryUnit(current, primary)
+		if mu != nil {
+			mu.Unlock()
+		}
+		// Re-read after possible stamp so the plan uses the frozen ratio.
+		primary, current = read()
+	}
 	failClosed := func(reason error) (string, bool, error) {
 		// Primary is open but the required hedge cannot be established/sized —
 		// never leave an unhedged primary (#1159 constraint 4).
@@ -151,15 +162,30 @@ func syncStrategyHedge(sc StrategyConfig, s *StrategyState, primarySym string, p
 	}
 	target := hedgeTarget{}
 	if primary != nil {
-		target, err = hedgeTargetForPrimary(sc, primary.Side, primary.Quantity, prices[primarySym], prices[hedgeCoin(sc)])
+		target, err = hedgeTargetForLifecycle(sc, primary, current, prices[primarySym], prices[hedgeCoin(sc)])
 		if err != nil {
+			// Already-balanced hedged pair: hold through a transient mark gap.
+			// Fail-closed only when establishing a hedge for an unhedged primary
+			// (#1159 review judgment: spurious liquidation on data-feed gaps is worse).
+			if current != nil {
+				if logger != nil {
+					logger.Warn("[hedge] holding existing hedged pair through sizing gap: %v", err)
+				}
+				return "", false, nil
+			}
 			return failClosed(err)
 		}
 	}
 	orders, err := planHedgeTransition(current, target)
 	if err != nil {
-		if primary != nil {
+		if primary != nil && current == nil {
 			return failClosed(err)
+		}
+		if primary != nil && current != nil {
+			if logger != nil {
+				logger.Warn("[hedge] holding existing hedged pair through plan error: %v", err)
+			}
+			return "", false, nil
 		}
 		return "", false, err
 	}

--- a/scheduler/hedge_sync.go
+++ b/scheduler/hedge_sync.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type hedgeLiveExecFn func(script, symbol, side string, size float64, marginMode string, leverage float64, closeFull bool, snapshot hlExecuteSnapshot) (*HyperliquidExecuteResult, string, error)
+
+var hedgeLiveCloser HyperliquidLiveCloser = defaultHyperliquidLiveCloser
+
+func defaultHedgeLiveExec(script, symbol, side string, size float64, marginMode string, leverage float64, closeFull bool, snapshot hlExecuteSnapshot) (*HyperliquidExecuteResult, string, error) {
+	return RunHyperliquidExecute(script, symbol, side, size, 0, 0, 0, marginMode, leverage, closeFull, snapshot)
+}
+
+func hedgeFill(result *HyperliquidExecuteResult, fallback float64) (px, qty, fee float64, oid string, ok bool) {
+	if result != nil && result.Execution != nil && result.Execution.Fill != nil {
+		f := result.Execution.Fill
+		if f.AvgPx > 0 && f.TotalSz > 0 {
+			if f.OID > 0 {
+				oid = strconv.FormatInt(f.OID, 10)
+			}
+			return f.AvgPx, f.TotalSz, f.Fee, oid, true
+		}
+	}
+	return fallback, 0, 0, "", fallback > 0
+}
+
+func unwindPrimaryAfterHedgeFailure(sc StrategyConfig, s *StrategyState, primarySym string, prices map[string]float64, closer HyperliquidLiveCloser, notifier *MultiNotifier, logger *StrategyLogger, mu *sync.RWMutex) bool {
+	if s == nil {
+		return false
+	}
+	if closer == nil {
+		closer = hedgeLiveCloser
+	}
+	if mu != nil {
+		mu.RLock()
+	}
+	primary := clonePosition(findPrimaryPosition(s, primarySym))
+	if mu != nil {
+		mu.RUnlock()
+	}
+	if primary == nil {
+		return false
+	}
+	res, err := closer(primarySym, nil, hyperliquidProtectionCancelOIDs(primary))
+	if err != nil || res == nil || res.Close == nil || res.Close.Fill == nil {
+		if logger != nil {
+			logger.Error("[hedge] primary reduce-only unwind failed for %s: %v", primarySym, err)
+		}
+		return false
+	}
+	f := res.Close.Fill
+	oid := ""
+	if f.OID > 0 {
+		oid = strconv.FormatInt(f.OID, 10)
+	}
+	px := f.AvgPx
+	if px <= 0 {
+		px = prices[primarySym]
+	}
+	if mu != nil {
+		mu.Lock()
+	}
+	ok := bookPerpsCloseWithFillFee(s, primarySym, px, f.Fee, true, oid, "hedge_primary_unwind", "[hedge] primary unwind", "[hedge] primary unwind", logger)
+	if mu != nil {
+		mu.Unlock()
+	}
+	if !ok {
+		return false
+	}
+	// Owner DM must run outside mu — Discord/Telegram HTTP under Lock deadlocks SIGHUP.
+	if notifier != nil {
+		notifier.SendOwnerDM(fmt.Sprintf("[hedge] strategy %s unwound primary %s after hedge order failure", sc.ID, primarySym))
+	}
+	return true
+}
+
+func clonePosition(pos *Position) *Position {
+	if pos == nil {
+		return nil
+	}
+	clone := *pos
+	return &clone
+}
+
+func flattenHedgeAfterFailure(sc StrategyConfig, s *StrategyState, logger *StrategyLogger, mu *sync.RWMutex) bool {
+	if mu != nil {
+		mu.RLock()
+	}
+	hedge := clonePosition(findHedgePosition(s, sc))
+	if mu != nil {
+		mu.RUnlock()
+	}
+	if hedge == nil {
+		return true
+	}
+	res, err := hedgeLiveCloser(hedge.Symbol, nil, nil)
+	if err != nil || res == nil || res.Close == nil || res.Close.Fill == nil {
+		return false
+	}
+	f := res.Close.Fill
+	oid := ""
+	if f.OID > 0 {
+		oid = strconv.FormatInt(f.OID, 10)
+	}
+	if mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
+	}
+	return bookPerpsCloseWithFillFee(s, hedge.Symbol, f.AvgPx, f.Fee, true, oid, "hedge_failure_flatten", "[hedge] failure flatten", "[hedge] failure flatten", logger)
+}
+
+// syncStrategyHedge runs only after a confirmed primary fill has been applied
+// to virtual state. It converges the hedge to the primary's current notional.
+// Every reduction uses the reduce-only closer; a failed hedge increase
+// immediately unwinds the primary, preserving the fail-closed invariant.
+func syncStrategyHedge(sc StrategyConfig, s *StrategyState, primarySym string, prices map[string]float64, hlPositions []HLPosition, exec hedgeLiveExecFn, notifier *MultiNotifier, logger *StrategyLogger, mu *sync.RWMutex) (detail string, primaryUnwound bool, err error) {
+	if !hedgeEnabled(sc) || s == nil {
+		return "", false, nil
+	}
+	if exec == nil {
+		exec = defaultHedgeLiveExec
+	}
+	primarySym = hyperliquidCoinFromSymbol(primarySym)
+	if primarySym == "" {
+		primarySym = hyperliquidConfiguredCoin(sc)
+	}
+	read := func() (*Position, *Position) {
+		if mu != nil {
+			mu.RLock()
+			defer mu.RUnlock()
+		}
+		return findPrimaryPosition(s, primarySym), findHedgePosition(s, sc)
+	}
+	primary, current := read()
+	failClosed := func(reason error) (string, bool, error) {
+		// Primary is open but the required hedge cannot be established/sized —
+		// never leave an unhedged primary (#1159 constraint 4).
+		hedgeFlat := flattenHedgeAfterFailure(sc, s, logger, mu)
+		unwound := unwindPrimaryAfterHedgeFailure(sc, s, primarySym, prices, nil, notifier, logger, mu)
+		msg := fmt.Sprintf("CRITICAL [%s] hedge sync fail-closed (%v); primary_unwound=%t hedge_flat=%t", sc.ID, reason, unwound, hedgeFlat)
+		if notifier != nil {
+			notifier.SendOwnerDM(msg)
+		}
+		return "", unwound, fmt.Errorf("%s", msg)
+	}
+	target := hedgeTarget{}
+	if primary != nil {
+		target, err = hedgeTargetForPrimary(sc, primary.Side, primary.Quantity, prices[primarySym], prices[hedgeCoin(sc)])
+		if err != nil {
+			return failClosed(err)
+		}
+	}
+	orders, err := planHedgeTransition(current, target)
+	if err != nil {
+		if primary != nil {
+			return failClosed(err)
+		}
+		return "", false, err
+	}
+	var actions []string
+	for _, order := range orders {
+		coin := hedgeCoin(sc)
+		if order.Close {
+			var partial *float64
+			if !order.FullClose {
+				q := order.Quantity
+				partial = &q
+			}
+			res, callErr := hedgeLiveCloser(coin, partial, nil)
+			if callErr != nil || res == nil || res.Close == nil || res.Close.Fill == nil {
+				if callErr == nil {
+					callErr = fmt.Errorf("no confirmed hedge close fill")
+				}
+				return strings.Join(actions, "; "), false, fmt.Errorf("hedge reduce-only close failed: %w", callErr)
+			}
+			f := res.Close.Fill
+			if f.AvgPx <= 0 || f.TotalSz <= 0 {
+				return strings.Join(actions, "; "), false, fmt.Errorf("hedge reduce-only close for %s returned no usable fill (avg_px=%.6f total_sz=%.6f)", coin, f.AvgPx, f.TotalSz)
+			}
+			oid := ""
+			if f.OID > 0 {
+				oid = strconv.FormatInt(f.OID, 10)
+			}
+			if mu != nil {
+				mu.Lock()
+			}
+			booked := false
+			if order.FullClose {
+				booked = bookPerpsCloseWithFillFee(s, coin, f.AvgPx, f.Fee, true, oid, "hedge_close", "[hedge] close", "[hedge] close", logger)
+			} else {
+				booked = bookPerpsPartialCloseWithFillFee(s, coin, math.Min(f.TotalSz, order.Quantity), f.AvgPx, f.Fee, true, oid, "hedge_partial_close", "[hedge] partial close", "[hedge] partial close", logger)
+			}
+			if mu != nil {
+				mu.Unlock()
+			}
+			if !booked {
+				return strings.Join(actions, "; "), false, fmt.Errorf("hedge reduce-only close for %s filled on-chain but virtual booking failed", coin)
+			}
+			actions = append(actions, fmt.Sprintf("close %.6f %s", f.TotalSz, coin))
+			if mu != nil {
+				mu.RLock()
+			}
+			current = findHedgePosition(s, sc)
+			if mu != nil {
+				mu.RUnlock()
+			}
+			continue
+		}
+		marginMode, leverage := "", float64(0)
+		if current == nil {
+			marginMode, leverage = sc.Hedge.MarginMode, sc.Hedge.Leverage
+		}
+		result, stderr, callErr := exec(sc.Script, coin, order.Side, order.Quantity, marginMode, leverage, false, hlExecuteSnapshotForCoin(hlPositions, coin))
+		if callErr != nil {
+			hedgeFlat := flattenHedgeAfterFailure(sc, s, logger, mu)
+			unwound := unwindPrimaryAfterHedgeFailure(sc, s, primarySym, prices, nil, notifier, logger, mu)
+			msg := fmt.Sprintf("CRITICAL [%s] hedge exposure order failed; primary_unwound=%t hedge_flat=%t: %v", sc.ID, unwound, hedgeFlat, callErr)
+			if notifier != nil {
+				notifier.SendOwnerDM(msg)
+			}
+			return "", unwound, fmt.Errorf("%s", msg)
+		}
+		fillPx, fillQty, fee, oid, fillOK := hedgeFill(result, prices[coin])
+		if !fillOK || fillQty <= 0 || fillPx <= 0 {
+			hedgeFlat := flattenHedgeAfterFailure(sc, s, logger, mu)
+			unwound := unwindPrimaryAfterHedgeFailure(sc, s, primarySym, prices, nil, notifier, logger, mu)
+			return strings.Join(actions, "; "), unwound, fmt.Errorf("CRITICAL [%s] hedge order for %s returned no confirmed fill; primary_unwound=%t hedge_flat=%t (%s)", sc.ID, coin, unwound, hedgeFlat, strings.TrimSpace(stderr))
+		}
+		if mu != nil {
+			mu.Lock()
+		}
+		if current == nil {
+			applyHedgeOpen(s, sc, primary, target.Side, fillQty, fillPx, fee, oid, logger)
+			actions = append(actions, fmt.Sprintf("open %.6f %s", fillQty, coin))
+			current = s.Positions[coin]
+		} else {
+			applyHedgeScale(current, fillQty, fillPx)
+			trade := Trade{Timestamp: timeNowUTC(), StrategyID: sc.ID, Symbol: coin, PositionID: current.TradePositionID, Side: order.Side, Quantity: fillQty, Price: fillPx, Value: fillQty * fillPx, TradeType: "perps", Details: "[hedge] scale", ExchangeOrderID: oid, ExchangeFee: fee, FeeSource: FeeSourceUserFills}
+			RecordTrade(s, trade)
+			s.Cash -= fee
+			actions = append(actions, fmt.Sprintf("scale %.6f %s", fillQty, coin))
+		}
+		if mu != nil {
+			mu.Unlock()
+		}
+	}
+	return strings.Join(actions, "; "), false, nil
+}
+
+var timeNowUTC = func() time.Time { return time.Now().UTC() }

--- a/scheduler/hedge_test.go
+++ b/scheduler/hedge_test.go
@@ -373,10 +373,51 @@ func TestForceCloseHyperliquidLiveIncludesConfiguredAndOrphanHedgeCoins(t *testi
 			"SOL": {Symbol: "SOL", Quantity: 2, Side: "short", IsHedge: true},
 		}},
 	}
-	report := forceCloseHyperliquidLive(context.Background(), positions, []StrategyConfig{sc}, closer, nil, strategies)
+	traded := hyperliquidKillSwitchTradedCoins([]StrategyConfig{sc}, strategies)
+	report := forceCloseHyperliquidLive(context.Background(), positions, []StrategyConfig{sc}, closer, nil, traded)
 	for _, coin := range []string{"ETH", "BTC", "SOL"} {
 		if !closed[coin] {
 			t.Fatalf("expected kill-switch to close %s; closed=%v report=%+v", coin, closed, report)
 		}
+	}
+}
+
+func TestHyperliquidKillSwitchTradedCoinsSnapshotsUnderCaller(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	strategies := map[string]*StrategyState{
+		"a": {Positions: map[string]*Position{
+			"BTC": {Symbol: "BTC", Quantity: 0.1, Side: "short", IsHedge: true},
+			"SOL": {Symbol: "SOL", Quantity: 1, Side: "short", IsHedge: true},
+		}},
+	}
+	got := hyperliquidKillSwitchTradedCoins([]StrategyConfig{sc}, strategies)
+	for _, coin := range []string{"ETH", "BTC", "SOL"} {
+		if !got[coin] {
+			t.Fatalf("missing traded coin %s in %v", coin, got)
+		}
+	}
+	// nil strategies still covers configured primary + hedge
+	cfgOnly := hyperliquidKillSwitchTradedCoins([]StrategyConfig{sc}, nil)
+	if !cfgOnly["ETH"] || !cfgOnly["BTC"] || cfgOnly["SOL"] {
+		t.Fatalf("config-only snapshot = %v", cfgOnly)
+	}
+}
+
+func TestHedgeLifecycleDueIntervalCapsOpenExposure(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	open := &StrategyState{Positions: map[string]*Position{
+		"ETH": {Symbol: "ETH", Quantity: 1, Side: "long"},
+		"BTC": {Symbol: "BTC", Quantity: 0.02, Side: "short", IsHedge: true},
+	}}
+	if got := hedgeLifecycleDueInterval(sc, open, 14400, 60); got != 60 {
+		t.Fatalf("open hedged pair interval = %d, want global 60", got)
+	}
+	flat := &StrategyState{Positions: map[string]*Position{}}
+	if got := hedgeLifecycleDueInterval(sc, flat, 14400, 60); got != 14400 {
+		t.Fatalf("flat hedge strategy interval = %d, want strategy 14400", got)
+	}
+	sc.Hedge = nil
+	if got := hedgeLifecycleDueInterval(sc, open, 14400, 60); got != 14400 {
+		t.Fatalf("non-hedge strategy interval = %d, want unchanged", got)
 	}
 }

--- a/scheduler/hedge_test.go
+++ b/scheduler/hedge_test.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func hedgeTestConfig(id, symbol, hedgeSymbol string) StrategyConfig {
+	return StrategyConfig{
+		ID:             id,
+		Type:           "perps",
+		Platform:       "hyperliquid",
+		Script:         "shared_scripts/check_hyperliquid.py",
+		Args:           []string{"rsi", symbol, "--mode=live"},
+		Capital:        1000,
+		MaxDrawdownPct: 20,
+		Leverage:       3,
+		Hedge: &HedgeConfig{
+			Enabled:    true,
+			Symbol:     hedgeSymbol,
+			Side:       HedgeSideInverse,
+			Ratio:      0.5,
+			Platform:   "hyperliquid",
+			Type:       "perps",
+			MarginMode: "cross",
+			Leverage:   2,
+		},
+	}
+}
+
+func TestHedgeTargetInverseNotionalSizing(t *testing.T) {
+	sc := hedgeTestConfig("hl-eth", "ETH", "BTC")
+	target, err := hedgeTargetForPrimary(sc, "long", 4, 2500, 50000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.Side != "short" || target.Quantity != 0.1 {
+		t.Fatalf("target = %+v, want short 0.1 BTC", target)
+	}
+	target, err = hedgeTargetForPrimary(sc, "short", 2, 2500, 50000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.Side != "long" || target.Quantity != 0.05 {
+		t.Fatalf("target = %+v, want long 0.05 BTC", target)
+	}
+}
+
+func TestPlanHedgeTransitionLifecycle(t *testing.T) {
+	tests := []struct {
+		name string
+		from *Position
+		to   hedgeTarget
+		want []hedgeOrder
+	}{
+		{"open", nil, hedgeTarget{Side: "short", Quantity: 2}, []hedgeOrder{{Side: "sell", Quantity: 2}}},
+		{"scale", &Position{Side: "short", Quantity: 2, IsHedge: true}, hedgeTarget{Side: "short", Quantity: 3}, []hedgeOrder{{Side: "sell", Quantity: 1}}},
+		{"partial", &Position{Side: "short", Quantity: 3, IsHedge: true}, hedgeTarget{Side: "short", Quantity: 1}, []hedgeOrder{{Close: true, Quantity: 2}}},
+		{"full", &Position{Side: "short", Quantity: 3, IsHedge: true}, hedgeTarget{}, []hedgeOrder{{Close: true, Quantity: 3, FullClose: true}}},
+		{"flip", &Position{Side: "short", Quantity: 3, IsHedge: true}, hedgeTarget{Side: "long", Quantity: 2}, []hedgeOrder{{Close: true, Quantity: 3, FullClose: true}, {Side: "buy", Quantity: 2}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := planHedgeTransition(tc.from, tc.to)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("orders = %+v, want %+v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("orders[%d] = %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestValidateHedgeConfigRejectsCollisions(t *testing.T) {
+	tests := []struct {
+		name       string
+		strategies []StrategyConfig
+		want       string
+	}{
+		{"own coin", []StrategyConfig{hedgeTestConfig("a", "ETH", "ETH")}, "matches its primary coin"},
+		{"strategy coin", []StrategyConfig{hedgeTestConfig("a", "ETH", "BTC"), hedgeTestConfig("b", "BTC", "SOL")}, "matches configured strategy"},
+		{"shared hedge", []StrategyConfig{hedgeTestConfig("a", "ETH", "BTC"), hedgeTestConfig("b", "SOL", "BTC")}, "shared by hedge-enabled strategies"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateConfig(&Config{Strategies: tc.strategies}, true)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateHedgeConfigRejectsUnsupportedShape(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*StrategyConfig)
+		want string
+	}{
+		{"paper", func(sc *StrategyConfig) { sc.Args[2] = "--mode=paper" }, "live Hyperliquid perps"},
+		{"side", func(sc *StrategyConfig) { sc.Hedge.Side = "same" }, "side must be"},
+		{"ratio", func(sc *StrategyConfig) { sc.Hedge.Ratio = 0 }, "ratio must be > 0"},
+		{"margin", func(sc *StrategyConfig) { sc.Hedge.MarginMode = "" }, "margin_mode"},
+		{"leverage", func(sc *StrategyConfig) { sc.Hedge.Leverage = 0 }, "leverage must"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := hedgeTestConfig("a", "ETH", "BTC")
+			tc.edit(&sc)
+			err := validateConfig(&Config{Strategies: []StrategyConfig{sc}}, true)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestHedgeHotReloadBlockedWhileOpen(t *testing.T) {
+	old := hedgeTestConfig("a", "ETH", "BTC")
+	next := old
+	clone := *old.Hedge
+	clone.Ratio = 0.75
+	next.Hedge = &clone
+	state := &AppState{Strategies: map[string]*StrategyState{"a": {
+		Positions: map[string]*Position{"BTC": {Symbol: "BTC", Quantity: 0.1, Side: "short", IsHedge: true, HedgePrimarySymbol: "ETH"}},
+	}}}
+	err := validateHotReloadStateCompatible(&Config{Strategies: []StrategyConfig{old}}, &Config{Strategies: []StrategyConfig{next}}, state)
+	if err == nil || !strings.Contains(err.Error(), "hedge changed with an open hedge leg") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestStrategyHasOpenHedgeLegIgnoresPrimaryOnly(t *testing.T) {
+	s := &StrategyState{Positions: map[string]*Position{
+		"ETH": {Quantity: 1, Side: "long"},
+	}}
+	if strategyHasOpenHedgeLeg(s) {
+		t.Fatal("primary-only position must not count as hedge")
+	}
+}
+
+func TestApplyHedgeOpenStampsOwnershipMetadata(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	s := NewStrategyState(sc)
+	primary := &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: "long"}
+	trade := applyHedgeOpen(s, sc, primary, "short", 0.02, 50000, 0.25, "42", nil)
+	if trade == nil {
+		t.Fatal("expected hedge trade")
+	}
+	pos := s.Positions["BTC"]
+	if pos == nil || !pos.IsHedge || pos.OwnerStrategyID != sc.ID || pos.HedgePrimarySymbol != "ETH" || pos.HedgePrimaryPositionID == "" || pos.TradePositionID != pos.HedgePrimaryPositionID+":hedge" || pos.Multiplier != 1 || pos.Leverage != sc.Hedge.Leverage {
+		t.Fatalf("hedge position metadata = %+v", pos)
+	}
+	if !strings.Contains(trade.Details, "[hedge]") || trade.StrategyID != sc.ID {
+		t.Fatalf("hedge trade = %+v", trade)
+	}
+}
+
+func TestApplyHedgePartialAndFullCloseClearsResidual(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	s := NewStrategyState(sc)
+	s.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.03, InitialQuantity: 0.03, AvgCost: 50000, Side: "short", IsHedge: true, OwnerStrategyID: sc.ID}
+	if !bookPerpsPartialCloseWithFillFee(s, "BTC", 0.01, 49000, 0, false, "", "hedge_partial", "[hedge]", "[hedge]", nil) {
+		t.Fatal("partial hedge close failed")
+	}
+	if got := s.Positions["BTC"].Quantity; got < 0.019999 || got > 0.020001 {
+		t.Fatalf("remaining hedge quantity = %g", got)
+	}
+	if !bookPerpsCloseWithFillFee(s, "BTC", 49000, 0, false, "", "hedge_full", "[hedge]", "[hedge]", nil) {
+		t.Fatal("full hedge close failed")
+	}
+	if _, ok := s.Positions["BTC"]; ok {
+		t.Fatal("full hedge close left residual position")
+	}
+}
+
+func TestSyncStrategyHedge_ScaleInMirrorsNotional(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	s := NewStrategyState(sc)
+	s.Positions["ETH"] = &Position{Symbol: "ETH", Quantity: 2, AvgCost: 2500, Side: "long"}
+	s.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.04, InitialQuantity: 0.04, AvgCost: 50000, Side: "short", IsHedge: true}
+	var calls []float64
+	exec := func(_ string, symbol, side string, size float64, _ string, _ float64, _ bool, _ hlExecuteSnapshot) (*HyperliquidExecuteResult, string, error) {
+		calls = append(calls, size)
+		return &HyperliquidExecuteResult{Execution: &HyperliquidExecution{Symbol: symbol, Action: side, Fill: &HyperliquidFill{AvgPx: 50000, TotalSz: size}}}, "", nil
+	}
+	_, _, err := syncStrategyHedge(sc, s, "ETH", map[string]float64{"ETH": 3000, "BTC": 50000}, nil, exec, nil, nil, &sync.RWMutex{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 1 || calls[0] < 0.019999 || calls[0] > 0.020001 {
+		t.Fatalf("scale calls = %v, want 0.02", calls)
+	}
+	if got := s.Positions["BTC"].Quantity; got < 0.059999 || got > 0.060001 {
+		t.Fatalf("hedge quantity = %g, want 0.06", got)
+	}
+}
+
+func TestSyncStrategyHedge_FailedOpenUnwindsPrimary(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	s := NewStrategyState(sc)
+	s.Positions["ETH"] = &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: "long"}
+	oldCloser := hedgeLiveCloser
+	t.Cleanup(func() { hedgeLiveCloser = oldCloser })
+	hedgeLiveCloser = func(symbol string, partial *float64, _ []int64) (*HyperliquidCloseResult, error) {
+		if symbol != "ETH" || partial != nil {
+			t.Fatalf("unexpected rollback %s partial=%v", symbol, partial)
+		}
+		return &HyperliquidCloseResult{Close: &HyperliquidClose{Fill: &HyperliquidCloseFill{AvgPx: 1990, TotalSz: 1, OID: 9}}}, nil
+	}
+	exec := func(_ string, symbol, side string, _ float64, _ string, _ float64, _ bool, _ hlExecuteSnapshot) (*HyperliquidExecuteResult, string, error) {
+		if symbol == "BTC" {
+			return nil, "", fmt.Errorf("hedge unavailable")
+		}
+		return &HyperliquidExecuteResult{Execution: &HyperliquidExecution{Fill: &HyperliquidFill{AvgPx: 2000, TotalSz: 1}}}, "", nil
+	}
+	_, unwound, err := syncStrategyHedge(sc, s, "ETH", map[string]float64{"ETH": 2000, "BTC": 50000}, nil, exec, nil, nil, &sync.RWMutex{})
+	if err == nil || !unwound {
+		t.Fatalf("err=%v unwound=%v", err, unwound)
+	}
+	if len(s.Positions) != 0 {
+		t.Fatalf("positions after unwind = %+v", s.Positions)
+	}
+}
+
+func TestHedgeMetadataPersistsAcrossRestart(t *testing.T) {
+	db, err := OpenStateDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	state := &AppState{Strategies: map[string]*StrategyState{"a": {
+		ID: "a", Type: "perps", Platform: "hyperliquid", Positions: map[string]*Position{
+			"BTC": {Symbol: "BTC", TradePositionID: "primary-1:hedge", Quantity: 0.1, InitialQuantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 1, OwnerStrategyID: "a", IsHedge: true, HedgePrimarySymbol: "ETH", HedgePrimaryPositionID: "primary-1"},
+		}, OptionPositions: map[string]*OptionPosition{},
+	}}}
+	if err := db.SaveState(state); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := loaded.Strategies["a"].Positions["BTC"]
+	if h == nil || !h.IsHedge || h.HedgePrimarySymbol != "ETH" || h.HedgePrimaryPositionID != "primary-1" {
+		t.Fatalf("loaded hedge = %+v", h)
+	}
+}
+
+func TestSyncStrategyHedge_MissingMarkUnwindsPrimary(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	s := NewStrategyState(sc)
+	s.Positions["ETH"] = &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: "long"}
+	oldCloser := hedgeLiveCloser
+	t.Cleanup(func() { hedgeLiveCloser = oldCloser })
+	hedgeLiveCloser = func(symbol string, partial *float64, _ []int64) (*HyperliquidCloseResult, error) {
+		if symbol != "ETH" {
+			t.Fatalf("unexpected closer call for %s", symbol)
+		}
+		return &HyperliquidCloseResult{Close: &HyperliquidClose{Fill: &HyperliquidCloseFill{AvgPx: 1995, TotalSz: 1, OID: 11}}}, nil
+	}
+	_, unwound, err := syncStrategyHedge(sc, s, "ETH", map[string]float64{"ETH": 2000}, nil, nil, nil, nil, &sync.RWMutex{})
+	if err == nil || !unwound {
+		t.Fatalf("err=%v unwound=%v, want fail-closed unwind on missing hedge mark", err, unwound)
+	}
+	if len(s.Positions) != 0 {
+		t.Fatalf("positions after missing-mark unwind = %+v", s.Positions)
+	}
+}
+
+func TestHedgeHotReloadAllowedWhenFlat(t *testing.T) {
+	old := hedgeTestConfig("a", "ETH", "BTC")
+	next := old
+	clone := *old.Hedge
+	clone.Ratio = 0.75
+	next.Hedge = &clone
+	state := &AppState{Strategies: map[string]*StrategyState{"a": {Positions: map[string]*Position{}}}}
+	if err := validateHotReloadStateCompatible(&Config{Strategies: []StrategyConfig{old}}, &Config{Strategies: []StrategyConfig{next}}, state); err != nil {
+		t.Fatalf("flat hedge reload should be allowed: %v", err)
+	}
+}
+
+func TestCollectPerpsMarkSymbolsIncludesHedgeCoin(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	hl, okx := collectPerpsMarkSymbols([]StrategyConfig{sc})
+	if len(okx) != 0 {
+		t.Fatalf("okx coins = %v", okx)
+	}
+	want := map[string]bool{"ETH": true, "BTC": true}
+	for _, c := range hl {
+		delete(want, c)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing hedge/primary marks: %v (got %v)", want, hl)
+	}
+}
+
+func TestForceCloseHyperliquidLiveIncludesConfiguredAndOrphanHedgeCoins(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	positions := []HLPosition{
+		{Coin: "ETH", Size: 1},
+		{Coin: "BTC", Size: -0.1},
+		{Coin: "SOL", Size: -2}, // orphan IsHedge claim only
+	}
+	closed := map[string]bool{}
+	closer := func(coin string, _ *float64, _ []int64) (*HyperliquidCloseResult, error) {
+		closed[coin] = true
+		return &HyperliquidCloseResult{Close: &HyperliquidClose{Fill: &HyperliquidCloseFill{AvgPx: 1, TotalSz: 1}}}, nil
+	}
+	strategies := map[string]*StrategyState{
+		"a": {Positions: map[string]*Position{
+			"SOL": {Symbol: "SOL", Quantity: 2, Side: "short", IsHedge: true},
+		}},
+	}
+	report := forceCloseHyperliquidLive(context.Background(), positions, []StrategyConfig{sc}, closer, nil, strategies)
+	for _, coin := range []string{"ETH", "BTC", "SOL"} {
+		if !closed[coin] {
+			t.Fatalf("expected kill-switch to close %s; closed=%v report=%+v", coin, closed, report)
+		}
+	}
+}

--- a/scheduler/hedge_test.go
+++ b/scheduler/hedge_test.go
@@ -158,7 +158,7 @@ func TestApplyHedgeOpenStampsOwnershipMetadata(t *testing.T) {
 		t.Fatal("expected hedge trade")
 	}
 	pos := s.Positions["BTC"]
-	if pos == nil || !pos.IsHedge || pos.OwnerStrategyID != sc.ID || pos.HedgePrimarySymbol != "ETH" || pos.HedgePrimaryPositionID == "" || pos.TradePositionID != pos.HedgePrimaryPositionID+":hedge" || pos.Multiplier != 1 || pos.Leverage != sc.Hedge.Leverage {
+	if pos == nil || !pos.IsHedge || pos.OwnerStrategyID != sc.ID || pos.HedgePrimarySymbol != "ETH" || pos.HedgePrimaryPositionID == "" || pos.TradePositionID != pos.HedgePrimaryPositionID+":hedge" || pos.Multiplier != 1 || pos.Leverage != sc.Hedge.Leverage || pos.HedgeQtyPerPrimaryUnit != 0.02 {
 		t.Fatalf("hedge position metadata = %+v", pos)
 	}
 	if !strings.Contains(trade.Details, "[hedge]") || trade.StrategyID != sc.ID {
@@ -187,8 +187,9 @@ func TestApplyHedgePartialAndFullCloseClearsResidual(t *testing.T) {
 func TestSyncStrategyHedge_ScaleInMirrorsNotional(t *testing.T) {
 	sc := hedgeTestConfig("a", "ETH", "BTC")
 	s := NewStrategyState(sc)
-	s.Positions["ETH"] = &Position{Symbol: "ETH", Quantity: 2, AvgCost: 2500, Side: "long"}
-	s.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.04, InitialQuantity: 0.04, AvgCost: 50000, Side: "short", IsHedge: true}
+	// Primary scaled from 2→3; frozen ratio 0.02 keeps mark drift out of the plan.
+	s.Positions["ETH"] = &Position{Symbol: "ETH", Quantity: 3, AvgCost: 2500, Side: "long"}
+	s.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.04, InitialQuantity: 0.04, AvgCost: 50000, Side: "short", IsHedge: true, HedgeQtyPerPrimaryUnit: 0.02}
 	var calls []float64
 	exec := func(_ string, symbol, side string, size float64, _ string, _ float64, _ bool, _ hlExecuteSnapshot) (*HyperliquidExecuteResult, string, error) {
 		calls = append(calls, size)
@@ -203,6 +204,28 @@ func TestSyncStrategyHedge_ScaleInMirrorsNotional(t *testing.T) {
 	}
 	if got := s.Positions["BTC"].Quantity; got < 0.059999 || got > 0.060001 {
 		t.Fatalf("hedge quantity = %g, want 0.06", got)
+	}
+}
+
+func TestSyncStrategyHedge_MarkDriftDoesNotRebalance(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	s := NewStrategyState(sc)
+	s.Positions["ETH"] = &Position{Symbol: "ETH", Quantity: 2, AvgCost: 2500, Side: "long"}
+	s.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.04, InitialQuantity: 0.04, AvgCost: 50000, Side: "short", IsHedge: true, HedgeQtyPerPrimaryUnit: 0.02}
+	calls := 0
+	exec := func(_ string, _ string, _ string, _ float64, _ string, _ float64, _ bool, _ hlExecuteSnapshot) (*HyperliquidExecuteResult, string, error) {
+		calls++
+		return &HyperliquidExecuteResult{Execution: &HyperliquidExecution{Fill: &HyperliquidFill{AvgPx: 1, TotalSz: 1}}}, "", nil
+	}
+	detail, _, err := syncStrategyHedge(sc, s, "ETH", map[string]float64{"ETH": 3000, "BTC": 51000}, nil, exec, nil, nil, &sync.RWMutex{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 0 || detail != "" {
+		t.Fatalf("mark drift must not rebalance: calls=%d detail=%q", calls, detail)
+	}
+	if got := s.Positions["BTC"].Quantity; got != 0.04 {
+		t.Fatalf("hedge quantity changed to %g", got)
 	}
 }
 
@@ -233,31 +256,7 @@ func TestSyncStrategyHedge_FailedOpenUnwindsPrimary(t *testing.T) {
 	}
 }
 
-func TestHedgeMetadataPersistsAcrossRestart(t *testing.T) {
-	db, err := OpenStateDB(filepath.Join(t.TempDir(), "state.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { db.Close() })
-	state := &AppState{Strategies: map[string]*StrategyState{"a": {
-		ID: "a", Type: "perps", Platform: "hyperliquid", Positions: map[string]*Position{
-			"BTC": {Symbol: "BTC", TradePositionID: "primary-1:hedge", Quantity: 0.1, InitialQuantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 1, OwnerStrategyID: "a", IsHedge: true, HedgePrimarySymbol: "ETH", HedgePrimaryPositionID: "primary-1"},
-		}, OptionPositions: map[string]*OptionPosition{},
-	}}}
-	if err := db.SaveState(state); err != nil {
-		t.Fatal(err)
-	}
-	loaded, err := db.LoadState()
-	if err != nil {
-		t.Fatal(err)
-	}
-	h := loaded.Strategies["a"].Positions["BTC"]
-	if h == nil || !h.IsHedge || h.HedgePrimarySymbol != "ETH" || h.HedgePrimaryPositionID != "primary-1" {
-		t.Fatalf("loaded hedge = %+v", h)
-	}
-}
-
-func TestSyncStrategyHedge_MissingMarkUnwindsPrimary(t *testing.T) {
+func TestSyncStrategyHedge_MissingMarkUnwindsUnhedgedPrimary(t *testing.T) {
 	sc := hedgeTestConfig("a", "ETH", "BTC")
 	s := NewStrategyState(sc)
 	s.Positions["ETH"] = &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: "long"}
@@ -271,10 +270,62 @@ func TestSyncStrategyHedge_MissingMarkUnwindsPrimary(t *testing.T) {
 	}
 	_, unwound, err := syncStrategyHedge(sc, s, "ETH", map[string]float64{"ETH": 2000}, nil, nil, nil, nil, &sync.RWMutex{})
 	if err == nil || !unwound {
-		t.Fatalf("err=%v unwound=%v, want fail-closed unwind on missing hedge mark", err, unwound)
+		t.Fatalf("err=%v unwound=%v, want fail-closed unwind when establishing hedge without marks", err, unwound)
 	}
 	if len(s.Positions) != 0 {
 		t.Fatalf("positions after missing-mark unwind = %+v", s.Positions)
+	}
+}
+
+func TestSyncStrategyHedge_MissingMarkHoldsExistingPair(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	s := NewStrategyState(sc)
+	s.Positions["ETH"] = &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: "long"}
+	s.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.02, AvgCost: 50000, Side: "short", IsHedge: true, HedgeQtyPerPrimaryUnit: 0.02}
+	detail, unwound, err := syncStrategyHedge(sc, s, "ETH", map[string]float64{"ETH": 2000}, nil, nil, nil, nil, &sync.RWMutex{})
+	if err != nil || unwound || detail != "" {
+		t.Fatalf("want hold: err=%v unwound=%v detail=%q", err, unwound, detail)
+	}
+	if s.Positions["ETH"] == nil || s.Positions["BTC"] == nil {
+		t.Fatalf("existing hedged pair must survive missing hedge mark: %+v", s.Positions)
+	}
+}
+
+func TestValidateHedgeConfigRejectsSharedPrimaryCoin(t *testing.T) {
+	a := hedgeTestConfig("a", "ETH", "BTC")
+	b := StrategyConfig{
+		ID: "b", Type: "perps", Platform: "hyperliquid",
+		Script:  "shared_scripts/check_hyperliquid.py",
+		Args:    []string{"rsi", "ETH", "--mode=live"},
+		Capital: 1000, MaxDrawdownPct: 20, Leverage: 3,
+	}
+	err := validateConfig(&Config{Strategies: []StrategyConfig{a, b}}, true)
+	if err == nil || !strings.Contains(err.Error(), "primary coin is shared") {
+		t.Fatalf("error = %v, want shared primary rejection", err)
+	}
+}
+
+func TestHedgeMetadataPersistsAcrossRestart(t *testing.T) {
+	db, err := OpenStateDB(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	state := &AppState{Strategies: map[string]*StrategyState{"a": {
+		ID: "a", Type: "perps", Platform: "hyperliquid", Positions: map[string]*Position{
+			"BTC": {Symbol: "BTC", TradePositionID: "primary-1:hedge", Quantity: 0.1, InitialQuantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 1, OwnerStrategyID: "a", IsHedge: true, HedgePrimarySymbol: "ETH", HedgePrimaryPositionID: "primary-1", HedgeQtyPerPrimaryUnit: 0.05},
+		}, OptionPositions: map[string]*OptionPosition{},
+	}}}
+	if err := db.SaveState(state); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := loaded.Strategies["a"].Positions["BTC"]
+	if h == nil || !h.IsHedge || h.HedgePrimarySymbol != "ETH" || h.HedgePrimaryPositionID != "primary-1" || h.HedgeQtyPerPrimaryUnit != 0.05 {
+		t.Fatalf("loaded hedge = %+v", h)
 	}
 }
 

--- a/scheduler/hedge_test.go
+++ b/scheduler/hedge_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func hedgeTestConfig(id, symbol, hedgeSymbol string) StrategyConfig {
@@ -403,21 +404,79 @@ func TestHyperliquidKillSwitchTradedCoinsSnapshotsUnderCaller(t *testing.T) {
 	}
 }
 
-func TestHedgeLifecycleDueIntervalCapsOpenExposure(t *testing.T) {
+func TestHedgeNeedsLifecycleSyncAndDelayCap(t *testing.T) {
 	sc := hedgeTestConfig("a", "ETH", "BTC")
 	open := &StrategyState{Positions: map[string]*Position{
 		"ETH": {Symbol: "ETH", Quantity: 1, Side: "long"},
 		"BTC": {Symbol: "BTC", Quantity: 0.02, Side: "short", IsHedge: true},
 	}}
-	if got := hedgeLifecycleDueInterval(sc, open, 14400, 60); got != 60 {
-		t.Fatalf("open hedged pair interval = %d, want global 60", got)
+	if !hedgeNeedsLifecycleSync(sc, open) {
+		t.Fatal("expected open hedged pair to need lifecycle sync")
 	}
 	flat := &StrategyState{Positions: map[string]*Position{}}
-	if got := hedgeLifecycleDueInterval(sc, flat, 14400, 60); got != 14400 {
-		t.Fatalf("flat hedge strategy interval = %d, want strategy 14400", got)
+	if hedgeNeedsLifecycleSync(sc, flat) {
+		t.Fatal("flat hedge strategy must not need lifecycle sync")
 	}
-	sc.Hedge = nil
-	if got := hedgeLifecycleDueInterval(sc, open, 14400, 60); got != 14400 {
-		t.Fatalf("non-hedge strategy interval = %d, want unchanged", got)
+	scNoHedge := hedgeTestConfig("b", "ETH", "BTC")
+	scNoHedge.Hedge = nil
+	if hedgeNeedsLifecycleSync(scNoHedge, open) {
+		t.Fatal("non-hedge strategy must not need lifecycle sync")
+	}
+
+	candidates := collectHedgeLifecycleCandidates(
+		[]StrategyConfig{sc, scNoHedge},
+		map[string]*StrategyState{"a": open, "b": open},
+	)
+	if len(candidates) != 1 || candidates[0].ID != "a" {
+		t.Fatalf("candidates = %+v, want only strategy a", candidates)
+	}
+
+	merged := mergeStrategyConfigsByID([]StrategyConfig{sc}, []StrategyConfig{sc, scNoHedge})
+	if len(merged) != 2 || merged[0].ID != "a" || merged[1].ID != "b" {
+		t.Fatalf("merge = %+v", merged)
+	}
+
+	got := capDelayForHedgeLifecycle(4*time.Hour, []StrategyConfig{sc}, map[string]*StrategyState{"a": open}, 60)
+	if got != time.Minute {
+		t.Fatalf("open-hedge delay cap = %v, want 1m", got)
+	}
+	got = capDelayForHedgeLifecycle(4*time.Hour, []StrategyConfig{sc}, map[string]*StrategyState{"a": flat}, 60)
+	if got != 4*time.Hour {
+		t.Fatalf("flat delay = %v, want unchanged 4h", got)
+	}
+}
+
+func TestApplyHedgeKillSwitchCloseFillMatchesPrimaryCloseReason(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	s := &StrategyState{
+		Cash: 10000,
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 2000, OpenedAt: time.Now().UTC()},
+			"BTC": {Symbol: "BTC", Quantity: 0.02, Side: "short", AvgCost: 50000, IsHedge: true, OpenedAt: time.Now().UTC()},
+		},
+	}
+	fills := map[string]HyperliquidCloseFill{
+		"ETH": {AvgPx: 2100, TotalSz: 1, Fee: 1, OID: 11},
+		"BTC": {AvgPx: 51000, TotalSz: 0.02, Fee: 0.5, OID: 12},
+	}
+	virtual := snapshotHyperliquidVirtualQuantities(map[string]*StrategyState{"a": s}, []StrategyConfig{sc})
+	if !applyHyperliquidKillSwitchCloseFill(s, sc, fills, []StrategyConfig{sc}, virtual) {
+		t.Fatal("expected kill-switch fill apply")
+	}
+	if len(s.Positions) != 0 {
+		t.Fatalf("expected both legs flat, still have %v", s.Positions)
+	}
+	if len(s.ClosedPositions) < 2 {
+		t.Fatalf("expected 2 closed positions, got %d", len(s.ClosedPositions))
+	}
+	reasons := map[string]string{}
+	for _, cp := range s.ClosedPositions {
+		reasons[cp.Symbol] = cp.CloseReason
+	}
+	if reasons["ETH"] != reasons["BTC"] {
+		t.Fatalf("paired kill-switch legs must share close_reason; got %v", reasons)
+	}
+	if reasons["ETH"] != "circuit_breaker" {
+		t.Fatalf("expected defaulted circuit_breaker reason, got %v", reasons)
 	}
 }

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -827,6 +827,9 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 			continue
 		}
 		coinStrategies[sym] = append(coinStrategies[sym], sc.ID)
+		if hedge := hedgeCoin(sc); hedge != "" {
+			coinStrategies[hedge] = append(coinStrategies[hedge], sc.ID)
+		}
 	}
 	strategyByID := make(map[string]StrategyConfig, len(allStrategies))
 	for _, sc := range allStrategies {
@@ -861,6 +864,18 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 		}
 		if reconcileHyperliquidPositionsForStrategy(sc, ss, sym, positions, resolveFee, logger, &pendingAlerts, &pendingOrphanCloses) {
 			changed = true
+		}
+		if hedgeEnabled(sc) {
+			hedgeSym := hedgeCoin(sc)
+			if hedgeSym != "" && findHedgePosition(ss, sc) != nil {
+				// Hedge ownership comes from the persisted IsHedge metadata above,
+				// never coin→configured-primary inference. Use the low-level
+				// reconciler with an empty config so hedge legs cannot acquire the
+				// primary's TP/SL or regime-direction policies.
+				if reconcileHyperliquidPositionsWithResolver(ss, hedgeSym, positions, resolveFee, logger, &pendingAlerts, nil, StrategyConfig{}) {
+					changed = true
+				}
+			}
 		}
 	}
 
@@ -1949,19 +1964,16 @@ func (r HyperliquidLiveCloseReport) SortedErrorCoins() []string {
 // should be cancelled before the close fires, so kill-switch flattening
 // doesn't leave orphan triggers consuming HL's open-order cap (#421, #479).
 // nil/empty disables the cancel; the closer is otherwise unchanged.
-func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLiveAll []StrategyConfig, closer HyperliquidLiveCloser, stopLossOIDsByCoin map[string][]int64) HyperliquidLiveCloseReport {
+func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLiveAll []StrategyConfig, closer HyperliquidLiveCloser, stopLossOIDsByCoin map[string][]int64, strategies map[string]*StrategyState) HyperliquidLiveCloseReport {
 	report := HyperliquidLiveCloseReport{
 		Fills:  make(map[string]HyperliquidCloseFill),
 		Errors: make(map[string]error),
 	}
 
-	tradedCoins := make(map[string]bool)
-	for _, sc := range hlLiveAll {
-		sym := hyperliquidSymbol(sc.Args)
-		if sym != "" {
-			tradedCoins[sym] = true
-		}
-	}
+	// strategies may be nil in unit tests that only exercise configured coins;
+	// production kill-switch threads AppState.Strategies so orphan IsHedge
+	// claims still flatten (#1159).
+	tradedCoins := hyperliquidKillSwitchTradedCoins(hlLiveAll, strategies)
 
 	for _, p := range positions {
 		if !tradedCoins[p.Coin] {
@@ -2007,6 +2019,36 @@ func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLi
 	}
 
 	return report
+}
+
+// hyperliquidKillSwitchTradedCoins returns the HL coins owned by the live
+// scheduler, including configured phase-1 hedge legs and state-only hedge
+// claims left by a removed/temporarily invalid config (#1159).
+func hyperliquidKillSwitchTradedCoins(hlLiveAll []StrategyConfig, strategies map[string]*StrategyState) map[string]bool {
+	tradedCoins := make(map[string]bool)
+	for _, sc := range hlLiveAll {
+		sym := hyperliquidSymbol(sc.Args)
+		if sym == "" {
+			sym = hyperliquidConfiguredCoin(sc)
+		}
+		if sym != "" {
+			tradedCoins[sym] = true
+		}
+		if hedge := hedgeCoin(sc); hedge != "" {
+			tradedCoins[hedge] = true
+		}
+	}
+	for _, ss := range strategies {
+		if ss == nil {
+			continue
+		}
+		for symbol, pos := range ss.Positions {
+			if pos != nil && pos.IsHedge && pos.Quantity > 0 {
+				tradedCoins[strings.ToUpper(strings.TrimSpace(symbol))] = true
+			}
+		}
+	}
+	return tradedCoins
 }
 
 func hlLiveStrategiesForCoin(coin string, hlLiveAll []StrategyConfig) []StrategyConfig {
@@ -2064,6 +2106,13 @@ func snapshotHyperliquidVirtualQuantities(strategies map[string]*StrategyState, 
 			out[coin] = make(map[string]float64)
 		}
 		out[coin][sc.ID] = pos.Quantity
+		if hedge := findHedgePosition(ss, sc); hedge != nil {
+			hedgeCoinName := strings.ToUpper(strings.TrimSpace(hedge.Symbol))
+			if out[hedgeCoinName] == nil {
+				out[hedgeCoinName] = make(map[string]float64)
+			}
+			out[hedgeCoinName][sc.ID] = hedge.Quantity
+		}
 	}
 	if len(out) == 0 {
 		return nil
@@ -2154,9 +2203,28 @@ func applyHyperliquidKillSwitchCloseFill(s *StrategyState, sc StrategyConfig, fi
 	}
 	fillSz, fillFee := hyperliquidKillSwitchFillShare(sc, coin, fill.TotalSz, fill.Fee, hlLiveAll, virtualQty)
 	if fillSz <= 1e-15 {
-		return false
+		return applyHedgeKillSwitchCloseFill(s, sc, fills, hlLiveAll, virtualQty)
 	}
 	applyHyperliquidCircuitCloseFill(s, coin, fillSz, fill.AvgPx, fillFee, 0, fill.OID, "")
+	applyHedgeKillSwitchCloseFill(s, sc, fills, hlLiveAll, virtualQty)
+	return true
+}
+
+func applyHedgeKillSwitchCloseFill(s *StrategyState, sc StrategyConfig, fills map[string]HyperliquidCloseFill, hlLiveAll []StrategyConfig, virtualQty hlVirtualQuantitySnapshot) bool {
+	hedge := findHedgePosition(s, sc)
+	if hedge == nil {
+		return false
+	}
+	coin := strings.ToUpper(strings.TrimSpace(hedge.Symbol))
+	fill, ok := fills[coin]
+	if !ok || fill.TotalSz <= 1e-15 || fill.AvgPx <= 0 {
+		return false
+	}
+	fillSz, fillFee := hyperliquidKillSwitchFillShare(sc, coin, fill.TotalSz, fill.Fee, hlLiveAll, virtualQty)
+	if fillSz <= 1e-15 {
+		return false
+	}
+	applyHyperliquidCircuitCloseFill(s, coin, fillSz, fill.AvgPx, fillFee, 0, fill.OID, "circuit_breaker")
 	return true
 }
 
@@ -2286,9 +2354,11 @@ func runPendingHyperliquidCircuitCloses(
 			if !ok || qty <= 0 {
 				continue
 			}
-			ss.RiskState.setPendingCircuitClose(PlatformPendingCloseHyperliquid, &PendingCircuitClose{
-				Symbols: []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}},
-			})
+			symbols := []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}}
+			if hedge := findHedgePosition(ss, sc); hedge != nil {
+				symbols = append(symbols, PendingCircuitCloseSymbol{Symbol: hedge.Symbol, Size: hedge.Quantity})
+			}
+			ss.RiskState.setPendingCircuitClose(PlatformPendingCloseHyperliquid, &PendingCircuitClose{Symbols: symbols})
 			fmt.Printf("[CRITICAL] hl-circuit-close: recovered pending for strategy %s coin %s sz=%.6f (CB latched, HL fetch had failed at fire time)\n",
 				sc.ID, sym, qty)
 		}
@@ -2316,8 +2386,24 @@ func runPendingHyperliquidCircuitCloses(
 		if p == nil || len(p.Symbols) == 0 {
 			continue
 		}
-		slOIDs := make(map[string][]int64, len(p.Symbols))
-		for _, c := range p.Symbols {
+		pending := *p
+		sc := lookupStrategyConfig(strategies, id)
+		if sc != nil && hedgeEnabled(*sc) {
+			if hedge := findHedgePosition(ss, *sc); hedge != nil {
+				found := false
+				for _, c := range pending.Symbols {
+					if c.Symbol == hedge.Symbol {
+						found = true
+						break
+					}
+				}
+				if !found {
+					pending.Symbols = append(pending.Symbols, PendingCircuitCloseSymbol{Symbol: hedge.Symbol, Size: hedge.Quantity})
+				}
+			}
+		}
+		slOIDs := make(map[string][]int64, len(pending.Symbols))
+		for _, c := range pending.Symbols {
 			if pos, ok := ss.Positions[c.Symbol]; ok && pos != nil {
 				slOIDs[c.Symbol] = appendUniquePositiveStopLossOID(slOIDs[c.Symbol], pos.StopLossOID)
 				for _, tpOID := range pos.TPOIDs {
@@ -2325,7 +2411,7 @@ func runPendingHyperliquidCircuitCloses(
 				}
 			}
 		}
-		jobs = append(jobs, job{id, *p, slOIDs})
+		jobs = append(jobs, job{id, pending, slOIDs})
 	}
 	mu.RUnlock()
 

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1967,16 +1967,17 @@ func (r HyperliquidLiveCloseReport) SortedErrorCoins() []string {
 // should be cancelled before the close fires, so kill-switch flattening
 // doesn't leave orphan triggers consuming HL's open-order cap (#421, #479).
 // nil/empty disables the cancel; the closer is otherwise unchanged.
-func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLiveAll []StrategyConfig, closer HyperliquidLiveCloser, stopLossOIDsByCoin map[string][]int64, strategies map[string]*StrategyState) HyperliquidLiveCloseReport {
+func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLiveAll []StrategyConfig, closer HyperliquidLiveCloser, stopLossOIDsByCoin map[string][]int64, tradedCoins map[string]bool) HyperliquidLiveCloseReport {
 	report := HyperliquidLiveCloseReport{
 		Fills:  make(map[string]HyperliquidCloseFill),
 		Errors: make(map[string]error),
 	}
 
-	// strategies may be nil in unit tests that only exercise configured coins;
-	// production kill-switch threads AppState.Strategies so orphan IsHedge
-	// claims still flatten (#1159).
-	tradedCoins := hyperliquidKillSwitchTradedCoins(hlLiveAll, strategies)
+	// tradedCoins must be a snapshot taken under mu by the caller. nil is the
+	// unit-test path: derive from config only (no live state.Strategies range).
+	if tradedCoins == nil {
+		tradedCoins = hyperliquidKillSwitchTradedCoins(hlLiveAll, nil)
+	}
 
 	for _, p := range positions {
 		if !tradedCoins[p.Coin] {

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -2228,7 +2228,11 @@ func applyHedgeKillSwitchCloseFill(s *StrategyState, sc StrategyConfig, fills ma
 	if fillSz <= 1e-15 {
 		return false
 	}
-	applyHyperliquidCircuitCloseFill(s, coin, fillSz, fill.AvgPx, fillFee, 0, fill.OID, "circuit_breaker")
+	// Same closeReason as the primary kill-switch path above ("" → defaults
+	// to circuit_breaker inside applyHyperliquidCircuitCloseFill). Keep the
+	// args identical so paired legs of one flatten never diverge if the
+	// defaulting rule changes (#1159 review optional).
+	applyHyperliquidCircuitCloseFill(s, coin, fillSz, fill.AvgPx, fillFee, 0, fill.OID, "")
 	return true
 }
 

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -845,6 +845,10 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 	}
 
 	// Reconcile non-shared coins normally for due strategies.
+	// Hedge legs are reconciled independently of whether the primary coin is
+	// shared — ownership comes from persisted IsHedge metadata (#1159 review).
+	// Phase-1 validation also rejects hedge+shared-primary, so the shared
+	// continue below is defense-in-depth for the primary path only.
 	for _, sc := range dueStrategies {
 		ss := state.Strategies[sc.ID]
 		if ss == nil {
@@ -854,16 +858,15 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 		if sym == "" {
 			continue
 		}
-		if sharedCoins[sym] {
-			continue // handled below
-		}
 		logger, err := logMgr.GetStrategyLogger(sc.ID)
 		if err != nil {
 			fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", sc.ID, err)
 			continue
 		}
-		if reconcileHyperliquidPositionsForStrategy(sc, ss, sym, positions, resolveFee, logger, &pendingAlerts, &pendingOrphanCloses) {
-			changed = true
+		if !sharedCoins[sym] {
+			if reconcileHyperliquidPositionsForStrategy(sc, ss, sym, positions, resolveFee, logger, &pendingAlerts, &pendingOrphanCloses) {
+				changed = true
+			}
 		}
 		if hedgeEnabled(sc) {
 			hedgeSym := hedgeCoin(sc)

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -2759,7 +2759,7 @@ func TestForceCloseHyperliquidLive_NonSharedCoin(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors, got %v", report.Errors)
@@ -2788,7 +2788,7 @@ func TestForceCloseHyperliquidLive_SharedCoinEmptyVirtual(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors, got %v", report.Errors)
@@ -2819,7 +2819,7 @@ func TestForceCloseHyperliquidLive_NetZeroSziAlreadyFlat(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors for net-zero coin, got %v", report.Errors)
@@ -2852,7 +2852,7 @@ func TestForceCloseHyperliquidLive_ShortPosition(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors, got %v", report.Errors)
@@ -2884,7 +2884,7 @@ func TestForceCloseHyperliquidLive_ClosePartialFailure(t *testing.T) {
 	closeErr := fmt.Errorf("hl rate limited")
 	closer, _ := fakeCloser(map[string]error{"BTC": closeErr})
 
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.ClosedCoins) != 1 || report.ClosedCoins[0] != "ETH" {
 		t.Errorf("ClosedCoins = %v, want [ETH]", report.ClosedCoins)
@@ -2913,7 +2913,7 @@ func TestForceCloseHyperliquidLive_UnownedPositionIgnored(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.ClosedCoins) != 1 || report.ClosedCoins[0] != "ETH" {
 		t.Errorf("ClosedCoins = %v, want [ETH]", report.ClosedCoins)
@@ -2933,7 +2933,7 @@ func TestForceCloseHyperliquidLive_EmptyInputs(t *testing.T) {
 	report := forceCloseHyperliquidLive(context.Background(), nil, nil, func(string, *float64, []int64) (*HyperliquidCloseResult, error) {
 		t.Fatalf("closer should not be called with empty inputs")
 		return nil, nil
-	}, nil)
+	}, nil, nil)
 	if len(report.ClosedCoins) != 0 || len(report.AlreadyFlat) != 0 || len(report.Errors) != 0 {
 		t.Errorf("expected empty report, got %+v", report)
 	}
@@ -2960,7 +2960,7 @@ func TestForceCloseHyperliquidLive_AdapterAlreadyFlatRoutedCorrectly(t *testing.
 		}, nil
 	}
 
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors, got %v", report.Errors)

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -560,6 +560,12 @@ func runHyperliquidProtectionSync(
 	if stratState == nil || symbol == "" {
 		return false
 	}
+	mu.RLock()
+	if pos := stratState.Positions[symbol]; pos != nil && pos.IsHedge {
+		mu.RUnlock()
+		return false
+	}
+	mu.RUnlock()
 	var plan hlProtectionPlan
 	var syncOK bool
 	if strategyUsesDynamicRegimeClose(sc) {

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -797,7 +797,7 @@ func TestForceCloseHyperliquidLive_ThreadsStopLossOIDs(t *testing.T) {
 		}, nil
 	}
 
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, slOIDs)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, slOIDs, nil)
 	if len(report.Errors) != 0 {
 		t.Fatalf("expected no errors, got %v", report.Errors)
 	}
@@ -831,7 +831,7 @@ func TestForceCloseHyperliquidLive_CancelsAllSharedCoinStopLossOIDs(t *testing.T
 		}, nil
 	}
 
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, slOIDs)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, slOIDs, nil)
 	if len(report.Errors) != 0 {
 		t.Fatalf("expected no errors, got %v", report.Errors)
 	}

--- a/scheduler/inspect_cmd.go
+++ b/scheduler/inspect_cmd.go
@@ -474,6 +474,10 @@ func formatStrategyInspection(sc StrategyConfig, explicit map[string]bool, cfg *
 			fmt.Fprintf(&b, "  margin_mode:         %s%s\n", sc.MarginMode, markIfDefault(explicit, "margin_mode"))
 		}
 	}
+	if hedgeEnabled(sc) {
+		fmt.Fprintf(&b, "  hedge:               %s × %.4f inverse (%s %dx)\n",
+			hedgeCoin(sc), sc.Hedge.Ratio, sc.Hedge.MarginMode, int(sc.Hedge.Leverage))
+	}
 
 	if sc.Platform == "hyperliquid" && (sc.Type == "perps" || sc.Type == "manual") {
 		sl := resolveStopLoss(sc, explicit)
@@ -596,6 +600,9 @@ func formatStrategySummaryLine(sc StrategyConfig, explicit map[string]bool, cfg 
 	// #1150: surface a paused strategy in the startup summary line.
 	if sc.Paused {
 		parts = append(parts, "paused")
+	}
+	if hedgeEnabled(sc) {
+		parts = append(parts, fmt.Sprintf("hedge=%s×%.4g", hedgeCoin(sc), sc.Hedge.Ratio))
 	}
 	// #1277: surface a non-default ATR smoothing method — wilder re-derives
 	// every ATR-based stop/TP distance, so the audit line must show it
@@ -914,6 +921,9 @@ func directionInspectJSON(sc StrategyConfig, cfg *Config, state *AppState) map[s
 			posDirRegime := positionDirectionalRegimeLabel(pos, sc)
 			positions = append(positions, map[string]interface{}{
 				"symbol":                      sym,
+				"is_hedge":                    pos.IsHedge,
+				"hedge_primary_symbol":        pos.HedgePrimarySymbol,
+				"hedge_primary_position_id":   pos.HedgePrimaryPositionID,
 				"side":                        pos.Side,
 				"quantity":                    pos.Quantity,
 				"regime":                      pos.Regime,

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -53,6 +53,12 @@ type KillSwitchCloseInputs struct {
 	// resting and burn HL's open-order cap (#421 review point 1, #479).
 	// nil/empty disables; coins with no resting SL are simply absent.
 	HLStopLossOIDs map[string][]int64
+	// HLStrategies is the live AppState.Strategies map. Threaded into
+	// forceCloseHyperliquidLive so phase-1 hedge legs claimed only via
+	// persisted IsHedge metadata (not hyperliquidConfiguredCoin) still
+	// flatten on kill-switch (#1159). nil is safe — configured hedge coins
+	// from HLLiveAll still close.
+	HLStrategies map[string]*StrategyState
 
 	// OKXLiveAllPerps: every live OKX perps strategy configured (used to
 	// decide which coins to close and to detect "unconfigured" positions).
@@ -386,7 +392,7 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 	case hlStateFetched && len(in.HLLiveAll) > 0:
 		recoverSince := time.Now().UTC().Add(-hlKillSwitchNoFillRecoveryLookback)
 		ctx, cancel := context.WithTimeout(context.Background(), in.platformCloseBudget(in.HLCloseTimeout))
-		plan.CloseReport = forceCloseHyperliquidLive(ctx, hlPositions, in.HLLiveAll, in.HLCloser, in.HLStopLossOIDs)
+		plan.CloseReport = forceCloseHyperliquidLive(ctx, hlPositions, in.HLLiveAll, in.HLCloser, in.HLStopLossOIDs, in.HLStrategies)
 		cancel()
 		if !plan.CloseReport.ConfirmedFlat() {
 			if in.HLAddr != "" && in.HLFetcher != nil {

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -53,12 +53,12 @@ type KillSwitchCloseInputs struct {
 	// resting and burn HL's open-order cap (#421 review point 1, #479).
 	// nil/empty disables; coins with no resting SL are simply absent.
 	HLStopLossOIDs map[string][]int64
-	// HLStrategies is the live AppState.Strategies map. Threaded into
-	// forceCloseHyperliquidLive so phase-1 hedge legs claimed only via
-	// persisted IsHedge metadata (not hyperliquidConfiguredCoin) still
-	// flatten on kill-switch (#1159). nil is safe — configured hedge coins
-	// from HLLiveAll still close.
-	HLStrategies map[string]*StrategyState
+	// HLTradedCoins is a snapshot of coins the kill-switch must flatten,
+	// built under mu (configured primary + hedge coins, plus any state-only
+	// IsHedge claims). forceCloseHyperliquidLive must NOT range live
+	// state.Strategies/Positions maps outside the lock (#1159 review).
+	// nil → derive from HLLiveAll config only (unit-test path).
+	HLTradedCoins map[string]bool
 
 	// OKXLiveAllPerps: every live OKX perps strategy configured (used to
 	// decide which coins to close and to detect "unconfigured" positions).
@@ -392,7 +392,7 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 	case hlStateFetched && len(in.HLLiveAll) > 0:
 		recoverSince := time.Now().UTC().Add(-hlKillSwitchNoFillRecoveryLookback)
 		ctx, cancel := context.WithTimeout(context.Background(), in.platformCloseBudget(in.HLCloseTimeout))
-		plan.CloseReport = forceCloseHyperliquidLive(ctx, hlPositions, in.HLLiveAll, in.HLCloser, in.HLStopLossOIDs, in.HLStrategies)
+		plan.CloseReport = forceCloseHyperliquidLive(ctx, hlPositions, in.HLLiveAll, in.HLCloser, in.HLStopLossOIDs, in.HLTradedCoins)
 		cancel()
 		if !plan.CloseReport.ConfirmedFlat() {
 			if in.HLAddr != "" && in.HLFetcher != nil {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -798,6 +798,7 @@ func main() {
 
 		// Determine which strategies are due this tick
 		dueStrategies := make([]StrategyConfig, 0)
+		mu.RLock()
 		for _, sc := range cfg.Strategies {
 			// #100: Skip strategies where capital_pct is set but capital resolved to $0
 			// (balance fetch failed and no fallback capital configured).
@@ -806,11 +807,17 @@ func main() {
 				continue
 			}
 			interval := intervals[sc.ID]
+			// #1159 review: a hedge-enabled strategy with open primary/hedge
+			// exposure must reconcile+sync at the global cadence, not wait for
+			// a multi-hour strategy interval — otherwise an on-chain primary
+			// SL/TP fill leaves the hedge naked until the next due cycle.
+			interval = hedgeLifecycleDueInterval(sc, state.Strategies[sc.ID], interval, cfg.IntervalSeconds)
 			last, exists := lastRun[sc.ID]
 			if !exists || cycleStart.Sub(last) >= time.Duration(interval)*time.Second {
 				dueStrategies = append(dueStrategies, sc)
 			}
 		}
+		mu.RUnlock()
 
 		if len(dueStrategies) == 0 {
 			// Nothing due, wait for next tick
@@ -1424,6 +1431,9 @@ func main() {
 					}
 				}
 				hlVirtualQty = snapshotHyperliquidVirtualQuantities(state.Strategies, hlLiveAll)
+				// Snapshot traded coins under the same RLock — forceCloseHyperliquidLive
+				// must not range live Strategies/Positions maps after unlock (#1159 review).
+				hlTradedCoins := hyperliquidKillSwitchTradedCoins(hlLiveAll, state.Strategies)
 				mu.RUnlock()
 
 				inputs := KillSwitchCloseInputs{
@@ -1435,7 +1445,7 @@ func main() {
 					HLFetcher:         defaultHLStateFetcher,
 					HLNoFillRecoverer: defaultHLKillSwitchNoFillRecoverer,
 					HLStopLossOIDs:    hlSLOIDs,
-					HLStrategies:      state.Strategies,
+					HLTradedCoins:     hlTradedCoins,
 					OKXLiveAllPerps:   okxLivePerps,
 					OKXLiveAllSpot:    okxLiveSpot,
 					OKXCloser:         defaultOKXLiveCloser,

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -796,8 +796,12 @@ func main() {
 		intervals := effectiveStrategyIntervals(cfg.Strategies, state.Strategies, cfg.IntervalSeconds, drawdownWarnThresholdPct)
 		mu.RUnlock()
 
-		// Determine which strategies are due this tick
+		// Determine which strategies are due this tick. Hedge lifecycle
+		// (reconcile+sync) is collected separately — accelerating dueStrategies
+		// for open hedges would collapse primary signal/scale-in cadence to the
+		// global tick (#1159 review).
 		dueStrategies := make([]StrategyConfig, 0)
+		var hedgeLifecycleDue []StrategyConfig
 		mu.RLock()
 		for _, sc := range cfg.Strategies {
 			// #100: Skip strategies where capital_pct is set but capital resolved to $0
@@ -807,19 +811,15 @@ func main() {
 				continue
 			}
 			interval := intervals[sc.ID]
-			// #1159 review: a hedge-enabled strategy with open primary/hedge
-			// exposure must reconcile+sync at the global cadence, not wait for
-			// a multi-hour strategy interval — otherwise an on-chain primary
-			// SL/TP fill leaves the hedge naked until the next due cycle.
-			interval = hedgeLifecycleDueInterval(sc, state.Strategies[sc.ID], interval, cfg.IntervalSeconds)
 			last, exists := lastRun[sc.ID]
 			if !exists || cycleStart.Sub(last) >= time.Duration(interval)*time.Second {
 				dueStrategies = append(dueStrategies, sc)
 			}
 		}
+		hedgeLifecycleDue = collectHedgeLifecycleCandidates(cfg.Strategies, state.Strategies)
 		mu.RUnlock()
 
-		if len(dueStrategies) == 0 {
+		if len(dueStrategies) == 0 && len(hedgeLifecycleDue) == 0 {
 			// Nothing due, wait for next tick
 			delay := schedulerDelay(cfg.Strategies, intervals, lastRun, cfg.IntervalSeconds, time.Now(), tickSeconds)
 			timer := time.NewTimer(delay)
@@ -838,9 +838,13 @@ func main() {
 			}
 		}
 
-		fmt.Printf("\n=== Cycle %d starting at %s (%d/%d strategies due) ===\n",
+		fmt.Printf("\n=== Cycle %d starting at %s (%d/%d strategies due",
 			cycle, cycleStart.UTC().Format("2006-01-02 15:04:05 UTC"),
 			len(dueStrategies), len(cfg.Strategies))
+		if len(hedgeLifecycleDue) > 0 {
+			fmt.Printf(", %d hedge-lifecycle", len(hedgeLifecycleDue))
+		}
+		fmt.Printf(") ===\n")
 
 		// Collect symbols that need prices. Spot strategies use the
 		// BinanceUS-formatted symbol directly (e.g. "BTC/USDT").
@@ -1024,6 +1028,17 @@ func main() {
 					hlReconcileDue = append(hlReconcileDue, sc)
 				}
 			}
+			// #1159 review: hedge-enabled strategies with open exposure must
+			// reconcile (and later sync) at the global cadence even when their
+			// primary signal interval has not elapsed — otherwise an on-chain
+			// primary SL/TP leaves the hedge naked until the next due cycle.
+			var hedgeReconcile []StrategyConfig
+			for _, sc := range hedgeLifecycleDue {
+				if isHLLiveReconcilable(sc) {
+					hedgeReconcile = append(hedgeReconcile, sc)
+				}
+			}
+			hlReconcileDue = mergeStrategyConfigsByID(hlReconcileDue, hedgeReconcile)
 
 			// #345: Partition live OKX strategies for the kill-switch close
 			// path. Perps and spot are separated because only perps support
@@ -2853,6 +2868,33 @@ func main() {
 					logger.Close()
 					lastRun[sc.ID] = time.Now()
 				}
+				// #1159 review: dedicated hedge reconcile already ran via
+				// hlReconcileDue above. Sync here for every open-hedge strategy
+				// — including ones whose primary signal interval has not
+				// elapsed — so an on-chain primary SL/TP flatten is mirrored
+				// onto the hedge within one global cadence. Does NOT touch
+				// lastRun / check scripts / scale-in.
+				for _, sc := range hedgeLifecycleDue {
+					if !hedgeEnabled(sc) {
+						continue
+					}
+					stratState := state.Strategies[sc.ID]
+					if stratState == nil {
+						continue
+					}
+					logger, err := logMgr.GetStrategyLogger(sc.ID)
+					if err != nil {
+						fmt.Printf("[ERROR] Logger for %s: %v\n", sc.ID, err)
+						continue
+					}
+					primarySym := hyperliquidConfiguredCoin(sc)
+					if hedgeDetail, _, hedgeErr := syncStrategyHedge(sc, stratState, primarySym, prices, hlPositions, nil, notifier, logger, &mu); hedgeErr != nil {
+						fmt.Printf("[ERROR] %s hedge lifecycle sync: %v\n", sc.ID, hedgeErr)
+					} else if hedgeDetail != "" {
+						fmt.Printf("[hedge] %s lifecycle: %s\n", sc.ID, hedgeDetail)
+					}
+					logger.Close()
+				}
 			} // end if !killSwitchFired
 		}
 
@@ -3059,8 +3101,9 @@ func main() {
 		// the warning band gets the fast (or slow) cadence immediately.
 		mu.RLock()
 		endIntervals := effectiveStrategyIntervals(cfg.Strategies, state.Strategies, cfg.IntervalSeconds, drawdownWarnThresholdPct)
-		mu.RUnlock()
 		delay := schedulerDelay(cfg.Strategies, endIntervals, lastRun, cfg.IntervalSeconds, time.Now(), tickSeconds)
+		delay = capDelayForHedgeLifecycle(delay, cfg.Strategies, state.Strategies, cfg.IntervalSeconds)
+		mu.RUnlock()
 		timer := time.NewTimer(delay)
 		select {
 		case <-timer.C:

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2369,7 +2369,11 @@ func main() {
 									if hedgeDetail, _, hedgeErr := syncStrategyHedge(sc, stratState, result.Symbol, prices, hlPositions, nil, notifier, logger, &mu); hedgeErr != nil {
 										logger.Error("[hedge] sync failed: %v", hedgeErr)
 									} else if hedgeDetail != "" {
-										detail = hedgeDetail
+										if detail != "" {
+											detail = detail + "; " + hedgeDetail
+										} else {
+											detail = hedgeDetail
+										}
 									}
 								}
 							}
@@ -2452,7 +2456,11 @@ func main() {
 										if hedgeDetail, _, hedgeErr := syncStrategyHedge(sc, stratState, result.Symbol, prices, hlPositions, nil, notifier, logger, &mu); hedgeErr != nil {
 											logger.Error("[hedge] sync failed: %v", hedgeErr)
 										} else if hedgeDetail != "" {
-											detail = hedgeDetail
+											if detail != "" {
+												detail = detail + "; " + hedgeDetail
+											} else {
+												detail = hedgeDetail
+											}
 										}
 									}
 									runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced after trade", hlReconcileFillHintsJSON)

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1435,6 +1435,7 @@ func main() {
 					HLFetcher:         defaultHLStateFetcher,
 					HLNoFillRecoverer: defaultHLKillSwitchNoFillRecoverer,
 					HLStopLossOIDs:    hlSLOIDs,
+					HLStrategies:      state.Strategies,
 					OKXLiveAllPerps:   okxLivePerps,
 					OKXLiveAllSpot:    okxLiveSpot,
 					OKXCloser:         defaultOKXLiveCloser,
@@ -2359,9 +2360,18 @@ func main() {
 									}
 								}
 							}
-							if hyperliquidIsLive(sc.Args) && result.Signal == 0 && hlPosQty > 0 {
-								runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced", hlReconcileFillHintsJSON)
-								runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger, hlOnChainAbsQty)
+							if hyperliquidIsLive(sc.Args) && result.Signal == 0 {
+								if hlPosQty > 0 {
+									runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced", hlReconcileFillHintsJSON)
+									runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger, hlOnChainAbsQty)
+								}
+								if hedgeEnabled(sc) {
+									if hedgeDetail, _, hedgeErr := syncStrategyHedge(sc, stratState, result.Symbol, prices, hlPositions, nil, notifier, logger, &mu); hedgeErr != nil {
+										logger.Error("[hedge] sync failed: %v", hedgeErr)
+									} else if hedgeDetail != "" {
+										detail = hedgeDetail
+									}
+								}
 							}
 							// #873 scale-in: a same-direction signal on an open HL
 							// perps position ADDS size when allow_scale_in is
@@ -2438,6 +2448,13 @@ func main() {
 								// for the scale-in branch and when no tier tightened.
 								notifyRatchetTrigger(notifier, sc.NotifyRatchetTriggersEnabled(cfg), ratchetAlert)
 								if execResult != nil && trades > 0 {
+									if hedgeEnabled(sc) {
+										if hedgeDetail, _, hedgeErr := syncStrategyHedge(sc, stratState, result.Symbol, prices, hlPositions, nil, notifier, logger, &mu); hedgeErr != nil {
+											logger.Error("[hedge] sync failed: %v", hedgeErr)
+										} else if hedgeDetail != "" {
+											detail = hedgeDetail
+										}
+									}
 									runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced after trade", hlReconcileFillHintsJSON)
 									runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger, hlOnChainAbsQty)
 									// #873/#882: for a trailing-SL owner the post-trade sync

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -8,21 +8,24 @@ import (
 
 // Position represents a spot, futures, or perps position.
 type Position struct {
-	Symbol              string    `json:"symbol"`
-	TradePositionID     string    `json:"position_id,omitempty"`
-	Quantity            float64   `json:"quantity"`
-	InitialQuantity     float64   `json:"initial_quantity,omitempty"` // original open size; partial closes must not rewrite it (#496)
-	AvgCost             float64   `json:"avg_cost"`
-	EntryATR            float64   `json:"entry_atr,omitempty"`               // ATR value from the entry strategy's open candle when available (#496)
-	Side                string    `json:"side"`                              // "long" or "short"
-	Multiplier          float64   `json:"multiplier,omitempty"`              // contract multiplier (0 = spot, >0 = futures/perps PnL branch; canonical perps value is 1 — do NOT set to leverage)
-	Leverage            float64   `json:"leverage,omitempty"`                // perps exchange leverage (informational; PnL is not scaled by leverage) (#254/#497)
-	OwnerStrategyID     string    `json:"owner_strategy_id,omitempty"`       // strategy that opened this position
-	OpenedAt            time.Time `json:"opened_at,omitempty"`               // when the position was opened
-	StopLossOID         int64     `json:"stop_loss_oid,omitempty"`           // HL perps: resting trigger-order OID for the per-trade stop-loss (0 = none) (#412)
-	StopLossTriggerPx   float64   `json:"stop_loss_trigger_px,omitempty"`    // HL perps: trigger price for the resting stop-loss (0 = unknown) (#421)
-	StopLossHighWaterPx float64   `json:"stop_loss_high_water_px,omitempty"` // HL perps trailing SL: best mark seen while position open (high for long, low for short) (#501)
-	TPOIDs              []int64   `json:"tp_oids,omitempty"`                 // HL perps: resting reduce-only TP limit OIDs, one per configured tier (#601/#612)
+	Symbol                 string    `json:"symbol"`
+	TradePositionID        string    `json:"position_id,omitempty"`
+	Quantity               float64   `json:"quantity"`
+	InitialQuantity        float64   `json:"initial_quantity,omitempty"` // original open size; partial closes must not rewrite it (#496)
+	AvgCost                float64   `json:"avg_cost"`
+	EntryATR               float64   `json:"entry_atr,omitempty"`                 // ATR value from the entry strategy's open candle when available (#496)
+	Side                   string    `json:"side"`                                // "long" or "short"
+	Multiplier             float64   `json:"multiplier,omitempty"`                // contract multiplier (0 = spot, >0 = futures/perps PnL branch; canonical perps value is 1 — do NOT set to leverage)
+	Leverage               float64   `json:"leverage,omitempty"`                  // perps exchange leverage (informational; PnL is not scaled by leverage) (#254/#497)
+	OwnerStrategyID        string    `json:"owner_strategy_id,omitempty"`         // strategy that opened this position
+	IsHedge                bool      `json:"is_hedge,omitempty"`                  // #1159: strategy-owned correlated hedge leg
+	HedgePrimarySymbol     string    `json:"hedge_primary_symbol,omitempty"`      // #1159: primary symbol whose lifecycle owns this hedge
+	HedgePrimaryPositionID string    `json:"hedge_primary_position_id,omitempty"` // #1159: owning primary round-trip identity
+	OpenedAt               time.Time `json:"opened_at,omitempty"`                 // when the position was opened
+	StopLossOID            int64     `json:"stop_loss_oid,omitempty"`             // HL perps: resting trigger-order OID for the per-trade stop-loss (0 = none) (#412)
+	StopLossTriggerPx      float64   `json:"stop_loss_trigger_px,omitempty"`      // HL perps: trigger price for the resting stop-loss (0 = unknown) (#421)
+	StopLossHighWaterPx    float64   `json:"stop_loss_high_water_px,omitempty"`   // HL perps trailing SL: best mark seen while position open (high for long, low for short) (#501)
+	TPOIDs                 []int64   `json:"tp_oids,omitempty"`                   // HL perps: resting reduce-only TP limit OIDs, one per configured tier (#601/#612)
 	// TPArmedTiers[i] = true once tier i has been observed with a positive OID
 	// (i.e. successfully placed by runHyperliquidProtectionSync at least once).
 	// findHighestClearedTier requires this so a tier whose first placement

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -8,24 +8,29 @@ import (
 
 // Position represents a spot, futures, or perps position.
 type Position struct {
-	Symbol                 string    `json:"symbol"`
-	TradePositionID        string    `json:"position_id,omitempty"`
-	Quantity               float64   `json:"quantity"`
-	InitialQuantity        float64   `json:"initial_quantity,omitempty"` // original open size; partial closes must not rewrite it (#496)
-	AvgCost                float64   `json:"avg_cost"`
-	EntryATR               float64   `json:"entry_atr,omitempty"`                 // ATR value from the entry strategy's open candle when available (#496)
-	Side                   string    `json:"side"`                                // "long" or "short"
-	Multiplier             float64   `json:"multiplier,omitempty"`                // contract multiplier (0 = spot, >0 = futures/perps PnL branch; canonical perps value is 1 — do NOT set to leverage)
-	Leverage               float64   `json:"leverage,omitempty"`                  // perps exchange leverage (informational; PnL is not scaled by leverage) (#254/#497)
-	OwnerStrategyID        string    `json:"owner_strategy_id,omitempty"`         // strategy that opened this position
-	IsHedge                bool      `json:"is_hedge,omitempty"`                  // #1159: strategy-owned correlated hedge leg
-	HedgePrimarySymbol     string    `json:"hedge_primary_symbol,omitempty"`      // #1159: primary symbol whose lifecycle owns this hedge
-	HedgePrimaryPositionID string    `json:"hedge_primary_position_id,omitempty"` // #1159: owning primary round-trip identity
-	OpenedAt               time.Time `json:"opened_at,omitempty"`                 // when the position was opened
-	StopLossOID            int64     `json:"stop_loss_oid,omitempty"`             // HL perps: resting trigger-order OID for the per-trade stop-loss (0 = none) (#412)
-	StopLossTriggerPx      float64   `json:"stop_loss_trigger_px,omitempty"`      // HL perps: trigger price for the resting stop-loss (0 = unknown) (#421)
-	StopLossHighWaterPx    float64   `json:"stop_loss_high_water_px,omitempty"`   // HL perps trailing SL: best mark seen while position open (high for long, low for short) (#501)
-	TPOIDs                 []int64   `json:"tp_oids,omitempty"`                   // HL perps: resting reduce-only TP limit OIDs, one per configured tier (#601/#612)
+	Symbol                 string  `json:"symbol"`
+	TradePositionID        string  `json:"position_id,omitempty"`
+	Quantity               float64 `json:"quantity"`
+	InitialQuantity        float64 `json:"initial_quantity,omitempty"` // original open size; partial closes must not rewrite it (#496)
+	AvgCost                float64 `json:"avg_cost"`
+	EntryATR               float64 `json:"entry_atr,omitempty"`                 // ATR value from the entry strategy's open candle when available (#496)
+	Side                   string  `json:"side"`                                // "long" or "short"
+	Multiplier             float64 `json:"multiplier,omitempty"`                // contract multiplier (0 = spot, >0 = futures/perps PnL branch; canonical perps value is 1 — do NOT set to leverage)
+	Leverage               float64 `json:"leverage,omitempty"`                  // perps exchange leverage (informational; PnL is not scaled by leverage) (#254/#497)
+	OwnerStrategyID        string  `json:"owner_strategy_id,omitempty"`         // strategy that opened this position
+	IsHedge                bool    `json:"is_hedge,omitempty"`                  // #1159: strategy-owned correlated hedge leg
+	HedgePrimarySymbol     string  `json:"hedge_primary_symbol,omitempty"`      // #1159: primary symbol whose lifecycle owns this hedge
+	HedgePrimaryPositionID string  `json:"hedge_primary_position_id,omitempty"` // #1159: owning primary round-trip identity
+	// HedgeQtyPerPrimaryUnit freezes hedge_qty/primary_qty at the moment the
+	// hedge opened (or self-healed on first sync after upgrade). Subsequent
+	// targets are primaryQty × this ratio so ordinary mark drift never
+	// rebalances the hedge — only primary quantity lifecycle events do (#1159 review).
+	HedgeQtyPerPrimaryUnit float64   `json:"hedge_qty_per_primary_unit,omitempty"`
+	OpenedAt               time.Time `json:"opened_at,omitempty"`               // when the position was opened
+	StopLossOID            int64     `json:"stop_loss_oid,omitempty"`           // HL perps: resting trigger-order OID for the per-trade stop-loss (0 = none) (#412)
+	StopLossTriggerPx      float64   `json:"stop_loss_trigger_px,omitempty"`    // HL perps: trigger price for the resting stop-loss (0 = unknown) (#421)
+	StopLossHighWaterPx    float64   `json:"stop_loss_high_water_px,omitempty"` // HL perps trailing SL: best mark seen while position open (high for long, low for short) (#501)
+	TPOIDs                 []int64   `json:"tp_oids,omitempty"`                 // HL perps: resting reduce-only TP limit OIDs, one per configured tier (#601/#612)
 	// TPArmedTiers[i] = true once tier i has been observed with a positive OID
 	// (i.e. successfully placed by runHyperliquidProtectionSync at least once).
 	// findHighestClearedTier requires this so a tier whose first placement

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -80,7 +80,12 @@ func collectPerpsMarkSymbols(strategies []StrategyConfig) (hlCoins, okxCoins []s
 		}
 		switch sc.Platform {
 		case "hyperliquid":
-			hlSet[coin] = true
+			hlSet[strings.ToUpper(strings.TrimSpace(coin))] = true
+			if hedgeEnabled(sc) {
+				if hedge := hedgeCoin(sc); hedge != "" {
+					hlSet[strings.ToUpper(strings.TrimSpace(hedge))] = true
+				}
+			}
 		case "okx":
 			okxSet[coin] = true
 		}
@@ -953,9 +958,11 @@ func setHyperliquidCircuitBreakerPending(sc *StrategyConfig, s *StrategyState, a
 	if !ok || qty <= 0 {
 		return
 	}
-	s.RiskState.setPendingCircuitClose(PlatformPendingCloseHyperliquid, &PendingCircuitClose{
-		Symbols: []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}},
-	})
+	symbols := []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}}
+	if hedge := findHedgePosition(s, *sc); hedge != nil {
+		symbols = append(symbols, PendingCircuitCloseSymbol{Symbol: hedge.Symbol, Size: hedge.Quantity})
+	}
+	s.RiskState.setPendingCircuitClose(PlatformPendingCloseHyperliquid, &PendingCircuitClose{Symbols: symbols})
 }
 
 func hyperliquidCircuitBreakerHasSharedCoin(sc *StrategyConfig, assist *PlatformRiskAssist) bool {


### PR DESCRIPTION
## Summary
- Add opt-in per-strategy `hedge` config for live Hyperliquid perps: inverse side, static notional×ratio sizing, own margin/leverage, peer-collision rejection (own coin / strategy coin / hedge-vs-hedge).
- Scheduler mirrors primary lifecycle (open / scale-in / partial / full close) with fail-closed primary unwind when hedge open/sizing fails; no hedge SL/TP; kill-switch, CB drain, reconcile, and protection paths treat hedge legs via persisted `IsHedge` metadata.
- Hot-reload blocks hedge changes while any position (or hedge leg) is open; backtester loudly rejects enabled hedges until parity lands; inspect/status/Discord surfaces tag hedge legs.

Closes #1159

## Test plan
- [x] `go -C scheduler test -count=1 -run 'TestHedge|TestValidateHedge|TestApplyHedge|TestSyncStrategy|TestCollectPerpsMarkSymbolsIncludesHedge|TestForceCloseHyperliquidLiveIncludes' .`
- [x] `go -C scheduler test -count=1 .`
- [x] `uv run --no-sync python -m pytest backtest/tests/test_backtester_scale_in.py -k hedge -q`
- [ ] Manual: enable hedge on a paper-ineligible live HL strategy config and confirm load validation / collision rejects
- [ ] Manual: after merge, smoke a sole-owner hedge open→close on a small live size and confirm fail-closed unwind path via injected hedge failure in tests

## Follow-ups (unfiled)
- Allow hedge coins that overlap peer strategies (extend coin-membership / margin / CB / KS / reconcile).
- Backtest hedge PnL/fee/slippage modeling with parity.

---
Created with LLM: Grok 4.5 | high | Harness: Cursor