### PR TITLE
feat(#1430): add live/paper config drift fleet audit [C37, Kimi, high]

### DIFF
--- a/scripts/check-live-paper-config-drift.sh
+++ b/scripts/check-live-paper-config-drift.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# check-live-paper-config-drift.sh — READ-ONLY fleet audit of live/paper
+# per-strategy cadence + sizing drift (#1430).
+#
+# When one strategy id runs in both a live and a paper deployment, the two
+# per-strategy config blocks can drift in cadence (interval_seconds) and
+# sizing (leverage, sizing_leverage, margin_per_trade_usd, capital,
+# capital_pct, initial_capital), making the two books incomparable. This
+# script finds every live/paper pair across the fleet and prints the drift.
+#
+# A pair is a sync CANDIDATE only when its differences are limited to
+# cadence, sizing, and the --mode arg; any OTHER differing field (script,
+# args beyond --mode, close_strategy, …) flags the pair SKIP — leave it
+# alone, it has a documented reason to differ or needs human review.
+#
+# Usage:
+#   bash scripts/check-live-paper-config-drift.sh                    # auto-discover active systemd deployments (#1055)
+#   bash scripts/check-live-paper-config-drift.sh /opt/go-trader ... # audit explicit deployment dirs instead
+#
+# Discovery mirrors update.sh --all: active go-trader systemd units, reading
+# each unit's ExecStart --config path (the #1056 out-of-tree location) and
+# falling back to <WorkingDirectory>/scheduler/config.json (the transition
+# symlink, or the legacy in-tree file).
+#
+# The script never writes anything — no config rewrite, no daemon
+# interaction. Mode classification mirrors the daemon: a strategy is live
+# when its args carry --mode=live (or "--mode live"), paper when they carry
+# --mode=paper; anything else is "unset" and never forms a pair.
+#
+# Exit codes:
+#   0 — every live/paper pair in sync on cadence/sizing (SKIP-only flags do
+#       not gate: those pairs are deliberately left alone)
+#   1 — cadence/sizing drift found, or a deployment unreadable/missing
+#   2 — nothing to audit (an empty audit is NOT a verified fleet)
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=update_helpers.sh
+source "${SCRIPT_DIR}/update_helpers.sh"
+
+rows_file=$(mktemp)
+trap 'rm -f "$rows_file"' EXIT
+rows=0
+
+add_row() {
+    local source="$1" cfg_path="$2"
+    printf '%s\t%s\n' "$source" "$cfg_path" >> "$rows_file"
+    rows=$((rows + 1))
+}
+
+if [[ $# -gt 0 ]]; then
+    for dir in "$@"; do
+        dir=$(canonicalize_deployment_dir "$dir")
+        add_row "$dir" "${dir}scheduler/config.json"
+    done
+else
+    if ! command -v systemctl >/dev/null 2>&1; then
+        echo "ERROR: systemctl not available and no deployment dirs given — pass dirs explicitly" >&2
+        exit 2
+    fi
+    globs=()
+    while IFS= read -r g; do
+        [[ -n "$g" ]] && globs+=("$g")
+    done < <(update_systemd_unit_globs)
+    units=()
+    while IFS= read -r unit; do
+        [[ -n "$unit" ]] && units+=("$unit")
+    done < <(systemctl list-units --type=service --state=active --no-legend --plain "${globs[@]}" 2>/dev/null | awk '{print $1}')
+    if [[ ${#units[@]} -eq 0 ]]; then
+        echo "ERROR: no active go-trader systemd units found — an empty audit is not a verified fleet" >&2
+        exit 2
+    fi
+    for unit in "${units[@]}"; do
+        execstart=$(systemctl show "$unit" -p ExecStart --value 2>/dev/null || true)
+        cfg_path=$(update_execstart_config_path "$execstart")
+        if [[ -z "$cfg_path" ]]; then
+            wd=$(systemctl show "$unit" -p WorkingDirectory --value 2>/dev/null || true)
+            if [[ -z "$wd" ]]; then
+                # Record an unreadable row so the audit fails loudly instead of
+                # silently skipping a deployment.
+                add_row "$unit" "-"
+                continue
+            fi
+            cfg_path="${wd%/}/scheduler/config.json"
+        fi
+        add_row "$unit" "$cfg_path"
+    done
+fi
+
+if [[ "$rows" -eq 0 ]]; then
+    echo "ERROR: nothing to audit" >&2
+    exit 2
+fi
+
+python3 - "$rows_file" <<'PY'
+import json
+import sys
+
+# Cadence + sizing fields the #1430 sync runbook is allowed to touch.
+WATCHED = [
+    "interval_seconds",
+    "leverage",
+    "sizing_leverage",
+    "margin_per_trade_usd",
+    "capital",
+    "capital_pct",
+    "initial_capital",
+]
+MISSING = object()
+
+
+def classify(args):
+    # Mirrors scheduler/state_presence.go isLiveArgs: --mode=live or
+    # "--mode live" wins; then explicit paper; anything else is unset and
+    # never forms a pair.
+    for i, a in enumerate(args):
+        if a == "--mode=live":
+            return "live"
+        if a == "--mode" and i + 1 < len(args) and args[i + 1] == "live":
+            return "live"
+    for i, a in enumerate(args):
+        if a == "--mode=paper":
+            return "paper"
+        if a == "--mode" and i + 1 < len(args) and args[i + 1] == "paper":
+            return "paper"
+    return "unset"
+
+
+def strip_mode(args):
+    # Remove the --mode token(s) so a pair whose args differ ONLY by
+    # --mode=live vs --mode=paper is not flagged as other-drift.
+    out = []
+    skip = False
+    for a in args:
+        if skip:
+            skip = False
+            continue
+        if a in ("--mode=live", "--mode=paper"):
+            continue
+        if a == "--mode":
+            skip = True
+            continue
+        out.append(a)
+    return out
+
+
+def fmt(v):
+    if v is MISSING:
+        return "-"
+    return json.dumps(v)
+
+
+rows = []
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.rstrip("\n")
+        if line:
+            rows.append(line.partition("\t"))
+
+print("go-trader live/paper config drift audit (#1430)")
+print("%-40s %-60s %s" % ("DEPLOYMENT", "CONFIG", "STRATEGIES live/paper/unset"))
+
+bad = 0
+entries = []  # (id, source, mode, block)
+for source, _, path in rows:
+    try:
+        with open(path) as f:
+            cfg = json.load(f)
+    except Exception:
+        print("%-40s %-60s %s" % (source, path, "FAIL (unreadable)"))
+        bad += 1
+        continue
+    strategies = cfg.get("strategies")
+    if not isinstance(strategies, list):
+        print("%-40s %-60s %s" % (source, path, "FAIL (no strategies list)"))
+        bad += 1
+        continue
+    counts = {"live": 0, "paper": 0, "unset": 0}
+    for s in strategies:
+        if not isinstance(s, dict) or not isinstance(s.get("id"), str):
+            continue
+        args = s.get("args")
+        if not isinstance(args, list):
+            args = []
+        args = [a for a in args if isinstance(a, str)]
+        mode = classify(args)
+        counts[mode] += 1
+        entries.append((s["id"], source, mode, s))
+    print("%-40s %-60s %d/%d/%d" % (source, path, counts["live"], counts["paper"], counts["unset"]))
+
+by_id = {}
+for e in entries:
+    by_id.setdefault(e[0], []).append(e)
+
+drift_pairs = 0
+skip_pairs = 0
+sync_pairs = 0
+for sid in sorted(by_id):
+    group = by_id[sid]
+    lives = sorted((e for e in group if e[2] == "live"), key=lambda e: e[1])
+    papers = sorted((e for e in group if e[2] == "paper"), key=lambda e: e[1])
+    if not lives or not papers:
+        continue
+    for live in lives:
+        for paper in papers:
+            lblock, pblock = live[3], paper[3]
+            watched_diffs = []
+            for k in WATCHED:
+                lv = lblock.get(k, MISSING)
+                pv = pblock.get(k, MISSING)
+                if lv is MISSING and pv is MISSING:
+                    continue
+                if lv is MISSING or pv is MISSING or lv != pv:
+                    watched_diffs.append((k, lv, pv))
+            other_diffs = []
+            for k in sorted((set(lblock) | set(pblock)) - set(WATCHED) - {"id"}):
+                lv = lblock.get(k, MISSING)
+                pv = pblock.get(k, MISSING)
+                if k == "args":
+                    la = strip_mode(lv) if isinstance(lv, list) else lv
+                    pa = strip_mode(pv) if isinstance(pv, list) else pv
+                    if la != pa:
+                        other_diffs.append((k, la, pa))
+                    continue
+                if lv is MISSING and pv is MISSING:
+                    continue
+                if lv is MISSING or pv is MISSING or lv != pv:
+                    other_diffs.append((k, lv, pv))
+            print()
+            print("PAIR %s" % sid)
+            print("  live : %s" % live[1])
+            print("  paper: %s" % paper[1])
+            for k, lv, pv in watched_diffs:
+                print("  DRIFT  %-22s live=%-14s paper=%s" % (k, fmt(lv), fmt(pv)))
+            for k, lv, pv in other_diffs:
+                print("  OTHER  %-22s live=%-14s paper=%s" % (k, fmt(lv), fmt(pv)))
+            if watched_diffs and other_diffs:
+                skip_pairs += 1
+                print("  VERDICT: SKIP — cadence/sizing drift present, but other fields differ; leave this pair alone")
+            elif watched_diffs:
+                drift_pairs += 1
+                print("  VERDICT: CANDIDATE — differences limited to cadence/sizing/--mode")
+            elif other_diffs:
+                skip_pairs += 1
+                print("  VERDICT: SKIP (in sync on cadence/sizing) — other fields differ; leave this pair alone")
+            else:
+                sync_pairs += 1
+                print("  VERDICT: IN SYNC")
+
+print()
+if bad:
+    print("VERDICT: FAIL — %d deployment(s) unreadable; cannot certify the fleet" % bad)
+    sys.exit(1)
+if drift_pairs:
+    print("VERDICT: DRIFT — %d live/paper pair(s) with syncable cadence/sizing drift, %d SKIP, %d in sync"
+          % (drift_pairs, skip_pairs, sync_pairs))
+    sys.exit(1)
+total = drift_pairs + skip_pairs + sync_pairs
+if total == 0:
+    print("VERDICT: OK — no live/paper pairs found across %d deployment(s)" % len(rows))
+else:
+    print("VERDICT: OK — %d pair(s) in sync, %d flagged SKIP (left alone)" % (sync_pairs, skip_pairs))
+sys.exit(0)
+PY

--- a/scripts/check-live-paper-config-drift.sh
+++ b/scripts/check-live-paper-config-drift.sh
@@ -25,7 +25,11 @@
 # The script never writes anything — no config rewrite, no daemon
 # interaction. Mode classification mirrors the daemon: a strategy is live
 # when its args carry --mode=live (or "--mode live"), paper when they carry
-# --mode=paper; anything else is "unset" and never forms a pair.
+# --mode=paper; anything else is "unset" — and since the daemon runs a
+# no-mode strategy as paper (!isLiveArgs), an unset block whose id has a
+# live twin pairs as the paper twin when no explicit --mode=paper block
+# exists, or is flagged UNPAIRED (never silently dropped, never
+# double-reported) when one does.
 #
 # Exit codes:
 #   0 — every live/paper pair in sync on cadence/sizing (a SKIP flag on
@@ -201,7 +205,22 @@ for sid in sorted(by_id):
     group = by_id[sid]
     lives = sorted((e for e in group if e[2] == "live"), key=lambda e: e[1])
     papers = sorted((e for e in group if e[2] == "paper"), key=lambda e: e[1])
-    if not lives or not papers:
+    unsets = sorted((e for e in group if e[2] == "unset"), key=lambda e: e[1])
+    if not lives:
+        continue
+    if not papers and unsets:
+        # The daemon runs a no-mode strategy as paper (!isLiveArgs,
+        # scheduler/config.go:517), so with no explicit --mode=paper twin the
+        # unset blocks ARE the paper twins — pair them, never drop them.
+        papers = unsets
+        unsets = []
+    for u in unsets:
+        # An explicit --mode=paper twin already pairs this id; a second pair
+        # per unset block would double-report, so flag it instead.
+        print()
+        print("UNPAIRED (unset mode) %s at %s — no --mode token; the daemon runs it as paper but an explicit --mode=paper twin exists. Add --mode=paper to audit it directly."
+              % (sid, u[1]))
+    if not papers:
         continue
     for live in lives:
         for paper in papers:
@@ -231,7 +250,8 @@ for sid in sorted(by_id):
             print()
             print("PAIR %s" % sid)
             print("  live : %s" % live[1])
-            print("  paper: %s" % paper[1])
+            note = " (no --mode token — daemon default is paper)" if paper[2] == "unset" else ""
+            print("  paper: %s%s" % (paper[1], note))
             for k, lv, pv in watched_diffs:
                 print("  DRIFT  %-22s live=%-14s paper=%s" % (k, fmt(lv), fmt(pv)))
             for k, lv, pv in other_diffs:

--- a/scripts/check-live-paper-config-drift.sh
+++ b/scripts/check-live-paper-config-drift.sh
@@ -28,9 +28,11 @@
 # --mode=paper; anything else is "unset" and never forms a pair.
 #
 # Exit codes:
-#   0 — every live/paper pair in sync on cadence/sizing (SKIP-only flags do
-#       not gate: those pairs are deliberately left alone)
-#   1 — cadence/sizing drift found, or a deployment unreadable/missing
+#   0 — every live/paper pair in sync on cadence/sizing (a SKIP flag on
+#       other-field differences alone does not gate: those pairs are
+#       deliberately left alone)
+#   1 — cadence/sizing drift found on any pair (CANDIDATE or SKIP), or a
+#       deployment unreadable/missing
 #   2 — nothing to audit (an empty audit is NOT a verified fleet)
 set -euo pipefail
 
@@ -235,7 +237,10 @@ for sid in sorted(by_id):
             for k, lv, pv in other_diffs:
                 print("  OTHER  %-22s live=%-14s paper=%s" % (k, fmt(lv), fmt(pv)))
             if watched_diffs and other_diffs:
+                # SKIP label (leave the pair alone), but the cadence/sizing
+                # drift still gates: any watched difference fails the audit.
                 skip_pairs += 1
+                drift_pairs += 1
                 print("  VERDICT: SKIP — cadence/sizing drift present, but other fields differ; leave this pair alone")
             elif watched_diffs:
                 drift_pairs += 1
@@ -252,7 +257,7 @@ if bad:
     print("VERDICT: FAIL — %d deployment(s) unreadable; cannot certify the fleet" % bad)
     sys.exit(1)
 if drift_pairs:
-    print("VERDICT: DRIFT — %d live/paper pair(s) with syncable cadence/sizing drift, %d SKIP, %d in sync"
+    print("VERDICT: DRIFT — %d live/paper pair(s) with cadence/sizing drift, %d flagged SKIP (left alone), %d in sync"
           % (drift_pairs, skip_pairs, sync_pairs))
     sys.exit(1)
 total = drift_pairs + skip_pairs + sync_pairs

--- a/scripts/test_update_helpers.sh
+++ b/scripts/test_update_helpers.sh
@@ -287,7 +287,7 @@ rm -rf "$fleet"
 # --- #1430: live/paper config drift audit ----------------------------------
 drift=$(mktemp -d)
 mkdir -p "$drift/live/scheduler" "$drift/paper/scheduler" "$drift/paper2/scheduler" \
-    "$drift/synced/scheduler" "$drift/broken/scheduler"
+    "$drift/paper3/scheduler" "$drift/synced/scheduler" "$drift/broken/scheduler"
 
 # Live twin: 5-minute cadence, leveraged, margin-sized.
 cat > "$drift/live/scheduler/config.json" <<'JSON'
@@ -321,6 +321,19 @@ cat > "$drift/paper2/scheduler/config.json" <<'JSON'
    "args": ["vwap", "ETH", "15m", "--mode=paper"],
    "interval_seconds": 300, "leverage": 20, "margin_per_trade_usd": 50,
    "capital": 100, "close_strategy": "trailing_tp_ratchet_regime"}
+]}
+JSON
+
+# Paper twin with BOTH cadence drift AND an other-field difference -> SKIP
+# flag, but the cadence/sizing drift must still gate (exit 1) even when this
+# is the only pair audited.
+cat > "$drift/paper3/scheduler/config.json" <<'JSON'
+{"config_version": 17, "strategies": [
+  {"id": "hl-vwap-eth-60", "type": "perps", "platform": "hyperliquid",
+   "script": "shared_scripts/check_strategy.py",
+   "args": ["vwap", "ETH", "1h", "--mode=paper"],
+   "interval_seconds": 3600, "leverage": 20, "margin_per_trade_usd": 50,
+   "capital": 100, "close_strategy": "tiered_tp_atr"}
 ]}
 JSON
 
@@ -383,6 +396,20 @@ audit_out=$(bash "${SCRIPT_DIR}/check-live-paper-config-drift.sh" "$drift/live" 
 assert_eq "$audit_rc" "1" "drift audit: any cadence/sizing drift gates the runbook"
 if [[ "$audit_out" != *"CANDIDATE"* || "$audit_out" != *"SKIP"* ]]; then
     echo "FAIL: expected both CANDIDATE and SKIP verdicts across pairs, got: $audit_out" >&2
+    exit 1
+fi
+
+# Single watched+other pair: the cadence/sizing drift must gate (exit 1) even
+# though the pair is flagged SKIP — no second CANDIDATE pair may be needed to
+# trip the exit code (PR #1434 review).
+audit_out=$(bash "${SCRIPT_DIR}/check-live-paper-config-drift.sh" "$drift/live" "$drift/paper3") && audit_rc=0 || audit_rc=$?
+assert_eq "$audit_rc" "1" "drift audit: a single watched+other pair still gates on its cadence/sizing drift"
+if [[ "$audit_out" != *"SKIP"* ]]; then
+    echo "FAIL: expected SKIP verdict for watched+other pair, got: $audit_out" >&2
+    exit 1
+fi
+if [[ "$audit_out" != *"DRIFT"* || "$audit_out" == *"VERDICT: OK"* ]]; then
+    echo "FAIL: expected overall DRIFT verdict for watched+other pair, got: $audit_out" >&2
     exit 1
 fi
 

--- a/scripts/test_update_helpers.sh
+++ b/scripts/test_update_helpers.sh
@@ -298,7 +298,9 @@ cat > "$drift/live/scheduler/config.json" <<'JSON'
    "interval_seconds": 300, "leverage": 20, "margin_per_trade_usd": 50,
    "capital": 100, "close_strategy": "trailing_tp_ratchet_regime"},
   {"id": "solo-live", "type": "perps",
-   "args": ["sma", "BTC", "1h", "--mode=live"], "interval_seconds": 300}
+   "args": ["sma", "BTC", "1h", "--mode=live"], "interval_seconds": 300},
+  {"id": "solo-unset", "type": "perps",
+   "args": ["sma", "DOGE", "1h"], "interval_seconds": 600}
 ]}
 JSON
 
@@ -349,6 +351,20 @@ cat > "$drift/synced/scheduler/config.json" <<'JSON'
 JSON
 
 printf 'not json\n' > "$drift/broken/scheduler/config.json"
+
+# Paper twin with NO --mode token (daemon runs no-mode as paper) and drifted
+# cadence -> must pair with the live twin and gate, not be silently dropped
+# (PR #1434 review).
+mkdir -p "$drift/paper4/scheduler"
+cat > "$drift/paper4/scheduler/config.json" <<'JSON'
+{"config_version": 17, "strategies": [
+  {"id": "hl-vwap-eth-60", "type": "perps", "platform": "hyperliquid",
+   "script": "shared_scripts/check_strategy.py",
+   "args": ["vwap", "ETH", "1h"],
+   "interval_seconds": 3600, "leverage": 1,
+   "capital": 10000, "close_strategy": "trailing_tp_ratchet_regime"}
+]}
+JSON
 
 # Drifted pair: exit 1, per-field drift lines, CANDIDATE verdict.
 audit_out=$(bash "${SCRIPT_DIR}/check-live-paper-config-drift.sh" "$drift/live" "$drift/paper") && audit_rc=0 || audit_rc=$?
@@ -410,6 +426,41 @@ if [[ "$audit_out" != *"SKIP"* ]]; then
 fi
 if [[ "$audit_out" != *"DRIFT"* || "$audit_out" == *"VERDICT: OK"* ]]; then
     echo "FAIL: expected overall DRIFT verdict for watched+other pair, got: $audit_out" >&2
+    exit 1
+fi
+
+# Unset-mode (no --mode token) paper twin: the daemon runs no-mode as paper
+# (!isLiveArgs, scheduler/config.go:517), so the audit must pair it with the
+# live twin and gate on its drift — never silently drop it (PR #1434 review).
+audit_out=$(bash "${SCRIPT_DIR}/check-live-paper-config-drift.sh" "$drift/live" "$drift/paper4") && audit_rc=0 || audit_rc=$?
+assert_eq "$audit_rc" "1" "drift audit: no-mode paper twin pairs with live and gates on drift"
+if [[ "$audit_out" != *"PAIR hl-vwap-eth-60"* || "$audit_out" != *"interval_seconds"* ]]; then
+    echo "FAIL: expected drift pair for no-mode paper twin, got: $audit_out" >&2
+    exit 1
+fi
+if [[ "$audit_out" != *"--mode"* ]]; then
+    echo "FAIL: expected a no-mode annotation on the pair, got: $audit_out" >&2
+    exit 1
+fi
+
+# Inverse: an unset block with a unique id (no live twin) must NOT produce a
+# spurious pair or phantom drift.
+audit_out=$(bash "${SCRIPT_DIR}/check-live-paper-config-drift.sh" "$drift/live" "$drift/synced") && audit_rc=0 || audit_rc=$?
+assert_eq "$audit_rc" "0" "drift audit: in-sync pair plus unique-id unset block exits 0"
+if [[ "$audit_out" == *"PAIR solo-unset"* || "$audit_out" == *"UNPAIRED solo-unset"* ]]; then
+    echo "FAIL: unique-id unset block must not be paired or flagged, got: $audit_out" >&2
+    exit 1
+fi
+
+# Live id with BOTH an explicit --mode=paper twin and a no-mode block: pair the
+# explicit twin once, flag the no-mode block UNPAIRED — never double-report.
+# The explicit pair here is in sync, so nothing gates (exit 0).
+audit_out=$(bash "${SCRIPT_DIR}/check-live-paper-config-drift.sh" "$drift/live" "$drift/synced" "$drift/paper4") && audit_rc=0 || audit_rc=$?
+assert_eq "$audit_rc" "0" "drift audit: in-sync explicit pair + UNPAIRED no-mode block exits 0"
+pair_count=$(printf '%s\n' "$audit_out" | grep -c '^PAIR ')
+assert_eq "$pair_count" "1" "drift audit: exactly one pair when explicit paper and no-mode blocks coexist"
+if [[ "$audit_out" != *"UNPAIRED"* ]]; then
+    echo "FAIL: expected UNPAIRED note for the no-mode block, got: $audit_out" >&2
     exit 1
 fi
 

--- a/scripts/test_update_helpers.sh
+++ b/scripts/test_update_helpers.sh
@@ -284,4 +284,127 @@ assert_eq "$audit_rc" "1" "fleet audit: missing config is a FAIL (cannot verify)
 assert_eq "$(cat "$fleet/old/scheduler/config.json")" '{"config_version": 12}' "fleet audit is read-only"
 rm -rf "$fleet"
 
+# --- #1430: live/paper config drift audit ----------------------------------
+drift=$(mktemp -d)
+mkdir -p "$drift/live/scheduler" "$drift/paper/scheduler" "$drift/paper2/scheduler" \
+    "$drift/synced/scheduler" "$drift/broken/scheduler"
+
+# Live twin: 5-minute cadence, leveraged, margin-sized.
+cat > "$drift/live/scheduler/config.json" <<'JSON'
+{"config_version": 17, "strategies": [
+  {"id": "hl-vwap-eth-60", "type": "perps", "platform": "hyperliquid",
+   "script": "shared_scripts/check_strategy.py",
+   "args": ["vwap", "ETH", "1h", "--mode=live"],
+   "interval_seconds": 300, "leverage": 20, "margin_per_trade_usd": 50,
+   "capital": 100, "close_strategy": "trailing_tp_ratchet_regime"},
+  {"id": "solo-live", "type": "perps",
+   "args": ["sma", "BTC", "1h", "--mode=live"], "interval_seconds": 300}
+]}
+JSON
+
+# Paper twin with drifted cadence + sizing (the #1430 worked example shape).
+cat > "$drift/paper/scheduler/config.json" <<'JSON'
+{"config_version": 17, "strategies": [
+  {"id": "hl-vwap-eth-60", "type": "perps", "platform": "hyperliquid",
+   "script": "shared_scripts/check_strategy.py",
+   "args": ["vwap", "ETH", "1h", "--mode=paper"],
+   "interval_seconds": 3600, "leverage": 1,
+   "capital": 10000, "close_strategy": "trailing_tp_ratchet_regime"}
+]}
+JSON
+
+# Paper twin synced on cadence/sizing but differing elsewhere -> SKIP flag.
+cat > "$drift/paper2/scheduler/config.json" <<'JSON'
+{"config_version": 17, "strategies": [
+  {"id": "hl-vwap-eth-60", "type": "perps", "platform": "hyperliquid",
+   "script": "shared_scripts/check_strategy.py",
+   "args": ["vwap", "ETH", "15m", "--mode=paper"],
+   "interval_seconds": 300, "leverage": 20, "margin_per_trade_usd": 50,
+   "capital": 100, "close_strategy": "trailing_tp_ratchet_regime"}
+]}
+JSON
+
+# Paper twin fully in sync (only --mode differs).
+cat > "$drift/synced/scheduler/config.json" <<'JSON'
+{"config_version": 17, "strategies": [
+  {"id": "hl-vwap-eth-60", "type": "perps", "platform": "hyperliquid",
+   "script": "shared_scripts/check_strategy.py",
+   "args": ["vwap", "ETH", "1h", "--mode=paper"],
+   "interval_seconds": 300, "leverage": 20, "margin_per_trade_usd": 50,
+   "capital": 100, "close_strategy": "trailing_tp_ratchet_regime"}
+]}
+JSON
+
+printf 'not json\n' > "$drift/broken/scheduler/config.json"
+
+# Drifted pair: exit 1, per-field drift lines, CANDIDATE verdict.
+audit_out=$(bash "${SCRIPT_DIR}/check-live-paper-config-drift.sh" "$drift/live" "$drift/paper") && audit_rc=0 || audit_rc=$?
+assert_eq "$audit_rc" "1" "drift audit: drifted live/paper pair exits 1"
+if [[ "$audit_out" != *"hl-vwap-eth-60"* ]]; then
+    echo "FAIL: expected pair header for hl-vwap-eth-60, got: $audit_out" >&2
+    exit 1
+fi
+if [[ "$audit_out" != *"interval_seconds"* || "$audit_out" != *"3600"* ]]; then
+    echo "FAIL: expected interval_seconds drift line (300 vs 3600), got: $audit_out" >&2
+    exit 1
+fi
+if [[ "$audit_out" != *"leverage"* || "$audit_out" != *"margin_per_trade_usd"* || "$audit_out" != *"capital"* ]]; then
+    echo "FAIL: expected leverage/margin/capital drift lines, got: $audit_out" >&2
+    exit 1
+fi
+if [[ "$audit_out" != *"CANDIDATE"* ]]; then
+    echo "FAIL: expected CANDIDATE verdict (differences limited to cadence/sizing/--mode), got: $audit_out" >&2
+    exit 1
+fi
+if [[ "$audit_out" == *"solo-live"* && "$audit_out" == *"PAIR solo-live"* ]]; then
+    echo "FAIL: live-only strategy must not form a pair, got: $audit_out" >&2
+    exit 1
+fi
+
+# In-sync pair: exit 0, IN SYNC verdict.
+audit_out=$(bash "${SCRIPT_DIR}/check-live-paper-config-drift.sh" "$drift/live" "$drift/synced") && audit_rc=0 || audit_rc=$?
+assert_eq "$audit_rc" "0" "drift audit: in-sync pair exits 0"
+if [[ "$audit_out" != *"IN SYNC"* ]]; then
+    echo "FAIL: expected IN SYNC verdict, got: $audit_out" >&2
+    exit 1
+fi
+
+# Other-fields-differ pair (sizing synced): SKIP flag, and NOT a hard failure —
+# the runbook gate fails only on syncable cadence/sizing drift.
+audit_out=$(bash "${SCRIPT_DIR}/check-live-paper-config-drift.sh" "$drift/live" "$drift/paper2") && audit_rc=0 || audit_rc=$?
+assert_eq "$audit_rc" "0" "drift audit: other-fields-only drift flags SKIP but does not gate"
+if [[ "$audit_out" != *"SKIP"* || "$audit_out" != *"OTHER"* ]]; then
+    echo "FAIL: expected SKIP verdict with OTHER lines, got: $audit_out" >&2
+    exit 1
+fi
+
+# Watched drift AND other drift together: still exit 1, flagged SKIP (leave alone).
+audit_out=$(bash "${SCRIPT_DIR}/check-live-paper-config-drift.sh" "$drift/live" "$drift/paper" "$drift/paper2") && audit_rc=0 || audit_rc=$?
+assert_eq "$audit_rc" "1" "drift audit: any cadence/sizing drift gates the runbook"
+if [[ "$audit_out" != *"CANDIDATE"* || "$audit_out" != *"SKIP"* ]]; then
+    echo "FAIL: expected both CANDIDATE and SKIP verdicts across pairs, got: $audit_out" >&2
+    exit 1
+fi
+
+# Unreadable config: exit 1 (cannot certify the fleet).
+audit_out=$(bash "${SCRIPT_DIR}/check-live-paper-config-drift.sh" "$drift/live" "$drift/broken") && audit_rc=0 || audit_rc=$?
+assert_eq "$audit_rc" "1" "drift audit: unreadable config exits 1"
+
+# Missing config: exit 1.
+audit_out=$(bash "${SCRIPT_DIR}/check-live-paper-config-drift.sh" "$drift/no-such-dir") && audit_rc=0 || audit_rc=$?
+assert_eq "$audit_rc" "1" "drift audit: missing config exits 1"
+
+# The audit must never mutate a config it reads.
+assert_eq "$(cat "$drift/paper/scheduler/config.json")" "$(cat <<'JSON'
+{"config_version": 17, "strategies": [
+  {"id": "hl-vwap-eth-60", "type": "perps", "platform": "hyperliquid",
+   "script": "shared_scripts/check_strategy.py",
+   "args": ["vwap", "ETH", "1h", "--mode=paper"],
+   "interval_seconds": 3600, "leverage": 1,
+   "capital": 10000, "close_strategy": "trailing_tp_ratchet_regime"}
+]}
+JSON
+)" "drift audit is read-only"
+rm -rf "$drift"
+
 echo "OK: update_helpers tests passed"


