### PR TITLE
feat(#1409): add Hurst exponent metric to regime payloads for observability [C41, Sonnet 5, high]

### DIFF
--- a/backtest/regime_enriched_features.py
+++ b/backtest/regime_enriched_features.py
@@ -15,6 +15,12 @@ canonical features (kept FIRST, in their canonical order) plus signals the hand-
                           higher-timeframe bar that has already CLOSED at or before the base bar's
                           open (strictly causal; conservatively staler than the canonical row,
                           never leaking).
+  * ``hurst``           — #1409 trailing DFA Hurst exponent (``indicators_core.hurst_exponent``,
+                          the SSoT — imported, never reimplemented). Uses its OWN trailing
+                          ``hurst_window`` (default 100 bars, independent of ``period``), because
+                          DFA needs ~100 points and the composite window (``period``, 14-50 bars
+                          live) is below that floor. Warmup (< ``hurst_window`` observations) or a
+                          degenerate segment -> NaN, same warmup convention as the other extras.
 
 Offline / research only. Live ``check_regime.py`` still builds only the canonical four-column
 matrix, so an enriched model is NOT drop-in for the live classifier — that delta is recorded for
@@ -32,7 +38,8 @@ import sys
 
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 for _p in (_THIS_DIR, os.path.abspath(os.path.join(_THIS_DIR, "..")),
-           os.path.abspath(os.path.join(_THIS_DIR, "..", "shared_tools"))):
+           os.path.abspath(os.path.join(_THIS_DIR, "..", "shared_tools")),
+           os.path.abspath(os.path.join(_THIS_DIR, "..", "shared_strategies", "open"))):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
@@ -40,23 +47,28 @@ import numpy as np
 import pandas as pd
 
 from regime import composite_feature_matrix, _DEFAULT_COMPOSITE_THRESHOLDS
+from indicators_core import hurst_exponent, HURST_DFA_MIN_POINTS
 
 # Canonical four, in the order composite_feature_matrix emits them. The naming path
 # (map_composite_label) consumes these by position; they MUST stay first and in this order.
 CANONICAL_COLUMNS = ["return_eff", "range_eff", "efficiency", "adx"]
 # Extra signals the hand-rule does not use. Appended AFTER the canonical block.
-ENRICHED_EXTRA_COLUMNS = ["funding_rate", "volume_z", "htf_range_eff"]
+ENRICHED_EXTRA_COLUMNS = ["funding_rate", "volume_z", "htf_range_eff", "hurst"]
 ENRICHED_COLUMNS = CANONICAL_COLUMNS + ENRICHED_EXTRA_COLUMNS
 # Position of (return_eff, range_eff, efficiency, adx) inside any canonical-first matrix.
 CANONICAL_INDICES = (0, 1, 2, 3)
+# #1409: hurst's own trailing window, independent of the composite `period`. Matches
+# indicators_core.HURST_DFA_MIN_POINTS (the DFA floor) so the column isn't NaN by construction.
+HURST_WINDOW_DEFAULT = HURST_DFA_MIN_POINTS
 
 # Recorded for #1074. An enriched model decodes from this column set on-cycle; live
 # check_regime.py builds only CANONICAL_COLUMNS, so live wiring would need to feed the same
-# enriched matrix (funding fetch + volume z-score + HTF resample) every cycle. Not solved here.
+# enriched matrix (funding fetch + volume z-score + HTF resample + hurst) every cycle. Not solved
+# here.
 LIVE_WIRING_DELTA = (
     "Enriched models decode from ENRICHED_COLUMNS; live check_regime.py builds only "
-    "CANONICAL_COLUMNS. Live wiring (#1074) must feed funding_rate + volume_z + htf_range_eff "
-    "on-cycle in this exact order, or forward_filter_labels reads garbage."
+    "CANONICAL_COLUMNS. Live wiring (#1074) must feed funding_rate + volume_z + htf_range_eff + "
+    "hurst on-cycle in this exact order, or forward_filter_labels reads garbage."
 )
 
 
