### PR TITLE
fix(#1432): classify http 5xx script failures as transient [C33, Grok 4.6, high]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@
 - `version_probe.go`/`probe_cmd.go`/`exit_codes.go` — new runtime CLI flag → both probe argvs; `ExitProbeFailure=78`.
 - `trade_diagnostics*.go` (#1147) — EAGER insert in `recordClosedPosition`; MFE/MAE async outside `mu`; never write `llm_verdict`.
 - `agent_info.go` (#1051) — read-only dump; `--bootstrap-md`→`AGENTS.generated.md` (NEVER `AGENTS.md`).
-- `failure_alerts.go`/`script_failure_alerts.go` — wire notifier on new `run*Check`; primary at 3; **#1128** transient 429 → WARN until 15 strikes or 75m.
+- `failure_alerts.go`/`script_failure_alerts.go` — wire notifier on new `run*Check`; primary at 3; **#1128** transient 429/5xx → WARN until 15 strikes or 75m.
 - `discord_commands.go`/`discord_mutating_commands.go`/… — new mutating cmd → `opsCommandNames`+`slashCommands()`+dispatch; `/clear-cash-reconcile` (#1400); `/closing-strategies` read-only.
 - `shared_wallet.go`/`shared_wallet_reconcile.go`/… (#918/#954/#921/#1408) — PRE-FEE `realized_pnl`; net via `tradeNetPnL*`; drift $0.01/2-cycle. **#1408 pool budgeting:** 2+ live HL/OKX perps omit capital fields + positive `margin_per_trade_usd` each; sizing from account equity − deployed margin; allocated↔pool flat-only/restart. **Mechanics → ARCHITECTURE.md.**
 - `cashflow_journal.go`/… (#1100-#1106) — HL total-drift LIVE; OKX/TopStep shadow; OUTSIDE `mu`.

--- a/scheduler/script_failure_alerts.go
+++ b/scheduler/script_failure_alerts.go
@@ -18,23 +18,28 @@ import (
 const scriptFailureAlertThreshold = 3
 
 // scriptFailureTransientAlertThreshold is the consecutive transient-only failure
-// count before operator alert (#1128). Higher than scriptFailureAlertThreshold
-// so brief 429 storms stay journald-only, while a sustained IP-level throttle
+// count before operator alert (#1128/#1432). Higher than scriptFailureAlertThreshold
+// so brief 429/5xx storms stay journald-only, while a sustained upstream error
 // still surfaces the #829 dead-strategy signal.
 const scriptFailureTransientAlertThreshold = 15
 
 // scriptFailureTransientAlertMaxDuration is the wall-clock cap on sustained
-// throttle before operator alert. Calibrated to scriptFailureTransientAlertThreshold
+// upstream error before operator alert. Calibrated to scriptFailureTransientAlertThreshold
 // at a 5-minute check interval (~75 min) so slow-interval strategies escalate
 // in the same window without waiting for 15 sparse cycles.
 const scriptFailureTransientAlertMaxDuration = 75 * time.Minute
 
-// scriptFailureTransientRE matches operator-visible upstream throttle errors.
-// Deliberately excludes bare "429" substrings (prices, OIDs, counts).
-var scriptFailureTransientRE = regexp.MustCompile(`(?i)(\(429[,\)]|(?:http|status)[\s_]?429|status_code[=:]\s*429|rate.?limit|error from cloudfront)`)
+// scriptFailureTransientRE matches operator-visible upstream throttle and HTTP
+// 5xx errors. Deliberately excludes bare status numbers (prices, OIDs, counts)
+// and bare HTML tags (parser errors). 4xx other than 429 stays on the primary
+// tracker. status: 5xx (colon) is excluded, matching the existing 429 shape.
+var scriptFailureTransientRE = regexp.MustCompile(
+	`(?i)(\(429[,\)]|(?:http|status)[\s_]?429|status_code[=:]\s*429|rate.?limit|error from cloudfront` +
+		`|\(5\d\d[,\)]|(?:http|status)[\s_]?5\d\d|status_code[=:]\s*5\d\d|bad.?gateway` +
+		`)`)
 
 // scriptFailureErrorIsTransient reports whether errMsg is a short-lived
-// upstream throttle that should not count toward the 3-strike alert.
+// upstream throttle or HTTP 5xx that should not count toward the 3-strike alert.
 func scriptFailureErrorIsTransient(errMsg string) bool {
 	return scriptFailureTransientRE.MatchString(errMsg)
 }
@@ -113,7 +118,7 @@ func (t *ScriptFailureTracker) Clear(strategyID string) (bool, int) {
 // scriptFailureTracker is the package-level singleton; resets on restart.
 var scriptFailureTracker = &ScriptFailureTracker{}
 
-// scriptFailureTransientTracker counts consecutive throttle-only failures per
+// scriptFailureTransientTracker counts consecutive throttle/5xx failures per
 // strategy; cleared on recovery alongside scriptFailureTracker.
 var scriptFailureTransientTracker = &ScriptFailureTracker{}
 
@@ -136,9 +141,9 @@ func formatScriptRecoveredAlert(sc StrategyConfig, priorCount int) string {
 }
 
 // formatScriptFailureTransientAlert builds the operator message when a strategy
-// has been failing with upstream throttle errors long enough to escalate.
+// has been failing with upstream throttle or HTTP 5xx errors long enough to escalate.
 func formatScriptFailureTransientAlert(sc StrategyConfig, mode scriptFailureMode, errMsg string, count int) string {
-	return fmt.Sprintf("**SIGNAL SCRIPT FAILING (sustained upstream throttle)** [%s] %s %s (pid=%d, %s, %d consecutive transient failures): %s",
+	return fmt.Sprintf("**SIGNAL SCRIPT FAILING (sustained upstream error)** [%s] %s %s (pid=%d, %s, %d consecutive transient failures): %s",
 		sc.ID, sc.Platform, sc.Script, os.Getpid(), scriptFailureModeLabel(mode), count, errMsg)
 }
 

--- a/scheduler/script_failure_alerts_test.go
+++ b/scheduler/script_failure_alerts_test.go
@@ -170,15 +170,39 @@ func TestScriptFailureErrorIsTransient(t *testing.T) {
 		{"X-Cache: Error from cloudfront", true},
 		{"HTTP 429 Too Many Requests", true},
 		{"status_code=429 from HL", true},
+		{"(502, '<html>...')", true},
+		{"regime bundle hyperliquid/BNB/30m: (502, '<html>...502 Bad Gateway...</html>')", true},
+		{"(502, None)", true},
+		{"HTTP 502 Bad Gateway", true},
+		{"status_code=503 from upstream", true},
+		{"HTTP 500 Internal Server Error", true},
 		{"order oid 429 rejected by exchange", false},
 		{"price crossed 42900.5", false},
 		{"list index out of range", false},
 		{"connection refused", false},
+		{"status: 504", false},
+		{"500 Internal Server Error", false},
+		{"<html> parser expected closing tag", false},
+		{"price 5500.50", false},
+		{"HTTP 404 Not Found", false},
+		{"(400, 'Bad Request')", false},
+		{"NameError: foo", false},
 	}
 	for _, tc := range cases {
 		if got := scriptFailureErrorIsTransient(tc.msg); got != tc.want {
 			t.Fatalf("transient(%q) = %v, want %v", tc.msg, got, tc.want)
 		}
+	}
+}
+
+func TestFormatScriptFailureTransientAlert_NamesUpstreamError(t *testing.T) {
+	sc := StrategyConfig{ID: "regime[hyperliquid/BNB/30m]", Platform: "hyperliquid", Script: "check_regime.py"}
+	msg := formatScriptFailureTransientAlert(sc, scriptFailureError, "regime bundle hyperliquid/BNB/30m: (502, None)", 15)
+	if !strings.Contains(msg, "upstream error") {
+		t.Fatalf("transient alert must name upstream error: %q", msg)
+	}
+	if strings.Contains(strings.ToLower(msg), "throttle") {
+		t.Fatalf("transient alert must not call 5xx a throttle: %q", msg)
 	}
 }
 
@@ -291,5 +315,77 @@ func TestScriptFailureTransientTracker_RecoveryResetsWallClock(t *testing.T) {
 	tr.Clear(id)
 	if notify, count := recordScriptFailureAtThreshold(tr, id, err429, t0.Add(scriptFailureTransientAlertMaxDuration+time.Minute), scriptFailureTransientAlertThreshold, scriptFailureTransientAlertMaxDuration); notify || count != 1 {
 		t.Fatalf("post-recovery streak must restart: notify=%v count=%d, want false/1", notify, count)
+	}
+}
+
+const wrapped502BundleErr = "regime bundle hyperliquid/BNB/30m: (502, '<html>\\r\\n<head><title>502 Bad Gateway</title></head>\\r\\n<body>\\r\\n<center><h1>502 Bad Gateway</h1></center>\\r\\n<hr><center>nginx/1.22.1</center>\\r\\n</body>\\r\\n</html>\\r\\n')"
+
+func TestNotifyScriptFailure_Wrapped502SkipsPrimaryStreak(t *testing.T) {
+	id := "regime[hyperliquid/BNB/30m]"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
+	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "shared_scripts/check_regime.py"}
+	for i := 0; i < scriptFailureAlertThreshold; i++ {
+		notifyScriptFailure(nil, sc, scriptFailureError, wrapped502BundleErr)
+	}
+	recovered, prior := scriptFailureTracker.Clear(id)
+	if recovered || prior != 0 {
+		t.Fatalf("three wrapped 502s must not touch primary tracker: recovered=%v prior=%d, want false/0", recovered, prior)
+	}
+	transientRecovered, transientPrior := scriptFailureTransientTracker.Clear(id)
+	if transientRecovered || transientPrior != scriptFailureAlertThreshold {
+		t.Fatalf("wrapped 502 must increment transient tracker only: recovered=%v prior=%d, want false/%d", transientRecovered, transientPrior, scriptFailureAlertThreshold)
+	}
+}
+
+func TestNotifyScriptFailure_Sustained502AlertsTransient(t *testing.T) {
+	id := "regime[hyperliquid/BNB/30m]-sustained"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
+	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "shared_scripts/check_regime.py"}
+	for i := 0; i < scriptFailureTransientAlertThreshold; i++ {
+		notifyScriptFailure(nil, sc, scriptFailureError, wrapped502BundleErr)
+	}
+	recovered, prior := scriptFailureTransientTracker.Clear(id)
+	if !recovered || prior != scriptFailureTransientAlertThreshold {
+		t.Fatalf("sustained 502: recovered=%v prior=%d, want true/%d", recovered, prior, scriptFailureTransientAlertThreshold)
+	}
+	primaryRecovered, primaryPrior := scriptFailureTracker.Clear(id)
+	if primaryRecovered || primaryPrior != 0 {
+		t.Fatalf("sustained 502 must leave primary at 0: recovered=%v prior=%d", primaryRecovered, primaryPrior)
+	}
+}
+
+func TestNotifyScriptFailure_502ThenRealStartsPrimary(t *testing.T) {
+	id := "regime[hyperliquid/BNB/30m]-handoff"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
+	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "shared_scripts/check_regime.py"}
+	notifyScriptFailure(nil, sc, scriptFailureError, wrapped502BundleErr)
+	notifyScriptFailure(nil, sc, scriptFailureError, "NameError: foo")
+	recovered, prior := scriptFailureTracker.Clear(id)
+	if recovered || prior != 1 {
+		t.Fatalf("real error after 502 must start primary at 1: recovered=%v prior=%d, want false/1", recovered, prior)
+	}
+}
+
+func TestClearScriptFailure_Clears502TransientTracker(t *testing.T) {
+	id := "regime[hyperliquid/BNB/30m]-clear"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
+	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "shared_scripts/check_regime.py"}
+	notifyScriptFailure(nil, sc, scriptFailureError, wrapped502BundleErr)
+	clearScriptFailure(nil, sc)
+	_, transientPrior := scriptFailureTransientTracker.Clear(id)
+	if transientPrior != 0 {
+		t.Fatalf("clearScriptFailure must reset 502 transient streak: prior=%d, want 0", transientPrior)
 	}
 }


### PR DESCRIPTION
## Plain simple English

When the price-data server returns a short 502, the bot no longer treats that as a broken script. A brief outage stays quiet. Only a long outage sends an alert, and that alert says the server failed.

## Summary

- Extend `scriptFailureTransientRE` with SDK `(5xx,` tuples, `http`/`status`/`status_code` 5xx prefixes, and `bad gateway`. Existing 429 / rate-limit / CloudFront tokens stay.
- 4xx other than 429, bare HTML tags, and `status: 504` stay on the 3-strike primary tracker. No new tracker and no regime-only branch.
- Transient operator DM now says **sustained upstream error** instead of throttle, so a 5xx is not named a rate limit.
- CLAUDE.md `#1128` one-liner names 429 and 5xx.

Closes #1432.

## Verification

- New classifier and routing tests failed on the unfixed regex (502 counted as a script bug; DM said throttle), then passed after the change.
- `go -C scheduler test -count=1 .` passed (37.5s).
- `go -C scheduler build` passed; `gofmt -l` clean.

---
Created with LLM: Grok 4.6 | high | Harness: Cursor
