### PR TITLE
feat(#1400): add owner command to clear CashReconcileRequired [C62, Cursor Grok 4.5, high]

### DIFF
--- a/scheduler/discord_commands.go
+++ b/scheduler/discord_commands.go
@@ -40,16 +40,17 @@ var readOnlyCommandNames = map[string]bool{
 // mutating set (config/add-strategy/remove-strategy/add-platform/paper-to-live)
 // changes the config file, so it gets the same owner-DM-only gate.
 var opsCommandNames = map[string]bool{
-	"restart":           true,
-	"backtest":          true,
-	"logs":              true,
-	"report-an-issue":   true,
-	"config":            true,
-	"add-strategy":      true,
-	"remove-strategy":   true,
-	"add-platform":      true,
-	"paper-to-live":     true,
-	"apply-regime-gate": true,
+	"restart":              true,
+	"backtest":             true,
+	"logs":                 true,
+	"report-an-issue":      true,
+	"config":               true,
+	"add-strategy":         true,
+	"remove-strategy":      true,
+	"add-platform":         true,
+	"paper-to-live":        true,
+	"apply-regime-gate":    true,
+	"clear-cash-reconcile": true,
 }
 
 // authorizeCommand decides whether invokerID may run command `name`. Read-only
@@ -437,6 +438,9 @@ func slashCommands() []*discordgo.ApplicationCommand {
 		{Name: commandPrefix + "apply-regime-gate", Description: "Interactively wire a regime entry-gate onto a strategy (owner DM only)", Contexts: dmContext(), Options: []*discordgo.ApplicationCommandOption{
 			{Type: discordgo.ApplicationCommandOptionString, Name: "gate", Description: "Gate preset (default comp_up_clean_p21)"},
 		}},
+		{Name: commandPrefix + "clear-cash-reconcile", Description: "Clear CashReconcileRequired after books match the venue (owner DM only)", Contexts: dmContext(), Options: []*discordgo.ApplicationCommandOption{
+			{Type: discordgo.ApplicationCommandOptionString, Name: "strategy", Description: "Strategy ID whose cash-reconcile latch to clear", Required: true},
+		}},
 	}
 }
 
@@ -528,6 +532,8 @@ func (d *DiscordNotifier) interactionCreate(s *discordgo.Session, i *discordgo.I
 		d.handlePaperToLive(s, i, data.Options)
 	case "apply-regime-gate":
 		d.handleApplyRegimeGate(s, i, data.Options)
+	case "clear-cash-reconcile":
+		d.handleClearCashReconcile(s, i, data.Options)
 	default:
 		respondEphemeral(s, i, "unknown command")
 	}

--- a/scheduler/discord_commands_test.go
+++ b/scheduler/discord_commands_test.go
@@ -40,6 +40,10 @@ func TestAuthorizeCommand(t *testing.T) {
 		{"restart", "intruder", "", false},  // ops: non-owner in DM rejected
 		{"backtest", owner, "", true},
 		{"backtest", "intruder", "", false},
+		// #1400 clear-cash-reconcile: owner-DM only (resumes live buys).
+		{"clear-cash-reconcile", owner, "", true},
+		{"clear-cash-reconcile", owner, "guild1", false},
+		{"clear-cash-reconcile", "intruder", "", false},
 		{"unknown", owner, "", false}, // unknown command rejected
 	}
 	for _, c := range cases {

--- a/scheduler/discord_mutating_commands.go
+++ b/scheduler/discord_mutating_commands.go
@@ -849,6 +849,57 @@ func (d *DiscordNotifier) handlePaperToLive(s *discordgo.Session, i *discordgo.I
 	d.applyConfigChange(s, i, true, msg)
 }
 
+// handleClearCashReconcile clears CashReconcileRequired for one strategy after
+// the owner confirms books were reconciled against the venue (#1400). Does not
+// invent cash — only drops the latch so live buys may resume. Persists via
+// SaveState when available so the clear survives restart before the next cycle.
+func (d *DiscordNotifier) handleClearCashReconcile(s *discordgo.Session, i *discordgo.InteractionCreate, opts []*discordgo.ApplicationCommandInteractionDataOption) {
+	deferAck(s, i)
+	id := optionString(opts, "strategy", "")
+	if id == "" {
+		followupText(s, i, "usage: /go-trader-clear-cash-reconcile <strategy>")
+		return
+	}
+	if d.ss == nil || d.ss.state == nil || d.ss.mu == nil {
+		followupText(s, i, "status server not ready")
+		return
+	}
+	prompt := fmt.Sprintf(
+		"Clear CashReconcileRequired for `%s`? This resumes live spot buys for that strategy. Only confirm after books match the venue — this command does not change virtual cash.",
+		id,
+	)
+	if !d.confirmDestructive(interactionUserID(i), prompt) {
+		followupText(s, i, "Cancelled — no confirmation received.")
+		return
+	}
+
+	d.ss.mu.Lock()
+	cash, cleared, err := clearCashReconcileRequiredForStrategy(d.ss.state, id)
+	var saveErr error
+	if err == nil && cleared && d.ss.stateDB != nil {
+		// Persist immediately so a restart before the next cycle SaveState
+		// does not resurrect the latch (and re-block buys the operator just
+		// cleared). Holding mu across SQLite matches the main-loop SaveState
+		// sites that already serialize state under the same lock.
+		saveErr = SaveStateWithDB(d.ss.state, d.cfg, d.ss.stateDB)
+	}
+	d.ss.mu.Unlock()
+
+	if err != nil {
+		followupText(s, i, err.Error())
+		return
+	}
+	if !cleared {
+		followupText(s, i, fmt.Sprintf("Strategy `%s` is not latched (cash=$%.4f) — nothing to clear.", id, cash))
+		return
+	}
+	msg := fmt.Sprintf("Cleared CashReconcileRequired for `%s` (cash=$%.4f). Live buys may resume; virtual cash was not changed.", id, cash)
+	if saveErr != nil {
+		msg += " WARNING: in-memory clear succeeded but SaveState failed (" + saveErr.Error() + ") — latch may return on restart until the next successful save."
+	}
+	followupText(s, i, msg)
+}
+
 // subcommandOptions extracts the chosen subcommand name and its options from a
 // command-with-subcommands interaction (e.g. /config show, /config set).
 func subcommandOptions(data discordgo.ApplicationCommandInteractionData) (string, []*discordgo.ApplicationCommandInteractionDataOption) {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2937,8 +2937,11 @@ func main() {
 			} // end if !killSwitchFired
 		}
 
-		// #1394: clear solvent latches and emit a throttled reminder for every
-		// strategy still needing cash reconciliation (covers DM-miss / restart).
+		// #1394/#1400: emit a throttled reminder for every strategy still
+		// needing cash reconciliation (covers DM-miss / restart). The latch
+		// clears only via /go-trader-clear-cash-reconcile — maybeClear below
+		// is a no-op retained so a future verified books-match clear can
+		// re-arm without rewiring this path (solvency alone does not clear).
 		mu.Lock()
 		for _, s := range state.Strategies {
 			maybeClearCashReconcileRequired(s)

--- a/scheduler/portfolio.go
+++ b/scheduler/portfolio.go
@@ -1078,20 +1078,42 @@ func notifySpotLiveCashOverBudget(sender ownerDMSender, msg string) {
 	}
 }
 
-// maybeClearCashReconcileRequired drops the #1394 latch once virtual cash is
-// solvent again (>= spotLiveCashBudgetTolerance). Solvency is a proxy, not
-// proof the books were reconciled against the venue — #1400 will replace this
-// auto-clear with an operator-explicit clear (removing it now would strand
-// latched strategies with no in-app resume path). Clamp-to-zero on load leaves
-// cash at 0 (< floor), so a persisted latch survives restart until cash
-// recovers or an operator clears it.
+// maybeClearCashReconcileRequired is a no-op after #1400. Solvency
+// (cash >= spotLiveCashBudgetTolerance) is not proof the books were reconciled
+// against the venue — only the owner-DM /clear-cash-reconcile command (or a
+// future verified books-match) clears CashReconcileRequired. Call sites on load,
+// per-cycle, and booking paths are retained so a later verified clear can
+// re-arm without rewiring those paths.
 func maybeClearCashReconcileRequired(s *StrategyState) {
+	_ = s
+}
+
+// clearCashReconcileRequired drops the #1394 latch after the operator explicitly
+// confirms books were reconciled (#1400). Does not invent or adjust cash.
+// Returns true when a latched strategy was cleared.
+func clearCashReconcileRequired(s *StrategyState) bool {
 	if s == nil || !s.CashReconcileRequired {
-		return
+		return false
 	}
-	if s.Cash >= spotLiveCashBudgetTolerance {
-		s.CashReconcileRequired = false
+	s.CashReconcileRequired = false
+	return true
+}
+
+// clearCashReconcileRequiredForStrategy looks up id in state and clears its
+// CashReconcileRequired latch (#1400). Returns (cash, true, nil) on a successful
+// clear; (cash, false, nil) when the strategy exists but was not latched; and a
+// non-nil error when the strategy ID is unknown. Never mutates cash.
+func clearCashReconcileRequiredForStrategy(state *AppState, id string) (cash float64, cleared bool, err error) {
+	if state == nil || state.Strategies == nil {
+		return 0, false, fmt.Errorf("unknown strategy ID: %s", id)
 	}
+	s, ok := state.Strategies[id]
+	if !ok || s == nil {
+		return 0, false, fmt.Errorf("unknown strategy ID: %s", id)
+	}
+	cash = s.Cash
+	cleared = clearCashReconcileRequired(s)
+	return cash, cleared, nil
 }
 
 // cashReconcileBlocksLiveBuy reports whether a live spot BUY placement must be
@@ -1114,7 +1136,7 @@ func formatSpotLiveCashReconcileReminder(ids []string, cashByID map[string]float
 		cash := cashByID[id]
 		b.WriteString(fmt.Sprintf("- %s cash=$%.4f\n", id, cash))
 	}
-	b.WriteString("Further live spot buys are held; closes still run. Top up / correct virtual cash above $0.01 to clear.")
+	b.WriteString("Further live spot buys are held; closes still run. Clear with /go-trader-clear-cash-reconcile after confirming books match the venue — cash ≥ $0.01 alone does not clear.")
 	return b.String()
 }
 

--- a/scheduler/portfolio_spot_cash_budget_test.go
+++ b/scheduler/portfolio_spot_cash_budget_test.go
@@ -212,15 +212,72 @@ func TestNotifySpotLiveCashOverBudget(t *testing.T) {
 }
 
 func TestMaybeClearCashReconcileRequired(t *testing.T) {
+	// #1400: solvency is not reconciliation — auto-clear is disabled.
 	s := &StrategyState{Cash: 0, CashReconcileRequired: true}
 	maybeClearCashReconcileRequired(s)
 	if !s.CashReconcileRequired {
-		t.Fatal("cash=0 must keep latch (ValidateState clamp must not auto-clear)")
+		t.Fatal("cash=0 must keep latch")
 	}
 	s.Cash = spotLiveCashBudgetTolerance
 	maybeClearCashReconcileRequired(s)
-	if s.CashReconcileRequired {
-		t.Fatal("solvent cash must clear latch")
+	if !s.CashReconcileRequired {
+		t.Fatal("solvent cash must NOT auto-clear latch (#1400 — use /clear-cash-reconcile)")
+	}
+	s.Cash = 1_000
+	maybeClearCashReconcileRequired(s)
+	if !s.CashReconcileRequired {
+		t.Fatal("large solvent cash must still keep latch without operator clear")
+	}
+}
+
+func TestClearCashReconcileRequired(t *testing.T) {
+	if clearCashReconcileRequired(nil) {
+		t.Fatal("nil strategy must return false")
+	}
+	unlatched := &StrategyState{Cash: 50, CashReconcileRequired: false}
+	if clearCashReconcileRequired(unlatched) {
+		t.Fatal("already-clear strategy must return false")
+	}
+	if unlatched.CashReconcileRequired {
+		t.Fatal("unlatched strategy must stay unlatched")
+	}
+	latched := &StrategyState{Cash: 0.005, CashReconcileRequired: true}
+	if !clearCashReconcileRequired(latched) {
+		t.Fatal("latched strategy must clear")
+	}
+	if latched.CashReconcileRequired {
+		t.Fatal("latch must be false after clear")
+	}
+	if latched.Cash != 0.005 {
+		t.Fatalf("clear must not invent cash: got %g", latched.Cash)
+	}
+}
+
+func TestClearCashReconcileRequiredForStrategy(t *testing.T) {
+	state := &AppState{Strategies: map[string]*StrategyState{
+		"rh-btc":  {ID: "rh-btc", Cash: 0.005, CashReconcileRequired: true},
+		"okx-eth": {ID: "okx-eth", Cash: 10, CashReconcileRequired: false},
+	}}
+	cash, cleared, err := clearCashReconcileRequiredForStrategy(state, "missing")
+	if err == nil || cleared || cash != 0 {
+		t.Fatalf("unknown id: cash=%g cleared=%v err=%v", cash, cleared, err)
+	}
+	cash, cleared, err = clearCashReconcileRequiredForStrategy(state, "okx-eth")
+	if err != nil || cleared || cash != 10 {
+		t.Fatalf("unlatched: cash=%g cleared=%v err=%v", cash, cleared, err)
+	}
+	if state.Strategies["okx-eth"].CashReconcileRequired {
+		t.Fatal("unlatched peer must stay unlatched")
+	}
+	cash, cleared, err = clearCashReconcileRequiredForStrategy(state, "rh-btc")
+	if err != nil || !cleared || cash != 0.005 {
+		t.Fatalf("latched clear: cash=%g cleared=%v err=%v", cash, cleared, err)
+	}
+	if state.Strategies["rh-btc"].CashReconcileRequired {
+		t.Fatal("latched strategy must be cleared")
+	}
+	if state.Strategies["rh-btc"].Cash != 0.005 {
+		t.Fatalf("clear must not invent cash: got %g", state.Strategies["rh-btc"].Cash)
 	}
 }
 
@@ -316,10 +373,18 @@ func TestCashReconcileBlocksLiveBuy(t *testing.T) {
 
 func TestFormatSpotLiveCashReconcileReminder(t *testing.T) {
 	msg := formatSpotLiveCashReconcileReminder([]string{"a", "b"}, map[string]float64{"a": 0, "b": -1.5})
-	for _, want := range []string{"CRITICAL: CASH RECONCILE STILL REQUIRED", "a", "b", "Further live spot buys are held"} {
+	for _, want := range []string{
+		"CRITICAL: CASH RECONCILE STILL REQUIRED",
+		"a", "b",
+		"Further live spot buys are held",
+		"/go-trader-clear-cash-reconcile",
+	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("reminder missing %q: %s", want, msg)
 		}
+	}
+	if strings.Contains(msg, "Top up / correct virtual cash above $0.01 to clear") {
+		t.Fatalf("reminder must not claim solvency clears the latch: %s", msg)
 	}
 }
 
@@ -518,7 +583,9 @@ func TestCollectCashReconcileRequiredSnapshots(t *testing.T) {
 	}
 }
 
-func TestSellClearsCashReconcileWhenSolvent(t *testing.T) {
+func TestSellDoesNotClearCashReconcileWhenSolvent(t *testing.T) {
+	// #1400: a round-trip close that restores cash must NOT drop the latch —
+	// solvency ≠ reconciled; only /clear-cash-reconcile clears it.
 	lm, err := NewLogManager("")
 	if err != nil {
 		t.Fatal(err)
@@ -551,8 +618,8 @@ func TestSellClearsCashReconcileWhenSolvent(t *testing.T) {
 	if s.Cash < spotLiveCashBudgetTolerance {
 		t.Fatalf("cash = %g, want solvent after sell", s.Cash)
 	}
-	if s.CashReconcileRequired {
-		t.Fatal("solvent sell must clear CashReconcileRequired")
+	if !s.CashReconcileRequired {
+		t.Fatal("solvent sell must NOT clear CashReconcileRequired (#1400)")
 	}
 }
 

--- a/scheduler/state.go
+++ b/scheduler/state.go
@@ -140,11 +140,13 @@ type StrategyState struct {
 	// (#1394). Venue fills are always booked (dropping them reproduces the
 	// #298 state-drift class); the latch keeps the condition observable after
 	// the one-shot CRITICAL DM: it is persisted to SQLite (strategies.cash_reconcile_required),
-	// surfaced in status/API, blocks further live spot buys until cash recovers,
-	// and drives a throttled cycle reminder. Cleared only when cash returns to a
-	// solvent level (>= spotLiveCashBudgetTolerance). Never inferred from
-	// negative cash on load — paper spot buys routinely end fee-negative
-	// (cash=-fee), and perps/futures can go negative from leveraged PnL.
+	// surfaced in status/API, blocks further live spot buys, and drives a
+	// throttled cycle reminder. Cleared only by the owner-DM
+	// /clear-cash-reconcile command after the operator confirms books match
+	// the venue (#1400) — solvency (cash >= spotLiveCashBudgetTolerance) alone
+	// does not clear. Never inferred from negative cash on load — paper spot
+	// buys routinely end fee-negative (cash=-fee), and perps/futures can go
+	// negative from leveraged PnL.
 	CashReconcileRequired bool `json:"cash_reconcile_required,omitempty"`
 }
 
@@ -191,8 +193,9 @@ func ValidateState(state *AppState) {
 			// Paper spot buys always end fee-negative (cash=-fee), and
 			// perps/futures can go negative from leveraged PnL — neither is a
 			// live over-budget book. Genuine live overshoots persist the latch
-			// via strategies.cash_reconcile_required; maybeClear below keeps a
-			// loaded latch when clamp leaves cash at 0 (< tolerance).
+			// via strategies.cash_reconcile_required; #1400 keeps a loaded
+			// latch until the operator clears it via /clear-cash-reconcile
+			// (maybeClear below is a no-op — solvency alone does not clear).
 		}
 		maybeClearCashReconcileRequired(s)
 		for sym, pos := range s.Positions {


### PR DESCRIPTION
## Plain simple English
Live spot buys that overshoot cash stay blocked until an owner explicitly clears them in Discord. Selling back to a positive cash balance no longer quietly unlocks buys — that only meant the books looked solvent, not that anyone checked them against the exchange.

## Summary
- Add owner-DM `/go-trader-clear-cash-reconcile <strategy>` (`opsCommandNames` + `slashCommands` + dispatch) with destructive confirm; clears latch in memory and persists via `SaveState` under `mu`.
- Disable `maybeClearCashReconcileRequired` solvency auto-clear (load / per-cycle / booking call sites retained as no-ops).
- Update reconcile reminder copy so operators know only the command clears the latch.
- Does not invent cash — flag clear only.

Closes #1400

## Verification
- Red→green: `TestMaybeClearCashReconcileRequired` and `TestSellDoesNotClearCashReconcileWhenSolvent` failed on unfixed code, then passed.
- `go test -C scheduler -count=1 .` — pass
- `go build -C scheduler -o /dev/null .` — pass
- Auth / unknown-ID / successful-clear / reminder-copy unit coverage

---
Created with LLM: Cursor Grok 4.5 | high | Harness: Cursor