### PR TITLE
fix(#1416): tighten resting SL same cycle after ratchet scale-out [C85, Grok 4.5, high]

### DIFF
--- a/scheduler/hyperliquid_open_trailing.go
+++ b/scheduler/hyperliquid_open_trailing.go
@@ -87,7 +87,7 @@ func armTrailingStopAtOpenNow(
 
 	// currentTrigger==0 / currentOID==0: the primitive computes the initial
 	// trigger and rests a fresh SL (no forceResize needed).
-	newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, symbol, side, slEffectiveQty, &posSnap, mark, 0, 0, 0, false, notifier, logger)
+	newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, symbol, side, slEffectiveQty, &posSnap, mark, 0, 0, 0, trailingReplacePolicy{}, notifier, logger)
 	mu.Lock()
 	defer mu.Unlock()
 	if immediateFill, fillPx := applyTrailingStopUpdateResult(stratState, symbol, side, 0, newHighWater, updateConfirmed, slUpdate, logger); immediateFill {

--- a/scheduler/hyperliquid_stop_loss_test.go
+++ b/scheduler/hyperliquid_stop_loss_test.go
@@ -258,7 +258,7 @@ func TestRunHyperliquidTrailingStopUpdate_CancelThenPlaceArgs(t *testing.T) {
 	logger := silentStrategyLogger("hl-test")
 	defer logger.Close()
 
-	newHighWater, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, &Position{AvgCost: 100}, 110, 100, 97, 111, false, nil, logger)
+	newHighWater, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, &Position{AvgCost: 100}, 110, 100, 97, 111, trailingReplacePolicy{}, nil, logger)
 	if !ok {
 		t.Fatalf("runHyperliquidTrailingStopUpdate returned ok=false")
 	}
@@ -306,12 +306,12 @@ func TestRunHyperliquidTrailingStopUpdate_RatchetFallbackNormalizeWidensOnce(t *
 				return &HyperliquidStopLossUpdateResult{StopLossOID: 222, StopLossTriggerPx: triggerPx}, "", nil
 			}
 
-			_, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", tc.side, 0.5, &Position{AvgCost: 100}, 100, 100, tc.currentTrigger, 111, false, nil, logger)
+			_, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", tc.side, 0.5, &Position{AvgCost: 100}, 100, 100, tc.currentTrigger, 111, trailingReplacePolicy{}, nil, logger)
 			if !ok || result != nil || called {
 				t.Fatalf("without marker expected no replace: ok=%v result=%+v called=%v", ok, result, called)
 			}
 
-			_, result, ok = runHyperliquidTrailingStopUpdate(sc, "ETH", tc.side, 0.5, &Position{AvgCost: 100, RatchetFallbackNormalizePending: true}, 100, 100, tc.currentTrigger, 111, false, nil, logger)
+			_, result, ok = runHyperliquidTrailingStopUpdate(sc, "ETH", tc.side, 0.5, &Position{AvgCost: 100, RatchetFallbackNormalizePending: true}, 100, 100, tc.currentTrigger, 111, trailingReplacePolicy{}, nil, logger)
 			if !ok || result == nil || !called {
 				t.Fatalf("with marker expected widen replace: ok=%v result=%+v called=%v", ok, result, called)
 			}
@@ -343,7 +343,7 @@ func TestRunHyperliquidTrailingStopUpdate_DefersOnCancelFailure(t *testing.T) {
 		ownerID:  "owner",
 	})
 
-	newHighWater, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, &Position{AvgCost: 100}, 110, 100, 97, 111, false, notifier, logger)
+	newHighWater, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, &Position{AvgCost: 100}, 110, 100, 97, 111, trailingReplacePolicy{}, notifier, logger)
 	if ok || result == nil {
 		t.Fatalf("runHyperliquidTrailingStopUpdate = (%+v, %v), want deferred result", result, ok)
 	}
@@ -374,7 +374,7 @@ func TestRunHyperliquidTrailingStopUpdate_DefersOnOpenOrderCheckFailure(t *testi
 	logger := silentStrategyLogger("hl-test")
 	defer logger.Close()
 
-	newHighWater, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, &Position{AvgCost: 100}, 110, 100, 97, 111, false, nil, logger)
+	newHighWater, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.5, &Position{AvgCost: 100}, 110, 100, 97, 111, trailingReplacePolicy{}, nil, logger)
 	if ok || result == nil {
 		t.Fatalf("runHyperliquidTrailingStopUpdate = (%+v, %v), want deferred result", result, ok)
 	}
