### PR TITLE
feat(#1159): per-strategy correlated hedge legs (phase 1, live HL perps) [Fable 5, high]

### DIFF
--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -756,6 +756,19 @@ def load_strategy_config(config_path: str, strategy_id: str,
                 f"release (backtester parity deferred — see #907). Use the "
                 f"static `direction` / `invert_signal` fields for backtesting."
             )
+        # #1159 phase 1: correlated hedge legs are HL-live-only. Silently
+        # backtesting only the primary would misstate PnL/fees vs live, so
+        # reject loudly (same pattern as regime_window_divergence above);
+        # parity modeling is a tracked follow-up. A disabled/empty hedge
+        # block is tolerated.
+        hedge_block = sc.get("hedge") or {}
+        if isinstance(hedge_block, dict) and hedge_block.get("enabled"):
+            raise ValueError(
+                f"{config_path}: strategy {strategy_id!r} has an enabled "
+                f"hedge block, which is HL-live-only in this release "
+                f"(backtester hedge PnL/fee parity deferred — see #1159). "
+                f"Disable the hedge block to backtest the primary alone."
+            )
         # #842: a strategy has a single close_strategy ref. Still accept the
         # legacy close_strategies array (length <=1 after the collapse) so old
         # configs keep backtesting; the backtester's close_strategies= list

--- a/backtest/tests/test_hedge_config_reject_1159.py
+++ b/backtest/tests/test_hedge_config_reject_1159.py
@@ -1,0 +1,54 @@
+"""#1159 phase 1: correlated hedge legs are HL-live-only — the backtester's
+--config reader must reject an enabled hedge block loudly instead of silently
+backtesting only the primary leg (which would misstate PnL/fees vs live).
+Mirrors the regime_window_divergence reject pattern.
+"""
+import json
+
+import pytest
+
+import run_backtest
+
+
+def _write_config(tmp_path, strategies):
+    cfg = {"config_version": 15, "strategies": strategies}
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(cfg, indent=2))
+    return str(p)
+
+
+def _hedge_strategy(hedge):
+    return {
+        "id": "hl-x",
+        "type": "perps",
+        "platform": "hyperliquid",
+        "args": ["tema_cross_bd", "ETH", "--mode=live"],
+        "open_strategy": {"name": "tema_cross_bd"},
+        "hedge": hedge,
+    }
+
+
+def test_enabled_hedge_block_rejected(tmp_path):
+    path = _write_config(tmp_path, [_hedge_strategy({
+        "enabled": True,
+        "symbol": "BTC/USDC:USDC",
+        "side": "inverse",
+        "ratio": 1.0,
+        "platform": "hyperliquid",
+        "type": "perps",
+        "margin_mode": "cross",
+        "leverage": 3,
+    })])
+    with pytest.raises(ValueError, match="hedge.*HL-live-only.*1159"):
+        run_backtest.load_strategy_config(path, "hl-x")
+
+
+def test_disabled_hedge_block_tolerated(tmp_path):
+    path = _write_config(tmp_path, [_hedge_strategy({
+        "enabled": False,
+        "symbol": "BTC/USDC:USDC",
+        "side": "inverse",
+        "ratio": 1.0,
+    })])
+    kwargs = run_backtest.load_strategy_config(path, "hl-x")
+    assert kwargs["open_strategy"]["name"] == "tema_cross_bd"

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -605,6 +605,28 @@ type StrategyRef struct {
 	Params map[string]interface{} `json:"params,omitempty"`
 }
 
+// HedgeSideInverse is the only hedge side policy in phase 1 (#1159): the
+// hedge leg always takes the opposite side of the primary position.
+const HedgeSideInverse = "inverse"
+
+// HedgeConfig declares a strictly-coupled correlated hedge leg (#1159 phase
+// 1: live Hyperliquid perps only). The hedge opens with the primary open,
+// scales with scale-in, reduces with partial close, and closes with full
+// close / force-close / kill-switch / circuit-breaker — no independent SL/TP
+// or close evaluator. MarginMode/Leverage are the hedge coin's OWN on-chain
+// margin assignment (never inherited from the primary). Validated by
+// validateHedgeConfigs (hedge.go); converged by hedge_sync.go.
+type HedgeConfig struct {
+	Enabled    bool    `json:"enabled"`
+	Symbol     string  `json:"symbol"`      // hedge instrument, e.g. "BTC/USDC:USDC" or "BTC"
+	Side       string  `json:"side"`        // must be "inverse" (phase 1)
+	Ratio      float64 `json:"ratio"`       // hedge notional = primary notional × ratio, sized at open/add marks
+	Platform   string  `json:"platform"`    // must be "hyperliquid" (phase 1)
+	Type       string  `json:"type"`        // must be "perps" (phase 1)
+	MarginMode string  `json:"margin_mode"` // "isolated" | "cross" — the hedge coin's own assignment
+	Leverage   float64 `json:"leverage"`    // hedge coin exchange leverage, [1, 50]
+}
+
 // StrategyConfig describes a single strategy job.
 type StrategyConfig struct {
 	ID                          string                   `json:"id"`
@@ -660,6 +682,7 @@ type StrategyConfig struct {
 	RegimeProfileAllocation     *RegimeProfileAllocation `json:"regime_profile_allocation,omitempty"` // HL perps only: slow regime switch between two validated open_strategy param profiles. A long-window regime label (from the #879 store) selects the active profile; switching is hysteretic (confirm_bars closed bars) and flat-only. Requires regime.enabled=true. Backtester replays the switch. (#998)
 	AllowScaleIn                bool                     `json:"allow_scale_in,omitempty"`            // HL perps/manual only: opt in to scale-in / pyramiding — a same-direction signal on an open position ADDS size (blends price+size, freezes EntryATR/regime/TP geometry) instead of being skipped. Default false preserves the legacy skip-on-same-direction behavior for every strategy that does not opt in. Gated by ScaleIn caps + spacing. (#873)
 	ScaleIn                     *ScaleInConfig           `json:"scale_in,omitempty"`                  // scale-in tuning; only consulted when AllowScaleIn is true. Nil = defaults (unlimited adds/notional, no spacing, per-add size = standard open notional). (#873)
+	Hedge                       *HedgeConfig             `json:"hedge,omitempty"`                     // #1159 phase 1 — strictly-coupled correlated hedge leg (live HL perps only). Peer-collision-rejected at load; hot-reload blocked while a hedge leg is open; managed exclusively by the hedge_sync convergence engine.
 }
 
 // ScaleInConfig tunes the opt-in scale-in / pyramiding path (#873). All fields
@@ -2222,6 +2245,12 @@ func validateConfig(cfg *Config, skipLiveCredentialChecks bool) error {
 	for _, msg := range hyperliquidPeerStrategyErrors(cfg.Strategies) {
 		errs = append(errs, msg)
 	}
+
+	// #1159: hedge legs — phase-1 shape checks plus peer-collision rejection
+	// (hedge coin vs any configured strategy coin, own primary coin, or
+	// another hedge coin), so hedge ownership is structurally unambiguous
+	// before any live order.
+	errs = append(errs, validateHedgeConfigs(cfg.Strategies)...)
 
 	// #42: Validate portfolio risk config.
 	if cfg.PortfolioRisk != nil {

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -350,6 +350,19 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 				sc.ScaleIn = nil
 			}
 		}
+		// #1159: hedge block is hot-reloadable while no hedge leg is open (the
+		// state-compat gate blocks it otherwise). Reaching here means the next
+		// hedge_sync cycle converges against the new shape — including opening
+		// a hedge for an already-open primary when the block was just enabled.
+		if !hedgeConfigEqual(sc.Hedge, ns.Hedge) {
+			addChange("strategy[%s].hedge: shape updated", sc.ID)
+			if ns.Hedge != nil {
+				clone := *ns.Hedge
+				sc.Hedge = &clone
+			} else {
+				sc.Hedge = nil
+			}
+		}
 	}
 
 	if portfolioRiskMaxDrawdown(cfg.PortfolioRisk) != portfolioRiskMaxDrawdown(next.PortfolioRisk) {
@@ -631,6 +644,17 @@ func validateHotReloadStateCompatible(cfg, next *Config, state *AppState) error 
 					sc.ID))
 			}
 		}
