### PR TITLE
fix(#1394): book live spot fills past virtual cash with CRITICAL reconcile [C62, Cursor Grok 4.5, high]

### DIFF
--- a/scheduler/db.go
+++ b/scheduler/db.go
@@ -57,7 +57,9 @@ CREATE TABLE IF NOT EXISTS strategies (
     -- DBs — one code path, no schema fork (#359).
     risk_pending_hl_close_json TEXT NOT NULL DEFAULT '',
     -- #998: regime-profile allocation active profile (flat-switch persistence).
-    active_profile TEXT NOT NULL DEFAULT ''
+    active_profile TEXT NOT NULL DEFAULT '',
+    -- #1394: live spot over-budget books still need operator reconciliation.
+    cash_reconcile_required INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS positions (
@@ -613,6 +615,10 @@ func (sdb *StateDB) migrateSchema() error {
 		// config edit + restart landing between queue and drain. "" = row
 		// queued pre-upgrade; the drain falls back to drain-time resolution.
 		"ALTER TABLE pending_manual_actions ADD COLUMN atr_method TEXT NOT NULL DEFAULT ''",
+		// #1394: persist the live-spot cash-reconcile latch so a restart (or a
+		// second restart after ValidateState clamped cash to 0) cannot silently
+		// clear the "books still need reconciliation" guard.
+		"ALTER TABLE strategies ADD COLUMN cash_reconcile_required INTEGER NOT NULL DEFAULT 0",
 	}
 	for _, ddl := range migrations {
 		if _, err := sdb.db.Exec(ddl); err != nil {
@@ -1216,8 +1222,9 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 	stmtStrat, err := tx.Prepare(`INSERT OR REPLACE INTO strategies (id, type, platform, cash, initial_capital,
 		risk_peak_value, risk_max_drawdown_pct, risk_current_drawdown_pct,
 		risk_daily_pnl, risk_daily_pnl_date, risk_consecutive_losses,
-		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_circuit_closes_json, active_profile)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_circuit_closes_json, active_profile,
+		cash_reconcile_required)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare strategy insert: %w", err)
 	}
@@ -1262,6 +1269,10 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 		if s.RiskState.CircuitBreaker {
 			cbInt = 1
 		}
+		cashReconcileInt := 0
+		if s.CashReconcileRequired {
+			cashReconcileInt = 1
+		}
 		if _, err := stmtStrat.Exec(
 			s.ID, s.Type, s.Platform, s.Cash, s.InitialCapital,
 			s.RiskState.PeakValue, s.RiskState.MaxDrawdownPct, s.RiskState.CurrentDrawdownPct,
@@ -1269,6 +1280,7 @@ func (sdb *StateDB) SaveState(state *AppState) error {
 			cbInt, formatTime(s.RiskState.CircuitBreakerUntil),
 			s.RiskState.MarshalPendingCircuitClosesJSON(),
 			strategyActiveProfile(s),
+			cashReconcileInt,
 		); err != nil {
 			return fmt.Errorf("insert strategy %s: %w", s.ID, err)
 		}
@@ -1674,7 +1686,8 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 		risk_peak_value, risk_max_drawdown_pct, risk_current_drawdown_pct,
 		risk_daily_pnl, risk_daily_pnl_date, risk_consecutive_losses,
 		risk_circuit_breaker, risk_circuit_breaker_until, risk_pending_circuit_closes_json,
-		COALESCE(active_profile, '') AS active_profile
+		COALESCE(active_profile, '') AS active_profile,
+		COALESCE(cash_reconcile_required, 0) AS cash_reconcile_required
 		FROM strategies`)
 	if err != nil {
 		return nil, fmt.Errorf("load strategies: %w", err)
@@ -1684,18 +1697,21 @@ func (sdb *StateDB) LoadState() (*AppState, error) {
 	for rows.Next() {
 		var s StrategyState
 		var cbInt int
+		var cashReconcileInt int
 		var cbUntilStr, pendingCircuitClosesJSON, activeProfile string
 		if err := rows.Scan(
 			&s.ID, &s.Type, &s.Platform, &s.Cash, &s.InitialCapital,
 			&s.RiskState.PeakValue, &s.RiskState.MaxDrawdownPct, &s.RiskState.CurrentDrawdownPct,
 			&s.RiskState.DailyPnL, &s.RiskState.DailyPnLDate, &s.RiskState.ConsecutiveLosses,
 			&cbInt, &cbUntilStr, &pendingCircuitClosesJSON, &activeProfile,
+			&cashReconcileInt,
 		); err != nil {
 			return nil, fmt.Errorf("scan strategy: %w", err)
 		}
 		s.RiskState.CircuitBreaker = cbInt != 0
 		s.RiskState.CircuitBreakerUntil = parseTime(cbUntilStr)
 		s.RiskState.UnmarshalPendingCircuitClosesJSON(pendingCircuitClosesJSON)
+		s.CashReconcileRequired = cashReconcileInt != 0
 		// #998: restore the flat-switch active profile; the pending counter
 		// re-arms from zero on restart (a restart can only delay a switch).
 		if activeProfile != "" {

--- a/scheduler/discord_commands.go
+++ b/scheduler/discord_commands.go
@@ -138,6 +138,7 @@ func formatStatusResponse(state *AppState, prices map[string]float64) string {
 	var cash, value float64
 	posCount, trades := 0, 0
 	regime := ""
+	var reconcileIDs []string
 	for _, id := range sortedAppStateIDs(state) {
 		s := state.Strategies[id]
 		cash += s.Cash
@@ -147,8 +148,15 @@ func formatStatusResponse(state *AppState, prices map[string]float64) string {
 		if regime == "" && s.Regime != "" {
 			regime = s.Regime
 		}
+		if s.CashReconcileRequired {
+			reconcileIDs = append(reconcileIDs, id)
+		}
 	}
-	return formatStatusLine(cash, posCount, value, trades, regime)
+	line := formatStatusLine(cash, posCount, value, trades, regime)
+	if len(reconcileIDs) == 0 {
+		return line
+	}
+	return line + "\n**CASH RECONCILE REQUIRED:** " + strings.Join(reconcileIDs, ", ")
 }
 
 // formatPositionsResponse lists open positions grouped by platform. Call under RLock.

--- a/scheduler/discord_commands_test.go
+++ b/scheduler/discord_commands_test.go
@@ -132,6 +132,41 @@ func TestFormatStatusResponse(t *testing.T) {
 	if !strings.Contains(got, "regime=trend_up") {
 		t.Errorf("expected regime in status, got: %s", got)
 	}
+	if strings.Contains(got, "CASH RECONCILE REQUIRED") {
+		t.Errorf("unlatched status must not mention reconcile, got: %s", got)
+	}
+}
+
+func TestFormatStatusResponse_CashReconcileRequired(t *testing.T) {
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"z-latched": {ID: "z-latched", Platform: "robinhood", Cash: 0, CashReconcileRequired: true,
+			Positions: map[string]*Position{}},
+		"a-latched": {ID: "a-latched", Platform: "okx", Cash: 0.005, CashReconcileRequired: true,
+			Positions: map[string]*Position{}},
+		"m-ok": {ID: "m-ok", Platform: "hyperliquid", Cash: 50, CashReconcileRequired: false,
+			Positions: map[string]*Position{}},
+	}}
+	got := formatStatusResponse(state, nil)
+	if !strings.Contains(got, "CASH RECONCILE REQUIRED") {
+		t.Fatalf("expected reconcile banner, got: %s", got)
+	}
+	// IDs are collected in sortedAppStateIDs order then appended when latched —
+	// assert both appear and unlatched does not.
+	if !strings.Contains(got, "a-latched") || !strings.Contains(got, "z-latched") {
+		t.Fatalf("expected both latched IDs, got: %s", got)
+	}
+	if strings.Contains(got, "m-ok") && strings.Contains(got[strings.Index(got, "CASH RECONCILE REQUIRED"):], "m-ok") {
+		t.Fatalf("unlatched strategy must not appear in reconcile list, got: %s", got)
+	}
+	// sortedAppStateIDs sorts keys; latched append order follows that sort.
+	idx := strings.Index(got, "CASH RECONCILE REQUIRED:")
+	list := got[idx:]
+	if !strings.Contains(list, "a-latched, z-latched") && !strings.Contains(list, "a-latched,z-latched") {
+		// format uses strings.Join(reconcileIDs, ", ") after walking sortedAppStateIDs
+		if !(strings.Contains(list, "a-latched") && strings.Index(list, "a-latched") < strings.Index(list, "z-latched")) {
+			t.Fatalf("expected a-latched before z-latched in sorted list, got: %s", list)
+		}
+	}
 }
 
 func testPnLState() *AppState {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2006,9 +2006,11 @@ func main() {
 									}
 								}
 								if !liveExecFailed {
+									var cashAlert string
 									mu.Lock()
-									trades, detail = executeOKXResult(sc, stratState, stateDB, result, execResult, signalStr, price, cfg.Regime, cfg, logger)
+									trades, detail, cashAlert = executeOKXResult(sc, stratState, stateDB, result, execResult, signalStr, price, cfg.Regime, cfg, logger)
 									mu.Unlock()
+									notifySpotLiveCashOverBudget(notifier, cashAlert)
 								}
 							}
 						} else if sc.Platform == "robinhood" {
@@ -2062,9 +2064,11 @@ func main() {
 									}
 								}
 								if !liveExecFailed {
+									var cashAlert string
 									mu.Lock()
-									trades, detail = executeRobinhoodResult(sc, stratState, stateDB, result, execResult, signalStr, price, cfg.Regime, cfg, logger)
+									trades, detail, cashAlert = executeRobinhoodResult(sc, stratState, stateDB, result, execResult, signalStr, price, cfg.Regime, cfg, logger)
 									mu.Unlock()
+									notifySpotLiveCashOverBudget(notifier, cashAlert)
 								}
 							}
 						} else if result, signalStr, price, ok := runSpotCheck(sc, prices, spotPosCtx, cfg.Regime, resolveATRMethod(sc, cfg), notifier, logger); ok {
@@ -2233,9 +2237,11 @@ func main() {
 									}
 								}
 								if !liveExecFailed {
+									var cashAlert string
 									mu.Lock()
-									trades, detail = executeOKXResult(sc, stratState, stateDB, result, execResult, signalStr, price, cfg.Regime, cfg, logger)
+									trades, detail, cashAlert = executeOKXResult(sc, stratState, stateDB, result, execResult, signalStr, price, cfg.Regime, cfg, logger)
 									mu.Unlock()
+									notifySpotLiveCashOverBudget(notifier, cashAlert)
 								}
 							}
 						} else if result, signalStr, price, ok := runHyperliquidCheck(&sc, prices, hlPosCtx, cfg.Regime, resolveATRMethod(sc, cfg), notifier, logger); ok {
@@ -4408,7 +4414,9 @@ func runRobinhoodExecuteOrder(sc StrategyConfig, result *RobinhoodResult, price,
 }
 
 // executeRobinhoodResult applies a Robinhood result to state. Must be called under Lock.
-func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *RobinhoodResult, execResult *RobinhoodExecuteResult, signalStr string, price float64, regime *RegimeConfig, cfg *Config, logger *StrategyLogger) (int, string) {
+// cashOverBudgetAlert is non-empty when a live spot buy was booked past virtual
+// cash (#1394); callers must notify AFTER releasing mu.
+func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *RobinhoodResult, execResult *RobinhoodExecuteResult, signalStr string, price float64, regime *RegimeConfig, cfg *Config, logger *StrategyLogger) (int, string, string) {
 	fillPrice := price
 	var fillQty float64
 	var fillFee float64
@@ -4424,7 +4432,7 @@ func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, db *StateDB, re
 	exec, err := ExecuteSpotSignalWithFillFeeDeferredOpen(s, result.Signal, result.Symbol, fillPrice, fillQty, fillFee, fillOID, result.CloseFraction, logger)
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
-		return 0, ""
+		return 0, "", ""
 	}
 	trades := exec.TradesExecuted
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
@@ -4444,7 +4452,11 @@ func executeRobinhoodResult(sc StrategyConfig, s *StrategyState, db *StateDB, re
 		}
 		detail = fmt.Sprintf("[%s] %s%s %s @ $%.2f", sc.ID, prefix, signalStr, result.Symbol, fillPrice)
 	}
-	return trades, detail
+	cashAlert := ""
+	if exec.CashReconcileRequired {
+		cashAlert = exec.CashOverBudgetAlert
+	}
+	return trades, detail, cashAlert
 }
 
 // okxIsLive reports whether --mode=live appears in strategy args.
@@ -4619,7 +4631,9 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 }
 
 // executeOKXResult applies an OKX result to state. Must be called under Lock.