@@ -121,18 +133,43 @@ def _htf_range_eff_column(df: pd.DataFrame, period: int, thresholds: dict,
     return merged["htf_range_eff"].to_numpy(dtype=float)
 
 
+def _hurst_column(df: pd.DataFrame, window: int) -> np.ndarray:
+    """Trailing per-bar Hurst exponent (DFA) over the last `window` closes, inclusive of the
+    current bar — same causal window convention as the other enriched columns.
+
+    `window` is independent of the composite `period`: DFA needs ~`indicators_core.
+    HURST_DFA_MIN_POINTS` points to produce a non-NaN estimate, well above the composite's
+    14-50 bar window, so this column intentionally does NOT reuse `period`/`vol_window`.
+    Estimator comes from ``indicators_core.hurst_exponent`` (the repo SSoT) — never
+    reimplemented here. `hurst_exponent` operates on LOG RETURNS internally, so a `window`-price
+    segment yields only `window - 1` returns — one short of `min_points=window` and NaN every
+    time. The segment therefore spans `window + 1` closes (`window` log returns), warming up one
+    bar later than the level-only extras above. Warmup or a degenerate segment -> NaN.
+    """
+    if window < 2:
+        raise ValueError("hurst_window must be >= 2")
+    closes = df["close"].astype(float).to_numpy()
+    n = len(closes)
+    out = np.full(n, np.nan, dtype=float)
+    for i in range(window, n):
+        seg = pd.Series(closes[i - window : i + 1])
+        out[i] = hurst_exponent(seg, min_points=window)
+    return out
+
+
 def enriched_feature_matrix(df: pd.DataFrame, period: int, thresholds: dict | None = None, *,
                             funding: pd.DataFrame | None = None, vol_window: int | None = None,
-                            htf_multiple: int = 4,
+                            htf_multiple: int = 4, hurst_window: int | None = None,
                             columns: list[str] | None = None) -> pd.DataFrame:
     """Per-bar enriched feature matrix (canonical four FIRST, then the enabled extras).
 
     All joins are causal — canonical window ends at the bar, funding/HTF use backward merges,
-    volume z-score uses a trailing window. Warmup and atr<=0 bars are NaN (dropped downstream by
-    the model's NaN mask). `funding` is the DataFrame(timestamp, rate) from
+    volume z-score and hurst use a trailing window. Warmup and atr<=0 bars are NaN (dropped
+    downstream by the model's NaN mask). `funding` is the DataFrame(timestamp, rate) from
     ``funding_fetcher.load_cached_funding``; when None/empty the funding column is all-NaN (the
     model mask then drops every row, so a funding-bearing subset is effectively unavailable — the
-    bake-off harness detects and reports that rather than fitting on nothing).
+    bake-off harness detects and reports that rather than fitting on nothing). `hurst_window`
+    defaults to `HURST_WINDOW_DEFAULT` (the DFA floor, NOT `period` — see `_hurst_column`).
 
     `columns` selects a subset for ablations; the result preserves ENRICHED_COLUMNS order so the
     canonical block stays first (canonical_indices == (0, 1, 2, 3)). Unknown names raise.
@@ -149,6 +186,7 @@ def enriched_feature_matrix(df: pd.DataFrame, period: int, thresholds: dict | No
     columns = [c for c in ENRICHED_COLUMNS if c in columns]
 
     vol_window = int(vol_window) if vol_window else int(period)
+    hurst_window = int(hurst_window) if hurst_window else HURST_WINDOW_DEFAULT
     out = pd.DataFrame(index=df.index)
     canon = composite_feature_matrix(df, period, thresholds)
     for col in CANONICAL_COLUMNS:
@@ -160,6 +198,8 @@ def enriched_feature_matrix(df: pd.DataFrame, period: int, thresholds: dict | No
         out["volume_z"] = _volume_z_column(df, vol_window)
     if "htf_range_eff" in columns:
         out["htf_range_eff"] = _htf_range_eff_column(df, period, thresholds, htf_multiple)
+    if "hurst" in columns:
+        out["hurst"] = _hurst_column(df, hurst_window)
     return out[columns]
 
 

--- a/backtest/tests/test_regime_enriched_features.py
+++ b/backtest/tests/test_regime_enriched_features.py
@@ -155,6 +155,51 @@ def test_volume_z_is_trailing_and_warmup_nan():
     assert vz[i] == pytest.approx(expected, rel=1e-9)
 
 
+def test_hurst_column_is_trailing_and_warmup_nan():
+    df = _synthetic_ohlcv(n=300)
+    mat = ref.enriched_feature_matrix(df, period=48, columns=ref.CANONICAL_COLUMNS + ["hurst"],
+                                      hurst_window=100)
+    h = mat["hurst"].to_numpy()
+    assert np.isnan(h[:100]).all()   # fewer than `hurst_window` observations -> NaN
+    assert np.isfinite(h[100])       # first full trailing window (101 closes) is defined
+    # recompute by hand from the SSoT estimator over the same trailing window
+    from indicators_core import hurst_exponent
+    close = df["close"].to_numpy()
+    i = 200
+    expected = hurst_exponent(pd.Series(close[i - 100: i + 1]), min_points=100)
+    assert h[i] == pytest.approx(expected, rel=1e-12)
+
+
+def test_hurst_column_uses_own_window_independent_of_period():
+    """#1409: hurst must NOT inherit `period` (14-50 bars live) as its window -- that would put it
+    below the ~100-point DFA floor and make it NaN almost every live cycle. Two calls with the
+    SAME hurst_window but different `period` must produce the identical hurst column."""
+    df = _synthetic_ohlcv(n=300)
+    mat_a = ref.enriched_feature_matrix(df, period=20, columns=ref.CANONICAL_COLUMNS + ["hurst"],
+                                        hurst_window=100)
+    mat_b = ref.enriched_feature_matrix(df, period=48, columns=ref.CANONICAL_COLUMNS + ["hurst"],
+                                        hurst_window=100)
+    pd.testing.assert_series_equal(mat_a["hurst"], mat_b["hurst"], check_exact=True)
+
+
+def test_hurst_column_is_causal_future_bars_do_not_change_past_rows():
+    df = _synthetic_ohlcv(n=300)
+    base = ref.enriched_feature_matrix(df, period=48, columns=ref.CANONICAL_COLUMNS + ["hurst"])
+    t = 200
+    mutated = df.copy()
+    mutated.iloc[t + 1:, mutated.columns.get_loc("close")] *= 3.0
+    after = ref.enriched_feature_matrix(mutated, period=48, columns=ref.CANONICAL_COLUMNS + ["hurst"])
+    a = base["hurst"].iloc[: t + 1].to_numpy()
+    b = after["hurst"].iloc[: t + 1].to_numpy()
+    assert np.array_equal(np.nan_to_num(a, nan=-7.0), np.nan_to_num(b, nan=-7.0))
+
+
+def test_hurst_extra_column_appended_after_canonical_block():
+    assert ref.ENRICHED_COLUMNS[-1] == "hurst"
+    assert ref.ENRICHED_COLUMNS[:4] == ref.CANONICAL_COLUMNS
+    assert "hurst" in ref.ENRICHED_EXTRA_COLUMNS
+
+
 # ---------------------------------------------------------------- fit / decode contract
 
 def test_fit_unsupervised_enriched_schema_and_decode():
@@ -215,7 +260,7 @@ def test_column_order_is_load_bearing_for_labels():
                                  canonical_indices=(0, 1, 2, 3))
     correct, _ = forward_filter_labels(mat.to_numpy(dtype=float), model)
     swapped = mat[["adx", "range_eff", "efficiency", "return_eff", "funding_rate",
-                   "volume_z", "htf_range_eff"]]  # return_eff <-> adx swapped (very different scale)
+                   "volume_z", "htf_range_eff", "hurst"]]  # return_eff <-> adx swapped (very different scale)
     wrong, _ = forward_filter_labels(swapped.to_numpy(dtype=float), model)
     valid = ~np.isnan(mat.to_numpy(dtype=float)).any(1)
     assert list(np.asarray(correct)[valid]) != list(np.asarray(wrong)[valid])

--- a/shared_scripts/test_regime_wiring.py
+++ b/shared_scripts/test_regime_wiring.py
@@ -21,7 +21,7 @@ _SHARED_TOOLS = pathlib.Path(__file__).parent.parent / "shared_tools"
 if str(_SHARED_TOOLS) not in sys.path:
     sys.path.insert(0, str(_SHARED_TOOLS))
 
-from regime import latest_regime
+from regime import latest_regime, latest_regime_composite
 
 _SHARED_STRATEGIES_TOOLS = str(_SHARED_TOOLS)
 
@@ -76,6 +76,32 @@ def test_latest_regime_output_json_serializable_flat():
     serialized = json.dumps(payload)
     parsed = json.loads(serialized)
     assert parsed["regime"] == "ranging"
+
+
+def test_composite_json_never_contains_nan_token_when_hurst_omitted():
+    """#1409: Go's json.Unmarshal into map[string]float64 rejects a bare NaN token, so a
+    below-the-DFA-floor hurst estimate must be OMITTED from the metrics dict, never serialized
+    as NaN. Python's json.dumps/loads are NaN-tolerant by default and would silently mask a
+    regression here, so this asserts on the raw serialized TEXT, not a round-tripped dict."""
+    df = _make_flat_df(n=60)  # full frame well below the ~100-point DFA floor
+    payload = latest_regime_composite(df, period=20)
+    assert "hurst" not in payload["metrics"]
+    serialized = json.dumps(payload)
+    assert "NaN" not in serialized
+    json.loads(serialized)  # still must be valid, permissive-parser JSON
+
+
+def test_composite_json_includes_finite_hurst_when_data_sufficient():
+    """#1409: with a full frame above the DFA floor, hurst is present, finite, and survives the
+    JSON boundary as an ordinary float (never the bare NaN token)."""
+    df = _make_uptrend_df(n=300)
+    payload = latest_regime_composite(df, period=20)
+    assert "hurst" in payload["metrics"]
+    serialized = json.dumps(payload)
+    assert "NaN" not in serialized
+    parsed = json.loads(serialized)
+    assert isinstance(parsed["metrics"]["hurst"], float)
+    assert np.isfinite(parsed["metrics"]["hurst"])
 
 
 def test_regime_label_string_is_safe_for_output_field():

--- a/shared_strategies/open/indicators_core.py
+++ b/shared_strategies/open/indicators_core.py
@@ -194,7 +194,13 @@ def atr_sma(
 # returns NaN so "unknown" stays distinguishable from "measured random walk".
 
 HURST_DFA_MIN_POINTS = 100
-_HURST_DFA_MIN_SCALE = 4
+# #1419 review: segment scales below ~8 bars bias the estimate upward on memoryless
+# (Gaussian random walk) data — measured mean H ~= 0.54 at n=200 and ~= 0.55 at n=101
+# with min_scale=4, vs ~= 0.51 / ~= 0.52 with min_scale=8, matching the short-scale DFA
+# bias documented in "On the Validity of Detrended Fluctuation Analysis at Short Scales"
+# (Entropy 24(1):61) — the bias does not vanish with a longer fetch. 8 was verified to
+# keep AR(1) persistent/mean-reverting separation intact (regression: test_indicators_core.py).
+_HURST_DFA_MIN_SCALE = 8
 _HURST_DFA_NUM_SCALES = 12
 
 
@@ -213,6 +219,14 @@ def _hurst_dfa_fluctuation(profile: np.ndarray, scale: int) -> float:
     Non-overlapping segments from both the start and the end of the profile
     (the standard DFA convention) so short scales still get two independent
     passes over the leftover bars a single direction would drop.
+
+    #1419 review: every segment at a given ``scale`` shares the same
+    design matrix (``t = arange(scale)``), so the per-segment linear
+    detrend is one fixed-design least-squares fit applied to the whole
+    reshaped segment block via its pseudo-inverse, rather than one
+    ``np.polyfit`` call per segment (verified numerically equivalent to
+    the old per-segment-polyfit path to <1e-9 relative tolerance at the
+    scales this estimator actually uses, sub-1e-12 in fuzz testing).
     """
     n = len(profile)
     n_segments = n // scale
@@ -223,14 +237,15 @@ def _hurst_dfa_fluctuation(profile: np.ndarray, scale: int) -> float:
     tail = profile[n - n_segments * scale :]
     if not np.array_equal(tail, starts[0]):
         starts.append(tail)
-    sq_residuals: list[float] = []
+    design = np.column_stack([t, np.ones_like(t)])
+    pinv_design = np.linalg.pinv(design)  # (2, scale): shared by every segment at this scale
+    sq_residuals: list[np.ndarray] = []
     for block in starts:
-        segments = block.reshape(n_segments, scale)
-        for seg in segments:
-            coeffs = np.polyfit(t, seg, 1)
-            trend = np.polyval(coeffs, t)
-            sq_residuals.append(float(np.mean((seg - trend) ** 2)))
-    return float(np.sqrt(np.mean(sq_residuals)))
+        segments = block.reshape(n_segments, scale)  # (n_segments, scale)
+        coeffs = segments @ pinv_design.T  # (n_segments, 2) = [slope, intercept] per segment
+        trend = coeffs @ design.T  # (n_segments, scale)
+        sq_residuals.append(np.mean((segments - trend) ** 2, axis=1))
+    return float(np.sqrt(np.mean(np.concatenate(sq_residuals))))
 
 
 def hurst_exponent(close: pd.Series, *, min_points: int = HURST_DFA_MIN_POINTS) -> float:
@@ -252,6 +267,14 @@ def hurst_exponent(close: pd.Series, *, min_points: int = HURST_DFA_MIN_POINTS) 
 
     H > 0.5 marks a persistent/trending series; H < 0.5 marks a
     mean-reverting series; H ~= 0.5 marks a Gaussian random walk (no memory).
+
+    Null-distribution caveat: DFA carries a known small upward bias at short
+    sample sizes that a longer fetch does not remove. Measured at this scale
+    floor (``_HURST_DFA_MIN_SCALE``) on memoryless (Gaussian random walk)
+    data, the estimate's own mean is ~0.51 at n=200 points and ~0.52 at
+    n=101 (sd ~0.06-0.09) rather than the "true" 0.50 -- a reading in the
+    ~0.50-0.55 band near those sample sizes is consistent with no memory at
+    all, not confirmed persistence.
     """
     prices = close.astype(float).to_numpy()
     prices = prices[np.isfinite(prices)]

--- a/shared_strategies/open/indicators_core.py
+++ b/shared_strategies/open/indicators_core.py
@@ -271,10 +271,16 @@ def hurst_exponent(close: pd.Series, *, min_points: int = HURST_DFA_MIN_POINTS) 
     Null-distribution caveat: DFA carries a known small upward bias at short
     sample sizes that a longer fetch does not remove. Measured at this scale
     floor (``_HURST_DFA_MIN_SCALE``) on memoryless (Gaussian random walk)
-    data, the estimate's own mean is ~0.51 at n=200 points and ~0.52 at
-    n=101 (sd ~0.06-0.09) rather than the "true" 0.50 -- a reading in the
-    ~0.50-0.55 band near those sample sizes is consistent with no memory at
-    all, not confirmed persistence.
+    data over 3000 independent trials, the estimate's own mean is ~0.51
+    (sd ~0.08) at n=201 points and ~0.51 (sd ~0.12) at n=101 -- the shortest
+    frame ``regime_enriched_features`` computes at -- rather than the "true"
+    0.50. The n=101 spread is wide enough that individual memoryless draws
+    regularly land at 0.65-0.70 (95th/99th percentile ~0.72/0.82); a single
+    reading near 0.50-0.55 is consistent with no memory, but at n=101 a
+    single high reading (even above 0.7) is NOT reliable evidence of
+    persistence on its own -- only a reading well outside this spread, or
+    persistence confirmed by other signals, should be trusted at short
+    sample sizes.
     """
     prices = close.astype(float).to_numpy()
     prices = prices[np.isfinite(prices)]

--- a/shared_strategies/open/indicators_core.py
+++ b/shared_strategies/open/indicators_core.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+import numpy as np
 import pandas as pd
 
 
@@ -179,3 +180,101 @@ def atr_sma(
         min_periods=min_periods,
         method=method,
     )
+
+
+# --- Hurst exponent (#1409) -------------------------------------------------
+#
+# Detrended fluctuation analysis (DFA) over log returns. DFA is used instead
+# of classic R/S (rescaled range) because R/S is materially noisier at the
+# series lengths this system observes in practice (a few hundred bars).
+#
+# Advisory-only, observability metric: no consumer of this function may use
+# its output for gating, sizing, or config surfaces (see #1409). It never
+# raises and never returns a fabricated 0.5 for "not enough data" — it
+# returns NaN so "unknown" stays distinguishable from "measured random walk".
+
+HURST_DFA_MIN_POINTS = 100
+_HURST_DFA_MIN_SCALE = 4
+_HURST_DFA_NUM_SCALES = 12
+
+
+def _hurst_dfa_scales(n_points: int) -> np.ndarray:
+    """Log-spaced integer segment sizes for DFA, from 4 bars to n/4 bars."""
+    max_scale = max(_HURST_DFA_MIN_SCALE, n_points // 4)
+    if max_scale <= _HURST_DFA_MIN_SCALE:
+        return np.array([max_scale], dtype=int)
+    scales = np.geomspace(_HURST_DFA_MIN_SCALE, max_scale, num=_HURST_DFA_NUM_SCALES)
+    return np.unique(scales.astype(int))
+
+
+def _hurst_dfa_fluctuation(profile: np.ndarray, scale: int) -> float:
+    """RMS detrended fluctuation of ``profile`` at one segment length.
+
+    Non-overlapping segments from both the start and the end of the profile
+    (the standard DFA convention) so short scales still get two independent
+    passes over the leftover bars a single direction would drop.
+    """
+    n = len(profile)
+    n_segments = n // scale
+    if n_segments < 1:
+        return float("nan")
+    t = np.arange(scale, dtype=float)
+    starts = [profile[: n_segments * scale]]
+    tail = profile[n - n_segments * scale :]
+    if not np.array_equal(tail, starts[0]):
+        starts.append(tail)
+    sq_residuals: list[float] = []
+    for block in starts:
+        segments = block.reshape(n_segments, scale)
+        for seg in segments:
+            coeffs = np.polyfit(t, seg, 1)
+            trend = np.polyval(coeffs, t)
+            sq_residuals.append(float(np.mean((seg - trend) ** 2)))
+    return float(np.sqrt(np.mean(sq_residuals)))
+
+
+def hurst_exponent(close: pd.Series, *, min_points: int = HURST_DFA_MIN_POINTS) -> float:
+    """Hurst exponent via detrended fluctuation analysis (DFA) over log returns.
+
+    Operates on log returns of ``close`` (not raw prices), so the estimate is
+    scale-invariant across assets. Deterministic — no randomness, no fitted
+    randomness-dependent seed.
+
+    Returns **NaN** — never raises, never a fabricated 0.5 — whenever there
+    are fewer than ``min_points`` valid log-return observations (default 100,
+    the floor below which the DFA scaling-exponent regression becomes
+    unstable), whenever prices are non-positive (breaks ``log``), or whenever
+    the series is degenerate (e.g. constant price -> zero-variance profile,
+    undefined log-log slope). Callers must treat NaN as "unknown", never as
+    "random walk" — a caller emitting this into a JSON payload must OMIT the
+    key rather than serialize NaN (bare ``NaN`` is not valid JSON and breaks
+    strict parsers such as Go's ``encoding/json``).
+
+    H > 0.5 marks a persistent/trending series; H < 0.5 marks a
+    mean-reverting series; H ~= 0.5 marks a Gaussian random walk (no memory).
+    """
+    prices = close.astype(float).to_numpy()
+    prices = prices[np.isfinite(prices)]
+    if len(prices) < min_points + 1 or np.any(prices <= 0):
+        return float("nan")
+    log_returns = np.diff(np.log(prices))
+    log_returns = log_returns[np.isfinite(log_returns)]
+    n = len(log_returns)
+    if n < min_points:
+        return float("nan")
+
+    profile = np.cumsum(log_returns - np.mean(log_returns))
+    scales = _hurst_dfa_scales(n)
+    if len(scales) < 2:
+        return float("nan")
+
+    fluctuations = np.array([_hurst_dfa_fluctuation(profile, int(s)) for s in scales])
+    if not np.all(np.isfinite(fluctuations)) or np.any(fluctuations <= 0):
+        return float("nan")
+
+    log_scales = np.log(scales.astype(float))
+    log_fluctuations = np.log(fluctuations)
+    slope, _intercept = np.polyfit(log_scales, log_fluctuations, 1)
+    if not np.isfinite(slope):
+        return float("nan")
+    return float(slope)

--- a/shared_strategies/open/indicators_core.py
+++ b/shared_strategies/open/indicators_core.py
@@ -205,7 +205,7 @@ _HURST_DFA_NUM_SCALES = 12
 
 
 def _hurst_dfa_scales(n_points: int) -> np.ndarray:
-    """Log-spaced integer segment sizes for DFA, from 4 bars to n/4 bars."""
+    """Log-spaced integer segment sizes for DFA, from ``_HURST_DFA_MIN_SCALE`` bars to n/4 bars."""
     max_scale = max(_HURST_DFA_MIN_SCALE, n_points // 4)
     if max_scale <= _HURST_DFA_MIN_SCALE:
         return np.array([max_scale], dtype=int)

--- a/shared_strategies/open/test_indicators_core.py
+++ b/shared_strategies/open/test_indicators_core.py
@@ -660,6 +660,58 @@ def test_hurst_random_walk_mean_near_half_at_enriched_column_frame_size():
     assert abs(mean_h - 0.5) < 0.03, mean_h
 
 
+# --- Null-distribution spread pinned to the docstring caveat (#1419 review) ---
+#
+# The mean-only tests above don't catch an understated spread: a reading can sit
+# well outside a narrow claimed sd while the *mean* over many draws still looks
+# fine. These regression-pin the empirical sd/percentiles the docstring caveat
+# now cites, using 1000-trial samples (same order as the review's own re-measure)
+# and seeds disjoint from the mean tests above so the two don't share draws.
+
+
+def test_hurst_random_walk_sd_within_caveat_at_live_frame_size():
+    """At n=201, the null-distribution sd must stay close to the ~0.08 the
+    docstring caveat cites -- not silently drift to the wider n=101 figure."""
+    values = [
+        hurst_exponent(_ar1_log_price_series(201, phi=0.0, seed=10_000 + i))
+        for i in range(1000)
+    ]
+    values = np.array([v for v in values if not np.isnan(v)])
+    assert len(values) > 800, "too many NaN draws to measure the null sd"
+    sd = float(values.std())
+    assert 0.05 < sd < 0.11, sd
+
+
+def test_hurst_random_walk_sd_within_caveat_at_enriched_column_frame_size():
+    """At n=101 -- the exact frame `regime_enriched_features` computes at -- the
+    null-distribution sd must stay close to the ~0.12 the docstring caveat cites.
+    A caveat claiming the tighter n=201 spread here would understate how often a
+    memoryless draw reads well above the 0.50-0.55 'no memory' band."""
+    values = [
+        hurst_exponent(_ar1_log_price_series(HURST_DFA_MIN_POINTS + 1, phi=0.0, seed=20_000 + i))
+        for i in range(1000)
+    ]
+    values = np.array([v for v in values if not np.isnan(v)])
+    assert len(values) > 800, "too many NaN draws to measure the null sd"
+    sd = float(values.std())
+    assert 0.09 < sd < 0.16, sd
+
+
+def test_hurst_random_walk_high_percentile_exceeds_no_memory_band_at_enriched_column_frame_size():
+    """At n=101, the docstring warns a single reading above 0.55 -- even above
+    0.7 -- is not reliable evidence of persistence on its own. Pin that: the 95th
+    percentile of memoryless draws must sit meaningfully above 0.55, matching the
+    caveat's ~0.72 figure within a wide tolerance."""
+    values = [
+        hurst_exponent(_ar1_log_price_series(HURST_DFA_MIN_POINTS + 1, phi=0.0, seed=30_000 + i))
+        for i in range(1000)
+    ]
+    values = np.array([v for v in values if not np.isnan(v)])
+    assert len(values) > 800, "too many NaN draws to measure the percentile"
+    p95 = float(np.percentile(values, 95))
+    assert 0.60 < p95 < 0.85, p95
+
+
 def test_hurst_dfa_fluctuation_vectorization_matches_naive_per_segment_polyfit():
     """#1419 review perf fix: `_hurst_dfa_fluctuation` now fits every segment at a
     scale with one batched pseudo-inverse product instead of one `np.polyfit` call

--- a/shared_strategies/open/test_indicators_core.py
+++ b/shared_strategies/open/test_indicators_core.py
@@ -623,3 +623,76 @@ def test_hurst_custom_min_points():
     close = _ar1_log_price_series(60, phi=0.0, seed=6)
     assert np.isnan(hurst_exponent(close, min_points=100))
     assert not np.isnan(hurst_exponent(close, min_points=50))
+
+
+# --- Short-scale null-distribution bias (#1419 review) ------------------------
+#
+# DFA carries a known small upward bias on memoryless (Gaussian random walk) data
+# at short segment scales -- see the caveat in `hurst_exponent`'s docstring. These
+# regression-test the mitigation (`_HURST_DFA_MIN_SCALE` raised from 4 to 8) rather
+# than any specific mean value, so they stay valid if the floor is tuned further.
+
+
+def test_hurst_random_walk_mean_near_half_at_live_frame_size():
+    """At n=200 (the live `check_regime.py --ohlcv-limit` default), the estimator's
+    OWN mean over many independent random walks must sit close to the true H=0.5 --
+    not the ~0.54 the review measured before the min-scale fix."""
+    values = [
+        hurst_exponent(_ar1_log_price_series(201, phi=0.0, seed=100 + i))
+        for i in range(200)
+    ]
+    values = [v for v in values if not np.isnan(v)]
+    assert len(values) > 150, "too many NaN draws to measure the null mean"
+    mean_h = float(np.mean(values))
+    assert abs(mean_h - 0.5) < 0.03, mean_h
+
+
+def test_hurst_random_walk_mean_near_half_at_enriched_column_frame_size():
+    """Same null-mean check at n=101 -- the exact per-bar segment length
+    `backtest/regime_enriched_features._hurst_column` uses (HURST_DFA_MIN_POINTS+1)."""
+    values = [
+        hurst_exponent(_ar1_log_price_series(HURST_DFA_MIN_POINTS + 1, phi=0.0, seed=200 + i))
+        for i in range(200)
+    ]
+    values = [v for v in values if not np.isnan(v)]
+    assert len(values) > 150, "too many NaN draws to measure the null mean"
+    mean_h = float(np.mean(values))
+    assert abs(mean_h - 0.5) < 0.03, mean_h
+
+
+def test_hurst_dfa_fluctuation_vectorization_matches_naive_per_segment_polyfit():
+    """#1419 review perf fix: `_hurst_dfa_fluctuation` now fits every segment at a
+    scale with one batched pseudo-inverse product instead of one `np.polyfit` call
+    per segment. Regression-pin it against the original naive per-segment-polyfit
+    reference implementation across a range of profile lengths and scales."""
+    from indicators_core import _hurst_dfa_fluctuation
+
+    def naive_fluctuation(profile, scale):
+        n = len(profile)
+        n_segments = n // scale
+        if n_segments < 1:
+            return float("nan")
+        t = np.arange(scale, dtype=float)
+        starts = [profile[: n_segments * scale]]
+        tail = profile[n - n_segments * scale:]
+        if not np.array_equal(tail, starts[0]):
+            starts.append(tail)
+        sq_residuals = []
+        for block in starts:
+            for seg in block.reshape(n_segments, scale):
+                coeffs = np.polyfit(t, seg, 1)
+                trend = np.polyval(coeffs, t)
+                sq_residuals.append(float(np.mean((seg - trend) ** 2)))
+        return float(np.sqrt(np.mean(sq_residuals)))
+
+    rng = np.random.default_rng(7)
+    for _ in range(50):
+        n = int(rng.integers(20, 400))
+        scale = int(rng.integers(4, max(5, n // 3)))
+        profile = np.cumsum(rng.normal(0, 1, n))
+        expected = naive_fluctuation(profile, scale)
+        actual = _hurst_dfa_fluctuation(profile, scale)
+        if np.isnan(expected):
+            assert np.isnan(actual)
+            continue
+        assert actual == pytest.approx(expected, rel=1e-9)

--- a/shared_strategies/open/test_indicators_core.py
+++ b/shared_strategies/open/test_indicators_core.py
@@ -18,9 +18,11 @@ import pandas as pd
 import pytest
 
 from indicators_core import (
+    HURST_DFA_MIN_POINTS,
     atr_from_true_range,
     atr_sma,
     atr_sma_series,
+    hurst_exponent,
     round_atr_large,
     true_range,
     true_range_series,
@@ -542,3 +544,82 @@ def test_standard_atr_reexport_threads_wilder():
     # latest_atr threads the method: on a >=100-ATR frame the simple value is
     # integer-rounded and the wilder one is not, so they must differ.
     assert atr_mod.latest_atr(df, method="wilder") != atr_mod.latest_atr(df)
+
+
+# --- Hurst exponent (#1409) ---------------------------------------------------
+
+
+def _ar1_log_price_series(n, phi, seed, drift=0.0, scale=100.0):
+    """Cumulative log-price walk from an AR(1) increment process.
+
+    phi > 0 makes increments positively autocorrelated (persistent/trending);
+    phi < 0 makes them negatively autocorrelated (mean-reverting); phi == 0
+    is a plain Gaussian random walk.
+    """
+    rng = np.random.RandomState(seed)
+    eps = rng.randn(n)
+    steps = np.zeros(n)
+    for i in range(1, n):
+        steps[i] = phi * steps[i - 1] + eps[i]
+    log_price = np.cumsum(steps) * 0.01 + np.linspace(0.0, drift, n)
+    return pd.Series(scale * np.exp(log_price))
+
+
+def test_hurst_random_walk_near_half():
+    close = _ar1_log_price_series(2000, phi=0.0, seed=1)
+    h = hurst_exponent(close)
+    assert 0.35 <= h <= 0.65, h
+
+
+def test_hurst_persistent_series_above_half():
+    close = _ar1_log_price_series(2000, phi=0.7, seed=2)
+    h = hurst_exponent(close)
+    assert h > 0.55, h
+
+
+def test_hurst_mean_reverting_series_below_half():
+    close = _ar1_log_price_series(2000, phi=-0.6, seed=3)
+    h = hurst_exponent(close)
+    assert h < 0.45, h
+
+
+def test_hurst_insufficient_data_returns_nan():
+    close = pd.Series(np.linspace(100.0, 110.0, HURST_DFA_MIN_POINTS))  # one short of the floor
+    assert np.isnan(hurst_exponent(close))
+
+
+def test_hurst_exactly_at_minimum_is_not_nan():
+    close = _ar1_log_price_series(HURST_DFA_MIN_POINTS + 1, phi=0.0, seed=4)
+    h = hurst_exponent(close)
+    assert not np.isnan(h)
+
+
+def test_hurst_constant_price_returns_nan():
+    close = pd.Series(np.full(300, 100.0))
+    assert np.isnan(hurst_exponent(close))
+
+
+def test_hurst_non_positive_price_returns_nan():
+    close = pd.Series(np.concatenate([np.full(150, 100.0), [-1.0], np.full(150, 100.0)]))
+    assert np.isnan(hurst_exponent(close))
+
+
+def test_hurst_never_raises_on_degenerate_input():
+    for close in (
+        pd.Series([], dtype=float),
+        pd.Series([100.0]),
+        pd.Series(np.full(500, float("nan"))),
+    ):
+        h = hurst_exponent(close)
+        assert np.isnan(h)
+
+
+def test_hurst_deterministic():
+    close = _ar1_log_price_series(500, phi=0.3, seed=5)
+    assert hurst_exponent(close) == hurst_exponent(close)
+
+
+def test_hurst_custom_min_points():
+    close = _ar1_log_price_series(60, phi=0.0, seed=6)
+    assert np.isnan(hurst_exponent(close, min_points=100))
+    assert not np.isnan(hurst_exponent(close, min_points=50))

--- a/shared_tools/regime.py
+++ b/shared_tools/regime.py
@@ -37,6 +37,24 @@ except ImportError:  # pragma: no cover - supports direct shared_tools/regime.py
     _ADX_SPEC.loader.exec_module(_ADX_MODULE)
     _compute_adx_components = _ADX_MODULE._compute_adx_components
 
+try:
+    from shared_strategies.open.indicators_core import hurst_exponent
+except ImportError:  # pragma: no cover - supports direct shared_tools/regime.py imports
+    import importlib.util
+    from pathlib import Path
+
+    _INDICATORS_CORE_PATH = (
+        Path(__file__).resolve().parents[1] / "shared_strategies" / "open" / "indicators_core.py"
+    )
+    _HURST_SPEC = importlib.util.spec_from_file_location(
+        "_regime_indicators_core", _INDICATORS_CORE_PATH
+    )
+    if _HURST_SPEC is None or _HURST_SPEC.loader is None:
+        raise
+    _HURST_MODULE = importlib.util.module_from_spec(_HURST_SPEC)
+    _HURST_SPEC.loader.exec_module(_HURST_MODULE)
+    hurst_exponent = _HURST_MODULE.hurst_exponent
+
 CLASSIFIER_ADX = "adx"
 CLASSIFIER_COMPOSITE = "composite"
 
@@ -319,17 +337,29 @@ def latest_regime_composite(
     label = map_composite_label(eff["return_eff"], adx_val, eff["range_eff"], eff["efficiency"], th)
     score = min(adx_val / 100.0, 1.0)
     close_end = eff["close_end"]
+    metrics = {
+        "adx": adx_val,
+        "return_eff": round(eff["return_eff"], 4),
+        "range_eff": round(eff["range_eff"], 4),
+        "efficiency": round(eff["efficiency"], 4),
+        "atr_pct": round(atr_val / close_end * 100.0, 4) if close_end else 0.0,
+    }
+    # #1409: observability-only Hurst exponent, over the FULL fetched frame
+    # (not the period-length `window` slice above) — DFA needs ~100 points,
+    # well above the 14-50 bar composite window. Omit the key entirely on
+    # NaN (insufficient data / degenerate series) rather than serialize NaN:
+    # json.dumps writes bare NaN, and Go's json.Unmarshal into
+    # map[string]float64 rejects that token, which would fail the whole
+    # RegimePayload parse. Advisory metric only — never read by
+    # map_composite_label, gating, or sizing.
+    hurst_val = hurst_exponent(df["close"])
+    if pd.notna(hurst_val):
+        metrics["hurst"] = round(hurst_val, 4)
     return {
         "regime": label,
         "score": score,
         "classifier": CLASSIFIER_COMPOSITE,
-        "metrics": {
-            "adx": adx_val,
-            "return_eff": round(eff["return_eff"], 4),
-            "range_eff": round(eff["range_eff"], 4),
-            "efficiency": round(eff["efficiency"], 4),
-            "atr_pct": round(atr_val / close_end * 100.0, 4) if close_end else 0.0,
-        },
+        "metrics": metrics,
     }
 
 

--- a/shared_tools/test_regime.py
+++ b/shared_tools/test_regime.py
@@ -1,5 +1,6 @@
 """Tests for shared_tools/regime.py."""
 
+import json
 import math
 import inspect
 import importlib
@@ -28,6 +29,15 @@ regime_label_from_payload = _regime_mod.regime_label_from_payload
 required_ohlcv_limit = _regime_mod.required_ohlcv_limit
 parse_regime_windows_json = _regime_mod.parse_regime_windows_json
 ensure_regime_columns = _regime_mod.ensure_regime_columns
+
+# #1409: loaded the same way as regime.py itself, to check the DFA floor
+# constant regime.py's hurst wiring relies on.
+_indicators_core_spec = importlib.util.spec_from_file_location(
+    "_test_regime_indicators_core",
+    pathlib.Path(__file__).resolve().parents[1] / "shared_strategies" / "open" / "indicators_core.py",
+)
+_indicators_core_mod = importlib.util.module_from_spec(_indicators_core_spec)
+_indicators_core_spec.loader.exec_module(_indicators_core_mod)
 
 
 # ─── Fixtures ────────────────────────────────────────────────────────────────
@@ -518,3 +528,142 @@ def test_normalize_regime_gate_on_failure():
     import pytest as _pytest
     with _pytest.raises(ValueError, match="regime_gate_on_failure"):
         _regime_mod.normalize_regime_gate_on_failure("fail-closed")
+
+
+# --- #1409: Hurst exponent metric (advisory-only, composite path) ------------
+
+
+def test_latest_regime_composite_includes_hurst_when_data_sufficient():
+    """Full fetched frame >= the DFA floor (default 100 points) -> hurst present
+    and finite, even though `period` (the window used for return_eff/range_eff/
+    efficiency/adx) is far smaller than that floor."""
+    df = _make_uptrend(n=300)
+    snap = _regime_mod.latest_regime_composite(df, period=20)
+    assert "hurst" in snap["metrics"]
+    assert np.isfinite(snap["metrics"]["hurst"])
+
+
+def test_latest_regime_composite_omits_hurst_when_full_frame_too_short():
+    """Below the DFA floor even over the FULL frame (not just the `period`
+    window) -> `hurst` key absent, never a NaN placeholder in the dict (NaN
+    must never reach the JSON payload boundary -- Go's json.Unmarshal into
+    map[string]float64 rejects bare NaN)."""
+    df = _make_uptrend(n=60)
+    snap = _regime_mod.latest_regime_composite(df, period=20)
+    assert "hurst" not in snap["metrics"]
+    assert all(v == v for v in snap["metrics"].values())  # no NaN anywhere (v==v is False for NaN)
+
+
+def test_latest_regime_composite_period_window_alone_would_be_too_short():
+    """Regression guard for the 'per window' misreading: `period` here (20) is
+    below the DFA floor on its own, yet hurst is still present because the
+    estimator reads the FULL 300-bar frame, not the period-length slice."""
+    df = _make_uptrend(n=300)
+    assert 20 < _indicators_core_mod.HURST_DFA_MIN_POINTS
+    snap = _regime_mod.latest_regime_composite(df, period=20)
+    assert "hurst" in snap["metrics"]
+
+
+def test_latest_regime_composite_metrics_and_label_unchanged_by_hurst():
+    """Zero-behavior-change guard for #1409: independently recompute the label,
+    score, and every pre-existing metric via the same helper functions
+    `latest_regime_composite` itself calls, and assert byte-identical output.
+    Only `hurst` may appear as a new key -- map_composite_label, thresholds,
+    and every other metric value must be untouched by the hurst addition."""
+    n = 300
+    period = 50
+    idx = pd.date_range("2024-01-01", periods=n, freq="h")
+    rng = np.random.default_rng(11)
+    prices = 100 + 3 * np.sin(np.linspace(0, 6 * np.pi, n)) + rng.normal(0, 0.4, n)
+    df = pd.DataFrame(
+        {"open": prices, "high": prices * 1.004, "low": prices * 0.996, "close": prices},
+        index=idx,
+    )
+    th = _regime_mod.normalize_composite_thresholds(None)
+
+    window = _regime_mod._window_slice(df, period)
+    atr_val = _regime_mod._atr_at_end(df, period)
+    eff = _regime_mod._composite_efficiency_metrics(window, atr_val, period)
+    adx_period = min(period, _regime_mod.COMPOSITE_ADX_PERIOD_CAP)
+    reg_df = _regime_mod.compute_regime(df, period=adx_period, adx_threshold=th["adx"])
+    adx_val = float(reg_df["adx"].iloc[-1])
+    expected_label = _regime_mod.map_composite_label(
+        eff["return_eff"], adx_val, eff["range_eff"], eff["efficiency"], th
+    )
+    expected_score = min(adx_val / 100.0, 1.0)
+    expected_metrics = {
+        "adx": adx_val,
+        "return_eff": round(eff["return_eff"], 4),
+        "range_eff": round(eff["range_eff"], 4),
+        "efficiency": round(eff["efficiency"], 4),
+        "atr_pct": round(atr_val / eff["close_end"] * 100.0, 4) if eff["close_end"] else 0.0,
+    }
+
+    snap = _regime_mod.latest_regime_composite(df, period=period)
+    assert snap["regime"] == expected_label
+    assert snap["score"] == expected_score
+    for key, val in expected_metrics.items():
+        assert snap["metrics"][key] == val
+    # Only "hurst" is allowed to be a new key beyond the pre-#1409 tuple.
+    assert set(snap["metrics"]) - set(expected_metrics) <= {"hurst"}
+
+
+@pytest.mark.parametrize(
+    "fixture_fn,period,thresholds",
+    [
+        (_make_uptrend, 50, None),
+        (_make_downtrend, 50, None),
+        (_make_flat, 50, None),
+    ],
+)
+def test_latest_regime_composite_labels_stay_valid_with_hurst_present(fixture_fn, period, thresholds):
+    """Existing-fixture regression guard: adding `hurst` must not push any
+    label outside the pre-#1409 seven-label composite vocabulary."""
+    df = fixture_fn(n=300)
+    snap = _regime_mod.latest_regime_composite(df, period=period, thresholds=thresholds)
+    assert snap["regime"] in _regime_mod.VALID_LABELS_COMPOSITE
+
+
+def test_regime_from_injected_payload_without_hurst_key_still_works():
+    """#879 regression guard (not new tolerance work): regime_from_injected_payload
+    already passes metric keys through untouched, so a payload snapshot with no
+    `hurst` key keeps working exactly as before #1409."""
+    payload = json.dumps({
+        "medium": {
+            "regime": "trending_up_clean",
+            "score": 0.8,
+            "classifier": "composite",
+            "metrics": {
+                "adx": 30.0, "return_eff": 0.1, "range_eff": 0.1,
+                "efficiency": 0.7, "atr_pct": 1.2,
+            },
+        },
+    })
+    windows, live_atr, strategy_payload = _regime_mod.regime_from_injected_payload(payload)
+    assert strategy_payload["regime"] == "trending_up_clean"
+    assert "hurst" not in strategy_payload["metrics"]
+
+
+def test_regime_from_injected_payload_with_hurst_key_passes_through():
+    """A hurst-bearing injected payload round-trips unchanged (no filtering of
+    unknown/extra metric keys at the injection boundary)."""
+    payload = json.dumps({
+        "medium": {
+            "regime": "trending_up_clean",
+            "score": 0.8,
+            "classifier": "composite",
+            "metrics": {
+                "adx": 30.0, "return_eff": 0.1, "range_eff": 0.1,
+                "efficiency": 0.7, "atr_pct": 1.2, "hurst": 0.62,
+            },
+        },
+    })
+    windows, live_atr, strategy_payload = _regime_mod.regime_from_injected_payload(payload)
+    assert strategy_payload["metrics"]["hurst"] == 0.62
+
+
+def test_default_metrics_stays_hurst_free():
+    """#1409 hard constraint: _DEFAULT_METRICS must never carry a fabricated
+    hurst default (e.g. 0.0 would masquerade as a strong mean-reversion
+    reading) -- absence is the only correct 'unknown' signal."""
+    assert "hurst" not in _regime_mod._DEFAULT_METRICS


### PR DESCRIPTION
## Plain simple English

This change adds a new market-condition number, the Hurst exponent, to the regime data the bot already tracks. The number shows whether a market is trending or bouncing back and forth. It is for humans and research only. It does not change any trading decision, label, or config.

## Summary

- New estimator: `shared_strategies/open/indicators_core.hurst_exponent` — detrended fluctuation analysis (DFA) over log returns. Chosen over classic R/S (rescaled range), which is materially noisier at the series lengths this system observes in practice (a few hundred bars). Deterministic, never raises, returns NaN (never a fabricated 0.5) below the ~100-point DFA floor, on non-positive prices, or on a degenerate (e.g. constant-price) series.
- `shared_tools/regime.py`'s composite classifier (`latest_regime_composite`, `regime.py:326`) adds a `hurst` key to its metrics dict, computed over the **full fetched OHLCV frame** (`check_regime.py` default `--ohlcv-limit 200`) — not the `period`-length composite window (14-50 bars live), which sits below the DFA floor and would be NaN almost every cycle.
- **NaN-at-the-boundary:** when the estimate is NaN, the `hurst` key is **omitted** from the metrics dict, never serialized as NaN. `json.dumps` writes a bare `NaN` token for a Python NaN float; Go's `json.Unmarshal` into `map[string]float64` (`scheduler/regime_multi_window.go:21`) rejects that token, which would break the entire `RegimePayload` parse for that strategy on that cycle. A dedicated test asserts on the raw serialized JSON text (not a round-tripped dict — Python's `json` module is itself NaN-tolerant and would mask a regression).
- `backtest/regime_enriched_features.py` exposes `hurst` as an enriched-only column, imported from the SSoT (never reimplemented), appended after `CANONICAL_COLUMNS` following the existing `ENRICHED_EXTRA_COLUMNS` pattern. It uses its own trailing `hurst_window` (default 100, independent of `period`) — the composite `period` alone is below the DFA floor.
- **This issue's scope is the composite metrics dict only** (`latest_regime_composite`, `regime.py:326`). The ADX-classifier payload (`latest_regime`, `regime.py:498`) does **not** get a `hurst` key — it is a separate, independently-built metrics dict; adding hurst there is explicitly out of scope.
- **No Go changes.** `RegimeSnapshot.Metrics` (`scheduler/regime_multi_window.go:21`) is already a generic `map[string]float64`, so `hurst` is carried with no schema change. The two Go readers of `Metrics` (`regime_divergence.go:369`, `regime_transitions.go:409`) only read `return_eff` and need no edits.

## Zero behavior change confirmed

- `map_composite_label` and all composite thresholds are byte-for-byte untouched.
- A dedicated test (`test_latest_regime_composite_metrics_and_label_unchanged_by_hurst`) independently recomputes the label, score, and every pre-existing metric via the same helper functions `latest_regime_composite` calls, and asserts the function's output is byte-identical aside from the new `hurst` key.
- The `#879` injection path (`regime_from_injected_payload`, `regime.py:593`) already passes unknown/absent metric keys through untouched — a payload snapshot without `hurst` keeps working. This is covered as a regression guard, not new tolerance work.
- `_DEFAULT_METRICS` stays hurst-free (asserted by test) — absence is the correct "unknown" signal; a fabricated default like `0.0` would masquerade as strong mean-reversion.

## Verification

- `uv run --no-sync python -m pytest shared_strategies/ shared_tools/ platforms/ backtest/` — all pass (including the 6 pre-existing files touched or newly-added tests).
- `uv run --no-sync python -m pytest shared_scripts/test_regime_wiring.py` — explicit invoke (not in `testpaths`), all pass, including new JSON-boundary tests proving no bare `NaN` token reaches the payload.
- `go -C scheduler build .` — builds clean (no Go files touched by this PR).
- Manual sanity: DFA estimator gives H ≈ 0.5 on a Gaussian random walk, H > 0.5 on a persistent AR(1) series, H < 0.5 on a mean-reverting AR(1) series, across multiple seeds.

## Merge order

Head of the serial chain #1409 → #1410 → #1411 → #1412 (milestone run `wf_fbd2b98e-ad4`). No dependency for this PR; it must land first.

Closes #1409

---
Created with LLM: Sonnet 5 | high | Harness: milestone-pipeline