+		// #1159: the hedge block is state-shifting for the OPEN hedge leg —
+		// enable/disable, symbol, side, ratio, and margin fields all change
+		// what the convergence engine would do to a live on-chain position
+		// (e.g. a symbol change would strand the old leg; a ratio change
+		// would re-derive coverage mid-flight). Block while a hedge leg is
+		// open; freely reloadable otherwise (issue constraint 7), including
+		// enabling a hedge for an already-open primary.
+		if !hedgeConfigEqual(sc.Hedge, ns.Hedge) && strategyHasOpenHedgeLeg(stateStrategy(state, sc.ID)) {
+			errs = append(errs, fmt.Sprintf("strategy[%s] hedge changed with an open hedge leg (flatten first or restart after close)",
+				sc.ID))
+		}
 		// #486: HL rejects margin-mode changes on an open position; treat
 		// the same way as Leverage. Stays hot-reloadable when flat.
 		if sc.Type == "perps" && sc.Platform == "hyperliquid" && sc.MarginMode != ns.MarginMode && strategyHasOpenPositions(stateStrategy(state, sc.ID)) {
@@ -839,6 +863,7 @@ func strategyRestartShape(sc StrategyConfig) StrategyConfig {
 	sc.AllowScaleIn = false          // #873: hot-reloadable when flat; state-compat blocks change while open
 	sc.ScaleIn = nil                 // #873: hot-reloadable when flat; state-compat blocks change while open
 	sc.ATRMethod = ""                // #1277: hot-reloadable when flat; state-compat blocks the effective-method flip while open
+	sc.Hedge = nil                   // #1159: hot-reloadable while no hedge leg is open; state-compat blocks change while a hedge leg is open
 	return sc
 }
 

--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -97,6 +97,9 @@ CREATE TABLE IF NOT EXISTS positions (
     llm_analysis_requested INTEGER NOT NULL DEFAULT 0,
     llm_verdict TEXT NOT NULL DEFAULT '',
     atr_method_at_open TEXT NOT NULL DEFAULT '',
+    is_hedge INTEGER NOT NULL DEFAULT 0,
+    hedge_primary_symbol TEXT NOT NULL DEFAULT '',
+    hedge_covered_primary_qty REAL NOT NULL DEFAULT 0,
     PRIMARY KEY (strategy_id, symbol)
 );
 
@@ -606,6 +609,12 @@ func (sdb *StateDB) migrateSchema() error {
 		// open — a gap the SIGHUP hot-reload guard can't see. "" = pre-#1277
 		// position, never stamped.
 		"ALTER TABLE positions ADD COLUMN atr_method_at_open TEXT NOT NULL DEFAULT ''",
+		// #1159 hedge-leg metadata: startup reconcile recovers hedge ownership
+		// from these persisted columns, never from coin→configured-symbol
+		// inference. hedge_covered_primary_qty is the convergence watermark.
+		"ALTER TABLE positions ADD COLUMN is_hedge INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE positions ADD COLUMN hedge_primary_symbol TEXT NOT NULL DEFAULT ''",
+		"ALTER TABLE positions ADD COLUMN hedge_covered_primary_qty REAL NOT NULL DEFAULT 0",
 		// #1277 hardening (review round 2): manual opens resolve atr_method at
 		// queue time (next to the EntryATR fetch in manualOpenCore) and carry
 		// it through the pending queue so the drain stamps the method the ATR
@@ -1223,8 +1232,8 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	}
 	defer stmtStrat.Close()
 
-	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, tp_armed_tiers_json, stop_loss_atr_mult, tp_tiers_json, sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, regime, regime_windows_json, regime_pending_label, regime_pending_count, regime_applied_label, scale_in_count, last_add_price, added_notional_usd, risk_anchor_price, scale_in_resize_pending, ratchet_fallback_normalize_pending, open_profile, direction_certified_at_open, direction_certified_states_json, llm_analysis_requested, llm_verdict, atr_method_at_open)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	stmtPos, err := tx.Prepare(`INSERT INTO positions (strategy_id, symbol, position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, tp1_oid, tp2_oid, tp_oids_json, tp_armed_tiers_json, stop_loss_atr_mult, tp_tiers_json, sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, regime, regime_windows_json, regime_pending_label, regime_pending_count, regime_applied_label, scale_in_count, last_add_price, added_notional_usd, risk_anchor_price, scale_in_resize_pending, ratchet_fallback_normalize_pending, open_profile, direction_certified_at_open, direction_certified_states_json, llm_analysis_requested, llm_verdict, atr_method_at_open, is_hedge, hedge_primary_symbol, hedge_covered_primary_qty)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare position insert: %w", err)
 	}
@@ -1292,7 +1301,11 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			if pos.LLMAnalysisRequested {
 				llmAnalysisRequested = 1
 			}
-			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), marshalTPArmedTiersJSON(pos.TPArmedTiers), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON, pos.SLAdjustedTiersProcessed, nullableFloat64(pos.PostTPTrailingATRMult), pos.Regime, marshalRegimeWindowsJSON(pos.RegimeWindows), pos.RegimePendingLabel, pos.RegimePendingCount, pos.RegimeAppliedLabel, pos.ScaleInCount, pos.LastAddPrice, pos.AddedNotionalUSD, pos.RiskAnchorPrice, scaleInResizePending, ratchetFallbackNormalizePending, pos.OpenProfile, directionCertifiedAtOpen, marshalStringMapJSON(pos.DirectionCertifiedStatesAtOpen), llmAnalysisRequested, pos.LLMVerdict, pos.ATRMethodAtOpen); err != nil {
+			isHedge := 0
+			if pos.IsHedge {
+				isHedge = 1
+			}
+			if _, err := stmtPos.Exec(s.ID, pos.Symbol, positionID, pos.Quantity, pos.InitialQuantity, pos.AvgCost, pos.EntryATR, pos.Side, pos.Multiplier, pos.OwnerStrategyID, formatTime(pos.OpenedAt), pos.StopLossOID, pos.StopLossTriggerPx, pos.StopLossHighWaterPx, tp1OID, tp2OID, marshalTPOIDsJSON(pos.TPOIDs), marshalTPArmedTiersJSON(pos.TPArmedTiers), nullableFloat64(pos.StopLossATRMult), pos.TPTiersJSON, pos.SLAdjustedTiersProcessed, nullableFloat64(pos.PostTPTrailingATRMult), pos.Regime, marshalRegimeWindowsJSON(pos.RegimeWindows), pos.RegimePendingLabel, pos.RegimePendingCount, pos.RegimeAppliedLabel, pos.ScaleInCount, pos.LastAddPrice, pos.AddedNotionalUSD, pos.RiskAnchorPrice, scaleInResizePending, ratchetFallbackNormalizePending, pos.OpenProfile, directionCertifiedAtOpen, marshalStringMapJSON(pos.DirectionCertifiedStatesAtOpen), llmAnalysisRequested, pos.LLMVerdict, pos.ATRMethodAtOpen, isHedge, pos.HedgePrimarySymbol, pos.HedgeCoveredPrimaryQty); err != nil {
 				return fmt.Errorf("insert position %s/%s: %w", s.ID, pos.Symbol, err)
 			}
 		}
@@ -1711,7 +1724,7 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	}
 
 	// 3. Load positions for each strategy.
-	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(tp_armed_tiers_json, '') AS tp_armed_tiers_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json, COALESCE(sl_adjusted_tiers_processed, 0) AS sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, COALESCE(regime, '') AS regime, COALESCE(regime_windows_json, '') AS regime_windows_json, COALESCE(regime_pending_label, '') AS regime_pending_label, COALESCE(regime_pending_count, 0) AS regime_pending_count, COALESCE(regime_applied_label, '') AS regime_applied_label, COALESCE(scale_in_count, 0) AS scale_in_count, COALESCE(last_add_price, 0) AS last_add_price, COALESCE(added_notional_usd, 0) AS added_notional_usd, COALESCE(risk_anchor_price, 0) AS risk_anchor_price, COALESCE(scale_in_resize_pending, 0) AS scale_in_resize_pending, COALESCE(ratchet_fallback_normalize_pending, 0) AS ratchet_fallback_normalize_pending, COALESCE(open_profile, '') AS open_profile, COALESCE(direction_certified_at_open, 0) AS direction_certified_at_open, COALESCE(direction_certified_states_json, '') AS direction_certified_states_json, COALESCE(llm_analysis_requested, 0) AS llm_analysis_requested, COALESCE(llm_verdict, '') AS llm_verdict, COALESCE(atr_method_at_open, '') AS atr_method_at_open FROM positions")
+	posRows, err := sdb.db.Query("SELECT strategy_id, symbol, COALESCE(position_id, '') AS position_id, quantity, initial_quantity, avg_cost, entry_atr, side, multiplier, owner_strategy_id, opened_at, stop_loss_oid, stop_loss_trigger_px, stop_loss_high_water_px, COALESCE(tp1_oid, 0) AS tp1_oid, COALESCE(tp2_oid, 0) AS tp2_oid, COALESCE(tp_oids_json, '') AS tp_oids_json, COALESCE(tp_armed_tiers_json, '') AS tp_armed_tiers_json, stop_loss_atr_mult, COALESCE(tp_tiers_json, '') AS tp_tiers_json, COALESCE(sl_adjusted_tiers_processed, 0) AS sl_adjusted_tiers_processed, post_tp_trailing_atr_mult, COALESCE(regime, '') AS regime, COALESCE(regime_windows_json, '') AS regime_windows_json, COALESCE(regime_pending_label, '') AS regime_pending_label, COALESCE(regime_pending_count, 0) AS regime_pending_count, COALESCE(regime_applied_label, '') AS regime_applied_label, COALESCE(scale_in_count, 0) AS scale_in_count, COALESCE(last_add_price, 0) AS last_add_price, COALESCE(added_notional_usd, 0) AS added_notional_usd, COALESCE(risk_anchor_price, 0) AS risk_anchor_price, COALESCE(scale_in_resize_pending, 0) AS scale_in_resize_pending, COALESCE(ratchet_fallback_normalize_pending, 0) AS ratchet_fallback_normalize_pending, COALESCE(open_profile, '') AS open_profile, COALESCE(direction_certified_at_open, 0) AS direction_certified_at_open, COALESCE(direction_certified_states_json, '') AS direction_certified_states_json, COALESCE(llm_analysis_requested, 0) AS llm_analysis_requested, COALESCE(llm_verdict, '') AS llm_verdict, COALESCE(atr_method_at_open, '') AS atr_method_at_open, COALESCE(is_hedge, 0) AS is_hedge, COALESCE(hedge_primary_symbol, '') AS hedge_primary_symbol, COALESCE(hedge_covered_primary_qty, 0) AS hedge_covered_primary_qty FROM positions")
 	if err != nil {
 		return nil, fmt.Errorf("load positions: %w", err)
 	}
@@ -1731,11 +1744,13 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		var directionCertifiedAtOpen int
 		var directionCertifiedStatesJSON string
 		var llmAnalysisRequested int
-		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &tpArmedTiersJSON, &slATRMult, &pos.TPTiersJSON, &pos.SLAdjustedTiersProcessed, &postTPTrailingMult, &pos.Regime, &regimeWindowsJSON, &pos.RegimePendingLabel, &pos.RegimePendingCount, &pos.RegimeAppliedLabel, &pos.ScaleInCount, &pos.LastAddPrice, &pos.AddedNotionalUSD, &pos.RiskAnchorPrice, &scaleInResizePending, &ratchetFallbackNormalizePending, &pos.OpenProfile, &directionCertifiedAtOpen, &directionCertifiedStatesJSON, &llmAnalysisRequested, &pos.LLMVerdict, &pos.ATRMethodAtOpen); err != nil {
+		var isHedge int
+		if err := posRows.Scan(&stratID, &pos.Symbol, &pos.TradePositionID, &pos.Quantity, &pos.InitialQuantity, &pos.AvgCost, &pos.EntryATR, &pos.Side, &pos.Multiplier, &pos.OwnerStrategyID, &openedAtStr, &pos.StopLossOID, &pos.StopLossTriggerPx, &pos.StopLossHighWaterPx, &tp1OID, &tp2OID, &tpOIDsJSON, &tpArmedTiersJSON, &slATRMult, &pos.TPTiersJSON, &pos.SLAdjustedTiersProcessed, &postTPTrailingMult, &pos.Regime, &regimeWindowsJSON, &pos.RegimePendingLabel, &pos.RegimePendingCount, &pos.RegimeAppliedLabel, &pos.ScaleInCount, &pos.LastAddPrice, &pos.AddedNotionalUSD, &pos.RiskAnchorPrice, &scaleInResizePending, &ratchetFallbackNormalizePending, &pos.OpenProfile, &directionCertifiedAtOpen, &directionCertifiedStatesJSON, &llmAnalysisRequested, &pos.LLMVerdict, &pos.ATRMethodAtOpen, &isHedge, &pos.HedgePrimarySymbol, &pos.HedgeCoveredPrimaryQty); err != nil {
 			return nil, fmt.Errorf("scan position: %w", err)
 		}
 		pos.ScaleInResizePending = scaleInResizePending != 0
 		pos.RatchetFallbackNormalizePending = ratchetFallbackNormalizePending != 0
+		pos.IsHedge = isHedge != 0
 		pos.LLMAnalysisRequested = llmAnalysisRequested != 0
 		pos.DirectionCertifiedAtOpen = directionCertifiedAtOpen != 0
 		pos.DirectionCertifiedStatesAtOpen = parseStringMapJSON(directionCertifiedStatesJSON)

--- a/scheduler/discord.go
+++ b/scheduler/discord.go
@@ -1116,6 +1116,20 @@ func collectPositions(sc StrategyConfig, ss *StrategyState, prices map[string]fl
 		if !pos.OpenedAt.IsZero() {
 			dateStr = fmt.Sprintf(" [%s]", pos.OpenedAt.Format("Jan 02 15:04"))
 		}
+		// #1159: a hedge leg is auto-managed coupling, not an independent
+		// position — mark it explicitly (so it's never mistaken for an
+		// unmanaged/foreign position) and skip the close/SL/TP extras, which
+		// describe the PRIMARY strategy's geometry, not the hedge's (it has
+		// no protection or close evaluator of its own).
+		if pos.IsHedge {
+			hedgeExtras := fmt.Sprintf(" | ⚖️ hedge for %s (auto-managed)", pos.HedgePrimarySymbol)
+			if pos.Leverage > 1 {
+				margin := positionMargin(pos.Quantity, pos.AvgCost, pos.Leverage)
+				hedgeExtras += fmt.Sprintf(" | %gx ($%s margin)", pos.Leverage, fmtComma(math.Round(margin)))
+			}
+			lines = append(lines, fmt.Sprintf("%s %s %s x%.3f @ $%s (%s$%s)%s%s", sc.ID, strings.ToUpper(pos.Side), sym, pos.Quantity, fmtComma2(pos.AvgCost), sign, fmtComma2(absPnl), hedgeExtras, dateStr))
+			continue
+		}
 		extras := ""
 		if name := closeStrategySummaryName(sc); name != "" {
 			extras += fmt.Sprintf(" | close: %s", name)

--- a/scheduler/hedge.go
+++ b/scheduler/hedge.go
@@ -1,0 +1,486 @@
+package main
+
+// #1159 phase 1: per-strategy correlated hedge legs, live Hyperliquid perps
+// only. A hedge-enabled strategy carries exactly one extra Position on a
+// DIFFERENT coin (Position.IsHedge=true, keyed by the hedge coin) whose
+// lifecycle is strictly coupled to the primary position: it opens with the
+// primary open, scales with scale-in, reduces with partial close, and closes
+// with full close / force-close / kill-switch / circuit-breaker. The hedge has
+// no check script, no close evaluator, and no on-chain SL/TP of its own — the
+// per-cycle convergence engine in hedge_sync.go is its only manager.
+//
+// Sizing model: the OPEN and each ADD are sized in USD-notional terms
+// (primary_qty_delta × primary_mark × ratio ÷ hedge_mark), but the ongoing
+// target is tracked in QUANTITY terms via Position.HedgeCoveredPrimaryQty (the
+// primary quantity the current hedge leg covers). Reductions are proportional
+// to the covered quantity, never re-priced from live marks — re-deriving a
+// notional target every cycle would churn orders as prices move.
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// hedgeQtyEpsilon is the absolute quantity below which a position/order is
+	// treated as flat/empty.
+	hedgeQtyEpsilon = 1e-9
+	// hedgeCoveredRelEpsilon is the relative tolerance between the primary
+	// quantity and the hedge's covered quantity before the convergence engine
+	// issues an order. Both values come from virtual state (not marks), so in
+	// practice they match exactly; the tolerance only absorbs float drift.
+	hedgeCoveredRelEpsilon = 1e-6
+)
+
+func hedgeEnabled(sc StrategyConfig) bool { return sc.Hedge != nil && sc.Hedge.Enabled }
+
+// hedgeCoin returns the normalized hedge coin ticker for a hedge-enabled
+// strategy, "" otherwise.
+func hedgeCoin(sc StrategyConfig) string {
+	if !hedgeEnabled(sc) {
+		return ""
+	}
+	return hyperliquidCoinFromSymbol(sc.Hedge.Symbol)
+}
+
+// hyperliquidCoinFromSymbol normalizes a symbol like "BTC/USDC:USDC" or
+// "btc" to the HL coin ticker ("BTC").
+func hyperliquidCoinFromSymbol(symbol string) string {
+	s := strings.TrimSpace(symbol)
+	if i := strings.IndexByte(s, '/'); i >= 0 {
+		s = s[:i]
+	}
+	return strings.ToUpper(strings.TrimSpace(s))
+}
+
+// hedgeConfigEqual reports whether two hedge blocks are identical for
+// hot-reload purposes. Mirrors scaleInConfigEqual: nil vs zero-value blocks
+// are distinct by pointer presence.
+func hedgeConfigEqual(a, b *HedgeConfig) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+// strategyHasOpenHedgeLeg reports whether the strategy state holds a live
+// hedge leg (any IsHedge position with positive quantity).
+func strategyHasOpenHedgeLeg(s *StrategyState) bool {
+	if s == nil {
+		return false
+	}
+	for _, pos := range s.Positions {
+		if pos != nil && pos.IsHedge && pos.Quantity > hedgeQtyEpsilon {
+			return true
+		}
+	}
+	return false
+}
+
+// findHedgePosition returns the strategy's open hedge leg. The configured
+// hedge coin is preferred; a state-only hedge under a different coin (config
+// edited between restarts) still matches so kill-switch/CB/status paths never
+// lose sight of a live leg.
+func findHedgePosition(s *StrategyState, sc StrategyConfig) *Position {
+	if s == nil {
+		return nil
+	}
+	coin := hedgeCoin(sc)
+	var fallback *Position
+	for sym, pos := range s.Positions {
+		if pos == nil || !pos.IsHedge || pos.Quantity <= hedgeQtyEpsilon {
+			continue
+		}
+		if coin != "" && strings.EqualFold(sym, coin) {
+			return pos
+		}
+		if fallback == nil || sym < fallback.Symbol {
+			fallback = pos
+		}
+	}
+	return fallback
+}
+
+// validateHedgeConfigs enforces the #1159 phase-1 constraints up front so no
+// live order is ever placed against an ambiguous-ownership hedge coin:
+//
+//   - live Hyperliquid perps only, on both the primary and the hedge leg;
+//   - side must be "inverse" (the only phase-1 policy);
+//   - ratio positive and finite; margin fields validated like the primary's;
+//   - the hedge coin must not equal the strategy's own primary coin (a
+//     same-coin "hedge" just nets the position on-chain), any configured
+//     strategy's coin (HL aggregates per coin per wallet — the hedge would
+//     share an on-chain position, margin assignment, and reduce-only slots
+//     with that strategy), or another hedge-enabled strategy's hedge coin.
+func validateHedgeConfigs(strategies []StrategyConfig) []string {
+	var errs []string
+	primaryOwners := make(map[string]string)
+	for _, sc := range strategies {
+		if coin := hyperliquidConfiguredCoin(sc); coin != "" {
+			if _, ok := primaryOwners[coin]; !ok {
+				primaryOwners[coin] = sc.ID
+			}
+		}
+	}
+	hedgeOwners := make(map[string]string)
+	for _, sc := range strategies {
+		if !hedgeEnabled(sc) {
+			continue
+		}
+		prefix := fmt.Sprintf("strategy[%s].hedge", sc.ID)
+		h := sc.Hedge
+		coin := hedgeCoin(sc)
+		if sc.Platform != "hyperliquid" || sc.Type != "perps" || !hyperliquidIsLive(sc.Args) {
+			errs = append(errs, prefix+": phase 1 requires a live Hyperliquid perps primary strategy (#1159)")
+		}
+		if h.Platform != "hyperliquid" || h.Type != "perps" {
+			errs = append(errs, prefix+`: phase 1 requires platform="hyperliquid" and type="perps" on the hedge leg (#1159)`)
+		}
+		if coin == "" {
+			errs = append(errs, prefix+".symbol is required")
+		}
+		if h.Side != HedgeSideInverse {
+			errs = append(errs, fmt.Sprintf("%s.side must be %q (the only phase-1 policy), got %q", prefix, HedgeSideInverse, h.Side))
+		}
+		if h.Ratio <= 0 || math.IsNaN(h.Ratio) || math.IsInf(h.Ratio, 0) {
+			errs = append(errs, fmt.Sprintf("%s.ratio must be > 0, got %g", prefix, h.Ratio))
+		}
+		if h.MarginMode != "isolated" && h.MarginMode != "cross" {
+			errs = append(errs, fmt.Sprintf("%s.margin_mode must be \"isolated\" or \"cross\", got %q", prefix, h.MarginMode))
+		}
+		if h.Leverage < 1 || h.Leverage > 50 {
+			errs = append(errs, fmt.Sprintf("%s.leverage must be in [1, 50], got %g", prefix, h.Leverage))
+		}
+		if coin == "" {
+			continue
+		}
+		if coin == hyperliquidConfiguredCoin(sc) {
+			errs = append(errs, fmt.Sprintf("%s.symbol %q matches its own primary coin — a same-coin hedge nets the on-chain position instead of hedging it", prefix, coin))
+		} else if owner, ok := primaryOwners[coin]; ok {
+			errs = append(errs, fmt.Sprintf("%s.symbol %q matches configured strategy %q's coin — hedge legs must not share an on-chain position with any strategy (phase 1, #1159)", prefix, coin, owner))
+		}
+		if owner, ok := hedgeOwners[coin]; ok && owner != sc.ID {
+			errs = append(errs, fmt.Sprintf("%s.symbol %q is already the hedge coin of strategy %q — two hedge legs on one coin would share an on-chain position (phase 1, #1159)", prefix, coin, owner))
+		} else if _, ok := hedgeOwners[coin]; !ok {
+			hedgeOwners[coin] = sc.ID
+		}
+	}
+	return errs
+}
+
+// validateHedgeStateConsistency flags persisted hedge legs whose strategy no
+// longer manages them — the config hedge block was removed/disabled, or the
+// hedge coin changed, across a restart (the SIGHUP guard can't see restarts).
+// Warning-only, mirroring ValidatePerpsDirectionConfig: the leg stays visible
+// and the kill switch still covers it (state-claimed coins), but nothing will
+// converge it — the operator must flatten it or restore the hedge block.
+func validateHedgeStateConsistency(state *AppState, cfg *Config) []string {
+	var warnings []string
+	byID := make(map[string]StrategyConfig, len(cfg.Strategies))
+	for _, sc := range cfg.Strategies {
+		byID[sc.ID] = sc
+	}
+	ids := make([]string, 0, len(state.Strategies))
+	for id := range state.Strategies {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		s := state.Strategies[id]
+		if s == nil {
+			continue
+		}
+		sc, configured := byID[id]
+		syms := make([]string, 0, len(s.Positions))
+		for sym := range s.Positions {
+			syms = append(syms, sym)
+		}
+		sort.Strings(syms)
+		for _, sym := range syms {
+			pos := s.Positions[sym]
+			if pos == nil || !pos.IsHedge || pos.Quantity <= hedgeQtyEpsilon {
+				continue
+			}
+			switch {
+			case !configured:
+				warnings = append(warnings, fmt.Sprintf("orphaned hedge leg: strategy %s no longer configured but holds hedge %s %s qty=%g (for %s) — nothing manages it; flatten manually or restore the strategy (#1159)",
+					id, pos.Side, sym, pos.Quantity, pos.HedgePrimarySymbol))
+			case !hedgeEnabled(sc):
+				warnings = append(warnings, fmt.Sprintf("orphaned hedge leg: strategy %s holds hedge %s %s qty=%g (for %s) but its hedge block is disabled/removed — nothing converges it; flatten manually or restore the hedge block (#1159)",
+					id, pos.Side, sym, pos.Quantity, pos.HedgePrimarySymbol))
+			case !strings.EqualFold(hedgeCoin(sc), sym):
+				warnings = append(warnings, fmt.Sprintf("hedge leg coin mismatch: strategy %s holds hedge %s %s qty=%g but config now hedges with %s — the old leg is converged as-is; flatten it to migrate coins (#1159)",
+					id, pos.Side, sym, pos.Quantity, hedgeCoin(sc)))
+			}
+		}
+	}
+	return warnings
+}
+
+// inverseSide maps a primary position side to the phase-1 hedge side.
+func inverseSide(side string) string {
+	if side == "long" {
+		return "short"
+	}
+	return "long"
+}
+
+// hedgePrimarySnapshot / hedgeLegSnapshot are lock-free copies of the fields
+// the convergence planner needs, captured under the RLock in hedge_sync.go.
+type hedgePrimarySnapshot struct {
+	Symbol   string
+	Side     string
+	Quantity float64
+}
+
+type hedgeLegSnapshot struct {
+	Symbol   string
+	Side     string
+	Quantity float64
+	Covered  float64 // Position.HedgeCoveredPrimaryQty
+}
+
+// hedgeOrder is one on-chain action the convergence engine must take.
+// Side != "" → market open/add of Quantity on the hedge coin.
+// Close → reduce-only close (FullClose closes the whole leg).
+// CoveredAfter is the HedgeCoveredPrimaryQty to stamp once the order books.
+type hedgeOrder struct {
+	Side         string
+	Quantity     float64
+	Close        bool
+	FullClose    bool
+	CoveredAfter float64
+}
+
+// hedgePlan is the convergence planner output. StampCovered (no orders) means
+// the covered watermark should be adopted/re-synced without touching the
+// exchange — e.g. a legacy hedge leg persisted before the watermark existed.
+type hedgePlan struct {
+	Orders       []hedgeOrder
+	StampCovered *float64
+}
+
+// hedgeOpenQty sizes an opening/adding hedge order: the primary quantity
+// delta's USD notional at the primary mark, scaled by ratio, converted to
+// hedge-coin units at the hedge mark.
+func hedgeOpenQty(ratio, primaryQtyDelta, primaryMark, hedgeMark float64) (float64, error) {
+	if primaryMark <= 0 || hedgeMark <= 0 {
+		return 0, fmt.Errorf("hedge sizing requires positive primary and hedge marks (primary=%g hedge=%g)", primaryMark, hedgeMark)
+	}
+	qty := primaryQtyDelta * primaryMark * ratio / hedgeMark
+	if math.IsNaN(qty) || math.IsInf(qty, 0) || qty <= hedgeQtyEpsilon {
+		return 0, fmt.Errorf("resolved hedge quantity %g is not positive", qty)
+	}
+	return qty, nil
+}
+
+// planHedgeConvergence derives the orders that bring the hedge leg in line
+// with the primary position. Pure — no locks, no I/O — so every lifecycle
+// case is unit-testable. Marks are only consulted when an opening/adding
+// order must be sized; reductions and closes are mark-free.
+func planHedgeConvergence(ratio float64, primary *hedgePrimarySnapshot, hedge *hedgeLegSnapshot, primaryMark, hedgeMark float64) (hedgePlan, error) {
+	if hedge != nil && (hedge.Quantity <= hedgeQtyEpsilon || (hedge.Side != "long" && hedge.Side != "short")) {
+		return hedgePlan{}, fmt.Errorf("corrupt hedge leg state (side=%q qty=%g)", hedge.Side, hedge.Quantity)
+	}
+	if primary == nil || primary.Quantity <= hedgeQtyEpsilon {
+		if hedge == nil {
+			return hedgePlan{}, nil
+		}
+		return hedgePlan{Orders: []hedgeOrder{{Close: true, FullClose: true, Quantity: hedge.Quantity}}}, nil
+	}
+	if primary.Side != "long" && primary.Side != "short" {
+		return hedgePlan{}, fmt.Errorf("invalid primary side %q", primary.Side)
+	}
+	want := inverseSide(primary.Side)
+
+	openOrder := func() (hedgeOrder, error) {
+		qty, err := hedgeOpenQty(ratio, primary.Quantity, primaryMark, hedgeMark)
+		if err != nil {
+			return hedgeOrder{}, err
+		}
+		return hedgeOrder{Side: openTradeSide(want), Quantity: qty, CoveredAfter: primary.Quantity}, nil
+	}
+
+	if hedge == nil {
+		open, err := openOrder()
+		if err != nil {
+			return hedgePlan{}, err
+		}
+		return hedgePlan{Orders: []hedgeOrder{open}}, nil
+	}
+	if hedge.Side != want {
+		// Primary flipped: flatten the stale hedge, then open the inverse leg.
+		open, err := openOrder()
+		if err != nil {
+			return hedgePlan{}, err
+		}
+		return hedgePlan{Orders: []hedgeOrder{
+			{Close: true, FullClose: true, Quantity: hedge.Quantity},
+			open,
+		}}, nil
+	}
+	covered := hedge.Covered
+	if covered <= hedgeQtyEpsilon {
+		// Legacy leg persisted before the covered watermark existed (or a
+		// zeroed stamp): adopt the current primary quantity — issuing orders
+		// against an unknown baseline would guess.
+		stamp := primary.Quantity
+		return hedgePlan{StampCovered: &stamp}, nil
+	}
+	switch {
+	case primary.Quantity < covered*(1-hedgeCoveredRelEpsilon):
+		// Primary reduced: shed the same fraction of the hedge leg.
+		frac := (covered - primary.Quantity) / covered
+		reduce := hedge.Quantity * frac
+		if reduce <= hedgeQtyEpsilon {
+			stamp := primary.Quantity
+			return hedgePlan{StampCovered: &stamp}, nil
+		}
+		if reduce >= hedge.Quantity*(1-hedgeCoveredRelEpsilon) {
+			return hedgePlan{Orders: []hedgeOrder{{Close: true, FullClose: true, Quantity: hedge.Quantity}}}, nil
+		}
+		return hedgePlan{Orders: []hedgeOrder{{Close: true, Quantity: reduce, CoveredAfter: primary.Quantity}}}, nil
+	case primary.Quantity > covered*(1+hedgeCoveredRelEpsilon):
+		// Primary grew (scale-in): add the uncovered delta at current marks.
+		qty, err := hedgeOpenQty(ratio, primary.Quantity-covered, primaryMark, hedgeMark)
+		if err != nil {
+			return hedgePlan{}, err
+		}
+		return hedgePlan{Orders: []hedgeOrder{{Side: openTradeSide(want), Quantity: qty, CoveredAfter: primary.Quantity}}}, nil
+	case covered != primary.Quantity:
+		// Sub-epsilon float drift: re-sync the watermark without an order.
+		stamp := primary.Quantity
+		return hedgePlan{StampCovered: &stamp}, nil
+	}
+	return hedgePlan{}, nil
+}
+
+// recordHedgeTradeResult books a hedge leg's realized PnL into the daily PnL
+// (real money — the #1269 daily loss limit must see it) WITHOUT touching the
+// consecutive-loss streak: a hedge leg is mechanical coupling, not an
+// independent alpha outcome, and it typically loses exactly when the primary
+// wins — feeding it to the streak would double-count every round trip and
+// mis-fire the loss-streak circuit breaker (#1048/#1273 semantics).
+func recordHedgeTradeResult(r *RiskState, pnl float64) {
+	rolloverDailyPnL(r)
+	r.DailyPnL += pnl
+}
+
+// recordCloseTradeResult routes a close leg's realized PnL to the right risk
+// recorder: hedge legs skip the consecutive-loss streak (see
+// recordHedgeTradeResult), everything else keeps the legacy behavior. Every
+// shared close-booking path that can see an IsHedge position must call this
+// instead of RecordTradeResult directly.
+func recordCloseTradeResult(s *StrategyState, pos *Position, pnl float64) {
+	if pos != nil && pos.IsHedge {
+		recordHedgeTradeResult(&s.RiskState, pnl)
+		return
+	}
+	RecordTradeResult(&s.RiskState, pnl)
+}
+
+// applyHedgeOpenFill books a confirmed hedge OPEN fill: creates the IsHedge
+// position keyed by the hedge coin and records the open Trade. Mirrors the
+// perps open-leg construction in executePerpsSignalWithLeverage (margin-based:
+// only the fee leaves cash; notional stays virtual). Caller holds mu.Lock().
+func applyHedgeOpenFill(s *StrategyState, sc StrategyConfig, primarySymbol, side string, fillQty, fillPx, fillFee float64, fillOID int64, covered float64, logger *StrategyLogger) *Position {
+	if s == nil || fillQty <= hedgeQtyEpsilon || fillPx <= 0 || (side != "long" && side != "short") {
+		return nil
+	}
+	coin := hedgeCoin(sc)
+	if coin == "" {
+		return nil
+	}
+	now := time.Now().UTC()
+	fee := executionFee(CalculatePlatformSpotFee(s.Platform, fillQty*fillPx), fillFee, true)
+	s.Cash -= fee
+	positionID := newTradePositionID(s.ID, coin, now)
+	pos := &Position{
+		Symbol:                 coin,
+		TradePositionID:        positionID,
+		Quantity:               fillQty,
+		InitialQuantity:        fillQty,
+		AvgCost:                fillPx,
+		Side:                   side,
+		Multiplier:             1, // perps PnL-branch convention
+		Leverage:               sc.Hedge.Leverage,
+		OwnerStrategyID:        s.ID,
+		OpenedAt:               now,
+		IsHedge:                true,
+		HedgePrimarySymbol:     primarySymbol,
+		HedgeCoveredPrimaryQty: covered,
+	}
+	s.Positions[coin] = pos
+	var oidStr string
+	if fillOID > 0 {
+		oidStr = fmt.Sprintf("%d", fillOID)
+	}
+	trade := Trade{
+		Timestamp:       now,
+		StrategyID:      s.ID,
+		Symbol:          coin,
+		PositionID:      positionID,
+		Side:            openTradeSide(side),
+		Quantity:        fillQty,
+		Price:           fillPx,
+		Value:           fillQty * fillPx,
+		TradeType:       "perps",
+		Details:         fmt.Sprintf("[hedge %s] Open %s %.6f @ $%.4f (ratio %gx, fee $%.4f)", primarySymbol, side, fillQty, fillPx, sc.Hedge.Ratio, fee),
+		ExchangeOrderID: oidStr,
+		ExchangeFee:     fee,
+		FeeSource:       executionFeeSource(fillFee, true),
+		PnLGross:        true,
+	}
+	trade.Regime = s.Regime
+	RecordTrade(s, trade)
+	if logger != nil {
+		logger.Info("[hedge] opened %s %.6f %s @ $%.4f covering %.6f %s (fee $%.4f)", side, fillQty, coin, fillPx, covered, primarySymbol, fee)
+	}
+	return pos
+}
+
+// applyHedgeAddFill books a confirmed hedge ADD fill onto the existing leg:
+// blends AvgCost, grows Quantity/InitialQuantity, and advances the covered
+// watermark. Caller holds mu.Lock().
+func applyHedgeAddFill(s *StrategyState, pos *Position, fillQty, fillPx, fillFee float64, fillOID int64, covered float64, logger *StrategyLogger) bool {
+	if s == nil || pos == nil || !pos.IsHedge || fillQty <= hedgeQtyEpsilon || fillPx <= 0 {
+		return false
+	}
+	now := time.Now().UTC()
+	fee := executionFee(CalculatePlatformSpotFee(s.Platform, fillQty*fillPx), fillFee, true)
+	s.Cash -= fee
+	newQty := pos.Quantity + fillQty
+	pos.AvgCost = (pos.Quantity*pos.AvgCost + fillQty*fillPx) / newQty
+	pos.Quantity = newQty
+	pos.InitialQuantity += fillQty
+	pos.HedgeCoveredPrimaryQty = covered
+	var oidStr string
+	if fillOID > 0 {
+		oidStr = fmt.Sprintf("%d", fillOID)
+	}
+	trade := Trade{
+		Timestamp:       now,
+		StrategyID:      s.ID,
+		Symbol:          pos.Symbol,
+		PositionID:      ensurePositionTradeID(s.ID, pos.Symbol, pos),
+		Side:            openTradeSide(pos.Side),
+		Quantity:        fillQty,
+		Price:           fillPx,
+		Value:           fillQty * fillPx,
+		TradeType:       "perps",
+		Details:         fmt.Sprintf("[hedge %s] Add %s %.6f @ $%.4f (fee $%.4f)", pos.HedgePrimarySymbol, pos.Side, fillQty, fillPx, fee),
+		ExchangeOrderID: oidStr,
+		ExchangeFee:     fee,
+		FeeSource:       executionFeeSource(fillFee, true),
+		PnLGross:        true,
+	}
+	trade.Regime = s.Regime
+	RecordTrade(s, trade)
+	if logger != nil {
+		logger.Info("[hedge] added %.6f %s @ $%.4f (total %.6f, covering %.6f %s, fee $%.4f)", fillQty, pos.Symbol, fillPx, newQty, covered, pos.HedgePrimarySymbol, fee)
+	}
+	return true
+}