-func executeOKXResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *OKXResult, execResult *OKXExecuteResult, signalStr string, price float64, regime *RegimeConfig, cfg *Config, logger *StrategyLogger) (int, string) {
+// cashOverBudgetAlert is non-empty when a live spot buy was booked past virtual
+// cash (#1394); callers must notify AFTER releasing mu. Perps never set it.
+func executeOKXResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *OKXResult, execResult *OKXExecuteResult, signalStr string, price float64, regime *RegimeConfig, cfg *Config, logger *StrategyLogger) (int, string, string) {
 	fillPrice := price
 	var fillQty float64
 	var fillFee float64
@@ -4646,7 +4660,7 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *
 	}
 	if err != nil {
 		logger.Error("Trade execution failed: %v", err)
-		return 0, ""
+		return 0, "", ""
 	}
 	trades := exec.TradesExecuted
 	stampEntryATRIfOpened(s, result.Symbol, result.Indicators)
@@ -4666,7 +4680,11 @@ func executeOKXResult(sc StrategyConfig, s *StrategyState, db *StateDB, result *
 		}
 		detail = fmt.Sprintf("[%s] %s%s %s @ $%.2f", sc.ID, prefix, signalStr, result.Symbol, fillPrice)
 	}
-	return trades, detail
+	cashAlert := ""
+	if exec.CashReconcileRequired {
+		cashAlert = exec.CashOverBudgetAlert
+	}
+	return trades, detail, cashAlert
 }
 
 // findLeaderboardSummariesByChannel returns every LeaderboardSummaryConfig

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2014,7 +2014,15 @@ func main() {
 									mu.Lock()
 									trades, detail, cashAlert = executeOKXResult(sc, stratState, stateDB, result, execResult, signalStr, price, cfg.Regime, cfg, logger)
 									mu.Unlock()
-									notifySpotLiveCashOverBudget(notifier, cashAlert)
+									if cashAlert != "" {
+										notifySpotLiveCashOverBudget(notifier, cashAlert)
+										// Seed the cycle reminder so the founding
+										// over-budget DM is not immediately double-sent.
+										mu.RLock()
+										ids, _ := collectCashReconcileRequiredSnapshots(state)
+										mu.RUnlock()
+										globalSpotCashReconcileReminder.MarkNotified(strings.Join(ids, ","), time.Now().UTC())
+									}
 								}
 							}
 						} else if sc.Platform == "robinhood" {
@@ -2072,7 +2080,15 @@ func main() {
 									mu.Lock()
 									trades, detail, cashAlert = executeRobinhoodResult(sc, stratState, stateDB, result, execResult, signalStr, price, cfg.Regime, cfg, logger)
 									mu.Unlock()
-									notifySpotLiveCashOverBudget(notifier, cashAlert)
+									if cashAlert != "" {
+										notifySpotLiveCashOverBudget(notifier, cashAlert)
+										// Seed the cycle reminder so the founding
+										// over-budget DM is not immediately double-sent.
+										mu.RLock()
+										ids, _ := collectCashReconcileRequiredSnapshots(state)
+										mu.RUnlock()
+										globalSpotCashReconcileReminder.MarkNotified(strings.Join(ids, ","), time.Now().UTC())
+									}
 								}
 							}
 						} else if result, signalStr, price, ok := runSpotCheck(sc, prices, spotPosCtx, cfg.Regime, resolveATRMethod(sc, cfg), notifier, logger); ok {
@@ -2245,7 +2261,15 @@ func main() {
 									mu.Lock()
 									trades, detail, cashAlert = executeOKXResult(sc, stratState, stateDB, result, execResult, signalStr, price, cfg.Regime, cfg, logger)
 									mu.Unlock()
-									notifySpotLiveCashOverBudget(notifier, cashAlert)
+									if cashAlert != "" {
+										notifySpotLiveCashOverBudget(notifier, cashAlert)
+										// Seed the cycle reminder so the founding
+										// over-budget DM is not immediately double-sent.
+										mu.RLock()
+										ids, _ := collectCashReconcileRequiredSnapshots(state)
+										mu.RUnlock()
+										globalSpotCashReconcileReminder.MarkNotified(strings.Join(ids, ","), time.Now().UTC())
+									}
 								}
 							}
 						} else if result, signalStr, price, ok := runHyperliquidCheck(&sc, prices, hlPosCtx, cfg.Regime, resolveATRMethod(sc, cfg), notifier, logger); ok {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1831,6 +1831,7 @@ func main() {
 						}
 					}
 					var okxCash float64
+					var okxCashReconcile bool
 					var okxPosQty float64
 					var okxPosSide string
 					var okxAvgCost float64
