### PR TITLE
fix(#1344): hold notional-cap opens without skipping close/SL paths [C62, Cursor Grok 4.5, high]

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -60,7 +60,7 @@ type TelegramConfig struct {
 // PortfolioRiskConfig controls aggregate portfolio-level risk (#42).
 type PortfolioRiskConfig struct {
 	MaxDrawdownPct   float64 `json:"max_drawdown_pct"`             // kill switch threshold (default 25)
-	MaxNotionalUSD   float64 `json:"max_notional_usd"`             // 0 = disabled
+	MaxNotionalUSD   float64 `json:"max_notional_usd"`             // 0 = disabled. #42/#1344 — when total gross notional exceeds the cap, position-INCREASING opens are held (per-signal via pausedBlocksSignal; options opens dropped; manual open/add/limit-open refuse). Closes, reductions, and SL/TP maintenance keep running; nothing is force-closed. Restart-required (not SIGHUP-hot-reloadable).
 	WarnThresholdPct float64 `json:"warn_threshold_pct,omitempty"` // % of MaxDrawdownPct to warn (default 60)
 	DailyMaxLossUSD  float64 `json:"daily_max_loss_usd,omitempty"` // #1269 — hard daily loss limit in USD (0 = disabled). When the day's aggregate PRE-FEE realized loss across all strategies reaches this, position-increasing actions (fresh opens, adds, flips, manual-open/add) are held until the UTC rollover; closes and SL/TP management keep running and nothing is force-closed. Hot-reloadable, including while tripped. Portfolio-level only — ignored inside platforms.<name>.risk overrides.
 	DailyMaxLossPct  float64 `json:"daily_max_loss_pct,omitempty"` // #1269 — same limit as a percent of the sum of per-strategy initial_capital (0 = disabled). Both arms may be set: the lower resolved USD threshold wins. The pct arm cannot evaluate when no strategy has initial_capital > 0 (surfaced in /status). Portfolio-level only.

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1939,7 +1939,16 @@ func main() {
 					// now land per-signal via pausedBlocksSignal at the six
 					// dispatch sites below (plus pausedOptionsActions); Signal==0
 					// manage paths and position-reducing actions pass through.
-					// (notionalCapSkipsStrategyCycle locks the never-skip invariant.)
+					//
+					// Any whole-strategy skip decision MUST route through
+					// notionalCapSkipsStrategyCycle (always false) so a helper
+					// regression fails CI — never a raw `if notionalBlocked { continue }`.
+					if notionalCapSkipsStrategyCycle(notionalBlocked) {
+						logger.Warn("Notional cap exceeded — skipping strategy cycle")
+						logger.Close()
+						lastRun[sc.ID] = time.Now()
+						continue
+					}
 
 					// Phase 3 (no lock) + Phase 4 (Lock): subprocess then state mutation
 					trades := 0

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1932,15 +1932,14 @@ func main() {
 						}
 					}
 
-					// #42: Notional cap blocks new trades for this strategy. Under
-					// manage-only the position is never grown anyway, so let the
-					// trailing-SL/TP management run instead of skipping.
-					if !cbManageOnly && notionalBlocked {
-						logger.Warn("Notional cap exceeded — skipping new trades")
-						logger.Close()
-						lastRun[sc.ID] = time.Now()
-						continue
-					}
+					// #1344: notional cap is an ENTRY hold, not a cycle skip.
+					// Pre-#1344 this site `continue`d the whole strategy when
+					// notionalBlocked, which also skipped close/reduce evaluation
+					// and perps trailing-SL / TP-ratchet / protection-sync. Holds
+					// now land per-signal via pausedBlocksSignal at the six
+					// dispatch sites below (plus pausedOptionsActions); Signal==0
+					// manage paths and position-reducing actions pass through.
+					// (notionalCapSkipsStrategyCycle locks the never-skip invariant.)
 
 					// Phase 3 (no lock) + Phase 4 (Lock): subprocess then state mutation
 					trades := 0
@@ -1970,6 +1969,12 @@ func main() {
 								// position-increasing signals held, position-reducing actions pass.
 								if dailyLossEntriesHeld && pausedBlocksSignal(result.Signal, result.CloseFraction, okxPosQty, okxPosSide, true, false) {
 									logger.Info("Daily loss limit: %s signal suppressed — entries held until UTC rollover (#1269)", signalStr)
+									result.Signal = 0
+								}
+								// #1344: portfolio notional cap — hold position-increasing signals
+								// only; closes/reductions and Signal==0 manage keep running.
+								if notionalBlocked && pausedBlocksSignal(result.Signal, result.CloseFraction, okxPosQty, okxPosSide, true, false) {
+									logger.Warn("Notional cap: %s signal suppressed — new opens blocked, exits continue (#1344)", signalStr)
 									result.Signal = 0
 								}
 								// #1270: same-direction exposure cap — only the capped direction's
@@ -2022,6 +2027,12 @@ func main() {
 									logger.Info("Daily loss limit: %s signal suppressed — entries held until UTC rollover (#1269)", signalStr)
 									result.Signal = 0
 								}
+								// #1344: portfolio notional cap — hold position-increasing signals
+								// only; closes/reductions and Signal==0 manage keep running.
+								if notionalBlocked && pausedBlocksSignal(result.Signal, result.CloseFraction, rhPosQty, rhPosSide, true, false) {
+									logger.Warn("Notional cap: %s signal suppressed — new opens blocked, exits continue (#1344)", signalStr)
+									result.Signal = 0
+								}
 								// #1270: same-direction exposure cap — only the capped direction's
 								// position-increasing signals are held; the other direction and all
 								// position-reducing actions pass.
@@ -2070,6 +2081,12 @@ func main() {
 								logger.Info("Daily loss limit: %s signal suppressed — entries held until UTC rollover (#1269)", signalStr)
 								result.Signal = 0
 							}
+							// #1344: portfolio notional cap — hold position-increasing signals
+							// only; closes/reductions and Signal==0 manage keep running.
+							if notionalBlocked && pausedBlocksSignal(result.Signal, result.CloseFraction, spotPosCtx.Quantity, spotPosCtx.Side, true, false) {
+								logger.Warn("Notional cap: %s signal suppressed — new opens blocked, exits continue (#1344)", signalStr)
+								result.Signal = 0
+							}
 							// #1270: same-direction exposure cap — only the capped direction's
 							// position-increasing signals are held; the other direction and all
 							// position-reducing actions pass.
@@ -2101,6 +2118,15 @@ func main() {
 								kept, dropped := pausedOptionsActions(result.Actions)
 								if dropped > 0 {
 									logger.Info("Daily loss limit: %d option open action(s) dropped — entries held until UTC rollover (#1269)", dropped)
+								}
+								result.Actions = kept
+							}
+							// #1344: portfolio notional cap — drop option open actions; closes
+							// and the theta-harvest walker still manage existing positions.
+							if notionalBlocked {
+								kept, dropped := pausedOptionsActions(result.Actions)
+								if dropped > 0 {
+									logger.Warn("Notional cap: %d option open action(s) dropped — new opens blocked, exits continue (#1344)", dropped)
 								}
 								result.Actions = kept
 							}
@@ -2172,6 +2198,12 @@ func main() {
 									logger.Info("Daily loss limit: %s signal suppressed — entries held until UTC rollover (#1269)", signalStr)
 									result.Signal = 0
 								}
+								// #1344: portfolio notional cap — hold position-increasing signals
+								// only; closes/reductions and Signal==0 manage keep running.
+								if notionalBlocked && pausedBlocksSignal(result.Signal, result.CloseFraction, okxPosQty, okxPosSide, PerpsAllowsLong(sc), PerpsAllowsShort(sc)) {
+									logger.Warn("Notional cap: %s signal suppressed — new opens blocked, exits continue (#1344)", signalStr)
+									result.Signal = 0
+								}
 								// #1270: same-direction exposure cap — only the capped direction's
 								// position-increasing signals are held; the other direction and all
 								// position-reducing actions pass.
@@ -2228,6 +2260,13 @@ func main() {
 							// position-increasing signals held, position-reducing actions pass.
 							if dailyLossEntriesHeld && pausedBlocksSignal(result.Signal, result.CloseFraction, hlPosQty, hlPosSide, PerpsAllowsLong(sc), PerpsAllowsShort(sc)) {
 								logger.Info("Daily loss limit: %s signal suppressed — entries held until UTC rollover (#1269)", signalStr)
+								result.Signal = 0
+							}
+							// #1344: portfolio notional cap — hold position-increasing signals
+							// only; closes/reductions and Signal==0 manage (trailing SL /
+							// TP ratchet / protection sync) keep running.
+							if notionalBlocked && pausedBlocksSignal(result.Signal, result.CloseFraction, hlPosQty, hlPosSide, PerpsAllowsLong(sc), PerpsAllowsShort(sc)) {
+								logger.Warn("Notional cap: %s signal suppressed — new opens blocked, exits continue (#1344)", signalStr)
 								result.Signal = 0
 							}
 							// #1270: same-direction exposure cap — only the capped direction's
@@ -2544,6 +2583,13 @@ func main() {
 							// position-increasing signals held, position-reducing actions pass.
 							if dailyLossEntriesHeld && pausedBlocksSignal(result.Signal, result.CloseFraction, tsContracts, tsPosSide, true, true) {
 								logger.Info("Daily loss limit: %s signal suppressed — entries held until UTC rollover (#1269)", signalStr)
+								result.Signal = 0
+							}
+							// #1344: portfolio notional cap — gross notional includes futures
+							// (unlike #1270's crypto-only bucket), so TopStep is gated too.
+							// Position-increasing signals held; closeFraction>0 reductions pass.
+							if notionalBlocked && pausedBlocksSignal(result.Signal, result.CloseFraction, tsContracts, tsPosSide, true, true) {
+								logger.Warn("Notional cap: %s signal suppressed — new opens blocked, exits continue (#1344)", signalStr)
 								result.Signal = 0
 							}
 							// #1270: deliberately NOT gated by the same-direction exposure

--- a/scheduler/manual.go
+++ b/scheduler/manual.go
@@ -129,6 +129,12 @@ func runManualOpen(args []string) int {
 					fmt.Fprintf(os.Stderr, "error: %s — manual-open blocked until UTC rollover (closes and SL edits are unaffected)\n", dailyLossHoldDetail(st))
 					return 1
 				}
+				// #1344: a resting limit open still grows gross notional once it
+				// fills — refuse while over cap, same as the market-order core path.
+				if held, detail := evaluateNotionalCapHold(cfg.PortfolioRisk, state.Strategies, nil); held {
+					fmt.Fprintf(os.Stderr, "error: %s — manual-open blocked (closes and SL edits are unaffected)\n", detail)
+					return 1
+				}
 				// #1270: a resting limit open increases exposure in resolvedSide's
 				// direction once it fills — refuse while that direction's bucket
 				// is capped or this asset is over-concentrated in that direction.

--- a/scheduler/manual_core.go
+++ b/scheduler/manual_core.go
@@ -97,6 +97,8 @@ type manualStateView struct {
 	PendingCBClose bool
 	DailyLossHold  bool   // #1269: portfolio daily loss limit tripped — position-increasing manual actions refuse
 	DailyLossNote  string // #1269: one-line detail for the refusal message (set iff DailyLossHold)
+	NotionalHold   bool   // #1344: portfolio gross notional cap breached — position-increasing manual actions refuse
+	NotionalNote   string // #1344: one-line detail for the refusal message (set iff NotionalHold)
 	// #1270: same-direction exposure cap — both arms. The bucket arm sums at
 	// AvgCost (no live feed on this path); the concentration arm evaluates
 	// against the displayStrategyValue basis (see manualExposureCapStatus), so
@@ -117,6 +119,14 @@ func manualStateViewFromState(cfg *Config, state *AppState, strategyID, symbol s
 		if st := evaluateDailyLossLimit(cfg.PortfolioRisk, state.Strategies, time.Now().UTC()); st.Tripped {
 			v.DailyLossHold = true
 			v.DailyLossNote = dailyLossHoldDetail(st)
+		}
+		// #1344: gross notional cap — manual opens/adds are CLI/dashboard-driven,
+		// not dispatch-loop signals, so the hold is enforced here next to the
+		// kill-switch / daily-loss / exposure-cap guards. nil prices → AvgCost
+		// inside PortfolioNotional (same fallback the exposure-cap manual path uses).
+		if held, detail := evaluateNotionalCapHold(cfg.PortfolioRisk, state.Strategies, nil); held {
+			v.NotionalHold = true
+			v.NotionalNote = detail
 		}
 		// #1270: same-direction exposure cap, both arms. nil prices →
 		// positions value at AvgCost (this path has no live price feed); the
@@ -525,6 +535,11 @@ func manualOpenCore(d manualCoreDeps, sc StrategyConfig, in manualOpenInputs) (*
 			if view.DailyLossHold {
 				return res, manualFailf("error: %s — manual-open blocked until UTC rollover (closes and SL edits are unaffected)", view.DailyLossNote)
 			}
+			// #1344: a manual open grows gross notional — refuse while over cap
+			// (closes and SL edits are unaffected).
+			if view.NotionalHold {
+				return res, manualFailf("error: %s — manual-open blocked (closes and SL edits are unaffected)", view.NotionalNote)
+			}
 			// #1270: a manual open increases exposure in `side`'s direction —
 			// refuse while that direction's bucket is capped or this asset is
 			// over-concentrated in that direction (the other direction,
@@ -848,6 +863,11 @@ func manualAddCore(d manualCoreDeps, sc StrategyConfig, in manualAddInputs) (*ma
 	pos := view.Pos
 	if pos == nil {
 		return res, manualFailf("error: no open position for %s/%s; open one first with manual-open", strategyID, sc.Symbol)
+	}
+	// #1344: an add grows gross notional — refuse while over cap (closes and
+	// SL edits are unaffected).
+	if view.NotionalHold {
+		return res, manualFailf("error: %s — manual-add blocked (closes and SL edits are unaffected)", view.NotionalNote)
 	}
 	// #1270: an add grows exposure in the position's direction — refuse while
 	// that direction's bucket is capped or this asset is over-concentrated in

--- a/scheduler/notional_cap.go
+++ b/scheduler/notional_cap.go
@@ -27,6 +27,11 @@ import "fmt"
 // notionalCapSkipsStrategyCycle reports whether the per-strategy dispatch
 // loop should skip the rest of the cycle when the notional cap is breached.
 // #1344: always false — holds are per-signal; never skip close/SL maintenance.
+//
+// main.go MUST call this (and only this) for any whole-strategy notional skip
+// so TestNotionalCapNeverSkipsStrategyCycle has production teeth: changing
+// the return to true fails CI, and a raw `if notionalBlocked { continue }`
+// bypass is caught by the main.go source scan in the same test.
 func notionalCapSkipsStrategyCycle(notionalBlocked bool) bool {
 	_ = notionalBlocked
 	return false

--- a/scheduler/notional_cap.go
+++ b/scheduler/notional_cap.go
@@ -1,0 +1,57 @@
+package main
+
+// #1344: portfolio gross notional cap (#42) is an ENTRY hold, not a cycle skip.
+//
+// CheckPortfolioRisk still returns notionalBlocked=true when total notional
+// exceeds portfolio_risk.max_notional_usd. The pre-#1344 consumer in main.go
+// answered that with a strategy-level `continue`, which skipped the entire
+// check-script dispatch — including close/reduce signal evaluation and the
+// perps trailing-SL / TP-ratchet / protection-sync manage paths that only
+// run inside that branch. Over-cap therefore suppressed risk-reducing work.
+//
+// The correct shape matches #1150/#1269/#1270: the strategy cycle always
+// runs, and position-INCREASING signals are forced to hold via
+// pausedBlocksSignal at the six regime-gated dispatch sites (plus
+// pausedOptionsActions for options opens). Position-REDUCING actions and
+// Signal==0 manage-only paths pass by construction. Manual open/add/
+// limit-open refuse next to their kill-switch / daily-loss / exposure-cap
+// guards. Nothing is ever force-closed.
+//
+// notionalCapSkipsStrategyCycle locks the invariant that the dispatch loop
+// must never `continue` past a strategy solely because the notional cap is
+// breached (the #1046 cbManageOnly carve-out is obsolete for this gate —
+// Signal==0 already no-ops the hold predicate).
+
+import "fmt"
+
+// notionalCapSkipsStrategyCycle reports whether the per-strategy dispatch
+// loop should skip the rest of the cycle when the notional cap is breached.
+// #1344: always false — holds are per-signal; never skip close/SL maintenance.
+func notionalCapSkipsStrategyCycle(notionalBlocked bool) bool {
+	_ = notionalBlocked
+	return false
+}
+
+// notionalCapHoldDetail is the operator-facing reason when the gross notional
+// cap is breached. Matches CheckPortfolioRisk's notional reason shape, with
+// the #1344 clarification that exits keep running.
+func notionalCapHoldDetail(totalNotional, capUSD float64) string {
+	return fmt.Sprintf("portfolio notional $%.2f exceeds cap $%.2f — new opens blocked, exits continue",
+		totalNotional, capUSD)
+}
+
+// evaluateNotionalCapHold is a pure read of the #42/#1344 gross notional
+// entry hold for paths that cannot call CheckPortfolioRisk (manual CLI /
+// dashboard — that helper also mutates peak/drawdown kill-switch state).
+// nil prices fall back to AvgCost inside PortfolioNotional, matching the
+// exposure-cap manual path. Safe under mu.RLock.
+func evaluateNotionalCapHold(pr *PortfolioRiskConfig, strategies map[string]*StrategyState, prices map[string]float64) (held bool, detail string) {
+	if pr == nil || pr.MaxNotionalUSD <= 0 {
+		return false, ""
+	}
+	total := PortfolioNotional(strategies, prices)
+	if total > pr.MaxNotionalUSD {
+		return true, notionalCapHoldDetail(total, pr.MaxNotionalUSD)
+	}
+	return false, ""
+}

--- a/scheduler/notional_cap_test.go
+++ b/scheduler/notional_cap_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1344: portfolio gross notional cap must hold entries without skipping the
+// strategy cycle (closes / SL/TP maintenance). Signal classification reuses
+// pausedBlocksSignal (covered by pause_test.go); these tests lock the
+// never-skip invariant, the entry-hold contract at the dispatch sites, and
+// the manual-core refusals.
+
+func TestNotionalCapNeverSkipsStrategyCycle(t *testing.T) {
+	// Pre-#1344 the dispatch loop `continue`d when notionalBlocked — that is
+	// the bug. The helper must stay false for both states so a reintroduced
+	// whole-strategy skip fails this regression.
+	if notionalCapSkipsStrategyCycle(false) {
+		t.Fatal("notionalCapSkipsStrategyCycle(false) must be false")
+	}
+	if notionalCapSkipsStrategyCycle(true) {
+		t.Fatal("notionalCapSkipsStrategyCycle(true) must be false — over-cap must not skip close/SL maintenance (#1344)")
+	}
+}
+
+func TestNotionalCapHoldPassesReduceAndManage(t *testing.T) {
+	// Acceptance: over max_notional with open long + SELL still closes/reduces;
+	// Signal==0 manage (trailing SL/TP) is never held. Fresh opens / adds hold.
+	// Mirrors the dispatch-site predicate: notionalBlocked && pausedBlocksSignal(...).
+	const notionalBlocked = true
+	cases := []struct {
+		name          string
+		signal        int
+		closeFraction float64
+		posQty        float64
+		posSide       string
+		allowsLong    bool
+		allowsShort   bool
+		wantHold      bool
+	}{
+		{"manage_only_signal0", 0, 0, 1, "long", true, true, false},
+		{"long_sell_pure_close", -1, 0, 1, "long", true, false, false},
+		{"long_close_fraction", -1, 0.5, 1, "long", true, true, false},
+		{"flat_buy_fresh_open", 1, 0, 0, "", true, true, true},
+		{"long_buy_scale_in", 1, 0, 1, "long", true, true, true},
+		{"long_sell_flip_both", -1, 0, 1, "long", true, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			held := notionalBlocked && pausedBlocksSignal(tc.signal, tc.closeFraction, tc.posQty, tc.posSide, tc.allowsLong, tc.allowsShort)
+			if held != tc.wantHold {
+				t.Fatalf("hold=%v want %v (signal=%d cf=%.2f qty=%.1f side=%q)",
+					held, tc.wantHold, tc.signal, tc.closeFraction, tc.posQty, tc.posSide)
+			}
+		})
+	}
+}
+
+func TestEvaluateNotionalCapHold(t *testing.T) {
+	states := map[string]*StrategyState{
+		"a": {ID: "a", Positions: map[string]*Position{
+			"BTC": {Symbol: "BTC", Quantity: 1, AvgCost: 60000, Side: "long"},
+		}},
+	}
+	// Unconfigured / nil — never holds.
+	if held, _ := evaluateNotionalCapHold(nil, states, nil); held {
+		t.Fatal("nil portfolio risk must not hold")
+	}
+	if held, _ := evaluateNotionalCapHold(&PortfolioRiskConfig{MaxNotionalUSD: 0}, states, nil); held {
+		t.Fatal("disabled notional cap must not hold")
+	}
+	// Under cap (AvgCost fallback with nil prices).
+	if held, _ := evaluateNotionalCapHold(&PortfolioRiskConfig{MaxNotionalUSD: 100000}, states, nil); held {
+		t.Fatal("under-cap book must not hold")
+	}
+	// Over cap.
+	held, detail := evaluateNotionalCapHold(&PortfolioRiskConfig{MaxNotionalUSD: 50000}, states, nil)
+	if !held {
+		t.Fatal("over-cap book must hold")
+	}
+	if !strings.Contains(detail, "new opens blocked, exits continue") {
+		t.Fatalf("detail=%q, want exits-continue audit wording", detail)
+	}
+	if !strings.Contains(detail, "60000.00") || !strings.Contains(detail, "50000.00") {
+		t.Fatalf("detail=%q, want notional and cap amounts", detail)
+	}
+}
+
+func TestCheckPortfolioRisk_NotionalCapReasonMentionsExitsContinue(t *testing.T) {
+	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxNotionalUSD: 50000, WarnThresholdPct: 80}
+	prs := &PortfolioRiskState{PeakValue: 10000.0}
+	_, nb, _, reason := CheckPortfolioRisk(prs, cfg, 10000.0, 60000.0, 0, 0)
+	if !nb {
+		t.Fatal("expected notionalBlocked=true over cap")
+	}
+	if !strings.Contains(reason, "new opens blocked, exits continue") {
+		t.Fatalf("reason=%q, want #1344 exits-continue wording", reason)
+	}
+}
+
+func TestManualStateViewNotionalHold(t *testing.T) {
+	cfg := &Config{PortfolioRisk: &PortfolioRiskConfig{MaxNotionalUSD: 50000}}
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"m": {ID: "m", Type: "manual", Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 30, AvgCost: 2000, Side: "long"}, // $60k > $50k
+		}},
+	}}
+	v := manualStateViewFromState(cfg, state, "m", "ETH")
+	if !v.NotionalHold || v.NotionalNote == "" {
+		t.Fatalf("view = %+v, want NotionalHold with note", v)
+	}
+	// Under the cap: no hold.
+	state.Strategies["m"].Positions["ETH"].Quantity = 10 // $20k
+	v = manualStateViewFromState(cfg, state, "m", "ETH")
+	if v.NotionalHold {
+		t.Fatalf("view = %+v, want no hold under cap", v)
+	}
+	// nil cfg must not panic or hold.
+	v = manualStateViewFromState(nil, state, "m", "ETH")
+	if v.NotionalHold {
+		t.Fatalf("nil cfg view = %+v, want no hold", v)
+	}
+}
+
+func TestManualOpenCoreRefusesNotionalHold(t *testing.T) {
+	sc := StrategyConfig{ID: "m", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 3}
+	deps := manualCoreDeps{
+		cfg: &Config{},
+		loadState: func(strategyID, symbol string) (manualStateView, error) {
+			return manualStateView{HasStrategy: true, NotionalHold: true,
+				NotionalNote: "portfolio notional $60000.00 exceeds cap $50000.00 — new opens blocked, exits continue"}, nil
+		},
+		execute: func(string, string, string, float64, float64, int64, float64, string, float64, bool, hlExecuteSnapshot, ...int64) (*HyperliquidExecuteResult, string, error) {
+			t.Error("execute must not be called while the notional cap is breached")
+			return nil, "", nil
+		},
+		fetchMids: func([]string) (map[string]float64, error) {
+			return map[string]float64{"ETH": 2000}, nil
+		},
+	}
+	_, err := manualOpenCore(deps, sc, manualOpenInputs{StrategyID: "m", Margin: 50})
+	if err == nil || !strings.Contains(err.Error(), "new opens blocked, exits continue") {
+		t.Fatalf("manual-open err = %v, want notional refusal", err)
+	}
+}
+
+func TestManualAddCoreRefusesNotionalHold(t *testing.T) {
+	sc := StrategyConfig{ID: "m", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 3}
+	pos := &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: "long"}
+	deps := manualCoreDeps{
+		cfg: &Config{},
+		loadState: func(strategyID, symbol string) (manualStateView, error) {
+			return manualStateView{HasStrategy: true, Pos: pos, NotionalHold: true,
+				NotionalNote: "portfolio notional $60000.00 exceeds cap $50000.00 — new opens blocked, exits continue"}, nil
+		},
+		execute: func(string, string, string, float64, float64, int64, float64, string, float64, bool, hlExecuteSnapshot, ...int64) (*HyperliquidExecuteResult, string, error) {
+			t.Error("execute must not be called while the notional cap is breached")
+			return nil, "", nil
+		},
+		fetchMids: func([]string) (map[string]float64, error) {
+			return map[string]float64{"ETH": 2000}, nil
+		},
+	}
+	_, err := manualAddCore(deps, sc, manualAddInputs{StrategyID: "m", Margin: 50})
+	if err == nil || !strings.Contains(err.Error(), "new opens blocked, exits continue") {
+		t.Fatalf("manual-add err = %v, want notional refusal", err)
+	}
+}

--- a/scheduler/notional_cap_test.go
+++ b/scheduler/notional_cap_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
 	"strings"
 	"testing"
 )
@@ -21,6 +25,89 @@ func TestNotionalCapNeverSkipsStrategyCycle(t *testing.T) {
 	if notionalCapSkipsStrategyCycle(true) {
 		t.Fatal("notionalCapSkipsStrategyCycle(true) must be false — over-cap must not skip close/SL maintenance (#1344)")
 	}
+
+	// Production teeth: main.go must route any whole-strategy notional skip
+	// through the helper (so changing the return to true fails CI), and must
+	// not reintroduce a raw `if notionalBlocked { continue }` / the pre-#1344
+	// `!cbManageOnly && notionalBlocked` bypass that would skip silently.
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	body := string(src)
+	if !strings.Contains(body, "notionalCapSkipsStrategyCycle(notionalBlocked)") {
+		t.Fatal("main.go must call notionalCapSkipsStrategyCycle(notionalBlocked) for the cycle-skip decision")
+	}
+	if strings.Contains(body, "!cbManageOnly && notionalBlocked") {
+		t.Fatal("main.go must not restore the pre-#1344 `!cbManageOnly && notionalBlocked` cycle skip")
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		ifs, ok := n.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		if !astCondMentionsIdent(ifs.Cond, "notionalBlocked") {
+			return true
+		}
+		// Allowed: if notionalCapSkipsStrategyCycle(notionalBlocked) { continue }
+		if astCondIsNotionalCapSkipHelper(ifs.Cond) {
+			return true
+		}
+		if astBlockContainsContinue(ifs.Body) {
+			t.Errorf("main.go:%s: raw notionalBlocked-conditioned continue bypasses notionalCapSkipsStrategyCycle",
+				fset.Position(ifs.Pos()))
+		}
+		return true
+	})
+}
+
+// astCondMentionsIdent reports whether expr references the given identifier
+// anywhere (including nested binary/unary/call expressions).
+func astCondMentionsIdent(expr ast.Expr, name string) bool {
+	found := false
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && id.Name == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// astCondIsNotionalCapSkipHelper reports whether expr is exactly
+// notionalCapSkipsStrategyCycle(...).
+func astCondIsNotionalCapSkipHelper(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	fun, ok := call.Fun.(*ast.Ident)
+	return ok && fun.Name == "notionalCapSkipsStrategyCycle"
+}
+
+// astBlockContainsContinue reports whether body (or any nested block) has a
+// bare `continue` statement.
+func astBlockContainsContinue(body *ast.BlockStmt) bool {
+	if body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		br, ok := n.(*ast.BranchStmt)
+		if ok && br.Tok == token.CONTINUE {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 func TestNotionalCapHoldPassesReduceAndManage(t *testing.T) {

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -457,7 +457,9 @@ func AggregatePerpsMarginInputs(strategies map[string]*StrategyState, configs []
 // CheckPortfolioRisk evaluates aggregate portfolio risk.
 // Returns (allowed, notionalBlocked, warning, reason).
 // allowed=false means the kill switch has fired or is latched; notionalBlocked=true
-// means new trades should be skipped but existing positions kept; warning=true
+// means position-INCREASING opens must be held (#1344 — per-signal via
+// pausedBlocksSignal at the dispatch sites; never a whole-strategy cycle skip)
+// while closes/reductions and SL/TP maintenance keep running; warning=true
 // means drawdown is approaching the kill switch threshold.
 //
 // Two independent drawdown signals feed the kill switch:
@@ -588,10 +590,10 @@ func CheckPortfolioRisk(prs *PortfolioRiskState, cfg *PortfolioRiskConfig, total
 		}
 	}
 
-	// Check notional cap — blocks new trades but does not force-close.
+	// Check notional cap — entry hold only (#1344); does not force-close and
+	// must not skip the strategy cycle (closes / SL/TP maintenance keep running).
 	if cfg.MaxNotionalUSD > 0 && totalNotional > cfg.MaxNotionalUSD {
-		return true, true, warning, fmt.Sprintf("portfolio notional $%.2f exceeds cap $%.2f — new trades blocked",
-			totalNotional, cfg.MaxNotionalUSD)
+		return true, true, warning, notionalCapHoldDetail(totalNotional, cfg.MaxNotionalUSD)
 	}
 
 	return true, false, warning, reason


### PR DESCRIPTION
## Plain simple English
When total open size was already over the portfolio size limit, the bot was also skipping exits and stop-loss upkeep. It now only blocks new size-increasing trades; exits and stop management keep running.

## Summary
- Removed the strategy-level `continue` on `notionalBlocked` in `scheduler/main.go` (the #42 consumer that skipped the whole check/close/manage branch).
- Wired `#1344` entry holds via `pausedBlocksSignal` at all 6 regime-gated dispatch sites, plus `pausedOptionsActions` for options opens — same shape as #1150/#1269/#1270.
- Manual open/add/limit-open refuse while over cap (`manualStateView.NotionalHold`); closes and SL edits remain allowed.
- Operator wording now says new opens are blocked and exits continue; `notionalCapSkipsStrategyCycle` locks the never-skip invariant.

Closes #1344

## Verification
- Red→green: `TestNotionalCapNeverSkipsStrategyCycle` failed under the old skip semantics (`return notionalBlocked`), then passed with the fix.
- `go -C scheduler test -count=1 -run 'TestNotionalCap|TestCheckPortfolioRisk_NotionalCap|TestManualStateViewNotional|TestManualOpenCoreRefusesNotional|TestManualAddCoreRefusesNotional' .`
- `go -C scheduler test -count=1 .`
- `go -C scheduler build -o /dev/null .`

---
Created with LLM: Cursor Grok 4.5 | high | Harness: Cursor