--- a/scheduler/hedge.go
+++ b/scheduler/hedge.go
@@ -33,6 +33,15 @@ const (
 	// issues an order. Both values come from virtual state (not marks), so in
 	// practice they match exactly; the tolerance only absorbs float drift.
 	hedgeCoveredRelEpsilon = 1e-6
+	// hedgeFillShortfallTolerance is the relative shortfall between a hedge
+	// order's requested and filled size before the engine treats it as a
+	// genuine partial fill. It must absorb exchange lot-size rounding: the HL
+	// adapter rounds order sizes to the asset's sz_decimals (round-to-nearest,
+	// platforms/hyperliquid/adapter.py market_open), so a FULLY-filled order
+	// legitimately reports up to half a lot less than the planner's unrounded
+	// quantity — a tight epsilon here would misread every such fill as
+	// partial and churn dust orders (review on #1333, round 3).
+	hedgeFillShortfallTolerance = 0.01
 )
 
 func hedgeEnabled(sc StrategyConfig) bool { return sc.Hedge != nil && sc.Hedge.Enabled }

--- a/scheduler/hedge_sync.go
+++ b/scheduler/hedge_sync.go
@@ -204,7 +204,20 @@ func syncHedgeLegForStrategy(sc StrategyConfig, ss *StrategyState, mu *sync.RWMu
 			}
 			result, err := deps.closer(hcoin, partial, nil)
 			if err != nil {
-				hedgeAlert(deps, logger, fmt.Sprintf("[CRITICAL] hedge-sync %s: reduce-only close of hedge leg %s (qty %.6f, full=%t) failed: %v — over-hedged until the next cycle retry", sc.ID, hcoin, order.Quantity, order.FullClose, err))
+				// The "retry next cycle" stance is safe ONLY while the
+				// residual hedge is INVERSE to the primary (a true over-
+				// hedge, which reduces net exposure). After a primary FLIP
+				// the stale hedge is the SAME side as the flipped primary —
+				// a failed close there holds 2× directional exposure with no
+				// stop on the hedge leg, so de-risk the primary reduce-only
+				// instead of passively retrying (review on #1333). Exposure
+				// cannot compound across cycles: once the primary is closed,
+				// later cycles only retry the stale-hedge close.
+				if prim != nil && hedge != nil && hedge.Side == prim.Side {
+					return trades + hedgeFailClosePrimary(sc, ss, mu, prim, 0, deps, logger,
+						fmt.Sprintf("stale hedge leg %s could not be closed after a primary flip (%v) — the residual hedge is the SAME side as the flipped primary (2x directional exposure, no hedge stop)", hcoin, err))
+				}
+				hedgeAlert(deps, logger, fmt.Sprintf("[CRITICAL] hedge-sync %s: reduce-only close of hedge leg %s (qty %.6f, full=%t) failed: %v — residual hedge stays inverse to the primary (over-hedged, net exposure reduced) until the next cycle retry", sc.ID, hcoin, order.Quantity, order.FullClose, err))
 				return trades
 			}
 			if result == nil || result.Close == nil || result.Close.AlreadyFlat || result.Close.Fill == nil {

--- a/scheduler/hedge_sync.go
+++ b/scheduler/hedge_sync.go
@@ -269,13 +269,30 @@ func syncHedgeLegForStrategy(sc StrategyConfig, ss *StrategyState, mu *sync.RWMu
 			return trades + hedgeFailClosePrimary(sc, ss, mu, prim, closeQty, deps, logger,
 				fmt.Sprintf("hedge %s order on %s (qty %.6f) failed: %s", order.Side, hcoin, order.Quantity, why))
 		}
+		// A partial fill covers proportionally less of the primary than the
+		// order intended: stamping the full CoveredAfter would record coverage
+		// the leg doesn't have, so the next cycle sees primary==covered and
+		// never re-adds the shortfall — a silent, permanent under-hedge that
+		// reconcile cannot repair (state qty == on-chain qty, no drift).
+		// Scale the watermark by the actual fill ratio so the shortfall
+		// re-triggers an add next cycle, and alert: under-hedged is the
+		// unsafe direction (review on #1333).
+		coveredAfter := order.CoveredAfter
+		if fill.TotalSz < order.Quantity*(1-hedgeCoveredRelEpsilon) {
+			coveredBefore := 0.0
+			if hedgeOpenLegLive && hedge != nil {
+				coveredBefore = hedge.Covered
+			}
+			coveredAfter = coveredBefore + (order.CoveredAfter-coveredBefore)*fill.TotalSz/order.Quantity
+			hedgeAlert(deps, logger, fmt.Sprintf("[WARN] hedge-sync %s: hedge %s on %s under-filled %.6f/%.6f — covered watermark scaled to %.6f of %.6f; the primary is under-hedged until the next cycle re-adds the shortfall", sc.ID, order.Side, hcoin, fill.TotalSz, order.Quantity, coveredAfter, order.CoveredAfter))
+		}
 		mu.Lock()
 		if hedgeOpenLegLive {
 			if hp := findHedgePosition(ss, sc); hp != nil {
-				applyHedgeAddFill(ss, hp, fill.TotalSz, fill.AvgPx, fill.Fee, fill.OID, order.CoveredAfter, logger)
+				applyHedgeAddFill(ss, hp, fill.TotalSz, fill.AvgPx, fill.Fee, fill.OID, coveredAfter, logger)
 			}
 		} else {
-			applyHedgeOpenFill(ss, sc, psym, inverseSide(prim.Side), fill.TotalSz, fill.AvgPx, fill.Fee, fill.OID, order.CoveredAfter, logger)
+			applyHedgeOpenFill(ss, sc, psym, inverseSide(prim.Side), fill.TotalSz, fill.AvgPx, fill.Fee, fill.OID, coveredAfter, logger)
 			hedgeOpenLegLive = true
 		}
 		mu.Unlock()

--- a/scheduler/hedge_sync.go
+++ b/scheduler/hedge_sync.go
@@ -1,0 +1,353 @@
+package main
+
+// #1159 phase 1: the per-cycle hedge convergence engine. Runs once per main
+// loop AFTER the dispatch loop (and never while the portfolio kill switch is
+// latched — the kill-switch close path owns flattening then), so any primary
+// lifecycle event that landed this cycle — fresh open, scale-in add, partial
+// close, full close, on-chain SL fill booked by reconcile, circuit-breaker
+// force-close — is mirrored onto the hedge leg within the same cycle.
+//
+// One mechanism covers every case: read the primary and hedge legs from
+// virtual state, plan the delta (planHedgeConvergence), place reduce-only
+// closes / market opens outside mu, and book confirmed fills under mu. This
+// is deliberately NOT wired into the signal dispatch: closes that bypass
+// dispatch (SL fills, CB) must converge through the same path.
+//
+// Fail-closed policy (issue constraint 4): if a hedge OPEN/ADD cannot be
+// placed or confirmed — order error, size rounded to zero, missing marks,
+// unverifiable or foreign on-chain state on the hedge coin — the engine
+// immediately closes the UNCOVERED primary quantity reduce-only (the full
+// leg for a fresh open/flip, the added delta for a scale-in) and alerts the
+// operator. The primary is never left unhedged silently. Reduce/close
+// failures alert and retry next cycle (an over-hedged residual reduces net
+// exposure — safe direction — unlike a naked primary).
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// hedgeExecuteFn places a market open/add order for the hedge leg and returns
+// the parsed execute result. Injectable so the engine is unit-testable
+// without subprocesses (repo pattern: HyperliquidLiveCloser).
+type hedgeExecuteFn func(sc StrategyConfig, coin, side string, size float64, snapshot hlExecuteSnapshot) (*HyperliquidExecuteResult, error)
+
+type hedgeSyncDeps struct {
+	execute hedgeExecuteFn
+	closer  HyperliquidLiveCloser
+	ownerDM func(string)
+}
+
+func defaultHedgeSyncDeps(notifier *MultiNotifier) hedgeSyncDeps {
+	return hedgeSyncDeps{
+		execute: defaultHedgeExecute,
+		closer:  defaultHyperliquidLiveCloser,
+		ownerDM: notifier.SendOwnerDM,
+	}
+}
+
+// defaultHedgeExecute shells to check_hyperliquid.py --execute for the hedge
+// coin. No --stop-loss-pct (phase 1: the hedge carries no protection orders
+// of its own), no SL-cancel OIDs; margin_mode/leverage come from the hedge
+// block — the hedge coin needs its own on-chain margin assignment, never the
+// primary's (issue constraint 3).
+func defaultHedgeExecute(sc StrategyConfig, coin, side string, size float64, snapshot hlExecuteSnapshot) (*HyperliquidExecuteResult, error) {
+	execResult, _, err := RunHyperliquidExecute(sc.Script, coin, side, size, 0, 0, 0, sc.Hedge.MarginMode, sc.Hedge.Leverage, false, snapshot)
+	if err != nil {
+		return execResult, err
+	}
+	if execResult != nil && execResult.Error != "" {
+		return execResult, fmt.Errorf("hedge execute error: %s", execResult.Error)
+	}
+	return execResult, nil
+}
+
+// hyperliquidOnChainSignedSize returns the signed on-chain size for coin (0
+// when absent).
+func hyperliquidOnChainSignedSize(positions []HLPosition, coin string) float64 {
+	for i := range positions {
+		if positions[i].Coin == coin {
+			return positions[i].Size
+		}
+	}
+	return 0
+}
+
+// runHedgeLegSync converges every hedge-enabled live HL perps strategy's
+// hedge leg with its primary position. Must be called WITHOUT holding mu;
+// spawns subprocesses. Returns the number of hedge trades booked.
+func runHedgeLegSync(ctx context.Context, strategies []StrategyConfig, state *AppState, mu *sync.RWMutex, prices map[string]float64, hlPositions []HLPosition, hlStateFetched bool, deps hedgeSyncDeps, logMgr *LogManager) int {
+	if state == nil || deps.closer == nil || deps.execute == nil {
+		return 0
+	}
+	var hedged []StrategyConfig
+	for _, sc := range strategies {
+		if hedgeEnabled(sc) && sc.Platform == "hyperliquid" && sc.Type == "perps" && hyperliquidIsLive(sc.Args) {
+			hedged = append(hedged, sc)
+		}
+	}
+	if len(hedged) == 0 {
+		return 0
+	}
+	sort.Slice(hedged, func(i, j int) bool { return hedged[i].ID < hedged[j].ID })
+
+	trades := 0
+	for _, sc := range hedged {
+		if err := ctx.Err(); err != nil {
+			fmt.Printf("[CRITICAL] hedge-sync: budget exhausted before strategy %s: %v\n", sc.ID, err)
+			return trades
+		}
+		ss := state.Strategies[sc.ID]
+		if ss == nil {
+			continue
+		}
+		var logger *StrategyLogger
+		if logMgr != nil {
+			if lg, err := logMgr.GetStrategyLogger(sc.ID); err == nil {
+				logger = lg
+			}
+		}
+		trades += syncHedgeLegForStrategy(sc, ss, mu, prices, hlPositions, hlStateFetched, deps, logger)
+		if logger != nil {
+			logger.Close()
+		}
+	}
+	return trades
+}
+
+func syncHedgeLegForStrategy(sc StrategyConfig, ss *StrategyState, mu *sync.RWMutex, prices map[string]float64, hlPositions []HLPosition, hlStateFetched bool, deps hedgeSyncDeps, logger *StrategyLogger) int {
+	hcoin := hedgeCoin(sc)
+	psym := hyperliquidSymbol(sc.Args)
+	if hcoin == "" || psym == "" {
+		return 0
+	}
+
+	mu.RLock()
+	var prim *hedgePrimarySnapshot
+	if pos, ok := ss.Positions[psym]; ok && pos != nil && !pos.IsHedge && pos.Quantity > hedgeQtyEpsilon {
+		prim = &hedgePrimarySnapshot{Symbol: psym, Side: pos.Side, Quantity: pos.Quantity}
+	}
+	var hedge *hedgeLegSnapshot
+	if hp := findHedgePosition(ss, sc); hp != nil {
+		hedge = &hedgeLegSnapshot{Symbol: hp.Symbol, Side: hp.Side, Quantity: hp.Quantity, Covered: hp.HedgeCoveredPrimaryQty}
+	}
+	mu.RUnlock()
+
+	// A state-only hedge under a different coin (config edited across a
+	// restart) is converged on ITS coin, not the configured one — never
+	// leave a live leg unmanaged.
+	if hedge != nil && hedge.Symbol != hcoin {
+		hcoin = hedge.Symbol
+	}
+
+	plan, err := planHedgeConvergence(sc.Hedge.Ratio, prim, hedge, prices[psym], prices[hcoin])
+	if err != nil {
+		if prim != nil && hedge == nil {
+			// Could not size/plan the opening leg — constraint 4.
+			return hedgeFailClosePrimary(sc, ss, mu, prim, 0, deps, logger,
+				fmt.Sprintf("hedge open for %s could not be planned: %v", hcoin, err))
+		}
+		hedgeAlert(deps, logger, fmt.Sprintf("[CRITICAL] hedge-sync %s: cannot converge hedge leg %s: %v — manual intervention may be required", sc.ID, hcoin, err))
+		return 0
+	}
+
+	if plan.StampCovered != nil {
+		mu.Lock()
+		if hp := findHedgePosition(ss, sc); hp != nil {
+			if hp.HedgeCoveredPrimaryQty != *plan.StampCovered && logger != nil {
+				logger.Info("[hedge] adopting covered watermark %.6f %s for %s leg", *plan.StampCovered, psym, hp.Symbol)
+			}
+			hp.HedgeCoveredPrimaryQty = *plan.StampCovered
+		}
+		mu.Unlock()
+		return 0
+	}
+	if len(plan.Orders) == 0 {
+		return 0
+	}
+
+	// Pre-flight for opening orders: the hedge coin's on-chain state must be
+	// verifiable and unambiguous. Structurally (validateHedgeConfigs) no
+	// configured strategy trades this coin, so an on-chain position with no
+	// state-side hedge leg is foreign (operator/manual or a lost-state fill)
+	// — fail closed per issue requirement 4: never place an order that would
+	// blend into an unattributable position.
+	needsOpen := false
+	for _, o := range plan.Orders {
+		if o.Side != "" {
+			needsOpen = true
+			break
+		}
+	}
+	if needsOpen {
+		if !hlStateFetched {
+			return hedgeFailClosePrimary(sc, ss, mu, prim, hedgeUncoveredQty(prim, hedge), deps, logger,
+				fmt.Sprintf("hedge open for %s refused: HL clearinghouse state unavailable this cycle (cannot verify the hedge coin is unowned)", hcoin))
+		}
+		onChain := hyperliquidOnChainSignedSize(hlPositions, hcoin)
+		if hedge == nil && (onChain > hedgeQtyEpsilon || onChain < -hedgeQtyEpsilon) {
+			return hedgeFailClosePrimary(sc, ss, mu, prim, hedgeUncoveredQty(prim, hedge), deps, logger,
+				fmt.Sprintf("hedge open for %s refused: foreign on-chain position (size %.6f) already exists on the hedge coin — resolve it manually", hcoin, onChain))
+		}
+	}
+
+	trades := 0
+	hedgeOpenLegLive := hedge != nil
+	for _, order := range plan.Orders {
+		if order.Close {
+			var partial *float64
+			if !order.FullClose {
+				v := order.Quantity
+				partial = &v
+			}
+			result, err := deps.closer(hcoin, partial, nil)
+			if err != nil {
+				hedgeAlert(deps, logger, fmt.Sprintf("[CRITICAL] hedge-sync %s: reduce-only close of hedge leg %s (qty %.6f, full=%t) failed: %v — over-hedged until the next cycle retry", sc.ID, hcoin, order.Quantity, order.FullClose, err))
+				return trades
+			}
+			if result == nil || result.Close == nil || result.Close.AlreadyFlat || result.Close.Fill == nil {
+				// State says the leg is open but the exchange has nothing to
+				// close: reconcile owns gap booking (hl_sync_external with the
+				// userFills VWAP) — never book a guessed fill here.
+				if logger != nil {
+					logger.Warn("[hedge] close of %s returned no fill (already flat?) — deferring to reconcile for gap booking", hcoin)
+				}
+				return trades
+			}
+			fill := result.Close.Fill
+			mu.Lock()
+			applyHyperliquidCircuitCloseFill(ss, hcoin, fill.TotalSz, fill.AvgPx, fill.Fee, 0, fill.OID, "hedge_sync")
+			if !order.FullClose {
+				if hp := findHedgePosition(ss, sc); hp != nil {
+					hp.HedgeCoveredPrimaryQty = order.CoveredAfter
+				}
+			}
+			mu.Unlock()
+			trades++
+			if !order.FullClose && fill.TotalSz < order.Quantity*0.99 {
+				hedgeAlert(deps, logger, fmt.Sprintf("[WARN] hedge-sync %s: hedge reduce on %s under-filled %.6f/%.6f — residual over-hedge remains until the leg closes", sc.ID, hcoin, fill.TotalSz, order.Quantity))
+			}
+			if order.FullClose {
+				hedgeOpenLegLive = false
+			}
+			continue
+		}
+
+		// Opening/adding market order.
+		snapshot := hlExecuteSnapshotForCoin(hlPositions, hcoin)
+		execResult, err := deps.execute(sc, hcoin, order.Side, order.Quantity, snapshot)
+		var fill *HyperliquidFill
+		if err == nil && execResult != nil && execResult.Execution != nil {
+			fill = execResult.Execution.Fill
+		}
+		if err != nil || fill == nil || fill.TotalSz <= hedgeQtyEpsilon || fill.AvgPx <= 0 {
+			why := "no fill returned"
+			if err != nil {
+				why = err.Error()
+			}
+			closeQty := hedgeUncoveredQty(prim, hedge)
+			if !hedgeOpenLegLive {
+				// Fresh open or the reopen leg of a flip whose close already
+				// filled: the whole primary is unhedged.
+				closeQty = 0
+			}
+			return trades + hedgeFailClosePrimary(sc, ss, mu, prim, closeQty, deps, logger,
+				fmt.Sprintf("hedge %s order on %s (qty %.6f) failed: %s", order.Side, hcoin, order.Quantity, why))
+		}
+		mu.Lock()
+		if hedgeOpenLegLive {
+			if hp := findHedgePosition(ss, sc); hp != nil {
+				applyHedgeAddFill(ss, hp, fill.TotalSz, fill.AvgPx, fill.Fee, fill.OID, order.CoveredAfter, logger)
+			}
+		} else {
+			applyHedgeOpenFill(ss, sc, psym, inverseSide(prim.Side), fill.TotalSz, fill.AvgPx, fill.Fee, fill.OID, order.CoveredAfter, logger)
+			hedgeOpenLegLive = true
+		}
+		mu.Unlock()
+		trades++
+	}
+	return trades
+}
+
+// hedgeUncoveredQty returns the primary quantity NOT yet covered by the hedge
+// leg — the fail-closed close size for a failed ADD (0 = close the full leg,
+// used when there is no live hedge at all).
+func hedgeUncoveredQty(prim *hedgePrimarySnapshot, hedge *hedgeLegSnapshot) float64 {
+	if prim == nil {
+		return 0
+	}
+	if hedge == nil || hedge.Covered <= hedgeQtyEpsilon {
+		return 0 // full close
+	}
+	delta := prim.Quantity - hedge.Covered
+	if delta <= hedgeQtyEpsilon {
+		return 0
+	}
+	return delta
+}
+
+// hedgeFailClosePrimary implements issue constraint 4: reduce-only close of
+// the uncovered primary quantity (closeQty <= 0 → the full virtual leg) after
+// a hedge open/add failure, booking whatever filled, then alerting the
+// operator. The close is ALWAYS sized (partialSz set, never nil) so a shared
+// primary coin's peer exposure is never flattened. Returns booked trades.
+func hedgeFailClosePrimary(sc StrategyConfig, ss *StrategyState, mu *sync.RWMutex, prim *hedgePrimarySnapshot, closeQty float64, deps hedgeSyncDeps, logger *StrategyLogger, why string) int {
+	if prim == nil {
+		hedgeAlert(deps, logger, fmt.Sprintf("[CRITICAL] hedge-sync %s: %s", sc.ID, why))
+		return 0
+	}
+	mu.RLock()
+	pos := ss.Positions[prim.Symbol]
+	var qty float64
+	var cancelOIDs []int64
+	if pos != nil && !pos.IsHedge && pos.Quantity > hedgeQtyEpsilon {
+		qty = pos.Quantity
+		if closeQty > hedgeQtyEpsilon && closeQty < qty {
+			qty = closeQty
+		} else {
+			// Full-leg close: cancel this strategy's resting protection so the
+			// flatten doesn't orphan trigger orders (#421/#479 convention).
+			cancelOIDs = hyperliquidProtectionCancelOIDs(pos)
+		}
+	}
+	mu.RUnlock()
+	if qty <= hedgeQtyEpsilon {
+		hedgeAlert(deps, logger, fmt.Sprintf("[CRITICAL] hedge-sync %s: %s (primary already flat — nothing to de-risk)", sc.ID, why))
+		return 0
+	}
+
+	partial := qty
+	result, err := deps.closer(prim.Symbol, &partial, cancelOIDs)
+	if err != nil {
+		hedgeAlert(deps, logger, fmt.Sprintf("[CRITICAL] hedge-sync %s: %s — AND the fail-closed primary close of %.6f %s FAILED (%v). The position is RUNNING UNHEDGED; the engine retries next cycle", sc.ID, why, qty, prim.Symbol, err))
+		return 0
+	}
+	trades := 0
+	if result != nil && result.Close != nil && !result.Close.AlreadyFlat && result.Close.Fill != nil {
+		fill := result.Close.Fill
+		mu.Lock()
+		applyHyperliquidCircuitCloseFill(ss, prim.Symbol, fill.TotalSz, fill.AvgPx, fill.Fee, 0, fill.OID, "hedge_open_failed")
+		if result.CancelStopLossSucceeded {
+			if p, ok := ss.Positions[prim.Symbol]; ok && p != nil {
+				p.StopLossOID = 0
+				p.TPOIDs = nil
+			}
+		}
+		mu.Unlock()
+		trades++
+	}
+	hedgeAlert(deps, logger, fmt.Sprintf("[CRITICAL] hedge-sync %s: %s — closed %.6f %s reduce-only (fail-closed per #1159 constraint 4: never run unhedged silently)", sc.ID, why, qty, prim.Symbol))
+	return trades
+}
+
+func hedgeAlert(deps hedgeSyncDeps, logger *StrategyLogger, msg string) {
+	if logger != nil {
+		logger.Error("%s", msg)
+	}
+	fmt.Println(msg)
+	if deps.ownerDM != nil {
+		deps.ownerDM(msg)
+	}
+}

--- a/scheduler/hedge_sync.go
+++ b/scheduler/hedge_sync.go
@@ -239,10 +239,35 @@ func syncHedgeLegForStrategy(sc StrategyConfig, ss *StrategyState, mu *sync.RWMu
 			}
 			mu.Unlock()
 			trades++
-			if !order.FullClose && fill.TotalSz < order.Quantity*0.99 {
+			if !order.FullClose && fill.TotalSz < order.Quantity*(1-hedgeFillShortfallTolerance) {
 				hedgeAlert(deps, logger, fmt.Sprintf("[WARN] hedge-sync %s: hedge reduce on %s under-filled %.6f/%.6f — residual over-hedge remains until the leg closes", sc.ID, hcoin, fill.TotalSz, order.Quantity))
 			}
 			if order.FullClose {
+				if fill.TotalSz < order.Quantity*(1-hedgeFillShortfallTolerance) {
+					// The "full" close left a residual leg in virtual state
+					// (applyHyperliquidCircuitCloseFill decrements, it doesn't
+					// delete). Proceeding to a same-coin re-open would
+					// overwrite that residual — silently discarding its
+					// quantity — so never continue past a partial full close
+					// (review on #1333, round 3). Which way to fail depends on
+					// the residual's side:
+					//  - flip (residual SAME side as the flipped primary):
+					//    2x directional exposure with no hedge stop — de-risk
+					//    the primary reduce-only, matching the flip-close
+					//    FAILURE path; next cycle the planner closes the
+					//    residual against the now-flat primary.
+					//  - no flip (primary flat, or a deep reduction whose
+					//    proportional close consumed the leg): the residual is
+					//    inverse or unopposed — the safe direction — alert and
+					//    retry the close next cycle.
+					residual := order.Quantity - fill.TotalSz
+					if prim != nil && hedge != nil && hedge.Side == prim.Side {
+						return trades + hedgeFailClosePrimary(sc, ss, mu, prim, 0, deps, logger,
+							fmt.Sprintf("stale hedge leg %s only partially closed during a primary flip (%.6f of %.6f filled, residual %.6f) — the residual is the SAME side as the flipped primary and a same-coin reopen would overwrite it", hcoin, fill.TotalSz, order.Quantity, residual))
+					}
+					hedgeAlert(deps, logger, fmt.Sprintf("[WARN] hedge-sync %s: full close of hedge leg %s under-filled %.6f/%.6f — residual %.6f retries next cycle", sc.ID, hcoin, fill.TotalSz, order.Quantity, residual))
+					continue
+				}
 				hedgeOpenLegLive = false
 			}
 			continue
@@ -276,9 +301,12 @@ func syncHedgeLegForStrategy(sc StrategyConfig, ss *StrategyState, mu *sync.RWMu
 		// reconcile cannot repair (state qty == on-chain qty, no drift).
 		// Scale the watermark by the actual fill ratio so the shortfall
 		// re-triggers an add next cycle, and alert: under-hedged is the
-		// unsafe direction (review on #1333).
+		// unsafe direction (review on #1333). The tolerance must absorb the
+		// adapter's sz_decimals lot rounding — a fully-filled order reports
+		// up to half a lot under the unrounded request, and treating that as
+		// partial would churn dust re-adds every open (round 3).
 		coveredAfter := order.CoveredAfter
-		if fill.TotalSz < order.Quantity*(1-hedgeCoveredRelEpsilon) {
+		if fill.TotalSz < order.Quantity*(1-hedgeFillShortfallTolerance) {
 			coveredBefore := 0.0
 			if hedgeOpenLegLive && hedge != nil {
 				coveredBefore = hedge.Covered

--- a/scheduler/hedge_sync_test.go
+++ b/scheduler/hedge_sync_test.go
@@ -344,3 +344,106 @@ func TestHedgeSyncSkipsNonHedgeAndPaperStrategies(t *testing.T) {
 		t.Fatalf("paper strategy produced hedge orders: %v %v", f.execCalls, f.closeCalls)
 	}
 }
+
+// Review finding 1 (#1333): downward on-chain hedge drift (partial ADL /
+// liquidation / manual reduction while the primary is unchanged) must
+// re-trigger an add that restores coverage — never be adopted as "fully
+// covering" and leave the position silently under-hedged.
+func TestHedgeSyncDownwardDriftReAddsShortfall(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, true)
+	ss := state.Strategies["a"]
+	// Reconcile observes the hedge shrunk on-chain 0.10 → 0.08.
+	resolve := func(coin string, oid int64, qty float64) (HLFillLookup, bool) { return HLFillLookup{}, false }
+	if !reconcileHedgeLegForStrategy(sc, ss, []HLPosition{{Coin: "BTC", Size: -0.08, EntryPrice: 50000, Leverage: 2}}, resolve, hedgeSilentLogger("a")) {
+		t.Fatal("expected drift resync")
+	}
+	// Covered must rescale proportionally (4 × 0.08/0.10 = 3.2), so the next
+	// sync re-adds the uncovered 0.8 ETH worth: 0.8×2500×0.5÷50000 = 0.02 BTC.
+	f := &fakeHedgeDeps{}
+	trades := runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 4}, {Coin: "BTC", Size: -0.08}}, true, f)
+	if trades != 1 || len(f.execCalls) != 1 {
+		t.Fatalf("trades=%d exec=%+v, want one re-add", trades, f.execCalls)
+	}
+	if f.execCalls[0].Side != "sell" || math.Abs(f.execCalls[0].Size-0.02) > 1e-9 {
+		t.Fatalf("re-add order = %+v, want sell 0.02 BTC", f.execCalls[0])
+	}
+	pos := ss.Positions["BTC"]
+	if pos == nil || math.Abs(pos.Quantity-0.10) > 1e-9 || math.Abs(pos.HedgeCoveredPrimaryQty-4) > 1e-9 {
+		t.Fatalf("hedge after re-add = %+v, want qty 0.10 covering 4", pos)
+	}
+}
+
+// Review finding 1 must-survive (b): the upward lost-add drift (crash between
+// an add fill and its booking) still must not double-place the add after the
+// proportional rescale.
+func TestHedgeSyncUpwardDriftNoDoubleAdd(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, true)
+	ss := state.Strategies["a"]
+	// Primary scale-in booked (4 → 6) but the matching hedge add fill was
+	// lost: covered is still 4, chain shows the add (0.10 → 0.15).
+	ss.Positions["ETH"].Quantity = 6
+	resolve := func(coin string, oid int64, qty float64) (HLFillLookup, bool) { return HLFillLookup{}, false }
+	if !reconcileHedgeLegForStrategy(sc, ss, []HLPosition{{Coin: "BTC", Size: -0.15, EntryPrice: 50000, Leverage: 2}}, resolve, hedgeSilentLogger("a")) {
+		t.Fatal("expected drift resync")
+	}
+	// covered rescales 4 × 0.15/0.10 = 6 = primary → converged, no orders.
+	f := &fakeHedgeDeps{}
+	if n := runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 6}, {Coin: "BTC", Size: -0.15}}, true, f); n != 0 {
+		t.Fatalf("double-placed after lost-add resync: exec=%+v close=%+v", f.execCalls, f.closeCalls)
+	}
+}
+
+// Review finding 2 (#1333): a flip whose stale-hedge close FAILS leaves the
+// hedge on the SAME side as the flipped primary (2× directional exposure, no
+// stop) — the engine must de-risk the primary reduce-only, not passively
+// retry, and must not mislabel the state as a benign over-hedge.
+func TestHedgeSyncFlipCloseFailureDeRisksPrimary(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, true)
+	ss := state.Strategies["a"]
+	ss.Positions["ETH"].Side = "short" // primary flipped; stale hedge is also short
+	f := &fakeHedgeDeps{closeErr: map[string]error{"BTC": fmt.Errorf("api down")}}
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: -4}, {Coin: "BTC", Size: -0.1}}, true, f)
+	// The failed BTC close, then the fail-closed ETH primary close.
+	if len(f.closeCalls) != 2 || f.closeCalls[0].Coin != "BTC" || f.closeCalls[1].Coin != "ETH" {
+		t.Fatalf("close calls = %+v, want failed BTC close then ETH de-risk", f.closeCalls)
+	}
+	if f.closeCalls[1].Partial == nil || math.Abs(*f.closeCalls[1].Partial-4) > 1e-9 {
+		t.Fatalf("primary de-risk close = %+v, want sized 4 ETH", f.closeCalls[1])
+	}
+	if _, open := ss.Positions["ETH"]; open {
+		t.Fatal("primary not de-risked after flip-close failure")
+	}
+	joined := strings.Join(f.alerts, "\n")
+	if strings.Contains(joined, "over-hedged") {
+		t.Fatalf("same-side residual mislabeled as over-hedged: %v", f.alerts)
+	}
+	if !strings.Contains(joined, "SAME side") {
+		t.Fatalf("alert must name the same-side 2x exposure: %v", f.alerts)
+	}
+	// Exposure must not compound on later cycles: primary is flat, so the
+	// next pass just retries the stale-hedge close.
+	f2 := &fakeHedgeDeps{closeErr: map[string]error{"BTC": fmt.Errorf("api down")}}
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "BTC", Size: -0.1}}, true, f2)
+	if len(f2.execCalls) != 0 || len(f2.closeCalls) != 1 || f2.closeCalls[0].Coin != "BTC" {
+		t.Fatalf("follow-up cycle = exec %+v close %+v, want only the hedge-close retry", f2.execCalls, f2.closeCalls)
+	}
+}
+
+// Review finding 2 must-survive (c): flip where the stale-hedge close
+// succeeds but the reopen fails → the existing full-primary fail-close path.
+func TestHedgeSyncFlipReopenFailureClosesPrimary(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, true)
+	ss := state.Strategies["a"]
+	ss.Positions["ETH"].Side = "short"
+	f := &fakeHedgeDeps{
+		execErr:   fmt.Errorf("reopen rejected"),
+		closeFill: map[string]*HyperliquidCloseFill{"BTC": {AvgPx: 50000, TotalSz: 0.1, OID: 5005, Fee: 0.4}},
+	}
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: -4}, {Coin: "BTC", Size: -0.1}}, true, f)
+	if _, open := ss.Positions["BTC"]; open {
+		t.Fatal("stale hedge not closed on flip")
+	}
+	if _, open := ss.Positions["ETH"]; open {
+		t.Fatal("primary not fail-closed when the flip reopen failed")
+	}
+}