@@ -1849,7 +1849,7 @@ func TestRunHyperliquidTrailingStopPaper(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			gotHW, gotTrig, gotBreach, gotPx := runHyperliquidTrailingStopPaper(c.sc, c.side, c.pos, c.mark, c.highWater, c.currentTrigger)
+			gotHW, gotTrig, gotBreach, gotPx := runHyperliquidTrailingStopPaper(c.sc, c.side, c.pos, c.mark, c.highWater, c.currentTrigger, trailingReplacePolicy{})
 			if floatDiff(gotHW, c.want.newHighWater) > 1e-9 ||
 				floatDiff(gotTrig, c.want.newTrigger) > 1e-9 ||
 				gotBreach != c.want.breach ||
@@ -1883,13 +1883,13 @@ func TestRunHyperliquidTrailingStopPaper_RegimeSnapshotArms(t *testing.T) {
 	}
 
 	incomplete := &Position{AvgCost: pos.AvgCost, EntryATR: pos.EntryATR}
-	_, gotTrig, gotBreach, gotPx := runHyperliquidTrailingStopPaper(sc, "long", incomplete, 2000, 0, 0)
+	_, gotTrig, gotBreach, gotPx := runHyperliquidTrailingStopPaper(sc, "long", incomplete, 2000, 0, 0, trailingReplacePolicy{})
 	if gotTrig != 0 || gotBreach || gotPx != 0 {
 		t.Fatalf("incomplete snapshot unexpectedly armed: trig=%v breach=%v px=%v", gotTrig, gotBreach, gotPx)
 	}
 
 	snapshot := hyperliquidProtectionPositionSnapshot(pos)
-	gotHW, gotTrig, gotBreach, gotPx := runHyperliquidTrailingStopPaper(sc, "long", snapshot, 2000, 0, 0)
+	gotHW, gotTrig, gotBreach, gotPx := runHyperliquidTrailingStopPaper(sc, "long", snapshot, 2000, 0, 0, trailingReplacePolicy{})
 	if !approxEq(gotHW, 2000) || !approxEq(gotTrig, 1900) || gotBreach || gotPx != 0 {
 		t.Fatalf("regime snapshot paper trail = (hw=%v trig=%v breach=%v px=%v), want (2000, 1900, false, 0)",
 			gotHW, gotTrig, gotBreach, gotPx)

--- a/scheduler/hyperliquid_trailing_stop.go
+++ b/scheduler/hyperliquid_trailing_stop.go
@@ -730,13 +730,24 @@ func runHyperliquidTrailingStopUpdate(sc StrategyConfig, symbol, side string, qt
 	newHighWater, newTrigger, replace := computeTrailingStopUpdateInternal(side, mark, highWater, trailingPct, effectiveTrailingStopMinMovePct(sc), currentTrigger, allowOneShotWiden, policy.ratchetTightened)
 	if policy.forceResize && !replace {
 		// #873: a scale-in grew the position; the resting trailing SL still
-		// covers only the pre-add size. Force a cancel+replace at the EXISTING
-		// trigger so the reduce-only SL covers the new total. Keep the current
-		// trigger price (no trailing move yet); fall through to the computed
-		// trigger when nothing is resting (currentTrigger==0).
+		// covers only the pre-add size. Force a cancel+replace so the reduce-only
+		// SL covers the new total. Fall through to the computed trigger when
+		// nothing is resting (currentTrigger==0).
 		replace = true
 		if currentTrigger > 0 {
 			newTrigger = currentTrigger
+			// A forced resize cancels and re-places the order regardless, so it
+			// must never re-arm a trigger LOOSER than the current trail distance
+			// implies. Re-run the decision with the debounce off and adopt the
+			// result when it is strictly favorable: the debounce exists to avoid
+			// order churn, and there is no churn to avoid on a replace we are
+			// already making. This is what keeps a ratchet tighten that an
+			// earlier cycle stamped but could not place — e.g. deferred by the
+			// #621 capped-qty guard above — from being re-frozen at the old wide
+			// trigger (#1416).
+			if _, tighter, ok := computeTrailingStopUpdateInternal(side, mark, highWater, trailingPct, effectiveTrailingStopMinMovePct(sc), currentTrigger, allowOneShotWiden, true); ok && tighter > 0 {
+				newTrigger = tighter
+			}
 		}
 	}
 	if !replace {

--- a/scheduler/hyperliquid_trailing_stop.go
+++ b/scheduler/hyperliquid_trailing_stop.go
@@ -480,11 +480,38 @@ func effectiveTrailingStopMinMovePct(sc StrategyConfig) float64 {
 	return defaultTrailingStopMinMovePct
 }
 
-func computeTrailingStopUpdate(side string, mark, highWater, trailingPct, minMovePct, currentTrigger float64) (float64, float64, bool) {
-	return computeTrailingStopUpdateInternal(side, mark, highWater, trailingPct, minMovePct, currentTrigger, false)
+// trailingReplacePolicy carries the per-call overrides to the walker's default
+// replacement rule ("replace only on a FAVORABLE trigger move that clears the
+// trailing_stop_min_move_pct debounce"). Both overrides are event-gated by the
+// caller, so neither can produce per-cycle cancel+replace churn.
+type trailingReplacePolicy struct {
+	// forceResize (#873) replaces at the EXISTING trigger when the walker would
+	// otherwise not replace, so the reduce-only SL covers the size a scale-in
+	// just added. Live-only; the paper walker rests no order to resize.
+	forceResize bool
+
+	// ratchetTightened (#1416) drops the min-move debounce for this one call.
+	//
+	// Why the debounce is wrong here: it exists to suppress churn from tiny
+	// high-water drifts at a CONSTANT trail distance. A ratchet tier instead
+	// shrinks the distance itself, and the resulting trigger shift is only
+	// Δmult × EntryATR / anchor — on a coin whose ATR is well under 1% of
+	// price, a whole tier step lands below the 0.5% default and the tightened
+	// stop silently never reaches the exchange, while the ratchet DM still
+	// reports the tighter trail. Worse, candidateTrigger is recomputed from the
+	// same high-water every later cycle, so the drop persists until price makes
+	// a materially new high — exactly the retrace the ratchet exists to cover.
+	//
+	// Direction is still gated: only a FAVORABLE candidate replaces, so a
+	// forced tighten can never widen the stop on either side.
+	ratchetTightened bool
 }
 
-func computeTrailingStopUpdateInternal(side string, mark, highWater, trailingPct, minMovePct, currentTrigger float64, allowOneShotWiden bool) (float64, float64, bool) {
+func computeTrailingStopUpdate(side string, mark, highWater, trailingPct, minMovePct, currentTrigger float64) (float64, float64, bool) {
+	return computeTrailingStopUpdateInternal(side, mark, highWater, trailingPct, minMovePct, currentTrigger, false, false)
+}
+
+func computeTrailingStopUpdateInternal(side string, mark, highWater, trailingPct, minMovePct, currentTrigger float64, allowOneShotWiden, bypassMinMove bool) (float64, float64, bool) {
 	if mark <= 0 || trailingPct <= 0 {
 		return highWater, 0, false
 	}
@@ -530,6 +557,12 @@ func computeTrailingStopUpdateInternal(side string, mark, highWater, trailingPct
 			return candidateHighWater, candidateTrigger, true
 		}
 		return candidateHighWater, 0, false
+	}
+	// #1416: a ratchet tightened the trail distance this cycle — replace at the
+	// newly computed (strictly favorable) trigger no matter how small the shift.
+	// The epsilon keeps a float-noise "move" from costing a cancel+replace.
+	if bypassMinMove && math.Abs(candidateTrigger-currentTrigger) > 1e-9 {
+		return candidateHighWater, candidateTrigger, true
 	}
 	movePct := math.Abs(candidateTrigger-currentTrigger) / currentTrigger * 100.0
 	if movePct >= minMovePct {
@@ -584,7 +617,11 @@ func trailingStopBreached(side string, mark, currentTrigger float64) bool {
 // is isolated in scheduler state, so a single strategy's breach closes only
 // that strategy's virtual quantity. Peer strategies on the same coin retain
 // their independent virtual exposure and run their own trailing loops.
-func runHyperliquidTrailingStopPaper(sc StrategyConfig, side string, pos *Position, mark, highWater, currentTrigger float64) (newHighWater, newTrigger float64, breach bool, breachPx float64) {
+//
+// policy carries the #1416 ratchet-tighten bypass of the min-move debounce.
+// policy.forceResize is ignored here: paper rests no exchange order, so there
+// is nothing to re-size.
+func runHyperliquidTrailingStopPaper(sc StrategyConfig, side string, pos *Position, mark, highWater, currentTrigger float64, policy trailingReplacePolicy) (newHighWater, newTrigger float64, breach bool, breachPx float64) {
 	trailingPct := effectiveTrailingStopPct(sc, pos)
 	if trailingPct <= 0 || mark <= 0 {
 		return highWater, 0, false, 0
@@ -603,7 +640,7 @@ func runHyperliquidTrailingStopPaper(sc StrategyConfig, side string, pos *Positi
 		highWater = avgCost
 	}
 	allowOneShotWiden := pos != nil && pos.RatchetFallbackNormalizePending
-	nhw, nt, replace := computeTrailingStopUpdateInternal(side, mark, highWater, trailingPct, effectiveTrailingStopMinMovePct(sc), currentTrigger, allowOneShotWiden)
+	nhw, nt, replace := computeTrailingStopUpdateInternal(side, mark, highWater, trailingPct, effectiveTrailingStopMinMovePct(sc), currentTrigger, allowOneShotWiden, policy.ratchetTightened)
 	if replace {
 		return nhw, nt, false, 0
 	}
@@ -672,7 +709,9 @@ func applyTrailingStopUpdateResult(s *StrategyState, symbol, expectedSide string
 // outside the state mutex so the subprocess call below can run without
 // blocking other strategies). The pointer is taken by value semantics; the
 // helper only reads, never writes through it.
-func runHyperliquidTrailingStopUpdate(sc StrategyConfig, symbol, side string, qty float64, pos *Position, mark, highWater, currentTrigger float64, currentOID int64, forceResize bool, notifier *MultiNotifier, logger *StrategyLogger) (float64, *HyperliquidStopLossUpdateResult, bool) {
+// policy selects the per-call overrides to the default replacement rule: the
+// #873 scale-in resize and the #1416 ratchet-tighten min-move bypass.
+func runHyperliquidTrailingStopUpdate(sc StrategyConfig, symbol, side string, qty float64, pos *Position, mark, highWater, currentTrigger float64, currentOID int64, policy trailingReplacePolicy, notifier *MultiNotifier, logger *StrategyLogger) (float64, *HyperliquidStopLossUpdateResult, bool) {
 	trailingPct := effectiveTrailingStopPct(sc, pos)
 	if trailingPct <= 0 || qty <= 0 || mark <= 0 {
 		return highWater, nil, true
@@ -688,8 +727,8 @@ func runHyperliquidTrailingStopUpdate(sc StrategyConfig, symbol, side string, qt
 		highWater = avgCost
 	}
 	allowOneShotWiden := pos != nil && pos.RatchetFallbackNormalizePending
-	newHighWater, newTrigger, replace := computeTrailingStopUpdateInternal(side, mark, highWater, trailingPct, effectiveTrailingStopMinMovePct(sc), currentTrigger, allowOneShotWiden)
-	if forceResize && !replace {
+	newHighWater, newTrigger, replace := computeTrailingStopUpdateInternal(side, mark, highWater, trailingPct, effectiveTrailingStopMinMovePct(sc), currentTrigger, allowOneShotWiden, policy.ratchetTightened)
+	if policy.forceResize && !replace {
 		// #873: a scale-in grew the position; the resting trailing SL still
 		// covers only the pre-add size. Force a cancel+replace at the EXISTING
 		// trigger so the reduce-only SL covers the new total. Keep the current

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2420,9 +2420,15 @@ func main() {
 							mu.Unlock()
 							var execResult *HyperliquidExecuteResult
 							liveExecFailed := false
+							// #1416: true only when a tier STRICTLY tightened the trail this
+							// cycle. The walkers below then drop the min-move debounce so the
+							// tighter trigger lands now; a watermark-only advance leaves this
+							// false and stays fully debounced.
+							manageRatchetTightened := false
 							if result.Signal == 0 && hlPosQty > 0 && strategyUsesTrailingTPRatchetClose(sc) {
 								ratchetAlert := applyTrailingTPRatchet(sc, stratState, result.Symbol, price, &mu, logger)
 								notifyRatchetTrigger(notifier, sc.NotifyRatchetTriggersEnabled(cfg), ratchetAlert)
+								manageRatchetTightened = ratchetAlert != nil
 								mu.RLock()
 								if pos, ok3 := stratState.Positions[result.Symbol]; ok3 && pos != nil {
 									hlPosSnapshot = hyperliquidProtectionPositionSnapshot(pos)
@@ -2447,7 +2453,7 @@ func main() {
 								// synthetic close when mark crosses the trigger. Each strategy's
 								// virtual position is isolated in stratState.Positions, so peers
 								// on the same coin are unaffected by this strategy's breach.
-								newHighWater, newTrigger, breach, breachPx := runHyperliquidTrailingStopPaper(sc, hlPosSide, hlPosSnapshot, price, hlStopLossHighWaterPx, hlStopLossTriggerPx)
+								newHighWater, newTrigger, breach, breachPx := runHyperliquidTrailingStopPaper(sc, hlPosSide, hlPosSnapshot, price, hlStopLossHighWaterPx, hlStopLossTriggerPx, trailingReplacePolicy{ratchetTightened: manageRatchetTightened})
 								mu.Lock()
 								if pos, ok3 := stratState.Positions[result.Symbol]; ok3 && pos.Quantity > 0 && pos.Side == hlPosSide {
 									if breach {
@@ -2478,7 +2484,7 @@ func main() {
 								// on-chain size (!capped) so the trailing SL covers the
 								// new total without waiting for a trailing trigger move.
 								forceResize := hlScaleInResizePending && !capped
-								newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, result.Symbol, hlPosSide, slEffectiveQty, hlPosSnapshot, price, hlStopLossHighWaterPx, hlStopLossTriggerPx, hlStopLossOID, forceResize, notifier, logger)
+								newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, result.Symbol, hlPosSide, slEffectiveQty, hlPosSnapshot, price, hlStopLossHighWaterPx, hlStopLossTriggerPx, hlStopLossOID, trailingReplacePolicy{forceResize: forceResize, ratchetTightened: manageRatchetTightened}, notifier, logger)
 								mu.Lock()
 								if immediateFill, fillPx := applyTrailingStopUpdateResult(stratState, result.Symbol, hlPosSide, hlStopLossOID, newHighWater, updateConfirmed, slUpdate, logger); immediateFill {
 									trades++
@@ -2845,9 +2851,13 @@ func main() {
 							// on cycle 1.
 							runPostTPStopLossAdjustment(sc, stratState, sc.Symbol, prices[sc.Symbol], cfg, &mu, notifier, logger, hlOnChainAbsQty)
 							mark := prices[sc.Symbol]
+							// #1416: same as the perps manage path — a strict tighten drops
+							// the walker's min-move debounce for this cycle only.
+							manualRatchetTightened := false
 							if mark > 0 && strategyUsesTrailingTPRatchetClose(sc) {
 								ratchetAlert := applyTrailingTPRatchet(sc, stratState, sc.Symbol, mark, &mu, logger)
 								notifyRatchetTrigger(notifier, sc.NotifyRatchetTriggersEnabled(cfg), ratchetAlert)
+								manualRatchetTightened = ratchetAlert != nil
 							}
 							mu.RLock()
 							pos = stratState.Positions[sc.Symbol]
@@ -2862,7 +2872,7 @@ func main() {
 								// position (the trailing SL otherwise covers only the
 								// pre-add size until the next trigger move).
 								forceResize := pos.ScaleInResizePending && !capped
-								newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, sc.Symbol, pos.Side, slEffectiveQty, pos, mark, pos.StopLossHighWaterPx, pos.StopLossTriggerPx, pos.StopLossOID, forceResize, notifier, logger)
+								newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, sc.Symbol, pos.Side, slEffectiveQty, pos, mark, pos.StopLossHighWaterPx, pos.StopLossTriggerPx, pos.StopLossOID, trailingReplacePolicy{forceResize: forceResize, ratchetTightened: manualRatchetTightened}, notifier, logger)
 								mu.Lock()
 								// Shared handler with the perps path — books an immediate fill,
 								// updates a resting replacement, or clears a cancelled-without-rest

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2628,6 +2628,16 @@ func main() {
 								// (Discord/Telegram HTTP must not run under mu). Nil-safe no-op
 								// for the scale-in branch and when no tier tightened.
 								notifyRatchetTrigger(notifier, sc.NotifyRatchetTriggersEnabled(cfg), ratchetAlert)
+								// #1416: scale-out ratchet tiers emit Signal!=0, so the
+								// manage-path walker never ran this cycle. Re-run it now
+								// that PostTPTrailingATRMult is stamped — live AND paper
+								// (outside the execResult gate; paper has nil execResult).
+								if ratchetAlert != nil {
+									if extraTrades, slDetail := runTrailingStopUpdateAfterRatchetTighten(sc, stratState, result.Symbol, price, hlOnChainAbsQty, &mu, notifier, logger); extraTrades > 0 {
+										trades += extraTrades
+										detail = slDetail
+									}
+								}
 								if execResult != nil && trades > 0 {
 									runHyperliquidProtectionSync(sc, stratState, stateDB, result.Symbol, &mu, notifier, logger, "HL protection synced after trade", hlReconcileFillHintsJSON)
 									runPostTPStopLossAdjustment(sc, stratState, result.Symbol, price, cfg, &mu, notifier, logger, hlOnChainAbsQty)

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2625,20 +2625,28 @@ func main() {
 								var openTrade *Trade
 								var ratchetAlert *RatchetTriggerAlert
 								if scaleInAddQty > 0 {
-									trades, detail, openTrade = executeHyperliquidScaleInDeferredOpen(sc, stratState, result, execResult, signalStr, price, scaleInAddQty, logger)
+									trades, detail, openTrade, ratchetAlert = executeHyperliquidScaleInDeferredOpen(sc, stratState, result, execResult, signalStr, price, scaleInAddQty, logger)
 								} else {
 									trades, detail, openTrade, ratchetAlert = executeHyperliquidResultDeferredOpen(sc, stratState, result, execResult, signalStr, price, cfg.Regime, cfg, logger)
 								}
 								mu.Unlock()
 								// #1110: deliver any ratchet-tighten DM after releasing the lock
 								// (Discord/Telegram HTTP must not run under mu). Nil-safe no-op
-								// for the scale-in branch and when no tier tightened.
+								// when no tier tightened.
 								notifyRatchetTrigger(notifier, sc.NotifyRatchetTriggersEnabled(cfg), ratchetAlert)
-								// #1416: scale-out ratchet tiers emit Signal!=0, so the
-								// manage-path walker never ran this cycle. Re-run it now
-								// that PostTPTrailingATRMult is stamped — live AND paper
-								// (outside the execResult gate; paper has nil execResult).
-								if ratchetAlert != nil {
+								// #1416: any execute cycle carries Signal != 0, so the manage-path
+								// walker never ran — the tighter PostTPTrailingATRMult stamped
+								// above would otherwise sit unenforced until a later Signal==0
+								// cycle. Exactly one owner moves the stop this cycle:
+								//   - a LIVE scale-in ADD routes through scaleInResizeTrailingSLNow
+								//     below, which alone knows the GROWN on-chain size; running the
+								//     helper here too would first rest an under-sized stop against
+								//     the stale pre-add snapshot and then replace it again.
+								//   - every other case (scale-out, paper add, no add) uses the
+								//     helper here — live AND paper, outside the execResult gate,
+								//     since paper has a nil execResult.
+								ratchetWalkerOwnedByScaleIn := scaleInAddQty > 0 && execResult != nil && trades > 0
+								if ratchetAlert != nil && !ratchetWalkerOwnedByScaleIn {
 									if extraTrades, slDetail := runTrailingStopUpdateAfterRatchetTighten(sc, stratState, result.Symbol, price, hlOnChainAbsQty, &mu, notifier, logger); extraTrades > 0 {
 										trades += extraTrades
 										detail = slDetail
@@ -2660,7 +2668,10 @@ func main() {
 										if execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.TotalSz > 0 {
 											filledAddQty = execResult.Execution.Fill.TotalSz
 										}
-										if extraTrades, slDetail := scaleInResizeTrailingSLNow(sc, stratState, result.Symbol, price, hlOnChainAbsQty, filledAddQty, &mu, notifier, logger); extraTrades > 0 {
+										// #1416: when this add also cleared a ratchet tier, the same
+										// single pass must place the grown size at the NEW tighter
+										// trigger instead of re-placing the old wider one.
+										if extraTrades, slDetail := scaleInResizeTrailingSLNow(sc, stratState, result.Symbol, price, hlOnChainAbsQty, filledAddQty, ratchetAlert != nil, &mu, notifier, logger); extraTrades > 0 {
 											trades += extraTrades
 											detail = slDetail
 										}

--- a/scheduler/scale_in.go
+++ b/scheduler/scale_in.go
@@ -453,6 +453,15 @@ func executeHyperliquidScaleInDeferredOpen(sc StrategyConfig, s *StrategyState, 
 			_, ratchetAlert = applyTrailingTPRatchetToPosition(sc, pos, result.Symbol, price, logger)
 		}
 	}
+	// Deliberate asymmetry with executeHyperliquidResultDeferredOpen, which
+	// re-seeds pos.StopLossHighWaterPx from the fill price: an ADD must NOT.
+	// The high-water belongs to the trail already in progress, and an add's fill
+	// price carries no information about it — stamping it would push the stored
+	// high-water backward whenever the add fills below the best price seen, and
+	// then hold the trail frozen until price climbs back through it. Leaving it
+	// alone is strictly safer, and the only zero case is covered: the walker
+	// seeds an unset high-water from riskAnchorPrice(), the FROZEN first entry
+	// rather than the blended average (#873). Do not "restore symmetry" here.
 	detail := ""
 	if trades > 0 {
 		prefix := ""

--- a/scheduler/scale_in.go
+++ b/scheduler/scale_in.go
@@ -61,7 +61,7 @@ func scaleInResizeTrailingSLNow(
 		logger.Warn("scale-in eager SL resize: %s still capped (virtual %.6f > on-chain %.6f); deferring to next walker cycle", symbol, posSnap.Quantity, slEffectiveQty)
 		return 0, ""
 	}
-	newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, symbol, side, slEffectiveQty, &posSnap, mark, highWater, triggerPx, slOID, true, notifier, logger)
+	newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, symbol, side, slEffectiveQty, &posSnap, mark, highWater, triggerPx, slOID, trailingReplacePolicy{forceResize: true}, notifier, logger)
 	mu.Lock()
 	defer mu.Unlock()
 	trades := 0

--- a/scheduler/scale_in.go
+++ b/scheduler/scale_in.go
@@ -24,6 +24,12 @@ import (
 // shared-coin reconcile lag), it leaves ScaleInResizePending set so the next
 // walker cycle still resizes — same-cycle coverage is best-effort, never worse
 // than the deferred path.
+//
+// ratchetTightened (#1416) is true when the SAME cycle's add also cleared a
+// ratchet tier. The single walker pass then both grows the size (forceResize)
+// and drops the min-move debounce, so the grown position rests at the NEW
+// tighter trigger after exactly one cancel+replace — never one replace per
+// concern, and never a resize that re-places the old wider trigger.
 func scaleInResizeTrailingSLNow(
 	sc StrategyConfig,
 	stratState *StrategyState,
@@ -31,6 +37,7 @@ func scaleInResizeTrailingSLNow(
 	mark float64,
 	preAddOnChainAbsQty map[string]float64,
 	filledAddQty float64,
+	ratchetTightened bool,
 	mu *sync.RWMutex,
 	notifier *MultiNotifier,
 	logger *StrategyLogger,
@@ -61,7 +68,7 @@ func scaleInResizeTrailingSLNow(
 		logger.Warn("scale-in eager SL resize: %s still capped (virtual %.6f > on-chain %.6f); deferring to next walker cycle", symbol, posSnap.Quantity, slEffectiveQty)
 		return 0, ""
 	}
-	newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, symbol, side, slEffectiveQty, &posSnap, mark, highWater, triggerPx, slOID, trailingReplacePolicy{forceResize: true}, notifier, logger)
+	newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(sc, symbol, side, slEffectiveQty, &posSnap, mark, highWater, triggerPx, slOID, trailingReplacePolicy{forceResize: true, ratchetTightened: ratchetTightened}, notifier, logger)
 	mu.Lock()
 	defer mu.Unlock()
 	trades := 0
@@ -407,7 +414,13 @@ func runHyperliquidScaleInOrder(sc StrategyConfig, result *HyperliquidResult, ad
 // fill price/qty/fee), nil for paper (use the modeled addQty at the mid). For
 // live, the scale_in trade is returned so the caller can run same-cycle
 // protection re-size before the single INSERT; for paper it is recorded here.
-func executeHyperliquidScaleInDeferredOpen(sc StrategyConfig, s *StrategyState, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price, addQty float64, logger *StrategyLogger) (int, string, *Trade) {
+//
+// #1416: an add cycle carries Signal != 0, so the manage path's ratchet never
+// runs — yet price on that same cycle can clear a ratchet tier. This applies
+// the ratchet here (mirroring executeHyperliquidResultDeferredOpen) and returns
+// the tighten alert, so the caller can DM the owner and move the resting stop
+// on the same cycle instead of waiting for the next Signal==0 cycle.
+func executeHyperliquidScaleInDeferredOpen(sc StrategyConfig, s *StrategyState, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price, addQty float64, logger *StrategyLogger) (int, string, *Trade, *RatchetTriggerAlert) {
 	fillPrice := price
 	fillAddQty := addQty
 	var fillOID string
@@ -429,6 +442,17 @@ func executeHyperliquidScaleInDeferredOpen(sc StrategyConfig, s *StrategyState, 
 		logger.Info("Live scale-in fill at $%.2f qty=%.6f (mid was $%.2f)", fillPrice, fillAddQty, price)
 	}
 	trades, openTrade := applyPerpsScaleIn(s, sc, result.Symbol, fillPrice, fillAddQty, fillFee, fillOID, useFillFee, logger)
+	// #1416: apply the ratchet AFTER the add lands, so the tier test reads the
+	// post-add position. Tier geometry is unaffected by the add itself — #873
+	// freezes the ladder to RiskAnchorPrice, not the blended AvgCost.
+	var ratchetAlert *RatchetTriggerAlert
+	if trades > 0 {
+		if pos, ok := s.Positions[result.Symbol]; ok {
+			// Snapshot captured under the caller's lock; the caller DMs it after
+			// releasing mu (#1110).
+			_, ratchetAlert = applyTrailingTPRatchetToPosition(sc, pos, result.Symbol, price, logger)
+		}
+	}
 	detail := ""
 	if trades > 0 {
 		prefix := ""
@@ -448,5 +472,5 @@ func executeHyperliquidScaleInDeferredOpen(sc StrategyConfig, s *StrategyState, 
 			openTrade = nil
 		}
 	}
-	return trades, detail, openTrade
+	return trades, detail, openTrade, ratchetAlert
 }

--- a/scheduler/scale_in_synthesis_test.go
+++ b/scheduler/scale_in_synthesis_test.go
@@ -197,22 +197,22 @@ func TestScaleInResizeTrailingSLNowGuards(t *testing.T) {
 
 	// not live → no-op
 	sc, st := mk([]string{"x.py", "ETH", "1h"}, nil, &trail, true, 2)
-	if n, d := scaleInResizeTrailingSLNow(sc, st, "ETH", 2050, map[string]float64{"ETH": 2}, 1, &mu, nil, newTestLogger(t)); n != 0 || d != "" {
+	if n, d := scaleInResizeTrailingSLNow(sc, st, "ETH", 2050, map[string]float64{"ETH": 2}, 1, false, &mu, nil, newTestLogger(t)); n != 0 || d != "" {
 		t.Errorf("not-live: got (%d,%q), want (0,\"\")", n, d)
 	}
 	// flag unset → no-op
 	sc, st = mk(liveArgs, nil, &trail, false, 2)
-	if n, _ := scaleInResizeTrailingSLNow(sc, st, "ETH", 2050, map[string]float64{"ETH": 2}, 1, &mu, nil, newTestLogger(t)); n != 0 {
+	if n, _ := scaleInResizeTrailingSLNow(sc, st, "ETH", 2050, map[string]float64{"ETH": 2}, 1, false, &mu, nil, newTestLogger(t)); n != 0 {
 		t.Errorf("flag-unset: got %d, want 0", n)
 	}
 	// non-trailing SL owner (fixed ATR) → sync already handled it, no-op
 	sc, st = mk(liveArgs, &fixed, nil, true, 2)
-	if n, _ := scaleInResizeTrailingSLNow(sc, st, "ETH", 2050, map[string]float64{"ETH": 2}, 1, &mu, nil, newTestLogger(t)); n != 0 {
+	if n, _ := scaleInResizeTrailingSLNow(sc, st, "ETH", 2050, map[string]float64{"ETH": 2}, 1, false, &mu, nil, newTestLogger(t)); n != 0 {
 		t.Errorf("non-trailing: got %d, want 0", n)
 	}
 	// still capped after correcting on-chain qty (preAdd 0.5 + fill 0.25 < virtual 2) → defer, no-op
 	sc, st = mk(liveArgs, nil, &trail, true, 2)
-	if n, _ := scaleInResizeTrailingSLNow(sc, st, "ETH", 2050, map[string]float64{"ETH": 0.5}, 0.25, &mu, nil, newTestLogger(t)); n != 0 {
+	if n, _ := scaleInResizeTrailingSLNow(sc, st, "ETH", 2050, map[string]float64{"ETH": 0.5}, 0.25, false, &mu, nil, newTestLogger(t)); n != 0 {
 		t.Errorf("capped: got %d, want 0 (deferred)", n)
 	}
 	// flag must remain set for the deferred walker when capped

--- a/scheduler/scale_in_test.go
+++ b/scheduler/scale_in_test.go
@@ -149,13 +149,13 @@ func TestTrailingStopForceResizeReplacesWithoutMove(t *testing.T) {
 	// mark==highWater, currentTrigger already at the trailing level → no move.
 	// forceResize=false: no replace.
 	called = false
-	_, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 2.0, &Position{AvgCost: 100}, 100, 100, 97, 111, false, nil, logger)
+	_, result, ok := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 2.0, &Position{AvgCost: 100}, 100, 100, 97, 111, trailingReplacePolicy{}, nil, logger)
 	if !ok || result != nil || called {
 		t.Fatalf("without force, expected no replace (called=%v result=%+v)", called, result)
 	}
 	// forceResize=true: replace at the existing trigger (97) with the grown size (2.0).
 	called = false
-	_, result, ok = runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 2.0, &Position{AvgCost: 100}, 100, 100, 97, 111, true, nil, logger)
+	_, result, ok = runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 2.0, &Position{AvgCost: 100}, 100, 100, 97, 111, trailingReplacePolicy{forceResize: true}, nil, logger)
 	if !ok || result == nil || !called {
 		t.Fatalf("with force, expected a replace (called=%v result=%+v ok=%v)", called, result, ok)
 	}

--- a/scheduler/trailing_tp_ratchet_scale_in_test.go
+++ b/scheduler/trailing_tp_ratchet_scale_in_test.go
@@ -225,3 +225,55 @@ func TestExecuteHyperliquidScaleInDeferredOpen_AppliesRatchet(t *testing.T) {
 		t.Errorf("no tier cleared: PostTPTrailingATRMult must stay unstamped")
 	}
 }
+
+// A scale-in add must leave StopLossHighWaterPx alone. executeHyperliquidResultDeferredOpen
+// re-seeds it from the fill price; the add path deliberately does not, since an
+// add's fill price says nothing about the trail already in progress and could
+// push the stored high-water backward. Pins that asymmetry, and pins the only
+// zero case: an unset high-water seeds from the FROZEN entry, not the blended
+// average (#873).
+func TestExecuteHyperliquidScaleInDeferredOpen_LeavesHighWaterUntouched(t *testing.T) {
+	sc := scaleInRatchetStrategy()
+	sc.Args = []string{"x.py", "ETH", "1h"} // paper: execResult is nil
+	const establishedHighWater = 1990.0
+	st := &StrategyState{ID: sc.ID, Platform: "hyperliquid", Type: "perps", Cash: 10000,
+		Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Side: "long", Quantity: 0.2, InitialQuantity: 0.2,
+				AvgCost: ratchetTestAnchor, EntryATR: ratchetTestEntryATR, RiskAnchorPrice: ratchetTestAnchor,
+				StopLossHighWaterPx: establishedHighWater, SLAdjustedTiersProcessed: 1,
+			},
+		}}
+	// Add fills BELOW the established high-water — the case where re-seeding
+	// would walk the trail backward.
+	addPrice := ratchetTestAnchor + 1.5*ratchetTestEntryATR
+	if addPrice >= establishedHighWater {
+		t.Fatalf("fixture invalid: add price %v must be below the high-water %v", addPrice, establishedHighWater)
+	}
+	executeHyperliquidScaleInDeferredOpen(sc, st, &HyperliquidResult{Symbol: "ETH", Signal: 1},
+		nil, "BUY", addPrice, 0.1, newTestLogger(t))
+
+	if got := st.Positions["ETH"].StopLossHighWaterPx; !approxEq(got, establishedHighWater) {
+		t.Fatalf("StopLossHighWaterPx = %v, want %v untouched by the add", got, establishedHighWater)
+	}
+
+	// Zero case: the walker seeds from RiskAnchorPrice, so the blended AvgCost
+	// never becomes the trail base.
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+	var gotTrigger float64
+	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		gotTrigger = triggerPx
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 6001, StopLossTriggerPx: triggerPx}, "", nil
+	}
+	pos := st.Positions["ETH"]
+	pos.StopLossHighWaterPx = 0
+	live := scaleInRatchetStrategy() // live args
+	// mark below the anchor so the anchor (not the mark) is the high-water base.
+	runHyperliquidTrailingStopUpdate(live, "ETH", "long", pos.Quantity, pos, ratchetTestAnchor-20,
+		0, 0, 0, trailingReplacePolicy{}, nil, newTestLogger(t))
+	if want := trailingTriggerFor("long", ratchetTestAnchor, 2.5); !approxEq(gotTrigger, want) {
+		t.Fatalf("trigger = %v, want %v (seeded from the frozen anchor %v, not the blended AvgCost %v)",
+			gotTrigger, want, ratchetTestAnchor, pos.AvgCost)
+	}
+}

--- a/scheduler/trailing_tp_ratchet_scale_in_test.go
+++ b/scheduler/trailing_tp_ratchet_scale_in_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+// #1416 (review round 2): a scale-in ADD cycle carries Signal != 0, so the
+// manage-path ratchet never runs. If price on that same cycle also clears a
+// ratchet tier, the tighter trail must still be stamped and the resting stop
+// moved on that cycle — the add branch must not defer it to a later Signal==0
+// cycle, and it must do it in ONE cancel+replace sized to the post-add total.
+
+// scaleInRatchetStrategy builds a live HL perps strategy with a two-rung
+// ratchet ladder over the issue's real geometry (ATR ~0.56% of price), so a
+// single tier step lands under the shipped 0.5% min-move default.
+func scaleInRatchetStrategy() StrategyConfig {
+	return StrategyConfig{
+		ID: "hl-scalein-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args:         []string{"x.py", "ETH", "1h", "--mode=live"},
+		AllowScaleIn: true,
+		CloseStrategy: &StrategyRef{
+			Name: trailingTPRatchetCloseName,
+			Params: map[string]interface{}{
+				"tp_tiers": []interface{}{
+					map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 2.0},
+					map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 0.0, "trailing_mult_after": 1.0},
+				},
+			},
+		},
+		TrailingStopATRMult: floatPtr(2.5),
+		// TrailingStopMinMovePct unset -> defaultTrailingStopMinMovePct (0.5).
+	}
+}
+
+// scaleInRatchetState builds a post-add position: the add already blended
+// AvgCost and set ScaleInResizePending, while RiskAnchorPrice stays frozen at
+// the first entry (#873).
+func scaleInRatchetState(side string, postAddQty, highWater, trigger, postTPMult float64) *StrategyState {
+	pos := &Position{
+		Symbol: "ETH", Side: side, Quantity: postAddQty, InitialQuantity: postAddQty,
+		AvgCost: ratchetTestAnchor + 3, EntryATR: ratchetTestEntryATR, RiskAnchorPrice: ratchetTestAnchor,
+		StopLossOID: 4242, StopLossHighWaterPx: highWater, StopLossTriggerPx: trigger,
+		ScaleInResizePending: true, ScaleInCount: 1, SLAdjustedTiersProcessed: 1,
+	}
+	if postTPMult > 0 {
+		m := postTPMult
+		pos.PostTPTrailingATRMult = &m
+	}
+	return &StrategyState{ID: "hl-scalein-eth", Platform: "hyperliquid", Type: "perps",
+		Positions: map[string]*Position{"ETH": pos}}
+}
+
+// (a) + (c): an add that also clears a tier resizes AND tightens in exactly one
+// replace, at the post-add quantity, on both sides.
+func TestScaleInResizeTrailingSLNow_AddPlusTightenIsOneReplace(t *testing.T) {
+	cases := []struct {
+		name, side string
+		highWater  float64
+	}{
+		{"long", "long", 1900.0},
+		{"short", "short", 1840.0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			old := runHyperliquidUpdateStopLossFunc
+			defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+			oldTrigger := trailingTriggerFor(c.side, c.highWater, 2.5)
+			wantTrigger := trailingTriggerFor(c.side, c.highWater, 2.0)
+			sc := scaleInRatchetStrategy()
+			// Post-add total 0.3 = pre-add on-chain 0.2 + confirmed add 0.1.
+			st := scaleInRatchetState(c.side, 0.3, c.highWater, oldTrigger, 2.0)
+			var mu sync.RWMutex
+
+			calls := 0
+			var gotSize, gotTrigger float64
+			var gotCancelOID int64
+			runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+				calls++
+				gotSize, gotTrigger, gotCancelOID = size, triggerPx, cancelStopLossOID
+				return &HyperliquidStopLossUpdateResult{StopLossOID: 5555, StopLossTriggerPx: triggerPx}, "", nil
+			}
+
+			scaleInResizeTrailingSLNow(sc, st, "ETH", c.highWater,
+				map[string]float64{"ETH": 0.2}, 0.1, true, &mu, nil, newTestLogger(t))
+
+			if calls != 1 {
+				t.Fatalf("cancel+replace calls = %d, want exactly 1 (resize and tighten in one pass)", calls)
+			}
+			if !approxEq(gotSize, 0.3) {
+				t.Errorf("size = %v, want 0.3 (post-add total)", gotSize)
+			}
+			if gotCancelOID != 4242 {
+				t.Errorf("cancel OID = %d, want 4242", gotCancelOID)
+			}
+			if !approxEq(gotTrigger, wantTrigger) {
+				t.Fatalf("trigger = %v, want %v (new 2.0xATR trail, not the old 2.5x %v)", gotTrigger, wantTrigger, oldTrigger)
+			}
+			if c.side == "long" && gotTrigger <= oldTrigger {
+				t.Errorf("long tighten must raise the trigger: got %v, old %v", gotTrigger, oldTrigger)
+			}
+			if c.side == "short" && gotTrigger >= oldTrigger {
+				t.Errorf("short tighten must lower the trigger: got %v, old %v", gotTrigger, oldTrigger)
+			}
+			if pos := st.Positions["ETH"]; pos.ScaleInResizePending {
+				t.Error("ScaleInResizePending must clear after a confirmed resize")
+			}
+		})
+	}
+}
+
+// (b): an add with no tier clear keeps the #873 behavior — one forced replace at
+// the grown size, no multiplier change and no trigger move.
+func TestScaleInResizeTrailingSLNow_AddWithoutTightenIsUnchanged(t *testing.T) {
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+	highWater := 1900.0
+	// Resting trigger already matches the live trail distance: nothing to tighten.
+	trigger := trailingTriggerFor("long", highWater, 2.0)
+	sc := scaleInRatchetStrategy()
+	st := scaleInRatchetState("long", 0.3, highWater, trigger, 2.0)
+	var mu sync.RWMutex
+
+	calls := 0
+	var gotSize, gotTrigger float64
+	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		calls++
+		gotSize, gotTrigger = size, triggerPx
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 5556, StopLossTriggerPx: triggerPx}, "", nil
+	}
+
+	scaleInResizeTrailingSLNow(sc, st, "ETH", highWater,
+		map[string]float64{"ETH": 0.2}, 0.1, false, &mu, nil, newTestLogger(t))
+
+	if calls != 1 {
+		t.Fatalf("cancel+replace calls = %d, want 1 (#873 forced resize)", calls)
+	}
+	if !approxEq(gotSize, 0.3) {
+		t.Errorf("size = %v, want 0.3 (grown total)", gotSize)
+	}
+	if !approxEq(gotTrigger, trigger) {
+		t.Errorf("trigger = %v, want %v unchanged (no spurious tighten)", gotTrigger, trigger)
+	}
+}
+
+// A forced resize must never re-arm a trigger LOOSER than the current trail
+// implies. Covers the tail of the #621 capped-qty deferral: an earlier cycle
+// stamped the tighter multiplier but could not place it, so this pass — which
+// is cancelling and re-placing anyway — has to adopt the tighter trigger even
+// with no tighten event of its own.
+func TestScaleInResizeTrailingSLNow_ForcedResizeAdoptsPendingTighten(t *testing.T) {
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+	highWater := 1900.0
+	staleTrigger := trailingTriggerFor("long", highWater, 2.5) // placed under the OLD trail
+	sc := scaleInRatchetStrategy()
+	st := scaleInRatchetState("long", 0.3, highWater, staleTrigger, 2.0) // stamped 2.0x, unplaced
+	var mu sync.RWMutex
+
+	var gotTrigger float64
+	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		gotTrigger = triggerPx
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 5557, StopLossTriggerPx: triggerPx}, "", nil
+	}
+
+	// ratchetTightened=false: this cycle saw no tier clear of its own.
+	scaleInResizeTrailingSLNow(sc, st, "ETH", highWater,
+		map[string]float64{"ETH": 0.2}, 0.1, false, &mu, nil, newTestLogger(t))
+
+	if want := trailingTriggerFor("long", highWater, 2.0); !approxEq(gotTrigger, want) {
+		t.Fatalf("trigger = %v, want %v — a forced resize must not re-place the stale wide trigger %v",
+			gotTrigger, want, staleTrigger)
+	}
+}
+
+// The add branch itself must apply the ratchet and hand the alert back, so the
+// caller can DM the owner and drive the same-cycle walker.
+func TestExecuteHyperliquidScaleInDeferredOpen_AppliesRatchet(t *testing.T) {
+	mk := func(mark float64) (StrategyConfig, *StrategyState, *HyperliquidResult) {
+		sc := scaleInRatchetStrategy()
+		sc.Args = []string{"x.py", "ETH", "1h"} // paper: execResult is nil
+		st := &StrategyState{ID: sc.ID, Platform: "hyperliquid", Type: "perps", Cash: 10000,
+			Positions: map[string]*Position{
+				"ETH": {
+					Symbol: "ETH", Side: "long", Quantity: 0.2, InitialQuantity: 0.2,
+					AvgCost: ratchetTestAnchor, EntryATR: ratchetTestEntryATR, RiskAnchorPrice: ratchetTestAnchor,
+					StopLossHighWaterPx: mark, SLAdjustedTiersProcessed: 1,
+				},
+			}}
+		return sc, st, &HyperliquidResult{Symbol: "ETH", Signal: 1}
+	}
+
+	// 3.0 ATR of profit clears the second rung -> trail tightens 2.5x -> 1.0x.
+	clearing := ratchetTestAnchor + 3.0*ratchetTestEntryATR
+	sc, st, res := mk(clearing)
+	trades, _, _, alert := executeHyperliquidScaleInDeferredOpen(sc, st, res, nil, "BUY", clearing, 0.1, newTestLogger(t))
+	if trades == 0 {
+		t.Fatal("expected the add to book a trade")
+	}
+	if alert == nil {
+		t.Fatal("expected a ratchet tighten alert from an add cycle that clears a tier (#1416)")
+	}
+	pos := st.Positions["ETH"]
+	if pos.PostTPTrailingATRMult == nil || !approxEq(*pos.PostTPTrailingATRMult, 1.0) {
+		t.Fatalf("stamped mult = %v, want 1.0", pos.PostTPTrailingATRMult)
+	}
+	if !approxEq(pos.Quantity, 0.3) {
+		t.Errorf("post-add quantity = %v, want 0.3", pos.Quantity)
+	}
+	if !approxEq(pos.RiskAnchorPrice, ratchetTestAnchor) {
+		t.Errorf("RiskAnchorPrice = %v, want %v frozen at the first entry", pos.RiskAnchorPrice, ratchetTestAnchor)
+	}
+
+	// An add with no tier newly cleared must not alert and must not stamp.
+	belowNextTier := ratchetTestAnchor + 1.5*ratchetTestEntryATR
+	sc, st, res = mk(belowNextTier)
+	_, _, _, alert = executeHyperliquidScaleInDeferredOpen(sc, st, res, nil, "BUY", belowNextTier, 0.1, newTestLogger(t))
+	if alert != nil {
+		t.Fatalf("no tier newly cleared: want nil alert, got %+v", alert)
+	}
+	if st.Positions["ETH"].PostTPTrailingATRMult != nil {
+		t.Errorf("no tier cleared: PostTPTrailingATRMult must stay unstamped")
+	}
+}

--- a/scheduler/trailing_tp_ratchet_sl.go
+++ b/scheduler/trailing_tp_ratchet_sl.go
@@ -5,6 +5,17 @@ import (
 	"sync"
 )
 
+// ratchetTightenReplacePolicy is the walker policy every ratchet→walker
+// dispatch uses on a cycle where applyTrailingTPRatchet* returned a non-nil
+// alert (i.e. a tier STRICTLY tightened the trail). It drops the min-move
+// debounce so the newly stamped, tighter trigger reaches the exchange the same
+// cycle instead of being discarded whenever Δmult × EntryATR / anchor lands
+// under trailing_stop_min_move_pct (#1416).
+//
+// Bounded by construction: a tier alerts at most once (SLAdjustedTiersProcessed
+// advances past it), so this can never turn into per-cycle cancel+replace churn.
+var ratchetTightenReplacePolicy = trailingReplacePolicy{ratchetTightened: true}
+
 // runTrailingStopUpdateAfterRatchetTighten re-runs the trailing walker on the
 // SAME cycle a ratchet tier tightened during execute (#1416).
 //
@@ -63,7 +74,7 @@ func runTrailingStopUpdateAfterRatchetTighten(
 			logger.Warn("ratchet same-cycle trailing SL: virtual qty %.6f > on-chain %.6f for %s; capping (#621)", qty, slEffectiveQty, symbol)
 		}
 		newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(
-			sc, symbol, side, slEffectiveQty, &posSnap, mark, highWater, triggerPx, slOID, false, notifier, logger)
+			sc, symbol, side, slEffectiveQty, &posSnap, mark, highWater, triggerPx, slOID, ratchetTightenReplacePolicy, notifier, logger)
 		mu.Lock()
 		defer mu.Unlock()
 		if immediateFill, fillPx := applyTrailingStopUpdateResult(stratState, symbol, side, slOID, newHighWater, updateConfirmed, slUpdate, logger); immediateFill {
@@ -74,7 +85,7 @@ func runTrailingStopUpdateAfterRatchetTighten(
 
 	// Paper (#532): no exchange trigger; advance the virtual HWM/trigger with the
 	// tightened PostTPTrailingATRMult already stamped by the ratchet.
-	newHighWater, newTrigger, breach, breachPx := runHyperliquidTrailingStopPaper(sc, side, &posSnap, mark, highWater, triggerPx)
+	newHighWater, newTrigger, breach, breachPx := runHyperliquidTrailingStopPaper(sc, side, &posSnap, mark, highWater, triggerPx, ratchetTightenReplacePolicy)
 	mu.Lock()
 	defer mu.Unlock()
 	pos, ok := stratState.Positions[symbol]

--- a/scheduler/trailing_tp_ratchet_sl.go
+++ b/scheduler/trailing_tp_ratchet_sl.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// runTrailingStopUpdateAfterRatchetTighten re-runs the trailing walker on the
+// SAME cycle a ratchet tier tightened during execute (#1416).
+//
+// Why this exists: the perps manage path (ratchet → re-snapshot → walker) is
+// gated on result.Signal == 0. A scale-out ratchet tier emits close_fraction > 0,
+// so that path is skipped; execute books the partial close and
+// applyTrailingTPRatchetToPosition stamps the tighter PostTPTrailingATRMult
+// afterward — but nothing replaces the resting SL until a later Signal==0
+// cycle. That leaves the residual under-protected at the OLD wider trigger for
+// up to a full strategy interval (and unbounded if every later cycle also
+// emits a close signal).
+//
+// Mirrors the manual manage sequence (ratchet then walker) and the #885/#882
+// same-cycle walker pattern: live cancel+replace runs OUTSIDE mu via
+// runHyperliquidTrailingStopUpdate; paper advances the virtual trigger via
+// runHyperliquidTrailingStopPaper. Caller gates on a non-nil tighten alert so
+// trail-only / no-op ratchet cycles don't pay an extra walker pass.
+//
+// Partial-close on-chain qty: the Phase-1 reconcile snapshot is pre-close
+// (larger than residual). hlSLEffectiveQty takes min(virtual, on-chain), so the
+// residual virtual qty wins — never oversized relative to what's left.
+func runTrailingStopUpdateAfterRatchetTighten(
+	sc StrategyConfig,
+	stratState *StrategyState,
+	symbol string,
+	mark float64,
+	hlOnChainAbsQty map[string]float64,
+	mu *sync.RWMutex,
+	notifier *MultiNotifier,
+	logger *StrategyLogger,
+) (int, string) {
+	if stratState == nil || symbol == "" || mark <= 0 {
+		return 0, ""
+	}
+	if sc.Platform != "hyperliquid" || sc.Type != "perps" {
+		return 0, ""
+	}
+
+	mu.RLock()
+	pos := stratState.Positions[symbol]
+	if pos == nil || pos.Quantity <= 0 || effectiveTrailingStopPct(sc, pos) <= 0 {
+		mu.RUnlock()
+		return 0, ""
+	}
+	side := pos.Side
+	highWater := pos.StopLossHighWaterPx
+	triggerPx := pos.StopLossTriggerPx
+	slOID := pos.StopLossOID
+	qty := pos.Quantity
+	posSnap := *pos
+	mu.RUnlock()
+
+	if hyperliquidIsLive(sc.Args) {
+		slEffectiveQty, capped := hlSLEffectiveQty(symbol, qty, hlOnChainAbsQty)
+		if capped && logger != nil {
+			logger.Warn("ratchet same-cycle trailing SL: virtual qty %.6f > on-chain %.6f for %s; capping (#621)", qty, slEffectiveQty, symbol)
+		}
+		newHighWater, slUpdate, updateConfirmed := runHyperliquidTrailingStopUpdate(
+			sc, symbol, side, slEffectiveQty, &posSnap, mark, highWater, triggerPx, slOID, false, notifier, logger)
+		mu.Lock()
+		defer mu.Unlock()
+		if immediateFill, fillPx := applyTrailingStopUpdateResult(stratState, symbol, side, slOID, newHighWater, updateConfirmed, slUpdate, logger); immediateFill {
+			return 1, fmt.Sprintf("[%s] LIVE TRAILING SL %s @ $%.2f", sc.ID, symbol, fillPx)
+		}
+		return 0, ""
+	}
+
+	// Paper (#532): no exchange trigger; advance the virtual HWM/trigger with the
+	// tightened PostTPTrailingATRMult already stamped by the ratchet.
+	newHighWater, newTrigger, breach, breachPx := runHyperliquidTrailingStopPaper(sc, side, &posSnap, mark, highWater, triggerPx)
+	mu.Lock()
+	defer mu.Unlock()
+	pos, ok := stratState.Positions[symbol]
+	if !ok || pos == nil || pos.Quantity <= 0 || pos.Side != side {
+		return 0, ""
+	}
+	if breach {
+		if recordPerpsStopLossClose(stratState, symbol, breachPx, "trailing_stop_loss_paper", logger) {
+			return 1, fmt.Sprintf("[%s] PAPER TRAILING SL %s @ $%.2f", sc.ID, symbol, breachPx)
+		}
+		return 0, ""
+	}
+	if newHighWater > 0 {
+		pos.StopLossHighWaterPx = newHighWater
+	}
+	if newTrigger > 0 {
+		pos.StopLossTriggerPx = newTrigger
+		pos.RatchetFallbackNormalizePending = false
+		if logger != nil {
+			logger.Info("Paper trailing SL trigger updated after ratchet @ $%.4f (high_water=$%.4f)", newTrigger, newHighWater)
+		}
+	}
+	return 0, ""
+}

--- a/scheduler/trailing_tp_ratchet_sl_test.go
+++ b/scheduler/trailing_tp_ratchet_sl_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+// #1416: after a scale-out ratchet stamps a tighter PostTPTrailingATRMult, the
+// resting SL must move same-cycle. These tests pin the helper that the perps
+// execute path calls when ratchetAlert != nil.
+func TestRunTrailingStopUpdateAfterRatchetTighten_LiveReplacesWiderTrigger(t *testing.T) {
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+	// Geometry mirrors the issue repro shape at smaller numbers:
+	// avg 100, entry ATR 5, residual after 80% scale-out, old trail 2.5×ATR
+	// (trigger left at prior HWM), new trail 0.75×ATR already stamped.
+	postTP := 0.75
+	minMove := 0.1 // below the expected move so min-move cannot mask the bug
+	liveArgs := []string{"x.py", "ETH", "1h", "--mode=live"}
+	sc := StrategyConfig{
+		ID: "hl-vwap-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: liveArgs,
+		CloseStrategy:          &StrategyRef{Name: trailingTPRatchetCloseName},
+		TrailingStopATRMult:    floatPtr(2.5),
+		TrailingStopMinMovePct: &minMove,
+	}
+	st := &StrategyState{ID: sc.ID, Positions: map[string]*Position{
+		"ETH": {
+			Symbol: "ETH", Side: "long", Quantity: 0.2, InitialQuantity: 1.0,
+			AvgCost: 100, EntryATR: 5, RiskAnchorPrice: 100,
+			StopLossOID: 510751, StopLossTriggerPx: 96.0, // old wider trigger @ prior HWM
+			StopLossHighWaterPx:      102.0, // fill/mark HWM after partial close
+			PostTPTrailingATRMult:    &postTP,
+			SLAdjustedTiersProcessed: 2,
+		},
+	}}
+	var mu sync.RWMutex
+
+	var called bool
+	var gotSize, gotTrigger float64
+	var gotCancelOID int64
+	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		called = true
+		gotSize, gotTrigger, gotCancelOID = size, triggerPx, cancelStopLossOID
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 999001, StopLossTriggerPx: triggerPx}, "", nil
+	}
+
+	// Intended trigger: HWM 102 * (1 - 0.75*5/100) = 102 * 0.9625 = 98.175
+	wantTrigger := 102.0 * (1.0 - 0.75*5.0/100.0)
+
+	n, _ := runTrailingStopUpdateAfterRatchetTighten(sc, st, "ETH", 102.0, map[string]float64{"ETH": 0.2}, &mu, nil, newTestLogger(t))
+	if n != 0 {
+		t.Fatalf("trades = %d, want 0 (resting replacement, not immediate fill)", n)
+	}
+	if !called {
+		t.Fatal("expected cancel+replace of resting SL after ratchet tighten (#1416)")
+	}
+	if gotCancelOID != 510751 {
+		t.Errorf("cancel OID = %d, want 510751 (old resting SL)", gotCancelOID)
+	}
+	if !approxEq(gotSize, 0.2) {
+		t.Errorf("size = %v, want 0.2 (residual after scale-out)", gotSize)
+	}
+	if !approxEq(gotTrigger, wantTrigger) {
+		t.Errorf("trigger = %v, want %v (0.75×ATR from HWM)", gotTrigger, wantTrigger)
+	}
+	pos := st.Positions["ETH"]
+	if pos.StopLossOID != 999001 {
+		t.Errorf("StopLossOID = %d, want 999001", pos.StopLossOID)
+	}
+	if !approxEq(pos.StopLossTriggerPx, wantTrigger) {
+		t.Errorf("StopLossTriggerPx = %v, want %v", pos.StopLossTriggerPx, wantTrigger)
+	}
+}
+
+func TestRunTrailingStopUpdateAfterRatchetTighten_PaperUpdatesVirtualTrigger(t *testing.T) {
+	postTP := 0.75
+	minMove := 0.1
+	sc := StrategyConfig{
+		ID: "hl-paper-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args:                   []string{"x.py", "ETH", "1h"}, // paper: no --mode=live
+		CloseStrategy:          &StrategyRef{Name: trailingTPRatchetCloseName},
+		TrailingStopATRMult:    floatPtr(2.5),
+		TrailingStopMinMovePct: &minMove,
+	}
+	st := &StrategyState{ID: sc.ID, Positions: map[string]*Position{
+		"ETH": {
+			Symbol: "ETH", Side: "long", Quantity: 0.2, InitialQuantity: 1.0,
+			AvgCost: 100, EntryATR: 5, RiskAnchorPrice: 100,
+			StopLossTriggerPx: 96.0, StopLossHighWaterPx: 102.0,
+			PostTPTrailingATRMult: &postTP,
+		},
+	}}
+	var mu sync.RWMutex
+	wantTrigger := 102.0 * (1.0 - 0.75*5.0/100.0)
+
+	n, _ := runTrailingStopUpdateAfterRatchetTighten(sc, st, "ETH", 102.0, nil, &mu, nil, newTestLogger(t))
+	if n != 0 {
+		t.Fatalf("trades = %d, want 0", n)
+	}
+	pos := st.Positions["ETH"]
+	if !approxEq(pos.StopLossTriggerPx, wantTrigger) {
+		t.Fatalf("paper StopLossTriggerPx = %v, want %v (#1416 paper path)", pos.StopLossTriggerPx, wantTrigger)
+	}
+}
+
+func TestRunTrailingStopUpdateAfterRatchetTighten_NoOpGuards(t *testing.T) {
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+	var called bool
+	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		called = true
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 1, StopLossTriggerPx: triggerPx}, "", nil
+	}
+
+	postTP := 0.75
+	liveArgs := []string{"x.py", "ETH", "1h", "--mode=live"}
+	mk := func() (*StrategyConfig, *StrategyState) {
+		sc := StrategyConfig{
+			ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: liveArgs,
+			CloseStrategy: &StrategyRef{Name: trailingTPRatchetCloseName}, TrailingStopATRMult: floatPtr(2.5),
+		}
+		st := &StrategyState{ID: sc.ID, Positions: map[string]*Position{
+			"ETH": {
+				Symbol: "ETH", Side: "long", Quantity: 0.2, InitialQuantity: 1.0,
+				AvgCost: 100, EntryATR: 5, RiskAnchorPrice: 100,
+				StopLossOID: 7, StopLossTriggerPx: 96, StopLossHighWaterPx: 102,
+				PostTPTrailingATRMult: &postTP,
+			},
+		}}
+		return &sc, st
+	}
+	var mu sync.RWMutex
+
+	// Flat residual → no-op (full close already booked).
+	sc, st := mk()
+	st.Positions["ETH"].Quantity = 0
+	called = false
+	runTrailingStopUpdateAfterRatchetTighten(*sc, st, "ETH", 102, map[string]float64{"ETH": 0}, &mu, nil, newTestLogger(t))
+	if called {
+		t.Error("flat position: expected no subprocess call")
+	}
+
+	// Non-HL platform → no-op.
+	sc, st = mk()
+	sc.Platform = "okx"
+	called = false
+	runTrailingStopUpdateAfterRatchetTighten(*sc, st, "ETH", 102, map[string]float64{"ETH": 0.2}, &mu, nil, newTestLogger(t))
+	if called {
+		t.Error("non-HL: expected no subprocess call")
+	}
+
+	// Mark missing → no-op.
+	sc, st = mk()
+	called = false
+	runTrailingStopUpdateAfterRatchetTighten(*sc, st, "ETH", 0, map[string]float64{"ETH": 0.2}, &mu, nil, newTestLogger(t))
+	if called {
+		t.Error("mark<=0: expected no subprocess call")
+	}
+}
+
+func TestRunTrailingStopUpdateAfterRatchetTighten_UsesResidualNotPreCloseOnChain(t *testing.T) {
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+	postTP := 0.75
+	minMove := 0.1
+	sc := StrategyConfig{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args:                []string{"x.py", "ETH", "1h", "--mode=live"},
+		CloseStrategy:       &StrategyRef{Name: trailingTPRatchetCloseName},
+		TrailingStopATRMult: floatPtr(2.5), TrailingStopMinMovePct: &minMove,
+	}
+	st := &StrategyState{ID: sc.ID, Positions: map[string]*Position{
+		"ETH": {
+			Symbol: "ETH", Side: "long", Quantity: 0.2, InitialQuantity: 1.0,
+			AvgCost: 100, EntryATR: 5, RiskAnchorPrice: 100,
+			StopLossOID: 7, StopLossTriggerPx: 96, StopLossHighWaterPx: 102,
+			PostTPTrailingATRMult: &postTP,
+		},
+	}}
+	var mu sync.RWMutex
+	var gotSize float64
+	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		gotSize = size
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 8, StopLossTriggerPx: triggerPx}, "", nil
+	}
+	// Stale Phase-1 on-chain still shows pre-partial-close size (1.0); residual
+	// virtual is 0.2 — hlSLEffectiveQty must pick the residual.
+	runTrailingStopUpdateAfterRatchetTighten(sc, st, "ETH", 102, map[string]float64{"ETH": 1.0}, &mu, nil, newTestLogger(t))
+	if !approxEq(gotSize, 0.2) {
+		t.Fatalf("SL size = %v, want residual 0.2 (not stale on-chain 1.0)", gotSize)
+	}
+}
+
+func floatPtr(v float64) *float64 { return &v }

--- a/scheduler/trailing_tp_ratchet_sl_test.go
+++ b/scheduler/trailing_tp_ratchet_sl_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math"
 	"sync"
 	"testing"
 )
@@ -74,6 +75,17 @@ func TestRunTrailingStopUpdateAfterRatchetTighten_LiveReplacesWiderTrigger(t *te
 }
 
 func TestRunTrailingStopUpdateAfterRatchetTighten_PaperUpdatesVirtualTrigger(t *testing.T) {
+	// Paper must never reach the exchange script. Stub the live hook and assert
+	// it stays untouched, so a regression that mis-detects paper as live fails
+	// here instead of spawning Python from Go CI.
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+	var called bool
+	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		called = true
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 1, StopLossTriggerPx: triggerPx}, "", nil
+	}
+
 	postTP := 0.75
 	minMove := 0.1
 	sc := StrategyConfig{
@@ -97,6 +109,9 @@ func TestRunTrailingStopUpdateAfterRatchetTighten_PaperUpdatesVirtualTrigger(t *
 	n, _ := runTrailingStopUpdateAfterRatchetTighten(sc, st, "ETH", 102.0, nil, &mu, nil, newTestLogger(t))
 	if n != 0 {
 		t.Fatalf("trades = %d, want 0", n)
+	}
+	if called {
+		t.Fatal("paper mode must not invoke the exchange stop-loss script")
 	}
 	pos := st.Positions["ETH"]
 	if !approxEq(pos.StopLossTriggerPx, wantTrigger) {
@@ -195,3 +210,215 @@ func TestRunTrailingStopUpdateAfterRatchetTighten_UsesResidualNotPreCloseOnChain
 }
 
 func floatPtr(v float64) *float64 { return &v }
+
+// --- #1416 min-move debounce interaction (default config, both sides) ---
+//
+// Geometry below mirrors the issue's live ETH position: anchor 1868.80 with
+// EntryATR 10.4989, so one ATR is ~0.56% of price. A single tier step of
+// Δmult = 0.5 therefore shifts the trigger only ~0.28% — under the SHIPPED
+// default trailing_stop_min_move_pct of 0.5. These cases pin that a ratchet
+// tighten still lands, and that nothing else loses the debounce.
+const (
+	ratchetTestAnchor   = 1868.80
+	ratchetTestEntryATR = 10.4989
+)
+
+func ratchetMinMoveStrategy(live bool) StrategyConfig {
+	args := []string{"x.py", "ETH", "1h"}
+	if live {
+		args = append(args, "--mode=live")
+	}
+	return StrategyConfig{
+		ID: "hl-vwap-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: args,
+		CloseStrategy:       &StrategyRef{Name: trailingTPRatchetCloseName},
+		TrailingStopATRMult: floatPtr(2.5),
+		// TrailingStopMinMovePct deliberately unset -> defaultTrailingStopMinMovePct (0.5).
+	}
+}
+
+func ratchetMinMovePosition(side string, mult, highWater float64) *StrategyState {
+	m := mult
+	return &StrategyState{ID: "hl-vwap-eth", Positions: map[string]*Position{
+		"ETH": {
+			Symbol: "ETH", Side: side, Quantity: 0.2, InitialQuantity: 1.0,
+			AvgCost: ratchetTestAnchor, EntryATR: ratchetTestEntryATR, RiskAnchorPrice: ratchetTestAnchor,
+			StopLossOID: 510751, StopLossHighWaterPx: highWater,
+			PostTPTrailingATRMult: &m, SLAdjustedTiersProcessed: 1,
+		},
+	}}
+}
+
+// trailingTriggerFor returns the trigger the walker should compute for the
+// given side, high-water and ATR multiple under this fixture's geometry.
+func trailingTriggerFor(side string, highWater, mult float64) float64 {
+	pct := mult * ratchetTestEntryATR / ratchetTestAnchor
+	if side == "short" {
+		return highWater * (1.0 + pct)
+	}
+	return highWater * (1.0 - pct)
+}
+
+func TestRunTrailingStopUpdateAfterRatchetTighten_LandsUnderDefaultMinMove(t *testing.T) {
+	cases := []struct {
+		name      string
+		side      string
+		highWater float64
+	}{
+		{"long", "long", 1900.0},
+		{"short", "short", 1840.0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			old := runHyperliquidUpdateStopLossFunc
+			defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+			// Trail tightened 2.5x -> 2.0x ATR; the resting trigger still sits at
+			// the 2.5x distance from the same high-water.
+			oldTrigger := trailingTriggerFor(c.side, c.highWater, 2.5)
+			wantTrigger := trailingTriggerFor(c.side, c.highWater, 2.0)
+
+			// Sanity: this move MUST be under the shipped default, else the case
+			// is not exercising the debounce at all.
+			movePct := math.Abs(wantTrigger-oldTrigger) / oldTrigger * 100.0
+			if movePct >= defaultTrailingStopMinMovePct {
+				t.Fatalf("fixture invalid: move %.4f%% >= default min-move %.2f%%", movePct, defaultTrailingStopMinMovePct)
+			}
+
+			sc := ratchetMinMoveStrategy(true)
+			st := ratchetMinMovePosition(c.side, 2.0, c.highWater)
+			st.Positions["ETH"].StopLossTriggerPx = oldTrigger
+			var mu sync.RWMutex
+
+			calls := 0
+			var gotTrigger float64
+			runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+				calls++
+				gotTrigger = triggerPx
+				return &HyperliquidStopLossUpdateResult{StopLossOID: 999001, StopLossTriggerPx: triggerPx}, "", nil
+			}
+
+			runTrailingStopUpdateAfterRatchetTighten(sc, st, "ETH", c.highWater, map[string]float64{"ETH": 0.2}, &mu, nil, newTestLogger(t))
+
+			if calls != 1 {
+				t.Fatalf("cancel+replace calls = %d, want 1 (#1416: tighten must not be debounced)", calls)
+			}
+			if !approxEq(gotTrigger, wantTrigger) {
+				t.Fatalf("trigger = %v, want %v (2.0xATR from high-water %v)", gotTrigger, wantTrigger, c.highWater)
+			}
+			// A tighten must move the stop toward the mark, never away from it.
+			if c.side == "long" && gotTrigger <= oldTrigger {
+				t.Errorf("long tighten must raise the trigger: got %v, old %v", gotTrigger, oldTrigger)
+			}
+			if c.side == "short" && gotTrigger >= oldTrigger {
+				t.Errorf("short tighten must lower the trigger: got %v, old %v", gotTrigger, oldTrigger)
+			}
+			if got := st.Positions["ETH"].StopLossTriggerPx; !approxEq(got, wantTrigger) {
+				t.Errorf("persisted StopLossTriggerPx = %v, want %v", got, wantTrigger)
+			}
+		})
+	}
+}
+
+// A watermark-only cycle (no tier tightened -> ratchetAlert == nil -> the manage
+// walker runs with a zero policy) must stay fully debounced: no forced replace,
+// no subprocess.
+func TestTrailingWalker_NoRatchetTighten_StaysDebounced(t *testing.T) {
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+	called := false
+	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		called = true
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 1, StopLossTriggerPx: triggerPx}, "", nil
+	}
+
+	sc := ratchetMinMoveStrategy(true)
+	highWater := 1900.0
+	pos := ratchetMinMovePosition("long", 2.0, highWater).Positions["ETH"]
+	// Trigger already at the 2.0x distance; a sub-threshold high-water drift is
+	// the only pending move.
+	pos.StopLossTriggerPx = trailingTriggerFor("long", highWater, 2.0)
+	drifted := highWater * 1.001 // +0.1% -> trigger shifts 0.1%, under the 0.5% default
+
+	_, result, _ := runHyperliquidTrailingStopUpdate(sc, "ETH", "long", 0.2, pos, drifted, highWater,
+		pos.StopLossTriggerPx, pos.StopLossOID, trailingReplacePolicy{}, nil, newTestLogger(t))
+	if called || result != nil {
+		t.Fatal("sub-threshold drift with no ratchet tighten must stay debounced")
+	}
+}
+
+// The bypass drops the debounce, never the direction gate: a candidate that
+// would WIDEN the stop must not replace even with ratchetTightened set.
+func TestTrailingWalker_RatchetBypassNeverWidens(t *testing.T) {
+	for _, side := range []string{"long", "short"} {
+		t.Run(side, func(t *testing.T) {
+			highWater := 1900.0
+			if side == "short" {
+				highWater = 1840.0
+			}
+			// Resting trigger is already TIGHTER (1.0xATR) than what the current
+			// 2.0x trail would compute, e.g. after a manual stop edit.
+			currentTrigger := trailingTriggerFor(side, highWater, 1.0)
+			trailingPct := 2.0 * ratchetTestEntryATR / ratchetTestAnchor * 100.0
+
+			_, trigger, replace := computeTrailingStopUpdateInternal(
+				side, highWater, highWater, trailingPct, defaultTrailingStopMinMovePct, currentTrigger, false, true)
+			if replace || trigger != 0 {
+				t.Fatalf("bypass must not widen: replace=%v trigger=%v (current %v)", replace, trigger, currentTrigger)
+			}
+		})
+	}
+}
+
+// Two tiers clearing in one cycle: the ratchet stamps only the tightest
+// multiplier, so the walker must issue exactly ONE cancel+replace at that
+// multiplier — not one per tier.
+func TestRunTrailingStopUpdateAfterRatchetTighten_TwoTiersOneCycleReplacesOnce(t *testing.T) {
+	old := runHyperliquidUpdateStopLossFunc
+	defer func() { runHyperliquidUpdateStopLossFunc = old }()
+
+	sc := ratchetMinMoveStrategy(true)
+	sc.CloseStrategy = &StrategyRef{
+		Name: trailingTPRatchetCloseName,
+		Params: map[string]interface{}{
+			"tp_tiers": []interface{}{
+				map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 2.0},
+				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.0, "trailing_mult_after": 1.0},
+			},
+		},
+	}
+	// Mark 2.5 ATR above the anchor clears BOTH tiers on this cycle.
+	mark := ratchetTestAnchor + 2.5*ratchetTestEntryATR
+	st := &StrategyState{ID: sc.ID, Positions: map[string]*Position{
+		"ETH": {
+			Symbol: "ETH", Side: "long", Quantity: 0.2, InitialQuantity: 1.0,
+			AvgCost: ratchetTestAnchor, EntryATR: ratchetTestEntryATR, RiskAnchorPrice: ratchetTestAnchor,
+			StopLossOID: 510751, StopLossHighWaterPx: mark,
+			StopLossTriggerPx: trailingTriggerFor("long", mark, 2.5),
+		},
+	}}
+	var mu sync.RWMutex
+
+	tightened, alert := applyTrailingTPRatchetToPosition(sc, st.Positions["ETH"], "ETH", mark, newTestLogger(t))
+	if !tightened || alert == nil {
+		t.Fatalf("expected a tighten alert from a two-tier cycle (got tightened=%v alert=%v)", tightened, alert)
+	}
+	if got := *st.Positions["ETH"].PostTPTrailingATRMult; !approxEq(got, 1.0) {
+		t.Fatalf("stamped mult = %v, want 1.0 (tightest cleared tier)", got)
+	}
+
+	calls := 0
+	var gotTrigger float64
+	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+		calls++
+		gotTrigger = triggerPx
+		return &HyperliquidStopLossUpdateResult{StopLossOID: 999002, StopLossTriggerPx: triggerPx}, "", nil
+	}
+	runTrailingStopUpdateAfterRatchetTighten(sc, st, "ETH", mark, map[string]float64{"ETH": 0.2}, &mu, nil, newTestLogger(t))
+
+	if calls != 1 {
+		t.Fatalf("cancel+replace calls = %d, want exactly 1 for a two-tier cycle", calls)
+	}
+	if want := trailingTriggerFor("long", mark, 1.0); !approxEq(gotTrigger, want) {
+		t.Fatalf("trigger = %v, want %v (tightest multiplier only)", gotTrigger, want)
+	}
+}


### PR DESCRIPTION
## Plain simple English

When a take-profit step sells part of a position and tightens the trailing stop, the exchange stop now moves to that tighter level on the same cycle. Before, the old wider stop could sit for a full cycle (or longer).

## Summary

- After execute stamps a ratchet tighten alert, call `runTrailingStopUpdateAfterRatchetTighten` (live cancel+replace + paper virtual trigger) **outside** the `execResult != nil` gate so paper is covered.
- Reuses existing walker primitives (`runHyperliquidTrailingStopUpdate` / `runHyperliquidTrailingStopPaper`); subprocess stays outside `mu`.
- Closes the #1416 under-protection window on scale-out tiers (`close_fraction > 0`); trail-only tiers already self-healed on the Signal==0 manage path.

Closes #1416

## Verification

- Red→green: stubbed helper → live/paper tests failed; restored helper → passed.
- `go test -C scheduler -count=1 -run 'TestRunTrailingStopUpdateAfterRatchetTighten|TestArmTrailingStopAtOpenNow|TestApplyTrailingTPRatchet|TestEffectiveTrailingStopPct_HonorsPostTP' .`
- `go build -C scheduler -o /dev/null .`

---
LLM: Grok 4.5 | high | Harness: Cursor