### PR DESCRIPTION
## Plain simple English

Some strategies run twice: once with real money and once on paper. The paper copies can drift to a slower schedule and smaller size, so the two results cannot be compared. This adds a read-only check that scans every deployment and reports each live/paper pair whose timing or size has drifted. Changing the configs stays a human-run step.

## Summary

Closes #1430. Repo deliverable only — the config sync itself is the operator runbook the issue specifies, not a code change.

- New `scripts/check-live-paper-config-drift.sh`, modeled on `check-config-versions.sh`:
  - Discovers active go-trader systemd units via the shared helpers (`update_systemd_unit_globs`, `update_execstart_config_path`), reading each unit's `ExecStart --config` path and falling back to `<WorkingDirectory>/scheduler/config.json`; explicit deployment dirs also accepted.
  - Groups strategy blocks by `id` across deployments and classifies each as live/paper from its `--mode` arg, mirroring `isLiveArgs` (`--mode=live` / `--mode live` win; `--mode=paper` explicit; anything else is `unset` and never pairs).
  - For every id on both sides, prints drift in `interval_seconds`, `leverage`, `sizing_leverage`, `margin_per_trade_usd`, `capital`, `capital_pct`, `initial_capital`; any **other** differing field (mode-stripped `args` included) flags the pair `SKIP` — leave it alone.
  - Read-only (no config writes, no daemon interaction). Exit 1 when syncable drift is found or a deployment is unreadable/missing, exit 2 on an empty audit, exit 0 when pairs are in sync or only SKIP-flagged.