--- a/scheduler/hedge_sync_test.go
+++ b/scheduler/hedge_sync_test.go
@@ -517,3 +517,94 @@ func TestHedgeSyncPartialAddFillScalesCovered(t *testing.T) {
 		t.Fatalf("partial add fill must alert; got %v", f.alerts)
 	}
 }
+
+// Review on #1333 (round 3): the HL adapter rounds order sizes to the asset's
+// sz_decimals, so a FULLY-filled hedge order legitimately reports slightly
+// less than the planner's unrounded request. That benign lot rounding must
+// NOT be misread as a partial fill — else every open scales the watermark,
+// fires a spurious under-hedge alert, and re-adds dust next cycle (which can
+// round to zero and cascade into hedgeFailClosePrimary).
+func TestHedgeSyncLotRoundedFullFillIsNotPartial(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, false)
+	// Requested 0.1 BTC; the exchange reports the lot-rounded 0.09999.
+	f := &fakeHedgeDeps{execFill: &HyperliquidFill{AvgPx: 50000, TotalSz: 0.09999, OID: 1003, Fee: 0.5}}
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 4}}, true, f)
+	pos := state.Strategies["a"].Positions["BTC"]
+	if pos == nil || math.Abs(pos.HedgeCoveredPrimaryQty-4) > 1e-12 {
+		t.Fatalf("lot-rounded full fill must stamp full coverage; covered = %+v", pos)
+	}
+	if len(f.alerts) != 0 {
+		t.Fatalf("lot-rounded full fill must not alert: %v", f.alerts)
+	}
+	// Converged: the next cycle must not chase the sub-lot dust.
+	f2 := &fakeHedgeDeps{}
+	if n := runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 4}, {Coin: "BTC", Size: -0.09999}}, true, f2); n != 0 {
+		t.Fatalf("dust re-add churn: exec=%v close=%v", f2.execCalls, f2.closeCalls)
+	}
+	// A fill that rounds UP is equally benign.
+	sc2, state2, prices2 := hedgeSyncFixture(4, false)
+	f3 := &fakeHedgeDeps{execFill: &HyperliquidFill{AvgPx: 50000, TotalSz: 0.1000001, OID: 1004, Fee: 0.5}}
+	runHedgeSyncTest(t, sc2, state2, prices2, []HLPosition{{Coin: "ETH", Size: 4}}, true, f3)
+	pos2 := state2.Strategies["a"].Positions["BTC"]
+	if pos2 == nil || math.Abs(pos2.HedgeCoveredPrimaryQty-4) > 1e-12 || len(f3.alerts) != 0 {
+		t.Fatalf("round-up full fill mishandled: pos=%+v alerts=%v", pos2, f3.alerts)
+	}
+}
+
+// Review on #1333 (round 3, optional): a flip whose stale-hedge full close
+// only PARTIALLY fills must not proceed to the re-open — the re-open would
+// overwrite the same-coin residual leg in virtual state, silently discarding
+// its quantity. The residual is the SAME side as the flipped primary, so the
+// engine de-risks the primary (constraint 4) and leaves the residual for the
+// next cycle's planner to close.
+func TestHedgeSyncFlipPartialCloseDeRisksPrimaryNotOverwrite(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, true)
+	ss := state.Strategies["a"]
+	ss.Positions["ETH"].Side = "short" // primary flipped; stale short hedge is now same-side
+	f := &fakeHedgeDeps{closeFill: map[string]*HyperliquidCloseFill{
+		"BTC": {AvgPx: 50000, TotalSz: 0.06, OID: 6006, Fee: 0.3}, // partial: 0.06 of 0.1
+		"ETH": {AvgPx: 2500, TotalSz: 4, OID: 6007, Fee: 0.8},
+	}}
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: -4}, {Coin: "BTC", Size: -0.1}}, true, f)
+	if len(f.execCalls) != 0 {
+		t.Fatalf("re-open must not run after a partial flip close: %+v", f.execCalls)
+	}
+	hp := ss.Positions["BTC"]
+	if hp == nil || !hp.IsHedge || hp.Side != "short" || math.Abs(hp.Quantity-0.04) > 1e-9 {
+		t.Fatalf("residual hedge leg must survive (0.04 short), got %+v", hp)
+	}
+	if _, open := ss.Positions["ETH"]; open {
+		t.Fatal("primary must be fail-closed when the flip close under-fills")
+	}
+	joined := strings.Join(f.alerts, "\n")
+	if !strings.Contains(joined, "partially closed") {
+		t.Fatalf("alert must name the partial flip close: %v", f.alerts)
+	}
+	// Next cycle: primary flat → the planner just closes the residual.
+	f2 := &fakeHedgeDeps{closeFill: map[string]*HyperliquidCloseFill{
+		"BTC": {AvgPx: 50000, TotalSz: 0.04, OID: 6008, Fee: 0.2},
+	}}
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "BTC", Size: -0.04}}, true, f2)
+	if _, open := ss.Positions["BTC"]; open {
+		t.Fatal("residual hedge not closed on the follow-up cycle")
+	}
+}
+
+// A partial full-close WITHOUT a flip (primary already flat, or a deep
+// reduction) leaves an INVERSE/naked-but-primary-flat residual — the safe
+// direction — so it alerts and retries next cycle instead of de-risking.
+func TestHedgeSyncPartialFullCloseWithoutFlipRetries(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(0, true) // primary flat, hedge leg 0.1 short
+	f := &fakeHedgeDeps{closeFill: map[string]*HyperliquidCloseFill{
+		"BTC": {AvgPx: 50000, TotalSz: 0.06, OID: 7007, Fee: 0.3},
+	}}
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "BTC", Size: -0.1}}, true, f)
+	hp := state.Strategies["a"].Positions["BTC"]
+	if hp == nil || math.Abs(hp.Quantity-0.04) > 1e-9 {
+		t.Fatalf("residual hedge leg = %+v, want 0.04 remaining", hp)
+	}
+	joined := strings.Join(f.alerts, "\n")
+	if !strings.Contains(joined, "under-filled") {
+		t.Fatalf("partial full close must alert: %v", f.alerts)
+	}
+}

