### PR TITLE
feat(#1368): configurable kill-switch reset DM timeout (default 6h)

### DIFF
--- a/scheduler/config.example.json
+++ b/scheduler/config.example.json
@@ -5,6 +5,7 @@
   "status_port": 8099,
   "default_stop_loss_atr_mult": 1.0,
   "alert_throttle_interval": "6h",
+  "kill_switch_reset_dm_timeout": "6h",
   "user_defaults": {
     "close": {
       "trailing_tp_ratchet": {

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -187,31 +187,32 @@ func (lc LeaderboardSummaryConfig) Key() string {
 
 // Config is the top-level scheduler configuration.
 type Config struct {
-	ConfigVersion          int                        `json:"config_version,omitempty"` // bumped when new fields are added; 0/missing = v1 baseline
-	IntervalSeconds        int                        `json:"interval_seconds"`
-	LogDir                 string                     `json:"log_dir"`
-	DBFile                 string                     `json:"db_file,omitempty"`     // SQLite state DB path (default: "scheduler/state.db")
-	StatusPort             int                        `json:"status_port,omitempty"` // HTTP status server port (default: 8099; auto-fallback if taken)
-	StatusToken            string                     `json:"-"`                     // loaded from STATUS_AUTH_TOKEN env var only
-	Discord                DiscordConfig              `json:"discord"`
-	Telegram               TelegramConfig             `json:"telegram,omitempty"`
-	AutoUpdate             string                     `json:"auto_update,omitempty"`           // "off", "daily", "heartbeat" (default: "off")
-	LeaderboardPostTime    string                     `json:"leaderboard_post_time,omitempty"` // "HH:MM" in UTC; auto-post daily leaderboard at this time (empty = disabled)
-	Strategies             []StrategyConfig           `json:"strategies"`
-	PortfolioRisk          *PortfolioRiskConfig       `json:"portfolio_risk,omitempty"`
-	Correlation            *CorrelationConfig         `json:"correlation,omitempty"`
-	Regime                 *RegimeConfig              `json:"regime,omitempty"`
-	Platforms              map[string]*PlatformConfig `json:"platforms,omitempty"`
-	LeaderboardSummaries   []LeaderboardSummaryConfig `json:"leaderboard_summaries,omitempty"`      // #308 — configurable per-channel leaderboards
-	SummaryFrequency       map[string]string          `json:"summary_frequency,omitempty"`          // #30 — per-channel summary cadence; keys match Discord/Telegram channel keys (e.g. "spot", "options", "hyperliquid"). Values: Go duration ("30m", "2h"), alias ("hourly", "every"/"per_check"/"always"), or empty for legacy default (continuous: every channel run; spot: hourly)
-	RiskFreeRate           *float64                   `json:"risk_free_rate,omitempty"`             // #397 — annualized risk-free rate used in Sharpe-ratio calculations (e.g. 0.02 for 2%). Nil/missing falls back to DefaultAnnualRiskFreeRate; an explicit 0 is respected so backtest comparisons can pin to a 0% benchmark.
-	DefaultStopLossATRMult *float64                   `json:"default_stop_loss_atr_mult,omitempty"` // #605 — top-level default applied to HL perps/manual strategies that omit all stop_loss_* / trailing_stop_* fields. Nil/missing falls back to 1.0; explicit values let operators tune the ATR stop without recompiling.
-	ATRMethod              string                     `json:"atr_method,omitempty"`                 // #1277 — global default ATR smoothing method for the standard_atr surface (EntryATR stamping, live market_ctx["atr"], manual fetch-atr, tuner simulate): "simple" (default; frozen legacy rolling mean with the #887 >=100 integer rounding) or "wilder" (published Wilder RMA, never rounded). Per-strategy atr_method overrides. Strategy-internal indicator math is NOT config-driven (see docs/research/1277-wilder-atr-cutover.md). Read via resolveATRMethod(sc, cfg), never directly. Hot-reload: blocked while the affected strategy has open positions (EntryATR/frozen stop geometry must not be re-based mid-position); applies when flat.
-	NotifyTPSLFills        *bool                      `json:"notify_tp_sl_fills,omitempty"`         // #661 — owner DM when HL on-chain TP/SL fills are detected by the reconciler. Nil/missing → enabled; explicit false disables.
-	NotifyRatchetTriggers  *bool                      `json:"notify_ratchet_triggers,omitempty"`    // #1110 — owner DM when a trailing_tp_ratchet* tier clears and tightens the trail. Nil/missing → enabled; explicit false disables.
-	AlertThrottleInterval  string                     `json:"alert_throttle_interval,omitempty"`    // #1266 — fleet-wide re-alert back-off for throttled operator alerts. Go duration ("6h", "30m"); empty → 6h.
-	TradingViewExport      TradingViewExportConfig    `json:"tradingview_export,omitempty"`         // #3 — optional symbol overrides for TradingView portfolio CSV exports
-	UserDefaults           *UserDefaultsConfig        `json:"user_defaults,omitempty"`              // #1135 — canonical operator override layer for defaults. close → close-evaluator tier ladders; regime_atr → standalone use_defaults-only *_atr_regime owners; manual → manual-open/type=manual defaults. Legacy user_close_defaults/manual_defaults are migrated to this tree at load.
+	ConfigVersion            int                        `json:"config_version,omitempty"` // bumped when new fields are added; 0/missing = v1 baseline
+	IntervalSeconds          int                        `json:"interval_seconds"`
+	LogDir                   string                     `json:"log_dir"`
+	DBFile                   string                     `json:"db_file,omitempty"`     // SQLite state DB path (default: "scheduler/state.db")
+	StatusPort               int                        `json:"status_port,omitempty"` // HTTP status server port (default: 8099; auto-fallback if taken)
+	StatusToken              string                     `json:"-"`                     // loaded from STATUS_AUTH_TOKEN env var only
+	Discord                  DiscordConfig              `json:"discord"`
+	Telegram                 TelegramConfig             `json:"telegram,omitempty"`
+	AutoUpdate               string                     `json:"auto_update,omitempty"`           // "off", "daily", "heartbeat" (default: "off")
+	LeaderboardPostTime      string                     `json:"leaderboard_post_time,omitempty"` // "HH:MM" in UTC; auto-post daily leaderboard at this time (empty = disabled)
+	Strategies               []StrategyConfig           `json:"strategies"`
+	PortfolioRisk            *PortfolioRiskConfig       `json:"portfolio_risk,omitempty"`
+	Correlation              *CorrelationConfig         `json:"correlation,omitempty"`
+	Regime                   *RegimeConfig              `json:"regime,omitempty"`
+	Platforms                map[string]*PlatformConfig `json:"platforms,omitempty"`
+	LeaderboardSummaries     []LeaderboardSummaryConfig `json:"leaderboard_summaries,omitempty"`        // #308 — configurable per-channel leaderboards
+	SummaryFrequency         map[string]string          `json:"summary_frequency,omitempty"`            // #30 — per-channel summary cadence; keys match Discord/Telegram channel keys (e.g. "spot", "options", "hyperliquid"). Values: Go duration ("30m", "2h"), alias ("hourly", "every"/"per_check"/"always"), or empty for legacy default (continuous: every channel run; spot: hourly)
+	RiskFreeRate             *float64                   `json:"risk_free_rate,omitempty"`               // #397 — annualized risk-free rate used in Sharpe-ratio calculations (e.g. 0.02 for 2%). Nil/missing falls back to DefaultAnnualRiskFreeRate; an explicit 0 is respected so backtest comparisons can pin to a 0% benchmark.
+	DefaultStopLossATRMult   *float64                   `json:"default_stop_loss_atr_mult,omitempty"`   // #605 — top-level default applied to HL perps/manual strategies that omit all stop_loss_* / trailing_stop_* fields. Nil/missing falls back to 1.0; explicit values let operators tune the ATR stop without recompiling.
+	ATRMethod                string                     `json:"atr_method,omitempty"`                   // #1277 — global default ATR smoothing method for the standard_atr surface (EntryATR stamping, live market_ctx["atr"], manual fetch-atr, tuner simulate): "simple" (default; frozen legacy rolling mean with the #887 >=100 integer rounding) or "wilder" (published Wilder RMA, never rounded). Per-strategy atr_method overrides. Strategy-internal indicator math is NOT config-driven (see docs/research/1277-wilder-atr-cutover.md). Read via resolveATRMethod(sc, cfg), never directly. Hot-reload: blocked while the affected strategy has open positions (EntryATR/frozen stop geometry must not be re-based mid-position); applies when flat.
+	NotifyTPSLFills          *bool                      `json:"notify_tp_sl_fills,omitempty"`           // #661 — owner DM when HL on-chain TP/SL fills are detected by the reconciler. Nil/missing → enabled; explicit false disables.
+	NotifyRatchetTriggers    *bool                      `json:"notify_ratchet_triggers,omitempty"`      // #1110 — owner DM when a trailing_tp_ratchet* tier clears and tightens the trail. Nil/missing → enabled; explicit false disables.
+	AlertThrottleInterval    string                     `json:"alert_throttle_interval,omitempty"`      // #1266 — fleet-wide re-alert back-off for throttled operator alerts. Go duration ("6h", "30m"); empty → 6h.
+	KillSwitchResetDMTimeout string                     `json:"kill_switch_reset_dm_timeout,omitempty"` // #1368 — AskOwnerDM wait for the portfolio kill-switch reset prompt. Go duration ("6h", "30m"); empty → 6h. Independent of alert_throttle_interval (re-alert back-off ≠ interactive reply wait).
+	TradingViewExport        TradingViewExportConfig    `json:"tradingview_export,omitempty"`           // #3 — optional symbol overrides for TradingView portfolio CSV exports
+	UserDefaults             *UserDefaultsConfig        `json:"user_defaults,omitempty"`                // #1135 — canonical operator override layer for defaults. close → close-evaluator tier ladders; regime_atr → standalone use_defaults-only *_atr_regime owners; manual → manual-open/type=manual defaults. Legacy user_close_defaults/manual_defaults are migrated to this tree at load.
 }
 
 // UserDefaultsConfig is the canonical #1135 operator defaults block.
@@ -2367,6 +2368,9 @@ func validateConfig(cfg *Config, skipLiveCredentialChecks bool) error {
 	}
 
 	if _, err := ParseAlertThrottleInterval(cfg.AlertThrottleInterval); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if _, err := ParseKillSwitchResetDMTimeout(cfg.KillSwitchResetDMTimeout); err != nil {
 		errs = append(errs, err.Error())
 	}
 

--- a/scheduler/config_reload.go
+++ b/scheduler/config_reload.go
@@ -59,6 +59,13 @@ func applyHotReloadConfig(cfg, next *Config, state *AppState, notifier *MultiNot
 			return nil, fmt.Errorf("alert_throttle_interval: %w", err)
 		}
 	}
+	if cfg.KillSwitchResetDMTimeout != next.KillSwitchResetDMTimeout {
+		addChange("kill_switch_reset_dm_timeout: %q -> %q", cfg.KillSwitchResetDMTimeout, next.KillSwitchResetDMTimeout)
+		cfg.KillSwitchResetDMTimeout = next.KillSwitchResetDMTimeout
+		if err := applyKillSwitchResetDMTimeoutFromConfig(cfg); err != nil {
+			return nil, fmt.Errorf("kill_switch_reset_dm_timeout: %w", err)
+		}
+	}
 	// #1135: user_defaults flows through hot-reload so SIGHUP edits to the
 	// operator-default layer shape subsequent manual-open invocations, new
 	// type=manual defaults, and close-default injection. The CLI loads fresh

--- a/scheduler/kill_switch_reset_dm.go
+++ b/scheduler/kill_switch_reset_dm.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DefaultKillSwitchResetDMTimeout is the AskOwnerDM wait for the portfolio
+// kill-switch reset prompt when kill_switch_reset_dm_timeout is omitted
+// from config.json (#1368). Quieter than the former hard-coded 30m.
+const DefaultKillSwitchResetDMTimeout = 6 * time.Hour
+
+// killSwitchResetDMTimeout is the active AskOwnerDM wait for the kill-switch
+// reset prompt. Set from config at load and on SIGHUP hot-reload. Independent
+// of alert_throttle_interval (#1266) — that knob is a fire-and-forget re-alert
+// back-off, not an interactive reply wait.
+var killSwitchResetDMTimeout = DefaultKillSwitchResetDMTimeout
+
+func effectiveKillSwitchResetDMTimeout() time.Duration {
+	return killSwitchResetDMTimeout
+}
+
+func applyKillSwitchResetDMTimeout(d time.Duration) {
+	killSwitchResetDMTimeout = d
+}
+
+// applyKillSwitchResetDMTimeoutFromConfig adopts cfg's
+// kill_switch_reset_dm_timeout into the live runtime. Call only when a config
+// is actually adopted (daemon startup or an accepted SIGHUP reload) — never
+// from loadConfig/LoadConfigForProbe.
+func applyKillSwitchResetDMTimeoutFromConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	d, err := ParseKillSwitchResetDMTimeout(cfg.KillSwitchResetDMTimeout)
+	if err != nil {
+		return err
+	}
+	applyKillSwitchResetDMTimeout(d)
+	return nil
+}
+
+// ParseKillSwitchResetDMTimeout converts kill_switch_reset_dm_timeout config
+// text to a duration. Empty/missing → DefaultKillSwitchResetDMTimeout (6h).
+func ParseKillSwitchResetDMTimeout(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return DefaultKillSwitchResetDMTimeout, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid kill_switch_reset_dm_timeout %q: %w", s, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("kill_switch_reset_dm_timeout must be > 0, got %s", s)
+	}
+	return d, nil
+}

--- a/scheduler/kill_switch_reset_dm_test.go
+++ b/scheduler/kill_switch_reset_dm_test.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseKillSwitchResetDMTimeout_DefaultsToSixHours(t *testing.T) {
+	d, err := ParseKillSwitchResetDMTimeout("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != DefaultKillSwitchResetDMTimeout {
+		t.Fatalf("got %s, want %s", d, DefaultKillSwitchResetDMTimeout)
+	}
+	// Regression: former hard-coded AskOwnerDM wait was 30m (#1368).
+	if DefaultKillSwitchResetDMTimeout == 30*time.Minute {
+		t.Fatal("default must not be the former hard-coded 30m")
+	}
+	if DefaultKillSwitchResetDMTimeout != 6*time.Hour {
+		t.Fatalf("default = %s, want 6h", DefaultKillSwitchResetDMTimeout)
+	}
+}
+
+func TestParseKillSwitchResetDMTimeout_ParsesGoDuration(t *testing.T) {
+	d, err := ParseKillSwitchResetDMTimeout("30m")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != 30*time.Minute {
+		t.Fatalf("got %s, want 30m", d)
+	}
+}
+
+func TestParseKillSwitchResetDMTimeout_RejectsInvalid(t *testing.T) {
+	if _, err := ParseKillSwitchResetDMTimeout("nonsense"); err == nil {
+		t.Fatal("expected error for invalid duration")
+	}
+}
+
+func TestParseKillSwitchResetDMTimeout_RejectsNonPositive(t *testing.T) {
+	for _, raw := range []string{"0", "-1h"} {
+		if _, err := ParseKillSwitchResetDMTimeout(raw); err == nil {
+			t.Fatalf("expected error for %q", raw)
+		}
+	}
+}
+
+func TestLoadConfig_AppliesKillSwitchResetDMTimeout(t *testing.T) {
+	prev := killSwitchResetDMTimeout
+	t.Cleanup(func() { killSwitchResetDMTimeout = prev })
+
+	dir := t.TempDir()
+	path := dir + "/config.json"
+	cfgJSON := `{
+		"kill_switch_reset_dm_timeout": "45m",
+		"strategies": [{
+			"id": "hl-sole",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 10,
+			"leverage": 5
+		}]
+	}`
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := LoadConfigForProbe(path)
+	if err != nil {
+		t.Fatalf("LoadConfigForProbe: %v", err)
+	}
+	if cfg.KillSwitchResetDMTimeout != "45m" {
+		t.Fatalf("KillSwitchResetDMTimeout = %q, want 45m", cfg.KillSwitchResetDMTimeout)
+	}
+	if err := applyKillSwitchResetDMTimeoutFromConfig(cfg); err != nil {
+		t.Fatalf("applyKillSwitchResetDMTimeoutFromConfig: %v", err)
+	}
+	if effectiveKillSwitchResetDMTimeout() != 45*time.Minute {
+		t.Fatalf("runtime timeout = %s, want 45m", effectiveKillSwitchResetDMTimeout())
+	}
+}
+
+func TestLoadConfig_KillSwitchResetDMTimeoutDefaultsToSixHours(t *testing.T) {
+	prev := killSwitchResetDMTimeout
+	t.Cleanup(func() { killSwitchResetDMTimeout = prev })
+
+	dir := t.TempDir()
+	path := dir + "/config.json"
+	cfgJSON := `{
+		"strategies": [{
+			"id": "hl-sole",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 10,
+			"leverage": 5
+		}]
+	}`
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := LoadConfigForProbe(path); err != nil {
+		t.Fatalf("LoadConfigForProbe: %v", err)
+	}
+	if err := applyKillSwitchResetDMTimeoutFromConfig(&Config{}); err != nil {
+		t.Fatalf("applyKillSwitchResetDMTimeoutFromConfig: %v", err)
+	}
+	if effectiveKillSwitchResetDMTimeout() != DefaultKillSwitchResetDMTimeout {
+		t.Fatalf("runtime timeout = %s, want %s", effectiveKillSwitchResetDMTimeout(), DefaultKillSwitchResetDMTimeout)
+	}
+}
+
+func TestLoadConfig_RejectsInvalidKillSwitchResetDMTimeout(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/config.json"
+	cfgJSON := `{
+		"kill_switch_reset_dm_timeout": "nonsense",
+		"strategies": [{
+			"id": "hl-sole",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 10,
+			"leverage": 5
+		}]
+	}`
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := LoadConfigForProbe(path); err == nil {
+		t.Fatal("expected LoadConfigForProbe to reject invalid kill_switch_reset_dm_timeout")
+	}
+}
+
+func TestApplyHotReloadConfig_UpdatesKillSwitchResetDMTimeout(t *testing.T) {
+	prev := killSwitchResetDMTimeout
+	t.Cleanup(func() { killSwitchResetDMTimeout = prev })
+	applyKillSwitchResetDMTimeout(time.Hour)
+
+	cfg := minimalReloadConfig(nil)
+	next := minimalReloadConfig(nil)
+	next.KillSwitchResetDMTimeout = "2h"
+
+	changes, err := applyHotReloadConfig(cfg, next, NewAppState(), nil, nil)
+	if err != nil {
+		t.Fatalf("applyHotReloadConfig: %v", err)
+	}
+	if !strings.Contains(strings.Join(changes, "\n"), "kill_switch_reset_dm_timeout") {
+		t.Fatalf("expected kill_switch_reset_dm_timeout change, got %v", changes)
+	}
+	if effectiveKillSwitchResetDMTimeout() != 2*time.Hour {
+		t.Fatalf("runtime timeout = %s, want 2h", effectiveKillSwitchResetDMTimeout())
+	}
+}
+
+func TestLoadConfigForProbe_DoesNotMutateAdoptedKillSwitchResetDMTimeout(t *testing.T) {
+	prev := killSwitchResetDMTimeout
+	t.Cleanup(func() { killSwitchResetDMTimeout = prev })
+	applyKillSwitchResetDMTimeout(90 * time.Minute)
+
+	dir := t.TempDir()
+	path := dir + "/config.json"
+	cfgJSON := `{
+		"kill_switch_reset_dm_timeout": "15m",
+		"strategies": [{
+			"id": "hl-sole",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 10,
+			"leverage": 5
+		}]
+	}`
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := LoadConfigForProbe(path); err != nil {
+		t.Fatalf("LoadConfigForProbe: %v", err)
+	}
+	if effectiveKillSwitchResetDMTimeout() != 90*time.Minute {
+		t.Fatalf("probe load mutated runtime timeout to %s, want 90m", effectiveKillSwitchResetDMTimeout())
+	}
+}
+
+// TestKillSwitchResetAskTimeoutIndependentOfAlertThrottle locks the #1368
+// invariant: the KS reset AskOwnerDM wait must not be sourced from
+// alert_throttle_interval.
+func TestKillSwitchResetAskTimeoutIndependentOfAlertThrottle(t *testing.T) {
+	prevKS := killSwitchResetDMTimeout
+	prevThrottle := alertThrottleInterval
+	t.Cleanup(func() {
+		killSwitchResetDMTimeout = prevKS
+		alertThrottleInterval = prevThrottle
+	})
+
+	applyAlertThrottleInterval(30 * time.Minute)
+	applyKillSwitchResetDMTimeout(6 * time.Hour)
+
+	if effectiveKillSwitchResetDMTimeout() != 6*time.Hour {
+		t.Fatalf("KS timeout = %s, want 6h", effectiveKillSwitchResetDMTimeout())
+	}
+	if effectiveAlertThrottleInterval() != 30*time.Minute {
+		t.Fatalf("alert throttle = %s, want 30m", effectiveAlertThrottleInterval())
+	}
+	if effectiveKillSwitchResetDMTimeout() == effectiveAlertThrottleInterval() {
+		t.Fatal("KS reset AskDM wait must stay independent of alert_throttle_interval")
+	}
+}
+
+func TestKillSwitchResetDMTimeout_ConcurrentProbeDoesNotRace(t *testing.T) {
+	prev := killSwitchResetDMTimeout
+	t.Cleanup(func() { killSwitchResetDMTimeout = prev })
+	applyKillSwitchResetDMTimeout(time.Hour)
+
+	dir := t.TempDir()
+	path := dir + "/config.json"
+	cfgJSON := `{
+		"kill_switch_reset_dm_timeout": "30m",
+		"strategies": [{
+			"id": "hl-sole",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 10,
+			"leverage": 5
+		}]
+	}`
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 200; i++ {
+			_ = effectiveKillSwitchResetDMTimeout()
+		}
+	}()
+	for i := 0; i < 20; i++ {
+		if _, err := LoadConfigForProbe(path); err != nil {
+			t.Fatalf("LoadConfigForProbe: %v", err)
+		}
+	}
+	<-done
+	if effectiveKillSwitchResetDMTimeout() != time.Hour {
+		t.Fatalf("runtime timeout = %s, want 1h", effectiveKillSwitchResetDMTimeout())
+	}
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -114,6 +114,10 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Failed to apply alert throttle interval: %v\n", err)
 		os.Exit(1)
 	}
+	if err := applyKillSwitchResetDMTimeoutFromConfig(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to apply kill-switch reset DM timeout: %v\n", err)
+		os.Exit(1)
+	}
 	fmt.Printf("Loaded config: %d strategies, interval=%ds\n", len(cfg.Strategies), cfg.IntervalSeconds)
 
 	// #1085: load the directional-certification artifact (SSoT for the
@@ -1560,12 +1564,14 @@ func main() {
 			}
 
 			// Kill switch reset goroutine: prompt owner to reset via DM.
+			// AskOwnerDM wait is kill_switch_reset_dm_timeout (default 6h, #1368).
 			if killSwitchFired && notifier.HasOwner() && !resetGoroutineRunning {
 				resetGoroutineRunning = true
 				resetPrompt := formatKillSwitchResetPrompt(killSwitchInstanceLabel(*configPath), hlAddr, plan)
+				resetDMTimeout := effectiveKillSwitchResetDMTimeout()
 				go func() {
 					defer func() { resetGoroutineRunning = false }()
-					resp, err := notifier.AskOwnerDM(resetPrompt, 30*time.Minute)
+					resp, err := notifier.AskOwnerDM(resetPrompt, resetDMTimeout)
 					if err != nil {
 						fmt.Printf("[update] Kill switch reset DM timed out or failed: %v\n", err)
 						return


### PR DESCRIPTION
## Summary
- Add `kill_switch_reset_dm_timeout` (Go duration; empty → **6h**) for the portfolio kill-switch reset `AskOwnerDM` wait, replacing the hard-coded `30*time.Minute`.
- Adopt at daemon start and on SIGHUP (same pattern as `alert_throttle_interval`); keep it **independent** of that throttle (re-alert back-off ≠ interactive reply wait).
- Document in `scheduler/config.example.json`; unit tests cover parse/default/reject, hot-reload, probe non-mutation, and throttle independence.

Closes #1368

## Test plan
- [x] `go -C scheduler test -count=1 -run 'KillSwitchReset|AlertThrottle' .`
- [x] Regression: default-must-not-be-30m fails when constant set to 30m, passes at 6h
- [x] `go -C scheduler build .`
- [ ] Optional: latch kill switch with owner DM; confirm next reset prompt wait follows config (omit → 6h; set `"30m"` → prior cadence)

LLM: Cursor Grok 4.5 | high | Harness: Cursor