- Tests added alongside the #1285 fleet-audit tests in `scripts/test_update_helpers.sh` (drifted pair → exit 1 + CANDIDATE; in-sync → exit 0 + IN SYNC; other-fields-only → SKIP, no gate; drift+other → SKIP, still gates; unreadable/missing config → exit 1; read-only assertion).

## Verification

- `bash scripts/test_update_helpers.sh` → `OK: update_helpers tests passed` (new tests were run red first against the missing script).
- `shellcheck` on the new script: no new findings (only the shared SC1091 source-resolution note the existing scripts also carry).
- Auto-discovery mode on a host without `systemctl` exits 2 with a clear error, as designed.

## Fleet output

The acceptance criterion asks for the audit's fleet output as the candidate list. This session ran on a macOS dev checkout with no go-trader systemd units, so the real fleet run must happen on the production host: `bash scripts/check-live-paper-config-drift.sh` (no args). Sample output against a fixture matching the issue's `hl-vwap-eth-60` worked example:

```
PAIR hl-vwap-eth-60
  DRIFT  interval_seconds       live=300   paper=3600
  DRIFT  leverage               live=20    paper=1
  DRIFT  margin_per_trade_usd   live=50    paper=-
  DRIFT  capital                live=100   paper=10000
  VERDICT: CANDIDATE — differences limited to cadence/sizing/--mode
```

## Judgment calls (not in the issue text)

- A pair whose **only** differences are outside cadence/sizing (e.g. a documented research variant) reports `SKIP` but does **not** fail the exit-code gate; the gate fires on syncable drift or unreadable deployments, so an intentional difference doesn't permanently block the runbook gate. SKIP pairs with cadence/sizing drift still gate (exit 1).
- Strategies with no `--mode` token are reported as `unset` and never paired, rather than assumed paper.

LLM: Kimi | high | Harness: Kimi Code CLI