--- a/scheduler/hedge_sync_test.go
+++ b/scheduler/hedge_sync_test.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeHedgeDeps records every order the engine places and returns scripted
+// results, so the full lifecycle is testable without subprocesses.
+type fakeHedgeDeps struct {
+	execCalls  []fakeHedgeExec
+	closeCalls []fakeHedgeClose
+	execErr    error
+	execFill   *HyperliquidFill
+	closeErr   map[string]error                 // per-coin close error
+	closeFill  map[string]*HyperliquidCloseFill // per-coin close fill
+	alerts     []string
+}
+
+type fakeHedgeExec struct {
+	Coin string
+	Side string
+	Size float64
+}
+
+type fakeHedgeClose struct {
+	Coin    string
+	Partial *float64
+	Cancel  []int64
+}
+
+func (f *fakeHedgeDeps) deps() hedgeSyncDeps {
+	return hedgeSyncDeps{
+		execute: func(sc StrategyConfig, coin, side string, size float64, snapshot hlExecuteSnapshot) (*HyperliquidExecuteResult, error) {
+			f.execCalls = append(f.execCalls, fakeHedgeExec{coin, side, size})
+			if f.execErr != nil {
+				return nil, f.execErr
+			}
+			fill := f.execFill
+			if fill == nil {
+				fill = &HyperliquidFill{AvgPx: 50000, TotalSz: size, OID: 1001, Fee: 0.5}
+			}
+			return &HyperliquidExecuteResult{Execution: &HyperliquidExecution{Action: side, Symbol: coin, Size: size, Fill: fill}}, nil
+		},
+		closer: func(coin string, partial *float64, cancel []int64) (*HyperliquidCloseResult, error) {
+			var pcopy *float64
+			if partial != nil {
+				v := *partial
+				pcopy = &v
+			}
+			f.closeCalls = append(f.closeCalls, fakeHedgeClose{coin, pcopy, append([]int64(nil), cancel...)})
+			if err := f.closeErr[coin]; err != nil {
+				return nil, err
+			}
+			fill := f.closeFill[coin]
+			if fill == nil {
+				sz := 0.0
+				if partial != nil {
+					sz = *partial
+				}
+				fill = &HyperliquidCloseFill{AvgPx: 50000, TotalSz: sz, OID: 2002, Fee: 0.4}
+			}
+			return &HyperliquidCloseResult{Close: &HyperliquidClose{Symbol: coin, Fill: fill}, CancelStopLossSucceeded: len(cancel) > 0}, nil
+		},
+		ownerDM: func(msg string) { f.alerts = append(f.alerts, msg) },
+	}
+}
+
+func hedgeSyncFixture(primaryQty float64, withHedge bool) (StrategyConfig, *AppState, map[string]float64) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	ss := hedgeTestState("a")
+	if primaryQty > 0 {
+		ss.Positions["ETH"] = &Position{
+			Symbol: "ETH", Quantity: primaryQty, InitialQuantity: primaryQty, AvgCost: 2500,
+			Side: "long", Multiplier: 1, Leverage: 3, OwnerStrategyID: "a",
+			StopLossOID: 555, TPOIDs: []int64{666},
+		}
+	}
+	if withHedge {
+		ss.Positions["BTC"] = &Position{
+			Symbol: "BTC", Quantity: 0.1, InitialQuantity: 0.1, AvgCost: 50000,
+			Side: "short", Multiplier: 1, Leverage: 2, OwnerStrategyID: "a",
+			IsHedge: true, HedgePrimarySymbol: "ETH", HedgeCoveredPrimaryQty: 4,
+		}
+	}
+	state := &AppState{Strategies: map[string]*StrategyState{"a": ss}}
+	prices := map[string]float64{"ETH": 2500, "BTC": 50000}
+	return sc, state, prices
+}
+
+func runHedgeSyncTest(t *testing.T, sc StrategyConfig, state *AppState, prices map[string]float64, hlPositions []HLPosition, hlStateFetched bool, f *fakeHedgeDeps) int {
+	t.Helper()
+	var mu sync.RWMutex
+	return runHedgeLegSync(context.Background(), []StrategyConfig{sc}, state, &mu, prices, hlPositions, hlStateFetched, f.deps(), nil)
+}
+
+func TestHedgeSyncOpensHedgeWithPrimary(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, false)
+	f := &fakeHedgeDeps{}
+	trades := runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 4}}, true, f)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	if len(f.execCalls) != 1 || f.execCalls[0].Coin != "BTC" || f.execCalls[0].Side != "sell" || math.Abs(f.execCalls[0].Size-0.1) > 1e-9 {
+		t.Fatalf("exec calls = %+v", f.execCalls)
+	}
+	ss := state.Strategies["a"]
+	pos := ss.Positions["BTC"]
+	if pos == nil || !pos.IsHedge || pos.Side != "short" || math.Abs(pos.Quantity-0.1) > 1e-9 {
+		t.Fatalf("hedge position = %+v", pos)
+	}
+	if pos.HedgePrimarySymbol != "ETH" || math.Abs(pos.HedgeCoveredPrimaryQty-4) > 1e-9 {
+		t.Fatalf("hedge metadata = %+v", pos)
+	}
+	if pos.Leverage != 2 {
+		t.Fatalf("hedge leverage = %g, want the hedge block's 2", pos.Leverage)
+	}
+	last := ss.TradeHistory[len(ss.TradeHistory)-1]
+	if last.IsClose || last.Symbol != "BTC" || last.Side != "sell" || last.ExchangeFee != 0.5 {
+		t.Fatalf("open trade = %+v", last)
+	}
+	// Converged: a second pass must be a no-op (no churn).
+	f2 := &fakeHedgeDeps{}
+	if n := runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 4}, {Coin: "BTC", Size: -0.1}}, true, f2); n != 0 {
+		t.Fatalf("second pass placed orders: exec=%v close=%v", f2.execCalls, f2.closeCalls)
+	}
+}
+
+func TestHedgeSyncNoPrimaryNoOrders(t *testing.T) {
+	// Failed/absent primary open → no hedge order is ever placed.
+	sc, state, prices := hedgeSyncFixture(0, false)
+	f := &fakeHedgeDeps{}
+	if n := runHedgeSyncTest(t, sc, state, prices, nil, true, f); n != 0 {
+		t.Fatalf("trades = %d, want 0", n)
+	}
+	if len(f.execCalls) != 0 || len(f.closeCalls) != 0 {
+		t.Fatalf("orders placed with no primary: exec=%v close=%v", f.execCalls, f.closeCalls)
+	}
+}
+
+func TestHedgeSyncOpenFailureClosesPrimaryFailClosed(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, false)
+	f := &fakeHedgeDeps{execErr: fmt.Errorf("boom")}
+	trades := runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 4}}, true, f)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want the fail-closed primary close", trades)
+	}
+	// Reduce-only SIZED close of the primary (never partialSz=nil — a shared
+	// primary coin's peer exposure must survive), with protection cancelled.
+	if len(f.closeCalls) != 1 || f.closeCalls[0].Coin != "ETH" || f.closeCalls[0].Partial == nil || math.Abs(*f.closeCalls[0].Partial-4) > 1e-9 {
+		t.Fatalf("close calls = %+v", f.closeCalls)
+	}
+	if len(f.closeCalls[0].Cancel) != 2 {
+		t.Fatalf("expected SL+TP OIDs cancelled, got %v", f.closeCalls[0].Cancel)
+	}
+	ss := state.Strategies["a"]
+	if _, open := ss.Positions["ETH"]; open {
+		t.Fatal("primary position not cleared after fail-closed close")
+	}
+	if len(f.alerts) == 0 || !strings.Contains(f.alerts[len(f.alerts)-1], "fail-closed") {
+		t.Fatalf("operator alert missing: %v", f.alerts)
+	}
+	last := ss.TradeHistory[len(ss.TradeHistory)-1]
+	if !last.IsClose || last.Symbol != "ETH" {
+		t.Fatalf("fail-closed close trade = %+v", last)
+	}
+}
+
+func TestHedgeSyncMissingMarkClosesPrimary(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, false)
+	delete(prices, "BTC") // hedge mark unavailable → cannot size the open
+	f := &fakeHedgeDeps{}
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 4}}, true, f)
+	if len(f.execCalls) != 0 {
+		t.Fatalf("open placed without a mark: %v", f.execCalls)
+	}
+	if _, open := state.Strategies["a"].Positions["ETH"]; open {
+		t.Fatal("primary not fail-closed when hedge open could not be sized")
+	}
+}
+
+func TestHedgeSyncForeignOnChainPositionRefusesOpen(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, false)
+	f := &fakeHedgeDeps{}
+	// Foreign BTC position on-chain, no state hedge → refuse + fail-close.
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 4}, {Coin: "BTC", Size: 0.5}}, true, f)
+	if len(f.execCalls) != 0 {
+		t.Fatalf("opened into a foreign position: %v", f.execCalls)
+	}
+	if _, open := state.Strategies["a"].Positions["ETH"]; open {
+		t.Fatal("primary not fail-closed on foreign hedge-coin position")
+	}
+	if len(f.alerts) == 0 || !strings.Contains(strings.Join(f.alerts, "\n"), "foreign on-chain position") {
+		t.Fatalf("foreign-position alert missing: %v", f.alerts)
+	}
+}
+
+func TestHedgeSyncUnfetchedChainStateRefusesOpen(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, false)
+	f := &fakeHedgeDeps{}
+	runHedgeSyncTest(t, sc, state, prices, nil, false, f)
+	if len(f.execCalls) != 0 {
+		t.Fatalf("opened without verifiable chain state: %v", f.execCalls)
+	}
+	if _, open := state.Strategies["a"].Positions["ETH"]; open {
+		t.Fatal("primary not fail-closed when chain state was unverifiable")
+	}
+}
+
+func TestHedgeSyncPartialCloseReducesHedge(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, true)
+	ss := state.Strategies["a"]
+	ss.Positions["ETH"].Quantity = 2 // primary partially closed this cycle
+	f := &fakeHedgeDeps{}
+	trades := runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 2}, {Coin: "BTC", Size: -0.1}}, true, f)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	if len(f.closeCalls) != 1 || f.closeCalls[0].Coin != "BTC" || f.closeCalls[0].Partial == nil || math.Abs(*f.closeCalls[0].Partial-0.05) > 1e-9 {
+		t.Fatalf("close calls = %+v", f.closeCalls)
+	}
+	pos := ss.Positions["BTC"]
+	if pos == nil || math.Abs(pos.Quantity-0.05) > 1e-9 || math.Abs(pos.HedgeCoveredPrimaryQty-2) > 1e-9 {
+		t.Fatalf("hedge after reduce = %+v", pos)
+	}
+}
+
+func TestHedgeSyncFullCloseFollowsPrimary(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(0, true) // primary gone, hedge open
+	f := &fakeHedgeDeps{closeFill: map[string]*HyperliquidCloseFill{
+		"BTC": {AvgPx: 49000, TotalSz: 0.1, OID: 3003, Fee: 0.4},
+	}}
+	trades := runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "BTC", Size: -0.1}}, true, f)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	if len(f.closeCalls) != 1 || f.closeCalls[0].Coin != "BTC" || f.closeCalls[0].Partial != nil {
+		t.Fatalf("close calls = %+v (full close must pass nil partial)", f.closeCalls)
+	}
+	ss := state.Strategies["a"]
+	if _, open := ss.Positions["BTC"]; open {
+		t.Fatal("hedge not removed after full close")
+	}
+	last := ss.TradeHistory[len(ss.TradeHistory)-1]
+	if !last.IsClose || math.Abs(last.RealizedPnL-(0.1*(50000-49000))) > 1e-6 {
+		t.Fatalf("hedge close trade = %+v, want gross PnL 100", last)
+	}
+}
+
+func TestHedgeSyncFlipClosesThenReopens(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, true)
+	ss := state.Strategies["a"]
+	ss.Positions["ETH"].Side = "short" // primary flipped this cycle
+	f := &fakeHedgeDeps{closeFill: map[string]*HyperliquidCloseFill{
+		"BTC": {AvgPx: 50000, TotalSz: 0.1, OID: 4004, Fee: 0.4},
+	}}
+	trades := runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: -4}, {Coin: "BTC", Size: -0.1}}, true, f)
+	if trades != 2 {
+		t.Fatalf("trades = %d, want close + reopen", trades)
+	}
+	if len(f.closeCalls) != 1 || len(f.execCalls) != 1 || f.execCalls[0].Side != "buy" {
+		t.Fatalf("orders: close=%+v exec=%+v", f.closeCalls, f.execCalls)
+	}
+	pos := ss.Positions["BTC"]
+	if pos == nil || pos.Side != "long" || !pos.IsHedge {
+		t.Fatalf("flipped hedge = %+v", pos)
+	}
+}
+
+func TestHedgeSyncAddFailureClosesUncoveredDelta(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, true)
+	ss := state.Strategies["a"]
+	ss.Positions["ETH"].Quantity = 6 // scale-in grew the primary; covered=4
+	f := &fakeHedgeDeps{execErr: fmt.Errorf("size rounded to zero")}
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 6}, {Coin: "BTC", Size: -0.1}}, true, f)
+	// Fail-closed: the UNCOVERED 2 ETH close, not the whole leg.
+	if len(f.closeCalls) != 1 || f.closeCalls[0].Coin != "ETH" || f.closeCalls[0].Partial == nil || math.Abs(*f.closeCalls[0].Partial-2) > 1e-9 {
+		t.Fatalf("close calls = %+v, want partial 2 ETH", f.closeCalls)
+	}
+	pos := ss.Positions["ETH"]
+	if pos == nil || math.Abs(pos.Quantity-4) > 1e-9 {
+		t.Fatalf("primary after delta close = %+v, want qty 4", pos)
+	}
+	hedge := ss.Positions["BTC"]
+	if hedge == nil || math.Abs(hedge.Quantity-0.1) > 1e-9 {
+		t.Fatalf("hedge disturbed by add failure: %+v", hedge)
+	}
+}
+
+func TestHedgeSyncReduceFailureAlertsAndRetries(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, true)
+	ss := state.Strategies["a"]
+	ss.Positions["ETH"].Quantity = 2
+	f := &fakeHedgeDeps{closeErr: map[string]error{"BTC": fmt.Errorf("api down")}}
+	trades := runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 2}, {Coin: "BTC", Size: -0.1}}, true, f)
+	if trades != 0 {
+		t.Fatalf("trades = %d, want 0 (close failed)", trades)
+	}
+	// Over-hedged is the safe direction: no destructive action, loud alert,
+	// hedge state untouched so next cycle retries the same reduce.
+	pos := ss.Positions["BTC"]
+	if pos == nil || math.Abs(pos.Quantity-0.1) > 1e-9 || math.Abs(pos.HedgeCoveredPrimaryQty-4) > 1e-9 {
+		t.Fatalf("hedge state mutated on failed close: %+v", pos)
+	}
+	if len(f.alerts) != 1 || !strings.Contains(f.alerts[0], "over-hedged") {
+		t.Fatalf("alerts = %v", f.alerts)
+	}
+}
+
+func TestHedgeSyncScaleInAddsToHedge(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, true)
+	ss := state.Strategies["a"]
+	ss.Positions["ETH"].Quantity = 6
+	f := &fakeHedgeDeps{}
+	trades := runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 6}, {Coin: "BTC", Size: -0.1}}, true, f)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	if len(f.execCalls) != 1 || f.execCalls[0].Side != "sell" || math.Abs(f.execCalls[0].Size-0.05) > 1e-9 {
+		t.Fatalf("exec calls = %+v, want sell 0.05 BTC", f.execCalls)
+	}
+	pos := ss.Positions["BTC"]
+	if pos == nil || math.Abs(pos.Quantity-0.15) > 1e-9 || math.Abs(pos.HedgeCoveredPrimaryQty-6) > 1e-9 {
+		t.Fatalf("hedge after add = %+v", pos)
+	}
+	// Add leg blends AvgCost and grows InitialQuantity (mirrors #873).
+	if math.Abs(pos.InitialQuantity-0.15) > 1e-9 {
+		t.Fatalf("InitialQuantity = %g, want 0.15", pos.InitialQuantity)
+	}
+}
+
+func TestHedgeSyncSkipsNonHedgeAndPaperStrategies(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	sc.Args[2] = "--mode=paper" // load-time validation rejects this; engine must also skip it
+	_, state, prices := hedgeSyncFixture(4, false)
+	f := &fakeHedgeDeps{}
+	var mu sync.RWMutex
+	n := runHedgeLegSync(context.Background(), []StrategyConfig{sc}, state, &mu, prices, nil, true, f.deps(), nil)
+	if n != 0 || len(f.execCalls) != 0 || len(f.closeCalls) != 0 {
+		t.Fatalf("paper strategy produced hedge orders: %v %v", f.execCalls, f.closeCalls)
+	}
+}

--- a/scheduler/hedge_sync_test.go
+++ b/scheduler/hedge_sync_test.go
@@ -447,3 +447,73 @@ func TestHedgeSyncFlipReopenFailureClosesPrimary(t *testing.T) {
 		t.Fatal("primary not fail-closed when the flip reopen failed")
 	}
 }
+
+// Review on #1333 (round 2): a PARTIALLY-filled hedge open must scale the
+// covered watermark by the actual fill ratio and alert — stamping the full
+// primary quantity would record coverage the leg doesn't have, and the next
+// cycle would see primary==covered and never re-add the shortfall (a silent,
+// permanent under-hedge that reconcile cannot repair).
+func TestHedgeSyncPartialOpenFillScalesCoveredAndReAdds(t *testing.T) {
+	sc, state, prices := hedgeSyncFixture(4, false)
+	// Requested open is 0.1 BTC (4 ETH x $2500 x ratio 0.5 / $50000); the
+	// exchange fills only half.
+	f := &fakeHedgeDeps{execFill: &HyperliquidFill{AvgPx: 50000, TotalSz: 0.05, OID: 1001, Fee: 0.5}}
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 4}}, true, f)
+	ss := state.Strategies["a"]
+	pos := ss.Positions["BTC"]
+	if pos == nil || math.Abs(pos.Quantity-0.05) > 1e-9 {
+		t.Fatalf("hedge leg = %+v", pos)
+	}
+	if math.Abs(pos.HedgeCoveredPrimaryQty-2) > 1e-9 {
+		t.Fatalf("covered = %g, want 2 (4 x 0.05/0.10 fill ratio)", pos.HedgeCoveredPrimaryQty)
+	}
+	underFillAlerted := false
+	for _, a := range f.alerts {
+		if strings.Contains(a, "under-filled") {
+			underFillAlerted = true
+		}
+	}
+	if !underFillAlerted {
+		t.Fatalf("partial open fill must alert; got %v", f.alerts)
+	}
+	// Next cycle re-adds the uncovered 2 ETH → a 0.05 BTC top-up.
+	f2 := &fakeHedgeDeps{}
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 4}, {Coin: "BTC", Size: -0.05}}, true, f2)
+	if len(f2.execCalls) != 1 || f2.execCalls[0].Coin != "BTC" || math.Abs(f2.execCalls[0].Size-0.05) > 1e-9 {
+		t.Fatalf("top-up calls = %+v", f2.execCalls)
+	}
+	if math.Abs(pos.HedgeCoveredPrimaryQty-4) > 1e-9 || math.Abs(pos.Quantity-0.1) > 1e-9 {
+		t.Fatalf("after top-up: covered=%g qty=%g, want 4 / 0.1", pos.HedgeCoveredPrimaryQty, pos.Quantity)
+	}
+	// Fully converged: a third pass is a no-op (no churn regression).
+	f3 := &fakeHedgeDeps{}
+	if n := runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 4}, {Coin: "BTC", Size: -0.1}}, true, f3); n != 0 {
+		t.Fatalf("third pass placed orders: exec=%v close=%v", f3.execCalls, f3.closeCalls)
+	}
+}
+
+// Same invariant for a scale-in ADD: covered advances only by the filled
+// fraction of the delta, so the next cycle tops up the remainder.
+func TestHedgeSyncPartialAddFillScalesCovered(t *testing.T) {
+	// Primary grew 4 → 6 ETH with covered=4: the add for the 2-ETH delta
+	// requests 0.05 BTC; the exchange fills half of it.
+	sc, state, prices := hedgeSyncFixture(6, true)
+	f := &fakeHedgeDeps{execFill: &HyperliquidFill{AvgPx: 50000, TotalSz: 0.025, OID: 1002, Fee: 0.3}}
+	runHedgeSyncTest(t, sc, state, prices, []HLPosition{{Coin: "ETH", Size: 6}, {Coin: "BTC", Size: -0.1}}, true, f)
+	pos := state.Strategies["a"].Positions["BTC"]
+	if pos == nil || math.Abs(pos.Quantity-0.125) > 1e-9 {
+		t.Fatalf("hedge leg = %+v", pos)
+	}
+	if math.Abs(pos.HedgeCoveredPrimaryQty-5) > 1e-9 {
+		t.Fatalf("covered = %g, want 5 (4 + half of the 2-ETH delta)", pos.HedgeCoveredPrimaryQty)
+	}
+	underFillAlerted := false
+	for _, a := range f.alerts {
+		if strings.Contains(a, "under-filled") {
+			underFillAlerted = true
+		}
+	}
+	if !underFillAlerted {
+		t.Fatalf("partial add fill must alert; got %v", f.alerts)
+	}
+}

