### PR TITLE
fix(#1396): synchronize kill-switch reset prompt flag [C33, Cursor Grok 4.5, high]

### DIFF
--- a/scheduler/kill_switch_reset_dm.go
+++ b/scheduler/kill_switch_reset_dm.go
@@ -3,8 +3,23 @@ package main
 import (
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 )
+
+// tryClaimKillSwitchResetPrompt atomically claims the single-flight slot for
+// the kill-switch reset AskOwnerDM goroutine (#1396). Returns true iff this
+// caller owns the prompt; the owner MUST call releaseKillSwitchResetPrompt
+// when the goroutine exits (typically via defer).
+func tryClaimKillSwitchResetPrompt(running *atomic.Bool) bool {
+	return running.CompareAndSwap(false, true)
+}
+
+// releaseKillSwitchResetPrompt clears the single-flight slot so a later cycle
+// can prompt again after the AskOwnerDM goroutine finishes.
+func releaseKillSwitchResetPrompt(running *atomic.Bool) {
+	running.Store(false)
+}
 
 // DefaultKillSwitchResetDMTimeout is the AskOwnerDM wait for the portfolio
 // kill-switch reset prompt when kill_switch_reset_dm_timeout is omitted

--- a/scheduler/kill_switch_reset_dm_test.go
+++ b/scheduler/kill_switch_reset_dm_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -257,5 +259,57 @@ func TestKillSwitchResetDMTimeout_ConcurrentProbeDoesNotRace(t *testing.T) {
 	<-done
 	if effectiveKillSwitchResetDMTimeout() != time.Hour {
 		t.Fatalf("runtime timeout = %s, want 1h", effectiveKillSwitchResetDMTimeout())
+	}
+}
+
+// TestTryClaimKillSwitchResetPrompt_SingleOwner: while held, a second claim
+// must fail; after release, a later claim must succeed (#1396).
+func TestTryClaimKillSwitchResetPrompt_SingleOwner(t *testing.T) {
+	var running atomic.Bool
+	if !tryClaimKillSwitchResetPrompt(&running) {
+		t.Fatal("first claim should succeed")
+	}
+	if tryClaimKillSwitchResetPrompt(&running) {
+		t.Fatal("second claim must fail while held")
+	}
+	releaseKillSwitchResetPrompt(&running)
+	if running.Load() {
+		t.Fatal("flag must be clear after release")
+	}
+	if !tryClaimKillSwitchResetPrompt(&running) {
+		t.Fatal("claim after release should succeed")
+	}
+	releaseKillSwitchResetPrompt(&running)
+}
+
+// TestTryClaimKillSwitchResetPrompt_ConcurrentClaimRelease stresses the
+// single-flight claim/release path under the race detector (#1396). The
+// pre-fix plain bool was read/written from the main loop and the AskOwnerDM
+// goroutine with no synchronization.
+func TestTryClaimKillSwitchResetPrompt_ConcurrentClaimRelease(t *testing.T) {
+	var running atomic.Bool
+	const goroutines = 64
+	const rounds = 400
+	var claims atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for r := 0; r < rounds; r++ {
+				if tryClaimKillSwitchResetPrompt(&running) {
+					claims.Add(1)
+					// Hold briefly so concurrent claimants observe the held state.
+					releaseKillSwitchResetPrompt(&running)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if claims.Load() == 0 {
+		t.Fatal("expected at least one successful claim")
+	}
+	if running.Load() {
+		t.Fatal("flag still set after all releases")
 	}
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 )
@@ -752,7 +753,7 @@ func main() {
 	lastAutoUpdateCheck := time.Now()
 
 	saveFailures := 0
-	resetGoroutineRunning := false
+	var resetGoroutineRunning atomic.Bool
 
 	// Main loop
 	for {
@@ -1577,12 +1578,13 @@ func main() {
 
 			// Kill switch reset goroutine: prompt owner to reset via DM.
 			// AskOwnerDM wait is kill_switch_reset_dm_timeout (default 6h, #1368).
-			if killSwitchFired && notifier.HasOwner() && !resetGoroutineRunning {
-				resetGoroutineRunning = true
+			// Claim via atomic CAS so the main loop and the prompt goroutine
+			// never race on the single-flight flag (#1396).
+			if killSwitchFired && notifier.HasOwner() && tryClaimKillSwitchResetPrompt(&resetGoroutineRunning) {
 				resetPrompt := formatKillSwitchResetPrompt(killSwitchInstanceLabel(*configPath), hlAddr, plan)
 				resetDMTimeout := effectiveKillSwitchResetDMTimeout()
 				go func() {
-					defer func() { resetGoroutineRunning = false }()
+					defer releaseKillSwitchResetPrompt(&resetGoroutineRunning)
 					resp, err := notifier.AskOwnerDM(resetPrompt, resetDMTimeout)
 					if err != nil {
 						fmt.Printf("[update] Kill switch reset DM timed out or failed: %v\n", err)


### PR DESCRIPTION
## Plain simple English

The kill-switch reset chat prompt used a shared on/off flag from two places at once with no lock. That could skip a real reset ask or start a duplicate one. It now uses a safe atomic handoff so only one prompt runs at a time.

## Summary

- Replace the plain `resetGoroutineRunning bool` with `atomic.Bool`.
- Claim the single-flight slot via `CompareAndSwap` (`tryClaimKillSwitchResetPrompt`) and clear it on goroutine exit (`releaseKillSwitchResetPrompt`), matching the existing `shutdownDraining` pattern.
- Add single-owner + concurrent claim/release tests; verified under `go test -race`.

Closes #1396

## Verification

- Red proof: unsynchronized plain-bool pattern fails under `go test -race` (DATA RACE).
- Green: `go -C scheduler test -race -count=1 -run 'TestTryClaimKillSwitchResetPrompt_' .` passes.
- `go -C scheduler test -count=1 -run 'KillSwitchReset' .` passes.
- `go -C scheduler build .` succeeds.

---
Created with LLM: Cursor Grok 4.5 | high | Harness: Cursor