@@ -1838,6 +1839,7 @@ func main() {
 					if sc.Platform == "okx" {
 						if okxLiveStrategy {
 							okxCash = stratState.Cash
+							okxCashReconcile = stratState.CashReconcileRequired
 						}
 						if sym := okxSymbol(sc.Args); sym != "" {
 							if pos, ok := stratState.Positions[sym]; ok {
@@ -1849,12 +1851,14 @@ func main() {
 						}
 					}
 					var rhCash float64
+					var rhCashReconcile bool
 					var rhPosQty float64
 					var rhPosSide string
 					var rhPosCtx PositionCtx
 					if sc.Platform == "robinhood" {
 						if rhLiveStrategy {
 							rhCash = stratState.Cash
+							rhCashReconcile = stratState.CashReconcileRequired
 						}
 						if sym := robinhoodSymbol(sc.Args); sym != "" {
 							if pos, ok := stratState.Positions[sym]; ok {
@@ -1999,7 +2003,7 @@ func main() {
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
 								if okxIsLive(sc.Args) && result.Signal != 0 {
-									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxPosQty, okxPosSide, okxAvgCost, notifier, logger); ok2 {
+									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxCashReconcile, okxPosQty, okxPosSide, okxAvgCost, notifier, logger); ok2 {
 										execResult = er
 									} else {
 										liveExecFailed = true
@@ -2057,7 +2061,7 @@ func main() {
 								var execResult *RobinhoodExecuteResult
 								liveExecFailed := false
 								if robinhoodIsLive(sc.Args) && result.Signal != 0 {
-									if er, ok2 := runRobinhoodExecuteOrder(sc, result, price, rhCash, rhPosQty, rhPosSide, notifier, logger); ok2 {
+									if er, ok2 := runRobinhoodExecuteOrder(sc, result, price, rhCash, rhCashReconcile, rhPosQty, rhPosSide, notifier, logger); ok2 {
 										execResult = er
 									} else {
 										liveExecFailed = true
@@ -2230,7 +2234,7 @@ func main() {
 								var execResult *OKXExecuteResult
 								liveExecFailed := false
 								if okxIsLive(sc.Args) && result.Signal != 0 {
-									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxPosQty, okxPosSide, okxAvgCost, notifier, logger); ok2 {
+									if er, ok2 := runOKXExecuteOrder(sc, result, price, okxCash, okxCashReconcile, okxPosQty, okxPosSide, okxAvgCost, notifier, logger); ok2 {
 										execResult = er
 									} else {
 										liveExecFailed = true
@@ -2892,12 +2896,40 @@ func main() {
 					}
 					mu.RUnlock()
 
-					logger.Info("%s", formatStatusLine(cash, posCount, pv, trades, regimeLabel))
+					statusLine := formatStatusLine(cash, posCount, pv, trades, regimeLabel)
+					mu.RLock()
+					cashReconcile := stratState.CashReconcileRequired
+					mu.RUnlock()
+					if cashReconcile {
+						statusLine += " | CASH RECONCILE REQUIRED"
+					}
+					logger.Info("%s", statusLine)
 
 					logger.Close()
 					lastRun[sc.ID] = time.Now()
 				}
 			} // end if !killSwitchFired
+		}
+
+		// #1394: clear solvent latches and emit a throttled reminder for every
+		// strategy still needing cash reconciliation (covers DM-miss / restart).
+		mu.Lock()
+		for _, s := range state.Strategies {
+			maybeClearCashReconcileRequired(s)
+		}
+		mu.Unlock()
+		mu.RLock()
+		reconcileIDs, reconcileCash := collectCashReconcileRequiredSnapshots(state)
+		mu.RUnlock()
+		if len(reconcileIDs) > 0 {
+			sig := strings.Join(reconcileIDs, ",")
+			if globalSpotCashReconcileReminder.ShouldNotify(sig, time.Now().UTC()) {
+				msg := formatSpotLiveCashReconcileReminder(reconcileIDs, reconcileCash)
+				fmt.Printf("[CRITICAL] %s\n", msg)
+				notifySpotLiveCashOverBudget(notifier, msg)
+			}
+		} else {
+			globalSpotCashReconcileReminder.ShouldNotify("", time.Now().UTC())
 		}
 
 		// Build per-channel strategy lists for channel-level summaries.
@@ -4357,7 +4389,7 @@ func runRobinhoodCheck(sc StrategyConfig, prices map[string]float64, posCtx Posi
 // calling the Python executor: otherwise a no-op ExecuteSpotSignalWithFillFee (e.g.
 // already-long with signal=1) would not record the live fill — the same bug
 // class as #298. See #300.
-func runRobinhoodExecuteOrder(sc StrategyConfig, result *RobinhoodResult, price, cash, posQty float64, posSide string, notifier *MultiNotifier, logger *StrategyLogger) (*RobinhoodExecuteResult, bool) {
+func runRobinhoodExecuteOrder(sc StrategyConfig, result *RobinhoodResult, price, cash float64, cashReconcileRequired bool, posQty float64, posSide string, notifier *MultiNotifier, logger *StrategyLogger) (*RobinhoodExecuteResult, bool) {
 	if reason := SpotOrderSkipReason(result.Signal, posSide); reason != "" {
 		logger.Info("Skipping live order for %s: %s", result.Symbol, reason)
 		return nil, false
@@ -4368,6 +4400,11 @@ func runRobinhoodExecuteOrder(sc StrategyConfig, result *RobinhoodResult, price,
 	side := "buy"
 
 	if isBuy {
+		// #1394: hold further live buys while books still need reconciliation.
+		if cashReconcileBlocksLiveBuy(cashReconcileRequired, true) {
+			logger.Warn("Skipping live buy for %s: cash reconcile required (#1394)", result.Symbol)
+			return nil, false
+		}
 		// #518: removed hardcoded 0.95 buffer for spot live buy.
 		amountUSD = cash
 		if amountUSD < 1 || price <= 0 {
@@ -4549,7 +4586,7 @@ func runOKXCheck(sc StrategyConfig, prices map[string]float64, posCtx PositionCt
 // ExecutePerpsSignalWithLeverage that must be mirrored to avoid the #298 bug class
 // (live fill placed but no Trade recorded because the in-memory execution
 // returned 0). See #300.
-func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQty float64, posSide string, avgCost float64, notifier *MultiNotifier, logger *StrategyLogger) (*OKXExecuteResult, bool) {
+func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash float64, cashReconcileRequired bool, posQty float64, posSide string, avgCost float64, notifier *MultiNotifier, logger *StrategyLogger) (*OKXExecuteResult, bool) {
 	var skip string
 	if sc.Type == "perps" {
 		skip = PerpsOrderSkipReason(result.Signal, posSide, EffectiveDirection(sc))
@@ -4561,6 +4598,12 @@ func runOKXExecuteOrder(sc StrategyConfig, result *OKXResult, price, cash, posQt
 		return nil, false
 	}
 	isBuy := result.Signal == 1
+	// #1394: hold further live SPOT buys while books still need reconciliation.
+	// Perps sizing is margin-based and out of scope for this latch.
+	if sc.Type != "perps" && cashReconcileBlocksLiveBuy(cashReconcileRequired, isBuy) {
+		logger.Warn("Skipping live buy for %s: cash reconcile required (#1394)", result.Symbol)
+		return nil, false
+	}
 	// #254/#497/#518: perps sizing uses PerpsOpenNotional (sizing_leverage or
 	// margin_per_trade_usd). EffectiveSizingLeverage returns 1 for spot, so
 	// the spot branch below remains a simple cash buy. #518 removed the

--- a/scheduler/main_test.go
+++ b/scheduler/main_test.go
@@ -933,7 +933,7 @@ func TestExecuteOKXResult_PerpsStampsExchangeData(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, _ := executeOKXResult(sc, s, nil, result, execResult, "BUY", 50000, nil, nil, logger)
+	trades, _, _ := executeOKXResult(sc, s, nil, result, execResult, "BUY", 50000, nil, nil, logger)
 	if trades != 1 {
 		t.Fatalf("trades = %d, want 1", trades)
 	}
@@ -972,7 +972,7 @@ func TestExecuteOKXResult_SpotStampsExchangeData(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, _ := executeOKXResult(sc, s, nil, result, execResult, "BUY", 50000, nil, nil, logger)
+	trades, _, _ := executeOKXResult(sc, s, nil, result, execResult, "BUY", 50000, nil, nil, logger)
 	if trades != 1 {
 		t.Fatalf("trades = %d, want 1", trades)
 	}
@@ -1011,7 +1011,7 @@ func TestExecuteRobinhoodResult_StampsExchangeData(t *testing.T) {
 	logger, _ := lm.GetStrategyLogger("test")
 	defer logger.Close()
 
-	trades, _ := executeRobinhoodResult(sc, s, nil, result, execResult, "BUY", 50000, nil, nil, logger)
+	trades, _, _ := executeRobinhoodResult(sc, s, nil, result, execResult, "BUY", 50000, nil, nil, logger)
 	if trades != 1 {
 		t.Fatalf("trades = %d, want 1", trades)
 	}
@@ -1021,6 +1021,85 @@ func TestExecuteRobinhoodResult_StampsExchangeData(t *testing.T) {
 	}
 	if tr.ExchangeFee != 0.07 {
 		t.Errorf("ExchangeFee = %g, want 0.07", tr.ExchangeFee)
+	}
+}
+
+func TestExecuteRobinhoodResult_LiveFillCashOverBudget(t *testing.T) {
+	s := &StrategyState{
+		ID:              "rh-momentum-btc",
+		Type:            "spot",
+		Platform:        "robinhood",
+		Cash:            50,
+		InitialCapital:  1000,
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+	sc := StrategyConfig{ID: "rh-momentum-btc", Type: "spot", Platform: "robinhood"}
+	result := &RobinhoodResult{Signal: 1, Symbol: "BTC", Price: 50000}
+	execResult := &RobinhoodExecuteResult{
+		Execution: &RobinhoodExecution{
+			Action: "buy", Symbol: "BTC", AmountUSD: 500,
+			Fill: &RobinhoodFill{AvgPx: 50000, Quantity: 0.01, OID: "rh-over-oid", Fee: 0.0},
+		},
+		Platform: "robinhood",
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	trades, _, cashAlert := executeRobinhoodResult(sc, s, nil, result, execResult, "BUY", 50000, nil, nil, logger)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1 — over-budget live fill must still book", trades)
+	}
+	if cashAlert == "" || !strings.Contains(cashAlert, "CRITICAL: LIVE SPOT CASH OVER BUDGET") {
+		t.Fatalf("cashAlert = %q, want CRITICAL over-budget alert", cashAlert)
+	}
+	if !s.CashReconcileRequired {
+		t.Fatal("CashReconcileRequired must latch on RH over-budget book")
+	}
+	if s.Positions["BTC"] == nil {
+		t.Fatal("position must exist after over-budget RH fill")
+	}
+}
+
+func TestExecuteOKXResult_SpotLiveFillCashOverBudget(t *testing.T) {
+	s := &StrategyState{
+		ID:              "okx-spot-btc",
+		Type:            "spot",
+		Platform:        "okx",
+		Cash:            0.40,
+		InitialCapital:  1000,
+		Positions:       make(map[string]*Position),
+		OptionPositions: make(map[string]*OptionPosition),
+		TradeHistory:    []Trade{},
+		RiskState:       RiskState{PeakValue: 1000},
+	}
+	sc := StrategyConfig{ID: "okx-spot-btc", Type: "spot", Platform: "okx"}
+	result := &OKXResult{Signal: 1, Symbol: "BTC", Price: 50000}
+	execResult := &OKXExecuteResult{
+		Execution: &OKXExecution{
+			Action: "buy", Symbol: "BTC", Size: 0.01,
+			Fill: &OKXFill{AvgPx: 50000, TotalSz: 0.01, OID: "okx-over-oid", Fee: 0.50},
+		},
+		Platform: "okx",
+	}
+
+	lm, _ := NewLogManager("")
+	logger, _ := lm.GetStrategyLogger("test")
+	defer logger.Close()
+
+	trades, _, cashAlert := executeOKXResult(sc, s, nil, result, execResult, "BUY", 50000, nil, nil, logger)
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1 — sub-dollar cash live fill must book (#1394)", trades)
+	}
+	if cashAlert == "" || !strings.Contains(cashAlert, "CRITICAL: LIVE SPOT CASH OVER BUDGET") {
+		t.Fatalf("cashAlert = %q, want CRITICAL over-budget alert", cashAlert)
+	}
+	if !s.CashReconcileRequired {
+		t.Fatal("CashReconcileRequired must latch on OKX over-budget book")
 	}
 }
 

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -1079,9 +1079,12 @@ func notifySpotLiveCashOverBudget(sender ownerDMSender, msg string) {
 }
 
 // maybeClearCashReconcileRequired drops the #1394 latch once virtual cash is
-// solvent again (>= spotLiveCashBudgetTolerance). Clamp-to-zero on load leaves
-// cash at 0, which is below the floor, so the latch survives restart until an
-// operator actually restores headroom.
+// solvent again (>= spotLiveCashBudgetTolerance). Solvency is a proxy, not
+// proof the books were reconciled against the venue — #1400 will replace this
+// auto-clear with an operator-explicit clear (removing it now would strand
+// latched strategies with no in-app resume path). Clamp-to-zero on load leaves
+// cash at 0 (< floor), so a persisted latch survives restart until cash
+// recovers or an operator clears it.
 func maybeClearCashReconcileRequired(s *StrategyState) {
 	if s == nil || !s.CashReconcileRequired {
 		return
@@ -1127,8 +1130,11 @@ type spotCashReconcileReminderTracker struct {
 var globalSpotCashReconcileReminder = &spotCashReconcileReminderTracker{}
 
 // ShouldNotify reports whether this cycle should re-DM the latched set. First
-// sighting of a non-empty set always notifies; thereafter on signature change
-// (strategy set changed) or once per effectiveAlertThrottleInterval.
+// sighting of a non-empty set always notifies; thereafter when a *new*
+// strategy ID appears in the set, or once per effectiveAlertThrottleInterval.
+// Shrinking the set (a peer cleared) must not re-DM strategies that were
+// already covered by the previous notification / MarkNotified seed — that
+// was the compound-cycle double-DM (#1397 review).
 func (t *spotCashReconcileReminderTracker) ShouldNotify(sig string, now time.Time) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -1142,12 +1148,39 @@ func (t *spotCashReconcileReminderTracker) ShouldNotify(sig string, now time.Tim
 		t.lastSig = sig
 		return true
 	case sig != t.lastSig:
-		t.lastNotifiedAt = now
+		if cashReconcileSigHasNewID(sig, t.lastSig) {
+			t.lastNotifiedAt = now
+			t.lastSig = sig
+			return true
+		}
+		// Subset shrink / reorder of an already-notified set: adopt the new
+		// signature without re-DMing.
 		t.lastSig = sig
-		return true
+		return false
 	case now.Sub(t.lastNotifiedAt) >= effectiveAlertThrottleInterval():
 		t.lastNotifiedAt = now
 		return true
+	}
+	return false
+}
+
+// cashReconcileSigHasNewID reports whether comma-joined sig contains any
+// strategy ID absent from lastSig. Empty tokens are ignored.
+func cashReconcileSigHasNewID(sig, lastSig string) bool {
+	last := make(map[string]struct{})
+	for _, id := range strings.Split(lastSig, ",") {
+		if id == "" {
+			continue
+		}
+		last[id] = struct{}{}
+	}
+	for _, id := range strings.Split(sig, ",") {
+		if id == "" {
+			continue
+		}
+		if _, ok := last[id]; !ok {
+			return true
+		}
 	}
 	return false
 }

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -1152,6 +1152,19 @@ func (t *spotCashReconcileReminderTracker) ShouldNotify(sig string, now time.Tim
 	return false
 }
 
+// MarkNotified seeds the throttle as if a reminder already fired for sig.
+// Call after the per-fill CRITICAL DM so the same-cycle reminder does not
+// double-DM the operator for the founding over-budget event (#1394 review).
+func (t *spotCashReconcileReminderTracker) MarkNotified(sig string, now time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if sig == "" {
+		return
+	}
+	t.lastNotifiedAt = now
+	t.lastSig = sig
+}
+
 // collectCashReconcileRequiredSnapshots returns sorted strategy IDs still
 // latched plus a cash map for the reminder body. Call under RLock.
 func collectCashReconcileRequiredSnapshots(state *AppState) (ids []string, cashByID map[string]float64) {

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -645,6 +645,11 @@ type Trade struct {
 type SignalExecutionResult struct {
 	TradesExecuted int
 	OpenTrade      *Trade
+	// CashReconcileRequired is true when THIS execution booked a live spot
+	// buy that exceeded virtual cash beyond spotLiveCashBudgetTolerance
+	// (#1394). Callers emit CashOverBudgetAlert after releasing mu.
+	CashReconcileRequired bool
+	CashOverBudgetAlert   string
 }
 
 var tradePositionNonce uint64
@@ -1033,6 +1038,43 @@ func perpsCloseActionSuppressesNewSL(signal int, posSide string, allowsLong, all
 	return false
 }
 
+// spotLiveCashBudgetTolerance is the explicit USD slack for live spot-buy
+// cash validation (#1394). Matches the cent-exact shared-wallet drift
+// tolerance: anything larger is a real over-budget book that must CRITICAL-
+// alert and latch CashReconcileRequired; anything at or under is float noise.
+const spotLiveCashBudgetTolerance = 0.01
+
+// spotLiveBuyExceedsCash reports whether a live spot buy's total debit
+// (fill notional + fee) exceeds available virtual cash beyond
+// spotLiveCashBudgetTolerance. Pure helper — booking always proceeds for
+// venue fills; this only decides the CRITICAL / reconcile latch (#1394).
+func spotLiveBuyExceedsCash(cash, totalDebit float64) bool {
+	return totalDebit > cash+spotLiveCashBudgetTolerance
+}
+
+// formatSpotLiveCashOverBudgetAlert builds the CRITICAL owner-DM body for a
+// live spot buy booked past virtual cash (#1394). Pure so tests assert the
+// copy without a notifier.
+func formatSpotLiveCashOverBudgetAlert(strategyID, symbol string, cashBefore, totalDebit, cashAfter, fillQty, fillPrice, fee float64) string {
+	return fmt.Sprintf(
+		"**CRITICAL: LIVE SPOT CASH OVER BUDGET** [%s] %s fill %.6f @ $%.4f (fee $%.4f, debit $%.4f) exceeded virtual cash $%.4f → cash now $%.4f. Fill was booked (venue already filled); reconcile virtual cash against the exchange — dropping the fill would leave state behind real holdings (#1394 / #298).",
+		strategyID, symbol, fillQty, fillPrice, fee, totalDebit, cashBefore, cashAfter,
+	)
+}
+
+// notifySpotLiveCashOverBudget emits the over-budget CRITICAL to the owner
+// (and all channels when a MultiNotifier is wired). No-ops on nil sender.
+// Call AFTER releasing mu — Discord/Telegram HTTP must not run under the lock.
+func notifySpotLiveCashOverBudget(sender ownerDMSender, msg string) {
+	if msg == "" || sender == nil || isNilSender(sender) {
+		return
+	}
+	sender.SendOwnerDM(msg)
+	if mn, ok := sender.(*MultiNotifier); ok && mn != nil && mn.HasBackends() {
+		mn.SendToAllChannels(msg)
+	}
+}
+
 // SpotOrderSkipReason mirrors PerpsOrderSkipReason for spot. ExecuteSpotSignalWithFillFee's
 // side-based skip branches ("already long, skipping buy" at signal=1,
 // "No long position to sell, skipping" at signal=-1) must be consulted BEFORE
@@ -1044,8 +1086,10 @@ func perpsCloseActionSuppressesNewSL(signal int, posSide string, allowsLong, all
 //   - signal == 1 && pos.Side == "long"  → "Already long, skipping buy"
 //   - signal == -1 && no long position    → "No long position to sell, skipping"
 //
-// Cash-insufficient skips inside the open-long path are not mirrored here —
-// live helpers guard cash upstream before placing the order.
+// Paper cash-insufficient skips (budget < $1 with fillQty==0) are not mirrored
+// here — live helpers guard cash upstream before placing the order. Once a
+// venue fill exists (fillQty>0), booking always proceeds (#1394); an over-
+// budget book latches CashReconcileRequired instead of dropping the fill.
 func SpotOrderSkipReason(signal int, posSide string) string {
 	switch signal {
 	case 1:
@@ -1600,25 +1644,38 @@ func perpsSizingLabel(sizing PerpsSizing) string {
 // leg reduces pos.Quantity (paper) or uses fillQty (live) without deleting
 // the position. closeFraction == 0 preserves the legacy full-close semantics.
 func ExecuteSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, fillQty float64, fillFee float64, fillOID string, closeFraction float64, logger *StrategyLogger) (int, error) {
-	return executeSpotSignalWithFillFee(s, signal, symbol, price, fillQty, fillFee, fillOID, closeFraction, logger, func(trade Trade) {
+	out, err := executeSpotSignalWithFillFee(s, signal, symbol, price, fillQty, fillFee, fillOID, closeFraction, logger, func(trade Trade) {
 		RecordTrade(s, trade)
 	})
+	return out.TradesExecuted, err
 }
 
 func ExecuteSpotSignalWithFillFeeDeferredOpen(s *StrategyState, signal int, symbol string, price float64, fillQty float64, fillFee float64, fillOID string, closeFraction float64, logger *StrategyLogger) (SignalExecutionResult, error) {
 	var result SignalExecutionResult
-	trades, err := executeSpotSignalWithFillFee(s, signal, symbol, price, fillQty, fillFee, fillOID, closeFraction, logger, func(trade Trade) {
+	out, err := executeSpotSignalWithFillFee(s, signal, symbol, price, fillQty, fillFee, fillOID, closeFraction, logger, func(trade Trade) {
 		t := trade
 		result.OpenTrade = &t
 	})
-	result.TradesExecuted = trades
+	result.TradesExecuted = out.TradesExecuted
+	result.CashReconcileRequired = out.CashReconcileRequired
+	result.CashOverBudgetAlert = out.CashOverBudgetAlert
 	return result, err
 }
 
-func executeSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, fillQty float64, fillFee float64, fillOID string, closeFraction float64, logger *StrategyLogger, recordOpen func(Trade)) (int, error) {
+// spotSignalExecOutcome is the internal return of executeSpotSignalWithFillFee
+// so DeferredOpen can surface CashReconcileRequired without changing the
+// public (int, error) ExecuteSpotSignalWithFillFee signature (#1394).
+type spotSignalExecOutcome struct {
+	TradesExecuted        int
+	CashReconcileRequired bool
+	CashOverBudgetAlert   string
+}
+
+func executeSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, price float64, fillQty float64, fillFee float64, fillOID string, closeFraction float64, logger *StrategyLogger, recordOpen func(Trade)) (spotSignalExecOutcome, error) {
 	if signal == 0 {
-		return 0, nil
+		return spotSignalExecOutcome{}, nil
 	}
+	out := spotSignalExecOutcome{}
 	tradesExecuted := 0
 	feePlatform := s.Platform
 	if s.Platform == "okx" && s.Type == "perps" {
@@ -1631,7 +1688,7 @@ func executeSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 		// Check if already long
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "long" {
 			logger.Info("Already long %s (qty=%.6f), skipping buy", symbol, pos.Quantity)
-			return 0, nil
+			return spotSignalExecOutcome{}, nil
 		}
 		// Close short if exists
 		if pos, exists := s.Positions[symbol]; exists && pos.Side == "short" {
@@ -1704,25 +1761,33 @@ func executeSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 		// open a long in the same cycle. Stop here when this signal is a
 		// close-action emitted by the open/close registry (#519).
 		if closeFraction > 0 {
-			return tradesExecuted, nil
+			out.TradesExecuted = tradesExecuted
+			return out, nil
 		}
 		// Open long — deploy full cash (paper) or exact fill qty (live). The
 		// hardcoded 0.95 safety buffer was removed in #518; spot has no
 		// margin to leave headroom for, and operators who want a buffer can
 		// reserve cash externally.
+		// #1394: the budget < $1 floor applies to PAPER only. A live venue
+		// fill (fillQty > 0) has already executed — dropping it here would
+		// leave virtual state behind real holdings (#298). Over-budget live
+		// fills are booked, then CRITICAL-alerted and marked reconcile-required.
 		budget := s.Cash
-		if budget < 1 {
+		liveBuy := fillQty > 0
+		if !liveBuy && budget < 1 {
 			logger.Info("Insufficient cash ($%.2f) to buy %s", s.Cash, symbol)
-			return tradesExecuted, nil
+			out.TradesExecuted = tradesExecuted
+			return out, nil
 		}
 		var execPrice, qty float64
-		if fillQty > 0 {
+		if liveBuy {
 			execPrice = price
 			qty = fillQty
 		} else {
 			execPrice = ApplySlippage(price)
 			if execPrice <= 0 {
-				return tradesExecuted, nil
+				out.TradesExecuted = tradesExecuted
+				return out, nil
 			}
 			qty = budget / execPrice
 		}
@@ -1732,7 +1797,10 @@ func executeSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 		if useFillMetadata {
 			fillMetadataUsed = true
 		}
-		s.Cash -= tradeCost + fee
+		totalDebit := tradeCost + fee
+		cashBefore := s.Cash
+		overBudget := liveBuy && spotLiveBuyExceedsCash(cashBefore, totalDebit)
+		s.Cash -= totalDebit
 		now := time.Now().UTC()
 		positionID := newTradePositionID(s.ID, symbol, now)
 		s.Positions[symbol] = &Position{
@@ -1745,6 +1813,16 @@ func executeSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			OwnerStrategyID: s.ID,
 			OpenedAt:        now,
 		}
+		details := fmt.Sprintf("Open long %.6f @ $%.2f (fee $%.2f)", qty, execPrice, fee)
+		if overBudget {
+			s.CashReconcileRequired = true
+			out.CashReconcileRequired = true
+			out.CashOverBudgetAlert = formatSpotLiveCashOverBudgetAlert(
+				s.ID, symbol, cashBefore, totalDebit, s.Cash, qty, execPrice, fee)
+			details += " [CASH OVER BUDGET — reconcile required]"
+			logger.Error("CRITICAL: live spot buy over virtual cash for %s: debit $%.4f > cash $%.4f (tol $%.2f) → cash now $%.4f — fill booked, reconcile required (#1394)",
+				symbol, totalDebit, cashBefore, spotLiveCashBudgetTolerance, s.Cash)
+		}
 		trade := Trade{
 			Timestamp:       now,
 			StrategyID:      s.ID,
@@ -1753,9 +1831,9 @@ func executeSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			Side:            "buy",
 			Quantity:        qty,
 			Price:           execPrice,
-			Value:           tradeCost + fee,
+			Value:           totalDebit,
 			TradeType:       "spot",
-			Details:         fmt.Sprintf("Open long %.6f @ $%.2f (fee $%.2f)", qty, execPrice, fee),
+			Details:         details,
 			ExchangeOrderID: exchangeOrderIDForTrade(fillOID, useFillMetadata),
 			ExchangeFee:     fee,
 			FeeSource:       executionFeeSource(fillFee, useFillMetadata),
@@ -1763,7 +1841,7 @@ func executeSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 		}
 		trade.Regime = s.Regime
 		recordOpen(trade)
-		logger.Info("BUY %s: %.6f @ $%.2f (fee $%.2f, total $%.2f)", symbol, qty, execPrice, fee, tradeCost+fee)
+		logger.Info("BUY %s: %.6f @ $%.2f (fee $%.2f, total $%.2f)", symbol, qty, execPrice, fee, totalDebit)
 		tradesExecuted++
 
 	} else if signal == -1 { // Sell
@@ -1837,7 +1915,8 @@ func executeSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			logger.Info("No long position in %s to sell, skipping", symbol)
 		}
 	}
-	return tradesExecuted, nil
+	out.TradesExecuted = tradesExecuted
+	return out, nil
 }
 
 // ExecuteFuturesSignalWithFillFee processes a futures signal with optional

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -1075,6 +1078,98 @@ func notifySpotLiveCashOverBudget(sender ownerDMSender, msg string) {
 	}
 }
 
+// maybeClearCashReconcileRequired drops the #1394 latch once virtual cash is
+// solvent again (>= spotLiveCashBudgetTolerance). Clamp-to-zero on load leaves
+// cash at 0, which is below the floor, so the latch survives restart until an
+// operator actually restores headroom.
+func maybeClearCashReconcileRequired(s *StrategyState) {
+	if s == nil || !s.CashReconcileRequired {
+		return
+	}
+	if s.Cash >= spotLiveCashBudgetTolerance {
+		s.CashReconcileRequired = false
+	}
+}
+
+// cashReconcileBlocksLiveBuy reports whether a live spot BUY placement must be
+// skipped because the strategy's books still need reconciliation (#1394).
+// Closes pass through — the operator must still be able to flatten.
+func cashReconcileBlocksLiveBuy(cashReconcileRequired bool, isBuy bool) bool {
+	return cashReconcileRequired && isBuy
+}
+
+// formatSpotLiveCashReconcileReminder builds the throttled cycle reminder for
+// every strategy still latched CashReconcileRequired (#1394). ids must already
+// be sorted. cashByID supplies current cash for the operator triage line.
+func formatSpotLiveCashReconcileReminder(ids []string, cashByID map[string]float64) string {
+	if len(ids) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("**CRITICAL: CASH RECONCILE STILL REQUIRED** — live spot books remain over-budget until virtual cash is restored:\n")
+	for _, id := range ids {
+		cash := cashByID[id]
+		b.WriteString(fmt.Sprintf("- %s cash=$%.4f\n", id, cash))
+	}
+	b.WriteString("Further live spot buys are held; closes still run. Top up / correct virtual cash above $0.01 to clear.")
+	return b.String()
+}
+
+// spotCashReconcileReminderTracker throttles the cycle reminder for latched
+// CashReconcileRequired strategies. In-memory; restart re-emits on first cycle
+// so a missed DM after reboot is not permanent.
+type spotCashReconcileReminderTracker struct {
+	mu             sync.Mutex
+	lastNotifiedAt time.Time
+	lastSig        string
+}
+
+var globalSpotCashReconcileReminder = &spotCashReconcileReminderTracker{}
+
+// ShouldNotify reports whether this cycle should re-DM the latched set. First
+// sighting of a non-empty set always notifies; thereafter on signature change
+// (strategy set changed) or once per effectiveAlertThrottleInterval.
+func (t *spotCashReconcileReminderTracker) ShouldNotify(sig string, now time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if sig == "" {
+		t.lastSig = ""
+		return false
+	}
+	switch {
+	case t.lastNotifiedAt.IsZero():
+		t.lastNotifiedAt = now
+		t.lastSig = sig
+		return true
+	case sig != t.lastSig:
+		t.lastNotifiedAt = now
+		t.lastSig = sig
+		return true
+	case now.Sub(t.lastNotifiedAt) >= effectiveAlertThrottleInterval():
+		t.lastNotifiedAt = now
+		return true
+	}
+	return false
+}
+
+// collectCashReconcileRequiredSnapshots returns sorted strategy IDs still
+// latched plus a cash map for the reminder body. Call under RLock.
+func collectCashReconcileRequiredSnapshots(state *AppState) (ids []string, cashByID map[string]float64) {
+	cashByID = make(map[string]float64)
+	if state == nil {
+		return nil, cashByID
+	}
+	for id, s := range state.Strategies {
+		if s == nil || !s.CashReconcileRequired {
+			continue
+		}
+		ids = append(ids, id)
+		cashByID[id] = s.Cash
+	}
+	sort.Strings(ids)
+	return ids, cashByID
+}
+
 // SpotOrderSkipReason mirrors PerpsOrderSkipReason for spot. ExecuteSpotSignalWithFillFee's
 // side-based skip branches ("already long, skipping buy" at signal=1,
 // "No long position to sell, skipping" at signal=-1) must be consulted BEFORE
@@ -1716,6 +1811,7 @@ func executeSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			pnl := closeQty*pos.AvgCost - totalCost
 			grossPnL := pnl + fee
 			s.Cash += closeQty*pos.AvgCost - totalCost
+			maybeClearCashReconcileRequired(s)
 			now := time.Now().UTC()
 			positionID := ensurePositionTradeID(s.ID, symbol, pos)
 			details := fmt.Sprintf("Close short, PnL: $%.2f (fee $%.2f)", pnl, fee)
@@ -1871,6 +1967,7 @@ func executeSpotSignalWithFillFee(s *StrategyState, signal int, symbol string, p
 			pnl := netProceeds - (closeQty * pos.AvgCost)
 			grossPnL := pnl + fee
 			s.Cash += netProceeds
+			maybeClearCashReconcileRequired(s)
 			now := time.Now().UTC()
 			positionID := ensurePositionTradeID(s.ID, symbol, pos)
 			details := fmt.Sprintf("Close long, PnL: $%.2f (fee $%.2f)", pnl, fee)

--- a/scheduler/portfolio_spot_cash_budget_test.go
+++ b/scheduler/portfolio_spot_cash_budget_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSpotLiveBuyExceedsCash(t *testing.T) {
@@ -205,5 +206,126 @@ func TestNotifySpotLiveCashOverBudget(t *testing.T) {
 	notifySpotLiveCashOverBudget(rec, "alert-body")
 	if len(rec.msgs) != 1 || rec.msgs[0] != "alert-body" {
 		t.Fatalf("msgs = %v, want [alert-body]", rec.msgs)
+	}
+}
+
+func TestMaybeClearCashReconcileRequired(t *testing.T) {
+	s := &StrategyState{Cash: 0, CashReconcileRequired: true}
+	maybeClearCashReconcileRequired(s)
+	if !s.CashReconcileRequired {
+		t.Fatal("cash=0 must keep latch (ValidateState clamp must not auto-clear)")
+	}
+	s.Cash = spotLiveCashBudgetTolerance
+	maybeClearCashReconcileRequired(s)
+	if s.CashReconcileRequired {
+		t.Fatal("solvent cash must clear latch")
+	}
+}
+
+func TestValidateStateLatchesCashReconcileOnNegativeClamp(t *testing.T) {
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"rh-btc": {ID: "rh-btc", Cash: -40.5, Positions: map[string]*Position{}},
+	}}
+	ValidateState(state)
+	s := state.Strategies["rh-btc"]
+	if s.Cash != 0 {
+		t.Fatalf("cash = %g, want 0 after clamp", s.Cash)
+	}
+	if !s.CashReconcileRequired {
+		t.Fatal("ValidateState must latch CashReconcileRequired when clamping negative cash")
+	}
+}
+
+func TestCashReconcileBlocksLiveBuy(t *testing.T) {
+	if !cashReconcileBlocksLiveBuy(true, true) {
+		t.Fatal("latched buy must block")
+	}
+	if cashReconcileBlocksLiveBuy(true, false) {
+		t.Fatal("latched sell/close must NOT block")
+	}
+	if cashReconcileBlocksLiveBuy(false, true) {
+		t.Fatal("unlatched buy must not block")
+	}
+}
+
+func TestFormatSpotLiveCashReconcileReminder(t *testing.T) {
+	msg := formatSpotLiveCashReconcileReminder([]string{"a", "b"}, map[string]float64{"a": 0, "b": -1.5})
+	for _, want := range []string{"CRITICAL: CASH RECONCILE STILL REQUIRED", "a", "b", "Further live spot buys are held"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("reminder missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestSpotCashReconcileReminderTracker(t *testing.T) {
+	tr := &spotCashReconcileReminderTracker{}
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	if !tr.ShouldNotify("a,b", now) {
+		t.Fatal("first sighting must notify")
+	}
+	if tr.ShouldNotify("a,b", now.Add(time.Minute)) {
+		t.Fatal("same sig inside throttle must not notify")
+	}
+	if !tr.ShouldNotify("a", now.Add(2*time.Minute)) {
+		t.Fatal("sig change must notify")
+	}
+	if tr.ShouldNotify("", now.Add(3*time.Minute)) {
+		t.Fatal("empty set must not notify")
+	}
+	if !tr.ShouldNotify("a", now.Add(3*time.Minute)) {
+		t.Fatal("re-onset after clear must notify")
+	}
+}
+
+func TestCollectCashReconcileRequiredSnapshots(t *testing.T) {
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"z": {CashReconcileRequired: true, Cash: 0.1},
+		"a": {CashReconcileRequired: true, Cash: -2},
+		"m": {CashReconcileRequired: false, Cash: 50},
+	}}
+	ids, cash := collectCashReconcileRequiredSnapshots(state)
+	if len(ids) != 2 || ids[0] != "a" || ids[1] != "z" {
+		t.Fatalf("ids = %v, want [a z]", ids)
+	}
+	if cash["a"] != -2 || cash["z"] != 0.1 {
+		t.Fatalf("cash map = %v", cash)
+	}
+}
+
+func TestSellClearsCashReconcileWhenSolvent(t *testing.T) {
+	lm, err := NewLogManager("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger, err := lm.GetStrategyLogger("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logger.Close()
+
+	s := &StrategyState{
+		ID:       "rh-btc",
+		Cash:     0,
+		Platform: "robinhood",
+		Positions: map[string]*Position{
+			"BTC": {Symbol: "BTC", Quantity: 0.01, InitialQuantity: 0.01, AvgCost: 50000, Side: "long", OwnerStrategyID: "rh-btc"},
+		},
+		OptionPositions:       make(map[string]*OptionPosition),
+		TradeHistory:          []Trade{},
+		CashReconcileRequired: true,
+	}
+	// Sell at a price that restores cash well above tolerance.
+	trades, err := ExecuteSpotSignalWithFillFee(s, -1, "BTC", 60000, 0.01, 0, "oid-close", 0, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trades != 1 {
+		t.Fatalf("trades = %d, want 1", trades)
+	}
+	if s.Cash < spotLiveCashBudgetTolerance {
+		t.Fatalf("cash = %g, want solvent after sell", s.Cash)
+	}
+	if s.CashReconcileRequired {
+		t.Fatal("solvent sell must clear CashReconcileRequired")
 	}
 }

--- a/scheduler/portfolio_spot_cash_budget_test.go
+++ b/scheduler/portfolio_spot_cash_budget_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestSpotLiveBuyExceedsCash(t *testing.T) {
+	tol := spotLiveCashBudgetTolerance
+	cases := []struct {
+		name       string
+		cash       float64
+		totalDebit float64
+		want       bool
+	}{
+		{"within_budget", 1000, 750, false},
+		{"exact_cash", 100, 100, false},
+		{"within_tolerance", 100, 100 + tol, false},
+		{"just_over_tolerance", 100, 100 + tol + 1e-9, true},
+		{"clear_overshoot", 100, 150, true},
+		{"sub_dollar_cash_overshoot", 0.50, 50, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := spotLiveBuyExceedsCash(tc.cash, tc.totalDebit)
+			if got != tc.want {
+				t.Fatalf("spotLiveBuyExceedsCash(%g, %g) = %v, want %v", tc.cash, tc.totalDebit, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecuteSpotLiveBuyCashBudget(t *testing.T) {
+	lm, err := NewLogManager("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger, err := lm.GetStrategyLogger("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logger.Close()
+
+	newState := func(cash float64) *StrategyState {
+		return &StrategyState{
+			ID:              "rh-momentum-btc",
+			Cash:            cash,
+			Platform:        "robinhood",
+			Positions:       make(map[string]*Position),
+			OptionPositions: make(map[string]*OptionPosition),
+			TradeHistory:    []Trade{},
+			RiskState:       RiskState{},
+		}
+	}
+
+	t.Run("within_budget", func(t *testing.T) {
+		s := newState(1000)
+		fillQty := 0.01
+		fillPrice := 50000.0
+		fillFee := 0.10
+		exec, err := ExecuteSpotSignalWithFillFeeDeferredOpen(s, 1, "BTC", fillPrice, fillQty, fillFee, "oid-ok", 0, logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exec.TradesExecuted != 1 {
+			t.Fatalf("trades = %d, want 1", exec.TradesExecuted)
+		}
+		if exec.CashReconcileRequired || s.CashReconcileRequired {
+			t.Fatal("within-budget fill must not latch CashReconcileRequired")
+		}
+		if exec.CashOverBudgetAlert != "" {
+			t.Fatalf("unexpected alert: %q", exec.CashOverBudgetAlert)
+		}
+		wantCash := 1000 - fillQty*fillPrice - fillFee
+		if math.Abs(s.Cash-wantCash) > 1e-9 {
+			t.Fatalf("cash = %g, want %g", s.Cash, wantCash)
+		}
+	})
+
+	t.Run("tolerance_covered_overshoot", func(t *testing.T) {
+		// Debit exceeds cash by exactly the tolerance — booked, not latched.
+		fillQty := 0.01
+		fillPrice := 50000.0
+		fillFee := 0.0 // robinhood modeled fee is 0
+		cash := fillQty*fillPrice - spotLiveCashBudgetTolerance
+		s := newState(cash)
+		exec, err := ExecuteSpotSignalWithFillFeeDeferredOpen(s, 1, "BTC", fillPrice, fillQty, fillFee, "oid-tol", 0, logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exec.TradesExecuted != 1 {
+			t.Fatalf("trades = %d, want 1 (must book)", exec.TradesExecuted)
+		}
+		if exec.CashReconcileRequired || s.CashReconcileRequired {
+			t.Fatal("tolerance-covered overshoot must not latch reconcile")
+		}
+		if s.Positions["BTC"] == nil {
+			t.Fatal("position must exist after tolerance-covered book")
+		}
+	})
+
+	t.Run("clear_overshoot", func(t *testing.T) {
+		s := newState(100)
+		fillQty := 0.01
+		fillPrice := 50000.0
+		fillFee := 0.25
+		exec, err := ExecuteSpotSignalWithFillFeeDeferredOpen(s, 1, "BTC", fillPrice, fillQty, fillFee, "oid-over", 0, logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exec.TradesExecuted != 1 {
+			t.Fatalf("trades = %d, want 1 (must book over-budget fill)", exec.TradesExecuted)
+		}
+		if !exec.CashReconcileRequired || !s.CashReconcileRequired {
+			t.Fatal("clear overshoot must latch CashReconcileRequired")
+		}
+		if exec.CashOverBudgetAlert == "" {
+			t.Fatal("clear overshoot must produce CashOverBudgetAlert")
+		}
+		if !strings.Contains(exec.CashOverBudgetAlert, "CRITICAL: LIVE SPOT CASH OVER BUDGET") {
+			t.Fatalf("alert missing CRITICAL headline: %q", exec.CashOverBudgetAlert)
+		}
+		wantCash := 100 - fillQty*fillPrice - fillFee
+		if math.Abs(s.Cash-wantCash) > 1e-9 {
+			t.Fatalf("cash = %g, want %g (negative is expected)", s.Cash, wantCash)
+		}
+		if s.Cash >= 0 {
+			t.Fatalf("cash = %g, want negative after clear overshoot", s.Cash)
+		}
+		tr := s.TradeHistory
+		if len(tr) != 0 {
+			// DeferredOpen does not RecordTrade; OpenTrade carries details.
+		}
+		if exec.OpenTrade == nil || !strings.Contains(exec.OpenTrade.Details, "CASH OVER BUDGET") {
+			t.Fatalf("OpenTrade details should mark reconcile; got %#v", exec.OpenTrade)
+		}
+	})
+
+	t.Run("live_fill_with_sub_dollar_cash", func(t *testing.T) {
+		// Pre-fix: budget < $1 returned early and dropped the venue fill (#298).
+		s := newState(0.50)
+		fillQty := 0.002
+		fillPrice := 50000.0
+		fillFee := 0.0
+		exec, err := ExecuteSpotSignalWithFillFeeDeferredOpen(s, 1, "BTC", fillPrice, fillQty, fillFee, "oid-sub", 0, logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exec.TradesExecuted != 1 {
+			t.Fatalf("trades = %d, want 1 — live fill must book even when cash < $1", exec.TradesExecuted)
+		}
+		if s.Positions["BTC"] == nil {
+			t.Fatal("position must exist after sub-dollar cash live fill")
+		}
+		if !exec.CashReconcileRequired || !s.CashReconcileRequired {
+			t.Fatal("sub-dollar cash live fill that overshoots must latch reconcile")
+		}
+	})
+
+	t.Run("paper_still_skips_sub_dollar_cash", func(t *testing.T) {
+		s := newState(0.50)
+		trades, err := ExecuteSpotSignalWithFillFee(s, 1, "BTC", 50000, 0, 0, "", 0, logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if trades != 0 {
+			t.Fatalf("paper trades = %d, want 0 when cash < $1", trades)
+		}
+		if s.CashReconcileRequired {
+			t.Fatal("paper skip must not latch CashReconcileRequired")
+		}
+	})
+}
+
+func TestFormatSpotLiveCashOverBudgetAlert(t *testing.T) {
+	msg := formatSpotLiveCashOverBudgetAlert("rh-btc", "BTC", 100, 500.25, -400.25, 0.01, 50000, 0.25)
+	for _, want := range []string{
+		"CRITICAL: LIVE SPOT CASH OVER BUDGET",
+		"rh-btc",
+		"BTC",
+		"reconcile",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("alert missing %q: %s", want, msg)
+		}
+	}
+}
+
+type recordingOwnerDM struct {
+	msgs []string
+}
+
+func (r *recordingOwnerDM) SendOwnerDM(content string) {
+	r.msgs = append(r.msgs, content)
+}
+
+func TestNotifySpotLiveCashOverBudget(t *testing.T) {
+	rec := &recordingOwnerDM{}
+	notifySpotLiveCashOverBudget(rec, "")
+	if len(rec.msgs) != 0 {
+		t.Fatalf("empty msg should no-op, got %v", rec.msgs)
+	}
+	notifySpotLiveCashOverBudget(nil, "alert")
+	notifySpotLiveCashOverBudget(rec, "alert-body")
+	if len(rec.msgs) != 1 || rec.msgs[0] != "alert-body" {
+		t.Fatalf("msgs = %v, want [alert-body]", rec.msgs)
+	}
+}

--- a/scheduler/portfolio_spot_cash_budget_test.go
+++ b/scheduler/portfolio_spot_cash_budget_test.go
@@ -332,13 +332,18 @@ func TestSpotCashReconcileReminderTracker(t *testing.T) {
 	if tr.ShouldNotify("a,b", now.Add(time.Minute)) {
 		t.Fatal("same sig inside throttle must not notify")
 	}
-	if !tr.ShouldNotify("a", now.Add(2*time.Minute)) {
-		t.Fatal("sig change must notify")
+	// Shrink (peer cleared) must not re-DM — those IDs were already covered.
+	if tr.ShouldNotify("a", now.Add(2*time.Minute)) {
+		t.Fatal("subset shrink must not notify")
 	}
-	if tr.ShouldNotify("", now.Add(3*time.Minute)) {
+	// New ID appearing must notify.
+	if !tr.ShouldNotify("a,c", now.Add(3*time.Minute)) {
+		t.Fatal("new strategy ID in set must notify")
+	}
+	if tr.ShouldNotify("", now.Add(4*time.Minute)) {
 		t.Fatal("empty set must not notify")
 	}
-	if !tr.ShouldNotify("a", now.Add(3*time.Minute)) {
+	if !tr.ShouldNotify("a", now.Add(4*time.Minute)) {
 		t.Fatal("re-onset after clear must notify")
 	}
 }
@@ -355,6 +360,29 @@ func TestSpotCashReconcileReminderMarkNotifiedSuppressesSameCycle(t *testing.T) 
 	tr.ShouldNotify("", now.Add(2*time.Second))
 	if !tr.ShouldNotify("rh-btc", now.Add(3*time.Second)) {
 		t.Fatal("re-onset after clear must still notify")
+	}
+}
+
+func TestSpotCashReconcileReminderCompoundClearDoesNotDoubleDM(t *testing.T) {
+	// Compound cycle: MarkNotified seeds "a,b" after B's per-fill CRITICAL
+	// while A was already latched; A then clears same cycle → end sig "b".
+	// B must not get a second DM.
+	tr := &spotCashReconcileReminderTracker{}
+	now := time.Date(2026, 7, 20, 16, 0, 0, 0, time.UTC)
+	tr.MarkNotified("a,b", now)
+	if tr.ShouldNotify("b", now.Add(time.Second)) {
+		t.Fatal("after MarkNotified(a,b), shrink to b must not re-DM b")
+	}
+	// Two strategies over-budget same cycle: final MarkNotified is full set.
+	tr2 := &spotCashReconcileReminderTracker{}
+	tr2.MarkNotified("a", now)
+	tr2.MarkNotified("a,b", now.Add(time.Millisecond))
+	if tr2.ShouldNotify("a,b", now.Add(2*time.Second)) {
+		t.Fatal("two founding over-budgets must not also fire the cycle reminder")
+	}
+	// Later cycle: new ID still notifies.
+	if !tr.ShouldNotify("b,c", now.Add(3*time.Second)) {
+		t.Fatal("new peer latching later must still notify")
 	}
 }
 

--- a/scheduler/portfolio_spot_cash_budget_test.go
+++ b/scheduler/portfolio_spot_cash_budget_test.go
@@ -224,35 +224,81 @@ func TestMaybeClearCashReconcileRequired(t *testing.T) {
 	}
 }
 
-func TestValidateStateLatchesCashReconcileOnNegativeClamp(t *testing.T) {
+func TestValidateStateDoesNotInferCashReconcileFromNegativeCash(t *testing.T) {
+	// Paper spot buys end fee-negative (cash=-fee); perps/futures can blow up
+	// cash-negative. None of these imply a live over-budget book.
 	state := &AppState{Strategies: map[string]*StrategyState{
-		"rh-btc": {ID: "rh-btc", Type: "spot", Cash: -40.5, Positions: map[string]*Position{}},
+		"paper-spot": {ID: "paper-spot", Type: "spot", Platform: "binanceus", Cash: -1.0, Positions: map[string]*Position{}},
+		"live-spot":  {ID: "live-spot", Type: "spot", Platform: "robinhood", Cash: -40.5, CashReconcileRequired: true, Positions: map[string]*Position{}},
+		"hl-perp":    {ID: "hl-perp", Type: "perps", Cash: -120, Positions: map[string]*Position{}},
+		"ts-fut":     {ID: "ts-fut", Type: "futures", Cash: -5, Positions: map[string]*Position{}},
 	}}
 	ValidateState(state)
-	s := state.Strategies["rh-btc"]
-	if s.Cash != 0 {
-		t.Fatalf("cash = %g, want 0 after clamp", s.Cash)
-	}
-	if !s.CashReconcileRequired {
-		t.Fatal("ValidateState must latch CashReconcileRequired when clamping negative cash")
+	for id, wantLatch := range map[string]bool{"paper-spot": false, "live-spot": true, "hl-perp": false, "ts-fut": false} {
+		s := state.Strategies[id]
+		if s.Cash != 0 {
+			t.Fatalf("%s cash = %g, want 0 after clamp", id, s.Cash)
+		}
+		if s.CashReconcileRequired != wantLatch {
+			t.Fatalf("%s CashReconcileRequired = %v, want %v (must not infer from negative cash)", id, s.CashReconcileRequired, wantLatch)
+		}
 	}
 }
 
-func TestValidateStateDoesNotLatchCashReconcileForNonSpotNegativeCash(t *testing.T) {
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-perp":  {ID: "hl-perp", Type: "perps", Cash: -120, Positions: map[string]*Position{}},
-		"ts-fut":   {ID: "ts-fut", Type: "futures", Cash: -5, Positions: map[string]*Position{}},
-		"okx-spot": {ID: "okx-spot", Type: "spot", Cash: -1, Positions: map[string]*Position{}},
-	}}
-	ValidateState(state)
-	if state.Strategies["hl-perp"].CashReconcileRequired {
-		t.Fatal("perps negative-cash clamp must NOT latch spot CashReconcileRequired")
+func TestPaperSpotFeeNegativeReloadDoesNotLatchCashReconcile(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "state.db")
+	db, err := OpenStateDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if state.Strategies["ts-fut"].CashReconcileRequired {
-		t.Fatal("futures negative-cash clamp must NOT latch spot CashReconcileRequired")
+	defer db.Close()
+
+	// Mirror TestExecuteSpotWithFillFeeBuy: paper buy leaves cash = -fee.
+	state := &AppState{
+		CycleCount: 1,
+		Strategies: map[string]*StrategyState{
+			"bn-btc": {
+				ID: "bn-btc", Type: "spot", Platform: "binanceus",
+				Cash: -1.0, InitialCapital: 1000,
+				CashReconcileRequired: false,
+				Positions: map[string]*Position{
+					"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.02, InitialQuantity: 0.02, AvgCost: 50000, Side: "long", OwnerStrategyID: "bn-btc"},
+				},
+				OptionPositions: make(map[string]*OptionPosition),
+				TradeHistory:    []Trade{},
+			},
+		},
 	}
-	if !state.Strategies["okx-spot"].CashReconcileRequired {
-		t.Fatal("spot negative-cash clamp must still latch CashReconcileRequired")
+	if err := SaveStateWithDB(state, &Config{}, db); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ValidateState(loaded)
+	s := loaded.Strategies["bn-btc"]
+	if s == nil {
+		t.Fatal("bn-btc missing after LoadState")
+	}
+	if s.Cash != 0 {
+		t.Fatalf("cash = %g, want 0 after ValidateState clamp", s.Cash)
+	}
+	if s.CashReconcileRequired {
+		t.Fatal("paper spot fee-negative reload must NOT latch CashReconcileRequired")
+	}
+	// Second restart after clamp-to-zero still must not invent the latch.
+	if err := SaveStateWithDB(loaded, &Config{}, db); err != nil {
+		t.Fatal(err)
+	}
+	loaded2, err := db.LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ValidateState(loaded2)
+	if loaded2.Strategies["bn-btc"].CashReconcileRequired {
+		t.Fatal("second paper-spot restart must still leave CashReconcileRequired false")
 	}
 }
 
@@ -321,8 +367,8 @@ func TestCashReconcileRequiredSaveLoadRoundTrip(t *testing.T) {
 	}
 	defer db.Close()
 
-	// cash in [0, 0.01) — the range where ValidateState will NOT re-latch from
-	// negative cash, so persistence (not clamp side-effect) must carry the flag.
+	// cash in [0, 0.01) — ValidateState never invents the latch from cash
+	// alone, so persistence (not clamp side-effect) must carry the flag.
 	state := &AppState{
 		CycleCount: 1,
 		Strategies: map[string]*StrategyState{

--- a/scheduler/portfolio_spot_cash_budget_test.go
+++ b/scheduler/portfolio_spot_cash_budget_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"math"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -274,6 +275,138 @@ func TestSpotCashReconcileReminderTracker(t *testing.T) {
 	}
 	if !tr.ShouldNotify("a", now.Add(3*time.Minute)) {
 		t.Fatal("re-onset after clear must notify")
+	}
+}
+
+func TestSpotCashReconcileReminderMarkNotifiedSuppressesSameCycle(t *testing.T) {
+	tr := &spotCashReconcileReminderTracker{}
+	now := time.Date(2026, 7, 20, 15, 0, 0, 0, time.UTC)
+	// Per-fill CRITICAL seeds the tracker; same-cycle reminder must not fire.
+	tr.MarkNotified("rh-btc", now)
+	if tr.ShouldNotify("rh-btc", now.Add(time.Second)) {
+		t.Fatal("MarkNotified must suppress same-cycle reminder for the founding sig")
+	}
+	// Re-onset after clear is still legitimate.
+	tr.ShouldNotify("", now.Add(2*time.Second))
+	if !tr.ShouldNotify("rh-btc", now.Add(3*time.Second)) {
+		t.Fatal("re-onset after clear must still notify")
+	}
+}
+
+func TestCashReconcileRequiredSaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "state.db")
+	db, err := OpenStateDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// cash in [0, 0.01) — the range where ValidateState will NOT re-latch from
+	// negative cash, so persistence (not clamp side-effect) must carry the flag.
+	state := &AppState{
+		CycleCount: 1,
+		Strategies: map[string]*StrategyState{
+			"rh-btc": {
+				ID: "rh-btc", Type: "spot", Platform: "robinhood",
+				Cash: 0.005, InitialCapital: 1000,
+				CashReconcileRequired: true,
+				Positions:             make(map[string]*Position),
+				OptionPositions:       make(map[string]*OptionPosition),
+				TradeHistory:          []Trade{},
+			},
+			"okx-btc": {
+				ID: "okx-btc", Type: "spot", Platform: "okx",
+				Cash: -12.5, InitialCapital: 1000,
+				CashReconcileRequired: true,
+				Positions:             make(map[string]*Position),
+				OptionPositions:       make(map[string]*OptionPosition),
+				TradeHistory:          []Trade{},
+			},
+		},
+	}
+	if err := SaveStateWithDB(state, &Config{}, db); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := db.LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rh := loaded.Strategies["rh-btc"]
+	if rh == nil {
+		t.Fatal("rh-btc missing after LoadState")
+	}
+	if !rh.CashReconcileRequired {
+		t.Fatal("CashReconcileRequired must survive Save/Load when cash is in [0, 0.01)")
+	}
+	if rh.Cash != 0.005 {
+		t.Fatalf("cash = %g, want 0.005 (not clamped)", rh.Cash)
+	}
+	okx := loaded.Strategies["okx-btc"]
+	if okx == nil || !okx.CashReconcileRequired {
+		t.Fatal("negative-cash strategy must also keep CashReconcileRequired across Save/Load")
+	}
+
+	// Second restart simulation: clamp cash to 0 via ValidateState, save again,
+	// reload — latch must still be true (persisted column, not negative-cash re-derive).
+	ValidateState(loaded)
+	if loaded.Strategies["rh-btc"].Cash != 0.005 {
+		// 0.005 >= 0 so ValidateState does not clamp; okx clamps to 0 and keeps latch
+	}
+	if !loaded.Strategies["okx-btc"].CashReconcileRequired || loaded.Strategies["okx-btc"].Cash != 0 {
+		t.Fatalf("okx after ValidateState: cash=%g latch=%v", loaded.Strategies["okx-btc"].Cash, loaded.Strategies["okx-btc"].CashReconcileRequired)
+	}
+	// Force rh into the post-clamp solvent-but-sub-tolerance zone and re-save.
+	loaded.Strategies["rh-btc"].Cash = 0
+	loaded.Strategies["rh-btc"].CashReconcileRequired = true
+	if err := SaveStateWithDB(loaded, &Config{}, db); err != nil {
+		t.Fatal(err)
+	}
+	loaded2, err := db.LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded2.Strategies["rh-btc"].CashReconcileRequired {
+		t.Fatal("second Save/Load with cash=0 must still restore CashReconcileRequired from SQLite")
+	}
+	ValidateState(loaded2)
+	if !loaded2.Strategies["rh-btc"].CashReconcileRequired {
+		t.Fatal("ValidateState must not clear a persisted latch when cash is 0")
+	}
+}
+
+func TestUIStrategyOverviewSurfacesCashReconcileRequired(t *testing.T) {
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"rh-btc": {
+			ID: "rh-btc", Type: "spot", Platform: "robinhood", Cash: 0,
+			CashReconcileRequired: true,
+			Positions:             make(map[string]*Position),
+			OptionPositions:       make(map[string]*OptionPosition),
+		},
+		"okx-btc": {
+			ID: "okx-btc", Type: "spot", Platform: "okx", Cash: 100,
+			CashReconcileRequired: false,
+			Positions:             make(map[string]*Position),
+			OptionPositions:       make(map[string]*OptionPosition),
+		},
+	}}
+	cfgs := []StrategyConfig{
+		{ID: "rh-btc", Type: "spot", Platform: "robinhood", Args: []string{"momentum", "BTC"}},
+		{ID: "okx-btc", Type: "spot", Platform: "okx", Args: []string{"momentum", "BTC"}},
+	}
+	ss := newOpsTestServer(t, cfgs, state, false)
+
+	ov, _, ok := ss.uiStrategyOverview("rh-btc")
+	if !ok {
+		t.Fatal("rh-btc overview missing")
+	}
+	if !ov.CashReconcileRequired {
+		t.Fatal("overview must surface CashReconcileRequired=true")
+	}
+	ov2, _, ok := ss.uiStrategyOverview("okx-btc")
+	if !ok || ov2.CashReconcileRequired {
+		t.Fatal("unlatched strategy must surface CashReconcileRequired=false/omitted")
 	}
 }
 

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -134,6 +134,13 @@ type StrategyState struct {
 	// strategy is not a shared-wallet member) makes display fall back to the
 	// modeled PortfolioValue.
 	SharedWalletValueSet bool `json:"-"`
+
+	// CashReconcileRequired latches when a live spot buy was booked whose
+	// notional+fee exceeded virtual cash beyond spotLiveCashBudgetTolerance
+	// (#1394). Venue fills are always booked (dropping them reproduces the
+	// #298 state-drift class); the latch + CRITICAL owner DM mark the books
+	// as needing operator reconciliation. In-memory only — restart clears it.
+	CashReconcileRequired bool `json:"-"`
 }
 
 func NewStrategyState(cfg StrategyConfig) *StrategyState {

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -139,10 +139,10 @@ type StrategyState struct {
 	// notional+fee exceeded virtual cash beyond spotLiveCashBudgetTolerance
 	// (#1394). Venue fills are always booked (dropping them reproduces the
 	// #298 state-drift class); the latch keeps the condition observable after
-	// the one-shot CRITICAL DM: it is persisted, surfaced in status/API,
-	// blocks further live spot buys until cash recovers, and drives a
-	// throttled cycle reminder. Cleared only when cash returns to a solvent
-	// level (>= spotLiveCashBudgetTolerance) — ValidateState's clamp-to-zero
+	// the one-shot CRITICAL DM: it is persisted to SQLite (strategies.cash_reconcile_required),
+	// surfaced in status/API, blocks further live spot buys until cash recovers,
+	// and drives a throttled cycle reminder. Cleared only when cash returns to a
+	// solvent level (>= spotLiveCashBudgetTolerance) — ValidateState's clamp-to-zero
 	// leaves the latch set so a restart cannot hide the overshoot.
 	CashReconcileRequired bool `json:"cash_reconcile_required,omitempty"`
 }

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -142,8 +142,9 @@ type StrategyState struct {
 	// the one-shot CRITICAL DM: it is persisted to SQLite (strategies.cash_reconcile_required),
 	// surfaced in status/API, blocks further live spot buys until cash recovers,
 	// and drives a throttled cycle reminder. Cleared only when cash returns to a
-	// solvent level (>= spotLiveCashBudgetTolerance) — ValidateState's clamp-to-zero
-	// leaves the latch set so a restart cannot hide the overshoot.
+	// solvent level (>= spotLiveCashBudgetTolerance). Never inferred from
+	// negative cash on load — paper spot buys routinely end fee-negative
+	// (cash=-fee), and perps/futures can go negative from leveraged PnL.
 	CashReconcileRequired bool `json:"cash_reconcile_required,omitempty"`
 }
 
@@ -186,14 +187,12 @@ func ValidateState(state *AppState) {
 		if s.Cash < 0 {
 			fmt.Printf("[WARN] state: strategy %s has negative cash=%g, clamping to 0\n", id, s.Cash)
 			s.Cash = 0
-			// #1394: clamp hides the overshoot amount but must not hide that
-			// reconciliation is still required — latch so status/API/reminders
-			// keep the condition discoverable after restart. Spot-only: perps/
-			// futures can go cash-negative from leveraged PnL; that is not a
-			// live-spot over-budget book and must not raise spot-reconcile CRITICAL.
-			if s.Type == "spot" {
-				s.CashReconcileRequired = true
-			}
+			// #1394: do NOT infer CashReconcileRequired from negative cash.
+			// Paper spot buys always end fee-negative (cash=-fee), and
+			// perps/futures can go negative from leveraged PnL — neither is a
+			// live over-budget book. Genuine live overshoots persist the latch
+			// via strategies.cash_reconcile_required; maybeClear below keeps a
+			// loaded latch when clamp leaves cash at 0 (< tolerance).
 		}
 		maybeClearCashReconcileRequired(s)
 		for sym, pos := range s.Positions {

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -138,9 +138,13 @@ type StrategyState struct {
 	// CashReconcileRequired latches when a live spot buy was booked whose
 	// notional+fee exceeded virtual cash beyond spotLiveCashBudgetTolerance
 	// (#1394). Venue fills are always booked (dropping them reproduces the
-	// #298 state-drift class); the latch + CRITICAL owner DM mark the books
-	// as needing operator reconciliation. In-memory only — restart clears it.
-	CashReconcileRequired bool `json:"-"`
+	// #298 state-drift class); the latch keeps the condition observable after
+	// the one-shot CRITICAL DM: it is persisted, surfaced in status/API,
+	// blocks further live spot buys until cash recovers, and drives a
+	// throttled cycle reminder. Cleared only when cash returns to a solvent
+	// level (>= spotLiveCashBudgetTolerance) — ValidateState's clamp-to-zero
+	// leaves the latch set so a restart cannot hide the overshoot.
+	CashReconcileRequired bool `json:"cash_reconcile_required,omitempty"`
 }
 
 func NewStrategyState(cfg StrategyConfig) *StrategyState {
@@ -182,7 +186,12 @@ func ValidateState(state *AppState) {
 		if s.Cash < 0 {
 			fmt.Printf("[WARN] state: strategy %s has negative cash=%g, clamping to 0\n", id, s.Cash)
 			s.Cash = 0
+			// #1394: clamp hides the overshoot amount but must not hide that
+			// reconciliation is still required — latch so status/API/reminders
+			// keep the condition discoverable after restart.
+			s.CashReconcileRequired = true
 		}
+		maybeClearCashReconcileRequired(s)
 		for sym, pos := range s.Positions {
 			if pos.Quantity <= 0 {
 				fmt.Printf("[WARN] state: strategy %s position %s has invalid quantity=%g, removing\n", id, sym, pos.Quantity)

--- a/scheduler/ui_server.go
+++ b/scheduler/ui_server.go
@@ -29,47 +29,49 @@ type UIStrategy struct {
 }
 
 type UIStrategyOverview struct {
-	ID                   string                 `json:"id"`
-	Platform             string                 `json:"platform"`
-	Symbol               string                 `json:"symbol"`
-	PnLPct               float64                `json:"pnl_pct"`
-	WinRate              float64                `json:"win_rate,omitempty"`
-	Sharpe               float64                `json:"sharpe,omitempty"`
-	Regime               string                 `json:"regime,omitempty"`
-	Direction            string                 `json:"direction,omitempty"`
-	PnL                  float64                `json:"pnl"`
-	PortfolioValue       float64                `json:"portfolio_value"`
-	InitialCapital       float64                `json:"initial_capital"`
-	RegimeDivergence     *RegimeDivergenceState `json:"regime_divergence,omitempty"`       // #907: active window-divergence state; nil when none
-	Paused               bool                   `json:"paused,omitempty"`                  // #1150
-	RegimeGateFailClosed bool                   `json:"regime_gate_fail_closed,omitempty"` // #1278: entry gate actively failing closed (opens held while regime unknown)
+	ID                    string                 `json:"id"`
+	Platform              string                 `json:"platform"`
+	Symbol                string                 `json:"symbol"`
+	PnLPct                float64                `json:"pnl_pct"`
+	WinRate               float64                `json:"win_rate,omitempty"`
+	Sharpe                float64                `json:"sharpe,omitempty"`
+	Regime                string                 `json:"regime,omitempty"`
+	Direction             string                 `json:"direction,omitempty"`
+	PnL                   float64                `json:"pnl"`
+	PortfolioValue        float64                `json:"portfolio_value"`
+	InitialCapital        float64                `json:"initial_capital"`
+	RegimeDivergence      *RegimeDivergenceState `json:"regime_divergence,omitempty"`       // #907: active window-divergence state; nil when none
+	Paused                bool                   `json:"paused,omitempty"`                  // #1150
+	RegimeGateFailClosed  bool                   `json:"regime_gate_fail_closed,omitempty"` // #1278: entry gate actively failing closed (opens held while regime unknown)
+	CashReconcileRequired bool                   `json:"cash_reconcile_required,omitempty"` // #1394: live spot over-budget books still need operator reconciliation
 }
 
 type UIStrategyStatus struct {
-	ID               string                     `json:"id"`
-	Type             string                     `json:"type"`
-	Platform         string                     `json:"platform"`
-	Symbol           string                     `json:"symbol"`
-	Timeframe        string                     `json:"timeframe"`
-	Direction        string                     `json:"direction,omitempty"`
-	Cash             float64                    `json:"cash"`
-	InitialCapital   float64                    `json:"initial_capital"`
-	PortfolioValue   float64                    `json:"portfolio_value"`
-	PnL              float64                    `json:"pnl"`
-	PnLPct           float64                    `json:"pnl_pct"`
-	TradeCount       int                        `json:"trade_count"`
-	WinRate          float64                    `json:"win_rate,omitempty"`
-	LifetimeStats    LifetimeTradeStats         `json:"lifetime_stats"`
-	Sharpe           float64                    `json:"sharpe,omitempty"`
-	Regime           string                     `json:"regime,omitempty"`
-	RegimeDivergence *RegimeDivergenceState     `json:"regime_divergence,omitempty"` // #907: active window-divergence state; nil when none
-	RiskState        RiskState                  `json:"risk_state"`
-	Positions        map[string]*Position       `json:"positions"`
-	OptionPositions  map[string]*OptionPosition `json:"option_positions"`
-	Leverage         float64                    `json:"leverage,omitempty"`
-	SizingLeverage   float64                    `json:"sizing_leverage,omitempty"`
-	MarginMode       string                     `json:"margin_mode,omitempty"`
-	Paused           bool                       `json:"paused,omitempty"` // #1150
+	ID                    string                     `json:"id"`
+	Type                  string                     `json:"type"`
+	Platform              string                     `json:"platform"`
+	Symbol                string                     `json:"symbol"`
+	Timeframe             string                     `json:"timeframe"`
+	Direction             string                     `json:"direction,omitempty"`
+	Cash                  float64                    `json:"cash"`
+	InitialCapital        float64                    `json:"initial_capital"`
+	PortfolioValue        float64                    `json:"portfolio_value"`
+	PnL                   float64                    `json:"pnl"`
+	PnLPct                float64                    `json:"pnl_pct"`
+	TradeCount            int                        `json:"trade_count"`
+	WinRate               float64                    `json:"win_rate,omitempty"`
+	LifetimeStats         LifetimeTradeStats         `json:"lifetime_stats"`
+	Sharpe                float64                    `json:"sharpe,omitempty"`
+	Regime                string                     `json:"regime,omitempty"`
+	RegimeDivergence      *RegimeDivergenceState     `json:"regime_divergence,omitempty"` // #907: active window-divergence state; nil when none
+	RiskState             RiskState                  `json:"risk_state"`
+	Positions             map[string]*Position       `json:"positions"`
+	OptionPositions       map[string]*OptionPosition `json:"option_positions"`
+	Leverage              float64                    `json:"leverage,omitempty"`
+	SizingLeverage        float64                    `json:"sizing_leverage,omitempty"`
+	MarginMode            string                     `json:"margin_mode,omitempty"`
+	Paused                bool                       `json:"paused,omitempty"`                  // #1150
+	CashReconcileRequired bool                       `json:"cash_reconcile_required,omitempty"` // #1394
 
 	// #779/#1157: directional-policy display fields, mirroring /status.
 	EffectiveDirection             string              `json:"effective_direction,omitempty"`
@@ -501,20 +503,21 @@ func (ss *StatusServer) uiStrategyOverview(id string) (UIStrategyOverview, Lifet
 	}
 
 	return UIStrategyOverview{
-		ID:                   id,
-		Platform:             sc.Platform,
-		Symbol:               strategyDisplaySymbol(sc),
-		PnLPct:               pnlPct,
-		WinRate:              winRate,
-		Sharpe:               sharpe,
-		Regime:               strategyDisplayRegimeLabel(&snapshot, sc, ss.regime),
-		Direction:            strategyDisplayDirection(sc),
-		PnL:                  pnl,
-		PortfolioValue:       pv,
-		InitialCapital:       initCap,
-		RegimeDivergence:     snapshot.RegimeDivergence,
-		Paused:               sc.Paused,
-		RegimeGateFailClosed: regimeGateFailClosedActive(sc, &snapshot, ss.regime),
+		ID:                    id,
+		Platform:              sc.Platform,
+		Symbol:                strategyDisplaySymbol(sc),
+		PnLPct:                pnlPct,
+		WinRate:               winRate,
+		Sharpe:                sharpe,
+		Regime:                strategyDisplayRegimeLabel(&snapshot, sc, ss.regime),
+		Direction:             strategyDisplayDirection(sc),
+		PnL:                   pnl,
+		PortfolioValue:        pv,
+		InitialCapital:        initCap,
+		RegimeDivergence:      snapshot.RegimeDivergence,
+		Paused:                sc.Paused,
+		RegimeGateFailClosed:  regimeGateFailClosedActive(sc, &snapshot, ss.regime),
+		CashReconcileRequired: snapshot.CashReconcileRequired,
 	}, lifetime, true
 }
 
@@ -547,31 +550,32 @@ func (ss *StatusServer) handleAPIStrategyStatus(w http.ResponseWriter, r *http.R
 	}
 
 	resp := UIStrategyStatus{
-		ID:               overview.ID,
-		Type:             sc.Type,
-		Platform:         overview.Platform,
-		Symbol:           overview.Symbol,
-		Timeframe:        strategyDisplayTimeframe(sc),
-		Direction:        overview.Direction,
-		Cash:             snapshot.Cash,
-		InitialCapital:   overview.InitialCapital,
-		PortfolioValue:   overview.PortfolioValue,
-		PnL:              overview.PnL,
-		PnLPct:           overview.PnLPct,
-		TradeCount:       len(snapshot.TradeHistory),
-		WinRate:          overview.WinRate,
-		LifetimeStats:    lifetime,
-		Sharpe:           overview.Sharpe,
-		Regime:           overview.Regime,
-		RegimeDivergence: overview.RegimeDivergence,
-		RiskState:        snapshot.RiskState,
-		Positions:        snapshot.Positions,
-		OptionPositions:  snapshot.OptionPositions,
-		Leverage:         EffectiveExchangeLeverage(sc),
-		SizingLeverage:   EffectiveSizingLeverage(sc),
-		MarginMode:       sc.MarginMode,
-		Paused:           sc.Paused,
-		RegimeProfile:    snapshot.RegimeProfile,
+		ID:                    overview.ID,
+		Type:                  sc.Type,
+		Platform:              overview.Platform,
+		Symbol:                overview.Symbol,
+		Timeframe:             strategyDisplayTimeframe(sc),
+		Direction:             overview.Direction,
+		Cash:                  snapshot.Cash,
+		InitialCapital:        overview.InitialCapital,
+		PortfolioValue:        overview.PortfolioValue,
+		PnL:                   overview.PnL,
+		PnLPct:                overview.PnLPct,
+		TradeCount:            len(snapshot.TradeHistory),
+		WinRate:               overview.WinRate,
+		LifetimeStats:         lifetime,
+		Sharpe:                overview.Sharpe,
+		Regime:                overview.Regime,
+		RegimeDivergence:      overview.RegimeDivergence,
+		RiskState:             snapshot.RiskState,
+		Positions:             snapshot.Positions,
+		OptionPositions:       snapshot.OptionPositions,
+		Leverage:              EffectiveExchangeLeverage(sc),
+		SizingLeverage:        EffectiveSizingLeverage(sc),
+		MarginMode:            sc.MarginMode,
+		Paused:                sc.Paused,
+		CashReconcileRequired: snapshot.CashReconcileRequired,
+		RegimeProfile:         snapshot.RegimeProfile,
 	}
 	dirView := directionalStatusForStrategy(sc, &snapshot, ss.regime, time.Now().UTC())
 	resp.EffectiveDirection = dirView.EffectiveDirection


### PR DESCRIPTION
## Plain simple English
Live exchange buys sometimes cost more than the bot's tracked cash. Before, those fills could be skipped or silently drive cash negative. Now every real fill is booked, and if cash goes over budget the operator gets a clear alert to fix the books.

## Summary
- Live spot opens (`fillQty > 0`) always book in `executeSpotSignalWithFillFee`, even when virtual cash is under the $1 paper floor.
- Debit (`fillQty * fillPrice + fee`) is checked against cash with an explicit $0.01 tolerance; clear overshoots latch `CashReconcileRequired`, stamp trade details, and return a CRITICAL alert via `SignalExecutionResult`.
- Robinhood and OKX execute paths surface the alert **after** releasing `mu` (`notifySpotLiveCashOverBudget`).
- Paper path unchanged: `budget < 1` with no fill still skips.

Closes #1394

## Verification
- Red→green: `TestExecuteSpotLiveBuyCashBudget/live_fill_with_sub_dollar_cash` fails under the old `budget < 1` early return, passes with the fix.
- `go test -run 'TestSpotLive|TestExecuteSpotLiveBuyCashBudget|TestExecuteRobinhoodResult_LiveFill|TestExecuteOKXResult_SpotLiveFill|TestFormatSpot|TestNotifySpot|TestExecuteRobinhoodResult_Stamps|TestExecuteOKXResult_SpotStamps|TestExecuteOKXResult_PerpsStamps'`

---
Created with LLM: Cursor Grok 4.5 | high | Harness: Cursor