--- a/scheduler/hedge_test.go
+++ b/scheduler/hedge_test.go
@@ -431,7 +431,7 @@ func TestReconcileHedgeLegExternalClose(t *testing.T) {
 func TestReconcileHedgeLegResyncsDrift(t *testing.T) {
 	sc := hedgeTestConfig("a", "ETH", "BTC")
 	ss := hedgeTestState("a")
-	ss.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 0, IsHedge: true, HedgePrimarySymbol: "ETH", OwnerStrategyID: "a"}
+	ss.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 0, IsHedge: true, HedgePrimarySymbol: "ETH", HedgeCoveredPrimaryQty: 4, OwnerStrategyID: "a"}
 	onChain := []HLPosition{{Coin: "BTC", Size: -0.08, EntryPrice: 50100, Leverage: 2}}
 	resolve := func(coin string, oid int64, qty float64) (HLFillLookup, bool) { return HLFillLookup{}, false }
 	if !reconcileHedgeLegForStrategy(sc, ss, onChain, resolve, hedgeSilentLogger("a")) {
@@ -441,11 +441,13 @@ func TestReconcileHedgeLegResyncsDrift(t *testing.T) {
 	if pos.Quantity != 0.08 || pos.Side != "short" || pos.AvgCost != 50100 || pos.Multiplier != 1 {
 		t.Fatalf("resynced pos = %+v", pos)
 	}
-	// A qty resync invalidates the covered watermark — it must zero so the
-	// next hedge_sync ADOPTS the current primary quantity instead of
-	// re-deriving deltas against the pre-drift baseline.
-	if pos.HedgeCoveredPrimaryQty != 0 {
-		t.Fatalf("covered watermark not reset on drift resync: %g", pos.HedgeCoveredPrimaryQty)
+	// A qty resync rescales the covered watermark proportionally (review
+	// finding on #1333): 4 covered by 0.10 → 0.08 on-chain ⇒ covers 3.2.
+	// Zeroing (adopt) would mark the shrunken hedge as FULL coverage and
+	// leave the position silently under-hedged; rescaling re-triggers the
+	// shortfall add while still absorbing lost-add upward drift.
+	if math.Abs(pos.HedgeCoveredPrimaryQty-3.2) > 1e-9 {
+		t.Fatalf("covered watermark = %g after drift resync, want proportional 3.2", pos.HedgeCoveredPrimaryQty)
 	}
 }
 

--- a/scheduler/hedge_test.go
+++ b/scheduler/hedge_test.go
@@ -1,0 +1,539 @@
+package main
+
+import (
+	"context"
+	"io"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+func hedgeTestConfig(id, symbol, hedgeSymbol string) StrategyConfig {
+	return StrategyConfig{
+		ID:             id,
+		Type:           "perps",
+		Platform:       "hyperliquid",
+		Script:         "shared_scripts/check_hyperliquid.py",
+		Args:           []string{"rsi", symbol, "--mode=live"},
+		Capital:        1000,
+		MaxDrawdownPct: 20,
+		Leverage:       3,
+		MarginMode:     "isolated",
+		Hedge: &HedgeConfig{
+			Enabled:    true,
+			Symbol:     hedgeSymbol,
+			Side:       HedgeSideInverse,
+			Ratio:      0.5,
+			Platform:   "hyperliquid",
+			Type:       "perps",
+			MarginMode: "cross",
+			Leverage:   2,
+		},
+	}
+}
+
+func hedgeTestState(id string) *StrategyState {
+	return &StrategyState{
+		ID:              id,
+		Type:            "perps",
+		Platform:        "hyperliquid",
+		Cash:            1000,
+		InitialCapital:  1000,
+		Positions:       map[string]*Position{},
+		OptionPositions: map[string]*OptionPosition{},
+	}
+}
+
+func hedgeSilentLogger(id string) *StrategyLogger {
+	return &StrategyLogger{stratID: id, writer: io.Discard}
+}
+
+// --- sizing -----------------------------------------------------------------
+
+func TestHedgeOpenQtyInverseNotionalSizing(t *testing.T) {
+	// 4 ETH @ $2500 = $10k notional × ratio 0.5 = $5k ÷ BTC $50k = 0.1 BTC.
+	qty, err := hedgeOpenQty(0.5, 4, 2500, 50000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if math.Abs(qty-0.1) > 1e-12 {
+		t.Fatalf("qty = %g, want 0.1", qty)
+	}
+	if _, err := hedgeOpenQty(0.5, 4, 0, 50000); err == nil {
+		t.Fatal("expected error for zero primary mark")
+	}
+	if _, err := hedgeOpenQty(0.5, 4, 2500, 0); err == nil {
+		t.Fatal("expected error for zero hedge mark")
+	}
+}
+
+// --- convergence planning ----------------------------------------------------
+
+func TestPlanHedgeConvergenceLifecycle(t *testing.T) {
+	long4 := &hedgePrimarySnapshot{Symbol: "ETH", Side: "long", Quantity: 4}
+	short4 := &hedgePrimarySnapshot{Symbol: "ETH", Side: "short", Quantity: 4}
+	tests := []struct {
+		name    string
+		primary *hedgePrimarySnapshot
+		hedge   *hedgeLegSnapshot
+		want    []hedgeOrder
+	}{
+		{
+			name:    "fresh open long primary → sell hedge",
+			primary: long4,
+			want:    []hedgeOrder{{Side: "sell", Quantity: 0.1, CoveredAfter: 4}},
+		},
+		{
+			name:    "fresh open short primary → buy hedge",
+			primary: short4,
+			want:    []hedgeOrder{{Side: "buy", Quantity: 0.1, CoveredAfter: 4}},
+		},
+		{
+			name:    "scale-in adds uncovered delta",
+			primary: &hedgePrimarySnapshot{Symbol: "ETH", Side: "long", Quantity: 6},
+			hedge:   &hedgeLegSnapshot{Symbol: "BTC", Side: "short", Quantity: 0.1, Covered: 4},
+			// delta 2 ETH × $2500 × 0.5 ÷ $50000 = 0.05 BTC
+			want: []hedgeOrder{{Side: "sell", Quantity: 0.05, CoveredAfter: 6}},
+		},
+		{
+			name:    "partial close reduces proportionally",
+			primary: &hedgePrimarySnapshot{Symbol: "ETH", Side: "long", Quantity: 2},
+			hedge:   &hedgeLegSnapshot{Symbol: "BTC", Side: "short", Quantity: 0.1, Covered: 4},
+			want:    []hedgeOrder{{Close: true, Quantity: 0.05, CoveredAfter: 2}},
+		},
+		{
+			name:  "primary flat → full close",
+			hedge: &hedgeLegSnapshot{Symbol: "BTC", Side: "short", Quantity: 0.1, Covered: 4},
+			want:  []hedgeOrder{{Close: true, FullClose: true, Quantity: 0.1}},
+		},
+		{
+			name:    "primary flip → close then reopen inverse",
+			primary: short4,
+			hedge:   &hedgeLegSnapshot{Symbol: "BTC", Side: "short", Quantity: 0.1, Covered: 4},
+			want: []hedgeOrder{
+				{Close: true, FullClose: true, Quantity: 0.1},
+				{Side: "buy", Quantity: 0.1, CoveredAfter: 4},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			plan, err := planHedgeConvergence(0.5, tc.primary, tc.hedge, 2500, 50000)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(plan.Orders) != len(tc.want) {
+				t.Fatalf("orders = %+v, want %+v", plan.Orders, tc.want)
+			}
+			for i := range plan.Orders {
+				got, want := plan.Orders[i], tc.want[i]
+				if got.Side != want.Side || got.Close != want.Close || got.FullClose != want.FullClose ||
+					math.Abs(got.Quantity-want.Quantity) > 1e-9 || math.Abs(got.CoveredAfter-want.CoveredAfter) > 1e-9 {
+					t.Fatalf("orders[%d] = %+v, want %+v", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+// Regression: the ongoing target is quantity-anchored (covered watermark),
+// never re-derived from live marks — a mark move with an unchanged primary
+// quantity must not emit an order, or the engine would churn every cycle.
+func TestPlanHedgeConvergenceNoChurnOnMarkMoves(t *testing.T) {
+	primary := &hedgePrimarySnapshot{Symbol: "ETH", Side: "long", Quantity: 4}
+	hedge := &hedgeLegSnapshot{Symbol: "BTC", Side: "short", Quantity: 0.1, Covered: 4}
+	for _, marks := range [][2]float64{{2500, 50000}, {3800, 41000}, {900, 93000}, {0, 0}} {
+		plan, err := planHedgeConvergence(0.5, primary, hedge, marks[0], marks[1])
+		if err != nil {
+			t.Fatalf("marks %v: %v", marks, err)
+		}
+		if len(plan.Orders) != 0 || plan.StampCovered != nil {
+			t.Fatalf("marks %v: expected no-op plan, got %+v", marks, plan)
+		}
+	}
+}
+
+func TestPlanHedgeConvergenceAdoptsLegacyCovered(t *testing.T) {
+	primary := &hedgePrimarySnapshot{Symbol: "ETH", Side: "long", Quantity: 4}
+	hedge := &hedgeLegSnapshot{Symbol: "BTC", Side: "short", Quantity: 0.1, Covered: 0}
+	plan, err := planHedgeConvergence(0.5, primary, hedge, 2500, 50000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Orders) != 0 || plan.StampCovered == nil || *plan.StampCovered != 4 {
+		t.Fatalf("expected adopt-covered stamp 4, got %+v", plan)
+	}
+}
+
+func TestPlanHedgeConvergenceOpenNeedsMarks(t *testing.T) {
+	primary := &hedgePrimarySnapshot{Symbol: "ETH", Side: "long", Quantity: 4}
+	if _, err := planHedgeConvergence(0.5, primary, nil, 2500, 0); err == nil {
+		t.Fatal("expected sizing error when hedge mark is missing")
+	}
+	// Closes must NOT need marks: primary flat, no marks at all.
+	hedge := &hedgeLegSnapshot{Symbol: "BTC", Side: "short", Quantity: 0.1, Covered: 4}
+	plan, err := planHedgeConvergence(0.5, nil, hedge, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Orders) != 1 || !plan.Orders[0].FullClose {
+		t.Fatalf("expected mark-free full close, got %+v", plan)
+	}
+}
+
+func TestPlanHedgeConvergenceRejectsCorruptHedge(t *testing.T) {
+	primary := &hedgePrimarySnapshot{Symbol: "ETH", Side: "long", Quantity: 4}
+	if _, err := planHedgeConvergence(0.5, primary, &hedgeLegSnapshot{Symbol: "BTC", Side: "sideways", Quantity: 0.1}, 2500, 50000); err == nil {
+		t.Fatal("expected corrupt-hedge error")
+	}
+}
+
+// --- validation ---------------------------------------------------------------
+
+func TestValidateHedgeConfigsRejectsCollisions(t *testing.T) {
+	manualBTC := StrategyConfig{ID: "man-btc", Type: "manual", Platform: "hyperliquid", Symbol: "BTC"}
+	tests := []struct {
+		name       string
+		strategies []StrategyConfig
+		want       string
+	}{
+		{"own primary coin", []StrategyConfig{hedgeTestConfig("a", "ETH", "ETH")}, "matches its own primary coin"},
+		{"another strategy's coin", []StrategyConfig{hedgeTestConfig("a", "ETH", "BTC"), hedgeTestConfig("b", "BTC", "SOL")}, "matches configured strategy"},
+		{"manual strategy's coin", []StrategyConfig{hedgeTestConfig("a", "ETH", "BTC"), manualBTC}, "matches configured strategy"},
+		{"shared hedge coin", []StrategyConfig{hedgeTestConfig("a", "ETH", "BTC"), hedgeTestConfig("b", "SOL", "BTC")}, "already the hedge coin"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateHedgeConfigs(tc.strategies)
+			if !hedgeErrsContain(errs, tc.want) {
+				t.Fatalf("errs = %v, want substring %q", errs, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateHedgeConfigsRejectsUnsupportedShape(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*StrategyConfig)
+		want string
+	}{
+		{"paper primary", func(sc *StrategyConfig) { sc.Args[2] = "--mode=paper" }, "live Hyperliquid perps"},
+		{"non-perps hedge type", func(sc *StrategyConfig) { sc.Hedge.Type = "spot" }, "type=\"perps\""},
+		{"non-inverse side", func(sc *StrategyConfig) { sc.Hedge.Side = "same" }, "side must be"},
+		{"zero ratio", func(sc *StrategyConfig) { sc.Hedge.Ratio = 0 }, "ratio must be > 0"},
+		{"nan ratio", func(sc *StrategyConfig) { sc.Hedge.Ratio = math.NaN() }, "ratio must be > 0"},
+		{"bad margin mode", func(sc *StrategyConfig) { sc.Hedge.MarginMode = "" }, "margin_mode"},
+		{"zero leverage", func(sc *StrategyConfig) { sc.Hedge.Leverage = 0 }, "leverage must be"},
+		{"missing symbol", func(sc *StrategyConfig) { sc.Hedge.Symbol = " " }, "symbol is required"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := hedgeTestConfig("a", "ETH", "BTC")
+			tc.edit(&sc)
+			errs := validateHedgeConfigs([]StrategyConfig{sc})
+			if !hedgeErrsContain(errs, tc.want) {
+				t.Fatalf("errs = %v, want substring %q", errs, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateHedgeConfigsAcceptsValidAndDisabled(t *testing.T) {
+	valid := hedgeTestConfig("a", "ETH", "BTC")
+	if errs := validateHedgeConfigs([]StrategyConfig{valid}); len(errs) != 0 {
+		t.Fatalf("valid config rejected: %v", errs)
+	}
+	disabled := hedgeTestConfig("a", "ETH", "ETH") // colliding but disabled → ignored
+	disabled.Hedge.Enabled = false
+	if errs := validateHedgeConfigs([]StrategyConfig{disabled}); len(errs) != 0 {
+		t.Fatalf("disabled block rejected: %v", errs)
+	}
+}
+
+func TestValidateConfigWiresHedgeChecks(t *testing.T) {
+	cfg := &Config{Strategies: []StrategyConfig{hedgeTestConfig("a", "ETH", "ETH")}}
+	err := validateConfig(cfg, true)
+	if err == nil || !strings.Contains(err.Error(), "matches its own primary coin") {
+		t.Fatalf("validateConfig error = %v, want hedge collision", err)
+	}
+}
+
+func hedgeErrsContain(errs []string, want string) bool {
+	for _, e := range errs {
+		if strings.Contains(e, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- hot reload ----------------------------------------------------------------
+
+func TestHedgeHotReloadBlockedWhileHedgeLegOpen(t *testing.T) {
+	old := hedgeTestConfig("a", "ETH", "BTC")
+	next := old
+	clone := *old.Hedge
+	clone.Ratio = 0.75
+	next.Hedge = &clone
+	state := &AppState{Strategies: map[string]*StrategyState{"a": {
+		Positions: map[string]*Position{
+			"BTC": {Symbol: "BTC", Quantity: 0.1, Side: "short", IsHedge: true, HedgePrimarySymbol: "ETH"},
+		},
+	}}}
+	err := validateHotReloadStateCompatible(&Config{Strategies: []StrategyConfig{old}}, &Config{Strategies: []StrategyConfig{next}}, state)
+	if err == nil || !strings.Contains(err.Error(), "hedge changed with an open hedge leg") {
+		t.Fatalf("error = %v, want hedge-open block", err)
+	}
+}
+
+func TestHedgeHotReloadAllowedWhileHedgeFlat(t *testing.T) {
+	// Primary open but no hedge leg (e.g. hedge just being enabled): the
+	// change must pass the state-compat gate (issue constraint 7).
+	old := hedgeTestConfig("a", "ETH", "BTC")
+	old.Hedge = nil
+	next := hedgeTestConfig("a", "ETH", "BTC")
+	state := &AppState{Strategies: map[string]*StrategyState{"a": {
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 4, Side: "long"},
+		},
+	}}}
+	if err := validateHotReloadStateCompatible(&Config{Strategies: []StrategyConfig{old}}, &Config{Strategies: []StrategyConfig{next}}, state); err != nil {
+		t.Fatalf("expected hedge enable to hot-reload while hedge flat, got %v", err)
+	}
+}
+
+// --- risk-streak exclusion -------------------------------------------------------
+
+func TestHedgeCloseSkipsLossStreakButFeedsDailyPnL(t *testing.T) {
+	ss := hedgeTestState("a")
+	ss.Positions["BTC"] = &Position{
+		Symbol: "BTC", Quantity: 0.1, InitialQuantity: 0.1, AvgCost: 50000,
+		Side: "short", Multiplier: 1, IsHedge: true, HedgePrimarySymbol: "ETH",
+		OwnerStrategyID: "a", OpenedAt: time.Now().UTC(),
+	}
+	ss.RiskState.ConsecutiveLosses = 2
+	// Losing hedge close: short from 50000, closed at 51000 → -100 gross.
+	applyHyperliquidCircuitCloseFill(ss, "BTC", 0.1, 51000, 1.0, 0, 777, "hedge_sync")
+	if ss.RiskState.ConsecutiveLosses != 2 {
+		t.Fatalf("hedge close mutated loss streak: %d", ss.RiskState.ConsecutiveLosses)
+	}
+	if ss.RiskState.DailyPnL >= 0 {
+		t.Fatalf("hedge loss missing from daily PnL: %g", ss.RiskState.DailyPnL)
+	}
+	if _, open := ss.Positions["BTC"]; open {
+		t.Fatal("hedge position not removed on full close")
+	}
+	// Non-hedge closes keep the legacy streak behavior.
+	ss.Positions["ETH"] = &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2500, Side: "long", Multiplier: 1, OwnerStrategyID: "a"}
+	applyHyperliquidCircuitCloseFill(ss, "ETH", 1, 2400, 1.0, 0, 778, "")
+	if ss.RiskState.ConsecutiveLosses != 3 {
+		t.Fatalf("primary losing close should extend streak: %d", ss.RiskState.ConsecutiveLosses)
+	}
+}
+
+// --- circuit breaker / kill switch coupling ---------------------------------------
+
+func TestCircuitBreakerPendingIncludesHedgeLeg(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	ss := hedgeTestState("a")
+	ss.Positions["ETH"] = &Position{Symbol: "ETH", Quantity: 4, AvgCost: 2500, Side: "long", Multiplier: 1}
+	ss.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 1, IsHedge: true, HedgePrimarySymbol: "ETH", HedgeCoveredPrimaryQty: 4}
+	assist := &PlatformRiskAssist{
+		HLPositions: []HLPosition{{Coin: "ETH", Size: 4}, {Coin: "BTC", Size: -0.1}},
+		HLLiveAll:   []StrategyConfig{sc},
+	}
+	setHyperliquidCircuitBreakerPending(&sc, ss, assist)
+	pending := ss.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
+	if pending == nil || len(pending.Symbols) != 2 {
+		t.Fatalf("pending = %+v, want primary + hedge symbols", pending)
+	}
+	if pending.Symbols[0].Symbol != "ETH" || pending.Symbols[1].Symbol != "BTC" || pending.Symbols[1].Size != 0.1 {
+		t.Fatalf("pending symbols = %+v", pending.Symbols)
+	}
+}
+
+func TestKillSwitchClosesHedgeCoins(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	positions := []HLPosition{{Coin: "ETH", Size: 4}, {Coin: "BTC", Size: -0.1}, {Coin: "DOGE", Size: 100}}
+	var closed []string
+	closer := func(coin string, partial *float64, cancelOIDs []int64) (*HyperliquidCloseResult, error) {
+		closed = append(closed, coin)
+		return &HyperliquidCloseResult{Close: &HyperliquidClose{Symbol: coin, Fill: &HyperliquidCloseFill{AvgPx: 1, TotalSz: 1}}}, nil
+	}
+	report := forceCloseHyperliquidLive(context.Background(), positions, []StrategyConfig{sc}, closer, nil, nil)
+	if len(report.Errors) != 0 {
+		t.Fatalf("errors: %v", report.Errors)
+	}
+	if !containsString(closed, "ETH") || !containsString(closed, "BTC") {
+		t.Fatalf("closed = %v, want ETH and BTC (hedge coin)", closed)
+	}
+	if containsString(closed, "DOGE") {
+		t.Fatalf("closed unowned DOGE: %v", closed)
+	}
+
+	// State-claimed hedge coin with no config hedge block (removed across a
+	// restart) still closes via the extra-coins roster.
+	scNoHedge := hedgeTestConfig("a", "ETH", "BTC")
+	scNoHedge.Hedge = nil
+	closed = nil
+	report = forceCloseHyperliquidLive(context.Background(), positions, []StrategyConfig{scNoHedge}, closer, nil, []string{"BTC"})
+	if !containsString(closed, "BTC") {
+		t.Fatalf("state-claimed hedge coin not closed: %v", closed)
+	}
+}
+
+func TestApplyHedgeKillSwitchCloseFill(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	ss := hedgeTestState("a")
+	ss.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 1, IsHedge: true, HedgePrimarySymbol: "ETH", OwnerStrategyID: "a"}
+	fills := map[string]HyperliquidCloseFill{
+		"BTC": {AvgPx: 49000, TotalSz: 0.1, OID: 42, Fee: 0.5},
+	}
+	if !applyHedgeKillSwitchCloseFill(ss, sc, fills) {
+		t.Fatal("hedge kill-switch fill not booked")
+	}
+	if _, open := ss.Positions["BTC"]; open {
+		t.Fatal("hedge position not cleared")
+	}
+	last := ss.TradeHistory[len(ss.TradeHistory)-1]
+	if !last.IsClose || last.Symbol != "BTC" || last.ExchangeFee != 0.5 || math.Abs(last.RealizedPnL-100) > 1e-9 {
+		t.Fatalf("hedge kill-switch close trade = %+v", last)
+	}
+}
+
+// --- reconcile --------------------------------------------------------------------
+
+func TestReconcileHedgeLegExternalClose(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	ss := hedgeTestState("a")
+	ss.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 1, IsHedge: true, HedgePrimarySymbol: "ETH", OwnerStrategyID: "a"}
+	resolve := func(coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		return HLFillLookup{Px: 48000, FilledQty: qty, Fee: 0.4}, true
+	}
+	changed := reconcileHedgeLegForStrategy(sc, ss, nil, resolve, hedgeSilentLogger("a"))
+	if !changed {
+		t.Fatal("expected reconcile to book the external hedge close")
+	}
+	if _, open := ss.Positions["BTC"]; open {
+		t.Fatal("hedge position not removed after external close")
+	}
+	last := ss.TradeHistory[len(ss.TradeHistory)-1]
+	if !last.IsClose || last.Symbol != "BTC" {
+		t.Fatalf("external close trade = %+v", last)
+	}
+	if math.Abs(last.RealizedPnL-(0.1*(50000-48000))) > 1e-6 {
+		t.Fatalf("external close gross PnL = %g, want 200", last.RealizedPnL)
+	}
+}
+
+func TestReconcileHedgeLegResyncsDrift(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	ss := hedgeTestState("a")
+	ss.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 0, IsHedge: true, HedgePrimarySymbol: "ETH", OwnerStrategyID: "a"}
+	onChain := []HLPosition{{Coin: "BTC", Size: -0.08, EntryPrice: 50100, Leverage: 2}}
+	resolve := func(coin string, oid int64, qty float64) (HLFillLookup, bool) { return HLFillLookup{}, false }
+	if !reconcileHedgeLegForStrategy(sc, ss, onChain, resolve, hedgeSilentLogger("a")) {
+		t.Fatal("expected drift resync")
+	}
+	pos := ss.Positions["BTC"]
+	if pos.Quantity != 0.08 || pos.Side != "short" || pos.AvgCost != 50100 || pos.Multiplier != 1 {
+		t.Fatalf("resynced pos = %+v", pos)
+	}
+	// A qty resync invalidates the covered watermark — it must zero so the
+	// next hedge_sync ADOPTS the current primary quantity instead of
+	// re-deriving deltas against the pre-drift baseline.
+	if pos.HedgeCoveredPrimaryQty != 0 {
+		t.Fatalf("covered watermark not reset on drift resync: %g", pos.HedgeCoveredPrimaryQty)
+	}
+}
+
+// --- direction validation exclusion ------------------------------------------------
+
+func TestValidatePerpsDirectionConfigSkipsHedgeLegs(t *testing.T) {
+	sc := hedgeTestConfig("a", "ETH", "BTC")
+	sc.Direction = "long"
+	state := &AppState{Strategies: map[string]*StrategyState{"a": {
+		ID: "a",
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 4, Side: "long", OwnerStrategyID: "a"},
+			// Inverse hedge: would be a "state-vs-config gap" without the skip.
+			"BTC": {Symbol: "BTC", Quantity: 0.1, Side: "short", IsHedge: true, HedgePrimarySymbol: "ETH", OwnerStrategyID: "a"},
+		},
+	}}}
+	warnings := ValidatePerpsDirectionConfig(state, &Config{Strategies: []StrategyConfig{sc}})
+	if len(warnings) != 0 {
+		t.Fatalf("hedge leg flagged as direction conflict: %v", warnings)
+	}
+}
+
+// --- orphaned-hedge startup warnings -----------------------------------------------
+
+func TestValidateHedgeStateConsistency(t *testing.T) {
+	mk := func() *AppState {
+		return &AppState{Strategies: map[string]*StrategyState{"a": {
+			ID: "a",
+			Positions: map[string]*Position{
+				"BTC": {Symbol: "BTC", Quantity: 0.1, Side: "short", IsHedge: true, HedgePrimarySymbol: "ETH"},
+			},
+		}}}
+	}
+	scOK := hedgeTestConfig("a", "ETH", "BTC")
+	if w := validateHedgeStateConsistency(mk(), &Config{Strategies: []StrategyConfig{scOK}}); len(w) != 0 {
+		t.Fatalf("healthy hedge flagged: %v", w)
+	}
+	scDisabled := hedgeTestConfig("a", "ETH", "BTC")
+	scDisabled.Hedge = nil
+	if w := validateHedgeStateConsistency(mk(), &Config{Strategies: []StrategyConfig{scDisabled}}); len(w) != 1 || !strings.Contains(w[0], "hedge block is disabled/removed") {
+		t.Fatalf("disabled-block warning = %v", w)
+	}
+	scMoved := hedgeTestConfig("a", "ETH", "SOL")
+	if w := validateHedgeStateConsistency(mk(), &Config{Strategies: []StrategyConfig{scMoved}}); len(w) != 1 || !strings.Contains(w[0], "coin mismatch") {
+		t.Fatalf("coin-mismatch warning = %v", w)
+	}
+	if w := validateHedgeStateConsistency(mk(), &Config{}); len(w) != 1 || !strings.Contains(w[0], "no longer configured") {
+		t.Fatalf("unconfigured warning = %v", w)
+	}
+}
+
+// --- persistence --------------------------------------------------------------------
+
+func TestHedgePositionPersistenceRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	now := time.Now().UTC()
+	state := &AppState{Strategies: map[string]*StrategyState{"a": {
+		ID: "a", Type: "perps", Platform: "hyperliquid", Cash: 1000, InitialCapital: 1000,
+		Positions: map[string]*Position{
+			"BTC": {
+				Symbol: "BTC", Quantity: 0.1, InitialQuantity: 0.1, AvgCost: 50000,
+				Side: "short", Multiplier: 1, Leverage: 2, OwnerStrategyID: "a", OpenedAt: now,
+				IsHedge: true, HedgePrimarySymbol: "ETH", HedgeCoveredPrimaryQty: 4,
+			},
+		},
+		OptionPositions: map[string]*OptionPosition{},
+	}}}
+	if err := db.SaveState(state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	pos := loaded.Strategies["a"].Positions["BTC"]
+	if pos == nil {
+		t.Fatal("hedge position not loaded")
+	}
+	if !pos.IsHedge || pos.HedgePrimarySymbol != "ETH" || pos.HedgeCoveredPrimaryQty != 4 {
+		t.Fatalf("hedge metadata lost on round trip: %+v", pos)
+	}
+}
+
+func containsString(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -728,6 +728,100 @@ func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym st
 	return changed
 }
 
+// reconcileHedgeLegForStrategy reconciles a strategy's hedge leg (#1159)
+// against the on-chain snapshot. Ownership comes exclusively from persisted
+// position metadata (Position.IsHedge); a hedge coin on-chain with no state
+// leg is deliberately untouched here (surfaced by the unowned-position filter
+// and fail-closed by hedge_sync's foreign-position refusal). Caller holds
+// mu.Lock().
+//
+//   - state leg exists, chain flat → externally closed (liquidation, manual
+//     flatten): book at the userFills VWAP when matched, else at AvgCost with
+//     zero PnL, reason hl_sync_external — never a guessed fill.
+//   - both exist → resync qty/side/AvgCost from chain (the hedge coin is
+//     structurally sole-owned, so on-chain IS this strategy's leg), keep
+//     Multiplier=1, seed leverage for legacy rows.
+func reconcileHedgeLegForStrategy(sc StrategyConfig, ss *StrategyState, positions []HLPosition, resolveFee hlReconcileFillResolver, logger *StrategyLogger) bool {
+	hedge := findHedgePosition(ss, sc)
+	if hedge == nil {
+		return false
+	}
+	sym := hedge.Symbol
+	var onChainPos *HLPosition
+	for i := range positions {
+		if positions[i].Coin == sym {
+			onChainPos = &positions[i]
+			break
+		}
+	}
+	if onChainPos == nil || math.Abs(onChainPos.Size) <= 1e-9 {
+		logger.Info("hl-sync: hedge leg %s (%.6f %s) no longer on-chain, booking external close",
+			sym, hedge.Quantity, hedge.Side)
+		lookupExt, useFillFeeExt := resolveFee(sym, 0, hedge.Quantity)
+		logHyperliquidReconcileFillLookup(logger, sym, 0, hedge.Quantity, lookupExt, useFillFeeExt)
+		closePx := hlReconcileExternalClosePx(0, lookupExt, useFillFeeExt)
+		if closePx <= 0 {
+			closePx = hedge.AvgCost
+			logger.Info("hl-sync: hedge %s external close has no price source — booking at avg cost $%.4f (zero PnL)", sym, closePx)
+		}
+		if !recordPerpsExternalCloseWithFillFee(ss, sym, closePx, lookupExt.Fee, useFillFeeExt, "", "hl_sync_external", logger) {
+			recordClosedPosition(ss, hedge, 0, 0, "hl_sync_external", time.Now().UTC())
+			delete(ss.Positions, sym)
+		}
+		return true
+	}
+	changed := false
+	qty := math.Abs(onChainPos.Size)
+	side := "long"
+	if onChainPos.Size < 0 {
+		side = "short"
+	}
+	if hedge.Quantity != qty || hedge.Side != side {
+		logger.Info("hl-sync: reconciled hedge %s: state=%.6f %s → on-chain=%.6f %s @ $%.2f",
+			sym, hedge.Quantity, hedge.Side, qty, side, onChainPos.EntryPrice)
+		hedge.Quantity = qty
+		hedge.Side = side
+		hedge.AvgCost = onChainPos.EntryPrice
+		// The covered watermark was derived from the pre-drift quantity —
+		// e.g. a crash between an add fill and its booking, now folded in
+		// from chain. Zero it so the next hedge_sync cycle ADOPTS the current
+		// primary quantity instead of re-deriving deltas against a stale
+		// baseline (which would double-place the lost add).
+		hedge.HedgeCoveredPrimaryQty = 0
+		changed = true
+	}
+	if hedge.Multiplier != 1 {
+		hedge.Multiplier = 1
+		changed = true
+	}
+	if onChainPos.Leverage > 0 && hedge.Leverage == 0 {
+		hedge.Leverage = onChainPos.Leverage
+		changed = true
+	}
+	return changed
+}
+
+// applyHedgeKillSwitchCloseFill books the hedge leg's kill-switch close fill
+// (#1159) before the generic forceCloseAllPositions cleanup runs — the same
+// ordering applyHyperliquidKillSwitchCloseFill uses for the primary. The
+// hedge coin is structurally sole-owned, so the full fill books to this
+// strategy (no peer share math).
+func applyHedgeKillSwitchCloseFill(s *StrategyState, sc StrategyConfig, fills map[string]HyperliquidCloseFill) bool {
+	if s == nil || sc.Platform != "hyperliquid" || sc.Type != "perps" || !hyperliquidIsLive(sc.Args) {
+		return false
+	}
+	hedge := findHedgePosition(s, sc)
+	if hedge == nil {
+		return false
+	}
+	fill, ok := fills[hedge.Symbol]
+	if !ok || fill.TotalSz <= 1e-15 || fill.AvgPx <= 0 {
+		return false
+	}
+	applyHyperliquidCircuitCloseFill(s, hedge.Symbol, fill.TotalSz, fill.AvgPx, fill.Fee, 0, fill.OID, "")
+	return true
+}
+
 // syncHyperliquidAccountPositions fetches on-chain positions once and reconciles
 // them across all live HL strategies using ownership tracking. Positions are only
 // assigned to the strategy that opened them (via OwnerStrategyID).
@@ -851,13 +945,20 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 		if sym == "" {
 			continue
 		}
-		if sharedCoins[sym] {
-			continue // handled below
-		}
 		logger, err := logMgr.GetStrategyLogger(sc.ID)
 		if err != nil {
 			fmt.Printf("[ERROR] hl-sync: logger for %s: %v\n", sc.ID, err)
 			continue
+		}
+		// #1159: reconcile the hedge leg from persisted position metadata
+		// (never coin→configured-symbol inference). Runs even when the
+		// PRIMARY coin is shared — the hedge coin itself is structurally
+		// sole-owned, so its reconcile is always safe.
+		if reconcileHedgeLegForStrategy(sc, ss, positions, resolveFee, logger) {
+			changed = true
+		}
+		if sharedCoins[sym] {
+			continue // handled below
 		}
 		if reconcileHyperliquidPositionsForStrategy(sc, ss, sym, positions, resolveFee, logger, &pendingAlerts, &pendingOrphanCloses) {
 			changed = true
@@ -1341,6 +1442,24 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 	tradedCoins := make(map[string]bool)
 	for coin := range coinStrategies {
 		tradedCoins[coin] = true
+	}
+	// #1159: hedge coins are strategy-owned — configured hedge blocks plus
+	// state-claimed IsHedge legs (config removed across a restart) — so they
+	// must not warn as unowned every cycle.
+	for _, sc := range allStrategies {
+		if hc := hedgeCoin(sc); hc != "" {
+			tradedCoins[hc] = true
+		}
+	}
+	for _, ss := range state.Strategies {
+		if ss == nil {
+			continue
+		}
+		for symb, pos := range ss.Positions {
+			if pos != nil && pos.IsHedge && pos.Quantity > 0 {
+				tradedCoins[symb] = true
+			}
+		}
 	}
 	for _, p := range positions {
 		if !tradedCoins[p.Coin] {
@@ -1949,7 +2068,7 @@ func (r HyperliquidLiveCloseReport) SortedErrorCoins() []string {
 // should be cancelled before the close fires, so kill-switch flattening
 // doesn't leave orphan triggers consuming HL's open-order cap (#421, #479).
 // nil/empty disables the cancel; the closer is otherwise unchanged.
-func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLiveAll []StrategyConfig, closer HyperliquidLiveCloser, stopLossOIDsByCoin map[string][]int64) HyperliquidLiveCloseReport {
+func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLiveAll []StrategyConfig, closer HyperliquidLiveCloser, stopLossOIDsByCoin map[string][]int64, extraTradedCoins []string) HyperliquidLiveCloseReport {
 	report := HyperliquidLiveCloseReport{
 		Fills:  make(map[string]HyperliquidCloseFill),
 		Errors: make(map[string]error),
@@ -1960,6 +2079,19 @@ func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLi
 		sym := hyperliquidSymbol(sc.Args)
 		if sym != "" {
 			tradedCoins[sym] = true
+		}
+		// #1159: hedge coins are scheduler-owned exposure — the kill switch
+		// must flatten them with everything else, not skip them as unowned.
+		if hc := hedgeCoin(sc); hc != "" {
+			tradedCoins[hc] = true
+		}
+	}
+	// State-claimed hedge coins (IsHedge positions whose config hedge block
+	// was removed across a restart) — passed by the caller from state
+	// metadata so a live leg never dodges the kill switch.
+	for _, c := range extraTradedCoins {
+		if c = strings.ToUpper(strings.TrimSpace(c)); c != "" {
+			tradedCoins[c] = true
 		}
 	}
 
@@ -2286,8 +2418,20 @@ func runPendingHyperliquidCircuitCloses(
 			if !ok || qty <= 0 {
 				continue
 			}
+			symbols := []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}}
+			// #1159: recover the coupled hedge leg too. State may already be
+			// virtually flat (forceCloseAllPositions ran at fire time), so
+			// fall back to the configured hedge coin's on-chain size —
+			// structurally sole-owned per validateHedgeConfigs.
+			if hedge := findHedgePosition(ss, sc); hedge != nil {
+				symbols = append(symbols, PendingCircuitCloseSymbol{Symbol: hedge.Symbol, Size: hedge.Quantity})
+			} else if hc := hedgeCoin(sc); hc != "" {
+				if hsz := math.Abs(hyperliquidOnChainSignedSize(positions, hc)); hsz > 1e-9 {
+					symbols = append(symbols, PendingCircuitCloseSymbol{Symbol: hc, Size: hsz})
+				}
+			}
 			ss.RiskState.setPendingCircuitClose(PlatformPendingCloseHyperliquid, &PendingCircuitClose{
-				Symbols: []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}},
+				Symbols: symbols,
 			})
 			fmt.Printf("[CRITICAL] hl-circuit-close: recovered pending for strategy %s coin %s sz=%.6f (CB latched, HL fetch had failed at fire time)\n",
 				sc.ID, sym, qty)
@@ -2562,6 +2706,10 @@ func hyperliquidOnChainCloseTradeLabel(closeReason string) string {
 		return "Circuit breaker on-chain close"
 	case "regime_direction_flip":
 		return "Regime/direction flip auto-close"
+	case "hedge_sync":
+		return "Hedge-leg on-chain close"
+	case "hedge_open_failed":
+		return "Fail-closed primary close (hedge open failed)"
 	case "":
 		return "On-chain close"
 	default:
@@ -2667,7 +2815,7 @@ func applyHyperliquidCircuitCloseFill(s *StrategyState, symbol string, fillSz, f
 		StopLossATRMult:   pos.StopLossATRMult,
 		TPTiersJSON:       pos.TPTiersJSON,
 	})
-	RecordTradeResult(&s.RiskState, pnl)
+	recordCloseTradeResult(s, pos, pnl)
 
 	remaining := pos.Quantity - qtyClosed
 	if remaining <= 1e-9 {

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -779,15 +779,22 @@ func reconcileHedgeLegForStrategy(sc StrategyConfig, ss *StrategyState, position
 	if hedge.Quantity != qty || hedge.Side != side {
 		logger.Info("hl-sync: reconciled hedge %s: state=%.6f %s → on-chain=%.6f %s @ $%.2f",
 			sym, hedge.Quantity, hedge.Side, qty, side, onChainPos.EntryPrice)
+		// The covered watermark was derived from the pre-drift quantity, so
+		// rescale it by the observed size change (review on #1333). This
+		// handles BOTH drift directions: an upward lost-add (crash between an
+		// add fill and its booking) rescales covered up to ≈ the grown
+		// primary so the next sync doesn't double-place the add, while a
+		// DOWNWARD drift (partial ADL / liquidation / manual reduction of the
+		// hedge) rescales covered down so the next sync re-adds the shortfall
+		// — zeroing here would instead mark the shrunken hedge as FULL
+		// coverage via the adopt branch and leave the primary silently
+		// under-hedged for its remaining life, violating the never-run-
+		// unhedged-silently guarantee. hedge.Quantity > 0 is guaranteed by
+		// findHedgePosition's qty filter.
+		hedge.HedgeCoveredPrimaryQty = hedge.HedgeCoveredPrimaryQty * qty / hedge.Quantity
 		hedge.Quantity = qty
 		hedge.Side = side
 		hedge.AvgCost = onChainPos.EntryPrice
-		// The covered watermark was derived from the pre-drift quantity —
-		// e.g. a crash between an add fill and its booking, now folded in
-		// from chain. Zero it so the next hedge_sync cycle ADOPTS the current
-		// primary quantity instead of re-deriving deltas against a stale
-		// baseline (which would double-place the lost add).
-		hedge.HedgeCoveredPrimaryQty = 0
 		changed = true
 	}
 	if hedge.Multiplier != 1 {

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -2759,7 +2759,7 @@ func TestForceCloseHyperliquidLive_NonSharedCoin(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors, got %v", report.Errors)
@@ -2788,7 +2788,7 @@ func TestForceCloseHyperliquidLive_SharedCoinEmptyVirtual(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors, got %v", report.Errors)
@@ -2819,7 +2819,7 @@ func TestForceCloseHyperliquidLive_NetZeroSziAlreadyFlat(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors for net-zero coin, got %v", report.Errors)
@@ -2852,7 +2852,7 @@ func TestForceCloseHyperliquidLive_ShortPosition(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors, got %v", report.Errors)
@@ -2884,7 +2884,7 @@ func TestForceCloseHyperliquidLive_ClosePartialFailure(t *testing.T) {
 	closeErr := fmt.Errorf("hl rate limited")
 	closer, _ := fakeCloser(map[string]error{"BTC": closeErr})
 
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.ClosedCoins) != 1 || report.ClosedCoins[0] != "ETH" {
 		t.Errorf("ClosedCoins = %v, want [ETH]", report.ClosedCoins)
@@ -2913,7 +2913,7 @@ func TestForceCloseHyperliquidLive_UnownedPositionIgnored(t *testing.T) {
 	}
 
 	closer, calls := fakeCloser(nil)
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.ClosedCoins) != 1 || report.ClosedCoins[0] != "ETH" {
 		t.Errorf("ClosedCoins = %v, want [ETH]", report.ClosedCoins)
@@ -2933,7 +2933,7 @@ func TestForceCloseHyperliquidLive_EmptyInputs(t *testing.T) {
 	report := forceCloseHyperliquidLive(context.Background(), nil, nil, func(string, *float64, []int64) (*HyperliquidCloseResult, error) {
 		t.Fatalf("closer should not be called with empty inputs")
 		return nil, nil
-	}, nil)
+	}, nil, nil)
 	if len(report.ClosedCoins) != 0 || len(report.AlreadyFlat) != 0 || len(report.Errors) != 0 {
 		t.Errorf("expected empty report, got %+v", report)
 	}
@@ -2960,7 +2960,7 @@ func TestForceCloseHyperliquidLive_AdapterAlreadyFlatRoutedCorrectly(t *testing.
 		}, nil
 	}
 
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, nil, nil)
 
 	if len(report.Errors) != 0 {
 		t.Errorf("expected no errors, got %v", report.Errors)

--- a/scheduler/hyperliquid_protection.go
+++ b/scheduler/hyperliquid_protection.go
@@ -560,6 +560,15 @@ func runHyperliquidProtectionSync(
 	if stratState == nil || symbol == "" {
 		return false
 	}
+	// #1159: hedge legs carry no protection orders in phase 1 — the sync is
+	// keyed by the primary symbol at every call site, so this guard is
+	// belt-and-suspenders against a future caller passing the hedge coin.
+	mu.RLock()
+	if pos, ok := stratState.Positions[symbol]; ok && pos != nil && pos.IsHedge {
+		mu.RUnlock()
+		return false
+	}
+	mu.RUnlock()
 	var plan hlProtectionPlan
 	var syncOK bool
 	if strategyUsesDynamicRegimeClose(sc) {

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -797,7 +797,7 @@ func TestForceCloseHyperliquidLive_ThreadsStopLossOIDs(t *testing.T) {
 		}, nil
 	}
 
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, slOIDs)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, slOIDs, nil)
 	if len(report.Errors) != 0 {
 		t.Fatalf("expected no errors, got %v", report.Errors)
 	}
@@ -831,7 +831,7 @@ func TestForceCloseHyperliquidLive_CancelsAllSharedCoinStopLossOIDs(t *testing.T
 		}, nil
 	}
 
-	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, slOIDs)
+	report := forceCloseHyperliquidLive(context.Background(), positions, hlLiveAll, closer, slOIDs, nil)
 	if len(report.Errors) != 0 {
 		t.Fatalf("expected no errors, got %v", report.Errors)
 	}

--- a/scheduler/inspect_cmd.go
+++ b/scheduler/inspect_cmd.go
@@ -842,6 +842,12 @@ func appendDirectionInspectLines(b *strings.Builder, sc StrategyConfig, explicit
 		sort.Strings(syms)
 		for _, sym := range syms {
 			pos := stratState.Positions[sym]
+			// #1159: hedge legs are deliberately inverse — direction analysis
+			// doesn't apply; mark them so they're not mistaken for orphans.
+			if pos.IsHedge {
+				fmt.Fprintf(b, "  position %s:         side=%s HEDGE LEG for %s (auto-managed, #1159)\n", sym, pos.Side, pos.HedgePrimarySymbol)
+				continue
+			}
 			currentDirRegime := stratState.Regime
 			if cfg != nil && cfg.Regime != nil {
 				currentDirRegime = regimeLabelFromWindows(stratState.RegimeWindows, sc.RegimeDirectionalWindow, cfg.Regime)
@@ -909,6 +915,16 @@ func directionInspectJSON(sc StrategyConfig, cfg *Config, state *AppState) map[s
 		positions := make([]map[string]interface{}, 0)
 		for sym, pos := range stratState.Positions {
 			if pos == nil || pos.Quantity <= 0 {
+				continue
+			}
+			if pos.IsHedge {
+				positions = append(positions, map[string]interface{}{
+					"symbol":               sym,
+					"side":                 pos.Side,
+					"quantity":             pos.Quantity,
+					"is_hedge":             true,
+					"hedge_primary_symbol": pos.HedgePrimarySymbol,
+				})
 				continue
 			}
 			posDirRegime := positionDirectionalRegimeLabel(pos, sc)

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -53,6 +53,11 @@ type KillSwitchCloseInputs struct {
 	// resting and burn HL's open-order cap (#421 review point 1, #479).
 	// nil/empty disables; coins with no resting SL are simply absent.
 	HLStopLossOIDs map[string][]int64
+	// HLHedgeStateCoins carries hedge coins claimed by persisted IsHedge
+	// positions (#1159) so the kill switch flattens a live hedge leg even
+	// when its config hedge block was removed across a restart. Configured
+	// hedge coins are derived from HLLiveAll inside the close path.
+	HLHedgeStateCoins []string
 
 	// OKXLiveAllPerps: every live OKX perps strategy configured (used to
 	// decide which coins to close and to detect "unconfigured" positions).
@@ -386,7 +391,7 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 	case hlStateFetched && len(in.HLLiveAll) > 0:
 		recoverSince := time.Now().UTC().Add(-hlKillSwitchNoFillRecoveryLookback)
 		ctx, cancel := context.WithTimeout(context.Background(), in.platformCloseBudget(in.HLCloseTimeout))
-		plan.CloseReport = forceCloseHyperliquidLive(ctx, hlPositions, in.HLLiveAll, in.HLCloser, in.HLStopLossOIDs)
+		plan.CloseReport = forceCloseHyperliquidLive(ctx, hlPositions, in.HLLiveAll, in.HLCloser, in.HLStopLossOIDs, in.HLHedgeStateCoins)
 		cancel()
 		if !plan.CloseReport.ConfirmedFlat() {
 			if in.HLAddr != "" && in.HLFetcher != nil {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -276,6 +276,11 @@ func main() {
 	// Collect here, forward to owner DM once the notifier is wired below.
 	atrMethodDriftWarnings := checkATRMethodDriftAtStartup(state, cfg)
 
+	// #1159: detect persisted hedge legs whose config hedge block was
+	// removed/disabled/re-pointed across a restart — nothing converges an
+	// orphaned leg, so surface it loudly at the one point that can see it.
+	hedgeStateWarnings := validateHedgeStateConsistency(state, cfg)
+
 	// #42 / #243: Initialize portfolio peak from sum of capitals on first run.
 	// For strategies that share an exchange wallet (e.g. multiple Hyperliquid
 	// perps strategies on the same account), use the real on-exchange balance
@@ -495,6 +500,17 @@ func main() {
 	// the SIGHUP guard never runs on this path.
 	if len(atrMethodDriftWarnings) > 0 && notifier.HasOwner() {
 		for _, msg := range atrMethodDriftWarnings {
+			notifier.SendOwnerDM("[state] " + msg)
+		}
+	}
+
+	// #1159: forward orphaned-hedge-leg warnings — a live inverse leg with
+	// nothing managing it must never sit silent.
+	for _, msg := range hedgeStateWarnings {
+		fmt.Printf("[WARN] %s\n", msg)
+	}
+	if len(hedgeStateWarnings) > 0 && notifier.HasOwner() {
+		for _, msg := range hedgeStateWarnings {
 			notifier.SendOwnerDM("[state] " + msg)
 		}
 	}
@@ -1424,6 +1440,20 @@ func main() {
 					}
 				}
 				hlVirtualQty = snapshotHyperliquidVirtualQuantities(state.Strategies, hlLiveAll)
+				// #1159: hedge coins claimed by persisted IsHedge positions —
+				// the kill switch must flatten a live hedge leg even when its
+				// config hedge block was removed across a restart.
+				var hlHedgeStateCoins []string
+				for _, ss := range state.Strategies {
+					if ss == nil {
+						continue
+					}
+					for hsym, hpos := range ss.Positions {
+						if hpos != nil && hpos.IsHedge && hpos.Quantity > 0 {
+							hlHedgeStateCoins = append(hlHedgeStateCoins, hsym)
+						}
+					}
+				}
 				mu.RUnlock()
 
 				inputs := KillSwitchCloseInputs{
@@ -1435,6 +1465,7 @@ func main() {
 					HLFetcher:         defaultHLStateFetcher,
 					HLNoFillRecoverer: defaultHLKillSwitchNoFillRecoverer,
 					HLStopLossOIDs:    hlSLOIDs,
+					HLHedgeStateCoins: hlHedgeStateCoins,
 					OKXLiveAllPerps:   okxLivePerps,
 					OKXLiveAllSpot:    okxLiveSpot,
 					OKXCloser:         defaultOKXLiveCloser,
@@ -2817,6 +2848,19 @@ func main() {
 
 					logger.Close()
 					lastRun[sc.ID] = time.Now()
+				}
+
+				// #1159: converge hedge legs AFTER the dispatch loop so any
+				// primary lifecycle event that landed this cycle — open,
+				// scale-in add, partial/full close, SL fill booked by
+				// reconcile, CB force-close — is mirrored onto the hedge leg
+				// within the same cycle. Runs every cycle (not just for due
+				// strategies): a no-op when primary and hedge already agree.
+				// Deliberately inside the !killSwitchFired branch — the
+				// kill-switch close path owns flattening (its traded-coin
+				// roster includes hedge coins). Subprocesses outside mu.
+				if len(hlLiveAll) > 0 {
+					totalTrades += runHedgeLegSync(shutdownSideEffectCtx, cfg.Strategies, state, &mu, prices, hlPositions, hlStateFetched, defaultHedgeSyncDeps(notifier), logMgr)
 				}
 			} // end if !killSwitchFired
 		}

--- a/scheduler/manual_core.go
+++ b/scheduler/manual_core.go
@@ -1256,6 +1256,12 @@ func forceCloseCore(d manualCoreDeps, sc StrategyConfig, sym string, in forceClo
 	if !manualPositionOwnedByStrategy(pos, strategyID) {
 		return res, manualFailf("error: position %s/%s is owned by %q, not %q", strategyID, sym, pos.OwnerStrategyID, strategyID)
 	}
+	// #1159: hedge legs are auto-managed coupling — closing one directly
+	// would leave the primary running unhedged behind the operator's back.
+	// Force-close the PRIMARY instead; the hedge follows within one cycle.
+	if pos.IsHedge {
+		return res, manualFailf("error: %s/%s is an auto-managed hedge leg for %s — force-close the primary position instead; the hedge follows it within one cycle (#1159)", strategyID, sym, pos.HedgePrimarySymbol)
+	}
 
 	closeQty := pos.Quantity
 	intentFullClose := true

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -8,21 +8,35 @@ import (
 
 // Position represents a spot, futures, or perps position.
 type Position struct {
-	Symbol              string    `json:"symbol"`
-	TradePositionID     string    `json:"position_id,omitempty"`
-	Quantity            float64   `json:"quantity"`
-	InitialQuantity     float64   `json:"initial_quantity,omitempty"` // original open size; partial closes must not rewrite it (#496)
-	AvgCost             float64   `json:"avg_cost"`
-	EntryATR            float64   `json:"entry_atr,omitempty"`               // ATR value from the entry strategy's open candle when available (#496)
-	Side                string    `json:"side"`                              // "long" or "short"
-	Multiplier          float64   `json:"multiplier,omitempty"`              // contract multiplier (0 = spot, >0 = futures/perps PnL branch; canonical perps value is 1 — do NOT set to leverage)
-	Leverage            float64   `json:"leverage,omitempty"`                // perps exchange leverage (informational; PnL is not scaled by leverage) (#254/#497)
-	OwnerStrategyID     string    `json:"owner_strategy_id,omitempty"`       // strategy that opened this position
-	OpenedAt            time.Time `json:"opened_at,omitempty"`               // when the position was opened
-	StopLossOID         int64     `json:"stop_loss_oid,omitempty"`           // HL perps: resting trigger-order OID for the per-trade stop-loss (0 = none) (#412)
-	StopLossTriggerPx   float64   `json:"stop_loss_trigger_px,omitempty"`    // HL perps: trigger price for the resting stop-loss (0 = unknown) (#421)
-	StopLossHighWaterPx float64   `json:"stop_loss_high_water_px,omitempty"` // HL perps trailing SL: best mark seen while position open (high for long, low for short) (#501)
-	TPOIDs              []int64   `json:"tp_oids,omitempty"`                 // HL perps: resting reduce-only TP limit OIDs, one per configured tier (#601/#612)
+	Symbol          string    `json:"symbol"`
+	TradePositionID string    `json:"position_id,omitempty"`
+	Quantity        float64   `json:"quantity"`
+	InitialQuantity float64   `json:"initial_quantity,omitempty"` // original open size; partial closes must not rewrite it (#496)
+	AvgCost         float64   `json:"avg_cost"`
+	EntryATR        float64   `json:"entry_atr,omitempty"`         // ATR value from the entry strategy's open candle when available (#496)
+	Side            string    `json:"side"`                        // "long" or "short"
+	Multiplier      float64   `json:"multiplier,omitempty"`        // contract multiplier (0 = spot, >0 = futures/perps PnL branch; canonical perps value is 1 — do NOT set to leverage)
+	Leverage        float64   `json:"leverage,omitempty"`          // perps exchange leverage (informational; PnL is not scaled by leverage) (#254/#497)
+	OwnerStrategyID string    `json:"owner_strategy_id,omitempty"` // strategy that opened this position
+	OpenedAt        time.Time `json:"opened_at,omitempty"`         // when the position was opened
+	// #1159 hedge-leg metadata. IsHedge marks a strategy-owned correlated
+	// hedge leg (keyed by the hedge coin in the same Positions map): no check
+	// script, no close evaluator, no protection orders — managed exclusively
+	// by the hedge_sync convergence engine, and excluded from the
+	// consecutive-loss streak (recordHedgeTradeResult). HedgePrimarySymbol is
+	// the primary coin whose lifecycle owns this leg. HedgeCoveredPrimaryQty
+	// is the primary quantity the current hedge size covers — the convergence
+	// watermark that keeps reductions proportional (never re-priced from live
+	// marks, which would churn orders as marks move). All three persist to
+	// the positions table so startup reconcile recovers hedge ownership from
+	// state metadata, never from coin→configured-symbol inference.
+	IsHedge                bool    `json:"is_hedge,omitempty"`
+	HedgePrimarySymbol     string  `json:"hedge_primary_symbol,omitempty"`
+	HedgeCoveredPrimaryQty float64 `json:"hedge_covered_primary_qty,omitempty"`
+	StopLossOID            int64   `json:"stop_loss_oid,omitempty"`           // HL perps: resting trigger-order OID for the per-trade stop-loss (0 = none) (#412)
+	StopLossTriggerPx      float64 `json:"stop_loss_trigger_px,omitempty"`    // HL perps: trigger price for the resting stop-loss (0 = unknown) (#421)
+	StopLossHighWaterPx    float64 `json:"stop_loss_high_water_px,omitempty"` // HL perps trailing SL: best mark seen while position open (high for long, low for short) (#501)
+	TPOIDs                 []int64 `json:"tp_oids,omitempty"`                 // HL perps: resting reduce-only TP limit OIDs, one per configured tier (#601/#612)
 	// TPArmedTiers[i] = true once tier i has been observed with a positive OID
 	// (i.e. successfully placed by runHyperliquidProtectionSync at least once).
 	// findHighestClearedTier requires this so a tier whose first placement
@@ -302,7 +316,7 @@ func bookPerpsCloseWithFillFee(s *StrategyState, symbol string, closePx, fillFee
 		}
 		trade.Regime = s.Regime
 		RecordTrade(s, trade)
-		RecordTradeResult(&s.RiskState, 0)
+		recordCloseTradeResult(s, pos, 0)
 		recordClosedPosition(s, pos, closePx, 0, reason+"_corrupt", now)
 		delete(s.Positions, symbol)
 		clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
@@ -389,7 +403,7 @@ func bookPerpsCloseWithFillFee(s *StrategyState, symbol string, closePx, fillFee
 	trade.StopLossATRMult = pos.StopLossATRMult
 	trade.TPTiersJSON = pos.TPTiersJSON
 	RecordTrade(s, trade)
-	RecordTradeResult(&s.RiskState, pnl)
+	recordCloseTradeResult(s, pos, pnl)
 	recordClosedPosition(s, pos, closePx, pnl, reason, now)
 	delete(s.Positions, symbol)
 	clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
@@ -472,7 +486,7 @@ func bookPerpsPartialCloseWithFillFee(s *StrategyState, symbol string, closeQty,
 	trade.StopLossATRMult = pos.StopLossATRMult
 	trade.TPTiersJSON = pos.TPTiersJSON
 	RecordTrade(s, trade)
-	RecordTradeResult(&s.RiskState, pnl)
+	recordCloseTradeResult(s, pos, pnl)
 
 	remaining := pos.Quantity - qty
 	if remaining <= 1e-9 {

--- a/scheduler/regime_directional_policy.go
+++ b/scheduler/regime_directional_policy.go
@@ -540,6 +540,11 @@ func perpsRegimeDirectionOrphanConflict(stratState *StrategyState, sc StrategyCo
 	if stratState == nil || pos == nil || pos.Quantity <= 0 {
 		return false, "", ""
 	}
+	// #1159: a hedge leg is deliberately inverse to the primary direction —
+	// it must never be queued for the #822 orphan auto-close.
+	if pos.IsHedge {
+		return false, "", ""
+	}
 	if sc.Type != "perps" || !hyperliquidIsLive(sc.Args) {
 		return false, "", ""
 	}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1356,6 +1356,21 @@ func perpsMarginDrawdownInputs(s *StrategyState, configLeverage float64, prices 
 	if configLeverage <= 0 {
 		return 0, 0
 	}
+	// #1159 (review on #1333): an IsHedge leg is deliberately inverse to its
+	// primary, so its isolated unrealized loss is not a drawdown — it loses
+	// exactly when the primary wins. The numerator sees the hedged pair's NET
+	// PnL instead of each leg's loss: a net-flat/profitable pair contributes
+	// nothing, while a correlation break where BOTH legs lose still counts in
+	// full (bare exclusion of the hedge leg would hide that). An orphaned
+	// hedge with no live primary nets against nothing, so its loss counts.
+	hedgedPrimaries := map[string]bool{}
+	for _, pos := range s.Positions {
+		if pos.IsHedge && pos.Multiplier > 0 && pos.HedgePrimarySymbol != "" {
+			hedgedPrimaries[pos.HedgePrimarySymbol] = true
+		}
+	}
+	var pairPnL float64
+	pairHasLegs := false
 	for sym, pos := range s.Positions {
 		if pos.Multiplier <= 0 {
 			continue
@@ -1387,9 +1402,17 @@ func perpsMarginDrawdownInputs(s *StrategyState, configLeverage float64, prices 
 		} else {
 			pnl = pos.Quantity * pos.Multiplier * (pos.AvgCost - price)
 		}
+		if pos.IsHedge || hedgedPrimaries[sym] {
+			pairPnL += pnl
+			pairHasLegs = true
+			continue
+		}
 		if pnl < 0 {
 			unrealizedLoss += -pnl
 		}
+	}
+	if pairHasLegs && pairPnL < 0 {
+		unrealizedLoss += -pairPnL
 	}
 	return unrealizedLoss, margin
 }

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -81,6 +81,12 @@ func collectPerpsMarkSymbols(strategies []StrategyConfig) (hlCoins, okxCoins []s
 		switch sc.Platform {
 		case "hyperliquid":
 			hlSet[coin] = true
+			// #1159: hedge legs need marks too — unrealized PnL, margin
+			// drawdown, exposure deltas, and hedge_sync open sizing all read
+			// prices[hedgeCoin].
+			if hc := hedgeCoin(sc); hc != "" {
+				hlSet[hc] = true
+			}
 		case "okx":
 			okxSet[coin] = true
 		}
@@ -953,8 +959,17 @@ func setHyperliquidCircuitBreakerPending(sc *StrategyConfig, s *StrategyState, a
 	if !ok || qty <= 0 {
 		return
 	}
+	symbols := []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}}
+	// #1159: the hedge leg is strictly coupled — a circuit-breaker flatten of
+	// the primary must flatten the hedge too. Captured here, BEFORE
+	// forceCloseAllPositions deletes the virtual positions; the drain clamps
+	// to the on-chain size anyway. Structurally sole-owned (validateHedgeConfigs),
+	// so no shared-coin guard applies to the hedge coin.
+	if hedge := findHedgePosition(s, *sc); hedge != nil {
+		symbols = append(symbols, PendingCircuitCloseSymbol{Symbol: hedge.Symbol, Size: hedge.Quantity})
+	}
 	s.RiskState.setPendingCircuitClose(PlatformPendingCloseHyperliquid, &PendingCircuitClose{
-		Symbols: []PendingCircuitCloseSymbol{{Symbol: sym, Size: qty}},
+		Symbols: symbols,
 	})
 }
 
@@ -1149,6 +1164,10 @@ func forceCloseKillSwitchPositions(s *StrategyState, sc StrategyConfig, prices m
 	// generic pass below remains the cleanup path for non-HL strategies,
 	// missing-fill fallbacks, options, and any residual virtual positions.
 	applyHyperliquidKillSwitchCloseFill(s, sc, hlFills, hlLiveAll, hlVirtualQty)
+	// #1159: book the hedge leg's real fill too (sole-owned coin, full fill)
+	// so its Trade/ClosedPosition rows carry exchange price/fee instead of
+	// the model-only cleanup below.
+	applyHedgeKillSwitchCloseFill(s, sc, hlFills)
 	forceCloseAllPositions(s, prices, logger)
 }
 
@@ -1262,7 +1281,7 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 			TPTiersJSON:       pos.TPTiersJSON,
 		}
 		RecordTrade(s, trade)
-		RecordTradeResult(&s.RiskState, pnl)
+		recordCloseTradeResult(s, pos, pnl)
 		recordClosedPosition(s, pos, price, pnl, reason, now)
 		delete(s.Positions, symbol)
 		clearATRMultMissingEntryATRWarningOnHLPerpsClose(s, symbol)
@@ -1352,7 +1371,15 @@ func perpsMarginDrawdownInputs(s *StrategyState, configLeverage float64, prices 
 		if notional <= 0 {
 			continue
 		}
-		margin += notional / configLeverage
+		// #1159: a hedge leg's margin is deployed at the hedge block's own
+		// leverage (stamped on the position at open), not the primary's
+		// config leverage — using the primary's would mis-scale the drawdown
+		// denominator whenever the two differ.
+		legLeverage := configLeverage
+		if pos.IsHedge && pos.Leverage > 0 {
+			legLeverage = pos.Leverage
+		}
+		margin += notional / legLeverage
 
 		var pnl float64
 		if pos.Side == "long" {

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -1716,6 +1716,84 @@ func TestPerpsMarginDrawdownInputs_ZeroConfigLeverageReturnsZero(t *testing.T) {
 	}
 }
 
+// #1159 (review on #1333): an IsHedge leg is deliberately inverse to its
+// primary, so the drawdown numerator must see the hedged pair's NET PnL, not
+// each leg's isolated loss — a correlated move that puts the hedge underwater
+// while the primary wins must not force-close a net-profitable pair.
+func TestPerpsMarginDrawdownInputs_HedgePairNetFlatNoLoss(t *testing.T) {
+	s := &StrategyState{
+		Positions: map[string]*Position{
+			// Primary long ETH +15%: PnL = 4 * (2875 - 2500) = +1500
+			"ETH": {Symbol: "ETH", Quantity: 4, AvgCost: 2500, Side: "long", Multiplier: 1, Leverage: 3},
+			// Inverse hedge short BTC underwater by the same amount:
+			// PnL = 0.1 * (50000 - 65000) = -1500 → net pair PnL = 0
+			"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 1, Leverage: 2,
+				IsHedge: true, HedgePrimarySymbol: "ETH", HedgeCoveredPrimaryQty: 4},
+		},
+	}
+	prices := map[string]float64{"ETH": 2875, "BTC": 65000}
+	loss, margin := perpsMarginDrawdownInputs(s, 3, prices)
+	if loss > 1e-9 {
+		t.Errorf("net-flat hedged pair produced drawdown loss %.4f; want 0", loss)
+	}
+	// Denominator untouched: primary at configLeverage=3, hedge at its own 2.
+	wantMargin := 4*2875/3.0 + 0.1*65000/2.0
+	if math.Abs(margin-wantMargin) > 1e-6 {
+		t.Errorf("margin = %.4f; want %.4f", margin, wantMargin)
+	}
+}
+
+// Correlation break — BOTH legs of the hedged pair underwater — must count in
+// full. Bare exclusion of the hedge leg (instead of pair netting) would hide
+// the hedge's real loss here.
+func TestPerpsMarginDrawdownInputs_HedgePairBothLosingCountsNet(t *testing.T) {
+	s := &StrategyState{
+		Positions: map[string]*Position{
+			// Primary long ETH down: PnL = 4 * (2400 - 2500) = -400
+			"ETH": {Symbol: "ETH", Quantity: 4, AvgCost: 2500, Side: "long", Multiplier: 1, Leverage: 3},
+			// Hedge short BTC also down: PnL = 0.1 * (50000 - 53000) = -300
+			"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 1, Leverage: 2,
+				IsHedge: true, HedgePrimarySymbol: "ETH", HedgeCoveredPrimaryQty: 4},
+		},
+	}
+	prices := map[string]float64{"ETH": 2400, "BTC": 53000}
+	loss, _ := perpsMarginDrawdownInputs(s, 3, prices)
+	if math.Abs(loss-700) > 1e-6 {
+		t.Errorf("both-losing hedged pair loss = %.4f; want 700 (400 + 300)", loss)
+	}
+}
+
+// A genuine primary drawdown partially offset by the hedge gain counts as the
+// NET loss (the offset is real money); an orphaned hedge leg with no primary
+// counts alone — it is a naked directional position at that point.
+func TestPerpsMarginDrawdownInputs_HedgePairNetLossAndOrphan(t *testing.T) {
+	s := &StrategyState{
+		Positions: map[string]*Position{
+			// Primary long ETH down: PnL = 4 * (2400 - 2500) = -400
+			"ETH": {Symbol: "ETH", Quantity: 4, AvgCost: 2500, Side: "long", Multiplier: 1, Leverage: 3},
+			// Hedge short BTC in profit: PnL = 0.1 * (50000 - 48500) = +150
+			"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 1, Leverage: 2,
+				IsHedge: true, HedgePrimarySymbol: "ETH", HedgeCoveredPrimaryQty: 4},
+		},
+	}
+	loss, _ := perpsMarginDrawdownInputs(s, 3, map[string]float64{"ETH": 2400, "BTC": 48500})
+	if math.Abs(loss-250) > 1e-6 {
+		t.Errorf("net pair loss = %.4f; want 250 (400 primary - 150 hedge offset)", loss)
+	}
+
+	// Orphaned hedge (primary already closed): its loss counts in full.
+	orphan := &StrategyState{
+		Positions: map[string]*Position{
+			"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 1, Leverage: 2,
+				IsHedge: true, HedgePrimarySymbol: "ETH", HedgeCoveredPrimaryQty: 4},
+		},
+	}
+	loss, _ = perpsMarginDrawdownInputs(orphan, 3, map[string]float64{"BTC": 53000})
+	if math.Abs(loss-300) > 1e-6 {
+		t.Errorf("orphaned hedge loss = %.4f; want 300", loss)
+	}
+}
+
 // #418: AggregatePerpsMarginInputs portfolio-kill-switch variant must also
 // source leverage from configs, not from pos.Leverage. Two strategies, one
 // with corrupted pos.Leverage from on-chain overwrite — the aggregate must

--- a/scheduler/server.go
+++ b/scheduler/server.go
@@ -539,7 +539,9 @@ func directionalStatusForStrategy(sc StrategyConfig, s *StrategyState, rc *Regim
 	posRegime := ""
 	var certStates map[string]string
 	for _, p := range s.Positions {
-		if p != nil && p.Quantity > 0 {
+		// #1159: skip hedge legs — map iteration could pick the (inverse)
+		// hedge first and misreport the directional view.
+		if p != nil && p.Quantity > 0 && !p.IsHedge {
 			posQty = p.Quantity
 			posRegime = positionDirectionalRegimeLabel(p, sc)
 			certStates = p.DirectionCertifiedStatesAtOpen

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -273,6 +273,12 @@ func ValidatePerpsDirectionConfig(state *AppState, cfg *Config) []string {
 			if pos == nil || pos.Quantity <= 0 {
 				continue
 			}
+			// #1159: a hedge leg is deliberately the INVERSE side of the
+			// primary — validating it against the strategy's direction would
+			// flag every hedge as a state-vs-config gap.
+			if pos.IsHedge {
+				continue
+			}
 			posRegime := positionDirectionalRegimeLabel(pos, *sc)
 			// #1085: gate by the open stamp. An uncertified/legacy directional
 			// position (certified=false) validates against BASE direction — this is


### PR DESCRIPTION
Closes #1159 (phase 1: live Hyperliquid perps only).

> Note: this is an independent implementation, opened deliberately alongside PR 1331 and PR 1332 per operator instruction — pick one, close the others.

## What

A hedge-enabled strategy carries one auto-managed inverse leg on a different coin, strictly coupled to the primary position's lifecycle. New per-strategy `hedge` config block (`enabled`/`symbol`/`side:"inverse"`/`ratio`/`platform`/`type`/`margin_mode`/`leverage`); default behavior unchanged for everyone else.

## Design: one convergence engine, not per-path mirroring

`hedge_sync.go` runs once per cycle **after** the dispatch loop and converges each hedge leg with its primary from virtual state. This single mechanism covers every lifecycle source — fresh open, scale-in add, partial close, full close, **on-chain SL fills booked by reconcile**, and CB force-closes — instead of hooking each dispatch path separately (SL-fill closes never pass through dispatch, so per-path mirroring would leave naked hedges).

The ongoing target is **quantity-anchored** via a persisted covered watermark (`Position.HedgeCoveredPrimaryQty`): marks are consulted only to size opens/adds (`primary_qty_delta × primary_mark × ratio ÷ hedge_mark`), reductions are proportional to covered quantity — so mark moves never churn orders (regression-tested).

**Fail-closed (constraint 4):** any hedge open/add that cannot be placed or confirmed — order error, missing mark, unverifiable clearinghouse state, or a foreign on-chain position on the hedge coin — immediately closes the *uncovered* primary quantity reduce-only (sized partial, never a full-coin close, so shared-primary peers survive) and DMs the operator. Reduce/close failures alert and retry next cycle (over-hedged is the safe direction).

## Coupling with every wallet mechanism

- **Kill switch** — hedge coins join the traded-coin roster (config-derived + state-claimed via `HLHedgeStateCoins` for legs whose hedge block was removed across a restart); hedge fills book to the owner before generic cleanup.
- **Circuit breaker** — pending closes capture the hedge leg at fire time (before `forceCloseAllPositions` wipes virtual state); the stuck-CB drain reconstruction re-derives it from config + on-chain size.
- **Reconcile** — hedge legs reconcile from persisted `IsHedge` metadata only, never coin→configured-symbol inference (constraint 5). External closes book `hl_sync_external` at the userFills VWAP; a qty-drift resync zeros the covered watermark so the next sync *adopts* the current primary quantity instead of double-placing a lost add. Hedge coins no longer warn as "unowned" every cycle.
- **Risk** — hedge closes feed `DailyPnL` (the #1269 daily loss limit sees real money) but never the consecutive-loss streak (a hedge loses exactly when the primary wins — feeding the streak would double-count every round trip and mis-fire the #1273 loss-streak CB). Margin drawdown uses the hedge block's own leverage. Direction validation, the #822 orphan auto-close, and the `/status` directional view all skip `IsHedge` legs (the hedge is *deliberately* inverse).
- **Protection** — hedge legs carry no SL/TP (constraint 1); protection sync guards `IsHedge` defensively.
- **Manual** — `force-close` refuses hedge legs with a pointer to close the primary instead.
- **Surfaces** — Discord `/status` marks hedge legs (`⚖️ hedge for <primary> (auto-managed)`); `inspect` marks them in the direction report and JSON; orphaned hedge legs (config removed/disabled/re-pointed across a restart) warn at startup + owner DM.

## Validation & hot reload

- `validateHedgeConfigs` rejects: non-live/non-HL-perps primary or hedge, non-inverse side, non-positive ratio, bad margin fields, and every coin collision — own primary coin, any configured strategy's coin (incl. `manual`), another hedge's coin (acceptance 5).
- Hot reload: the `hedge` block is blocked while a hedge leg is open, freely reloadable otherwise (constraint 7) — including enabling a hedge for an already-open primary (the next sync opens it, fail-closed if it can't).

## State & backtest

- `is_hedge` / `hedge_primary_symbol` / `hedge_covered_primary_qty` persist as positions-table columns with idempotent migrations — startup recovery reads metadata, never infers.
- `run_backtest.py --config` loudly rejects an enabled hedge block (constraint 6; same pattern as the `regime_window_divergence` reject). Disabled blocks are tolerated.

## Verification

- `go build` + full `go test` package: **ok** (36 new hedge tests: convergence planning incl. no-churn regression, collision/shape validation, engine lifecycle against fake executor/closer — open, add, reduce, full close, flip, foreign-position refusal, unfetched-state refusal, failed-open → primary closed, failed-add → uncovered delta closed, failed-reduce → alert+retry — CB/kill-switch coupling, reconcile external close + drift resync, DB round-trip, hot-reload gates, loss-streak exclusion).
- Full pytest suite (`shared_strategies shared_tools platforms backtest`, `-n auto`): **2728 passed, 1 skipped** (skip pre-existing), incl. the new backtest-reject tests.
- `gofmt` clean; `py_compile` clean.

## Known phase-1 limitations (documented, not regressions)

- Hedge open/close legs appear in lifetime trade stats (`#T`, W/L per position) as their own position — attribution to the owning strategy's ledger is correct (requirement 6), but stats don't yet net hedge legs into the primary round trip. Candidate fast-follow.
- Paper-mode hedging is rejected at load (phase 1 is live-only, matching the issue's live-exec framing).
- Backtest hedge PnL/fee parity and peer-coin overlap remain the issue's tracked follow-ups (unfiled).

---
LLM: Fable 5 | high | Harness: Claude Code

https://claude.ai/code/session_014CNC3B5HQbEqLzLMp3KnFW
