### PR TITLE
fix(#1433): classify script timeout as transient [C37, Grok 4.6, high]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@
 - `version_probe.go`/`probe_cmd.go`/`exit_codes.go` — new runtime CLI flag → both probe argvs; `ExitProbeFailure=78`.
 - `trade_diagnostics*.go` (#1147) — EAGER insert in `recordClosedPosition`; MFE/MAE async outside `mu`; never write `llm_verdict`.
 - `agent_info.go` (#1051) — read-only dump; `--bootstrap-md`→`AGENTS.generated.md` (NEVER `AGENTS.md`).
-- `failure_alerts.go`/`script_failure_alerts.go` — wire notifier on new `run*Check`; primary at 3; **#1128** transient 429/5xx → WARN until 15 strikes or 75m.
+- `failure_alerts.go`/`script_failure_alerts.go` — wire notifier on new `run*Check`; primary at 3; **#1128** transient 429/5xx/timeout → WARN until 15 strikes or 75m.
 - `discord_commands.go`/`discord_mutating_commands.go`/… — new mutating cmd → `opsCommandNames`+`slashCommands()`+dispatch; `/clear-cash-reconcile` (#1400); `/closing-strategies` read-only.
 - `shared_wallet.go`/`shared_wallet_reconcile.go`/… (#918/#954/#921/#1408) — PRE-FEE `realized_pnl`; net via `tradeNetPnL*`; drift $0.01/2-cycle. **#1408 pool budgeting:** 2+ live HL/OKX perps omit capital fields + positive `margin_per_trade_usd` each; sizing from account equity − deployed margin; allocated↔pool flat-only/restart. **Mechanics → ARCHITECTURE.md.**
 - `cashflow_journal.go`/… (#1100-#1106) — HL total-drift LIVE; OKX/TopStep shadow; OUTSIDE `mu`.

--- a/scheduler/script_failure_alerts.go
+++ b/scheduler/script_failure_alerts.go
@@ -18,8 +18,8 @@ import (
 const scriptFailureAlertThreshold = 3
 
 // scriptFailureTransientAlertThreshold is the consecutive transient-only failure
-// count before operator alert (#1128/#1432). Higher than scriptFailureAlertThreshold
-// so brief 429/5xx storms stay journald-only, while a sustained upstream error
+// count before operator alert (#1128/#1432/#1433). Higher than scriptFailureAlertThreshold
+// so brief 429/5xx/timeout storms stay journald-only, while a sustained upstream error
 // still surfaces the #829 dead-strategy signal.
 const scriptFailureTransientAlertThreshold = 15
 
@@ -29,17 +29,21 @@ const scriptFailureTransientAlertThreshold = 15
 // in the same window without waiting for 15 sparse cycles.
 const scriptFailureTransientAlertMaxDuration = 75 * time.Minute
 
-// scriptFailureTransientRE matches operator-visible upstream throttle and HTTP
-// 5xx errors. Deliberately excludes bare status numbers (prices, OIDs, counts)
-// and bare HTML tags (parser errors). 4xx other than 429 stays on the primary
-// tracker. status: 5xx (colon) is excluded, matching the existing 429 shape.
+// scriptFailureTransientRE matches operator-visible upstream throttle, HTTP 5xx,
+// and subprocess timeouts (`script timed out after`). Deliberately excludes bare
+// status numbers (prices, OIDs, counts), bare HTML tags (parser errors), Go
+// net/http timeout strings, and phase-budget cancellation. 4xx other than 429
+// stays on the primary tracker. status: 5xx (colon) is excluded, matching the
+// existing 429 shape.
 var scriptFailureTransientRE = regexp.MustCompile(
 	`(?i)(\(429[,\)]|(?:http|status)[\s_]?429|status_code[=:]\s*429|rate.?limit|error from cloudfront` +
 		`|\(5\d\d[,\)]|(?:http|status)[\s_]?5\d\d|status_code[=:]\s*5\d\d|bad.?gateway` +
+		`|script timed out after` +
 		`)`)
 
 // scriptFailureErrorIsTransient reports whether errMsg is a short-lived
-// upstream throttle or HTTP 5xx that should not count toward the 3-strike alert.
+// upstream throttle, HTTP 5xx, or subprocess timeout that should not count
+// toward the 3-strike alert.
 func scriptFailureErrorIsTransient(errMsg string) bool {
 	return scriptFailureTransientRE.MatchString(errMsg)
 }
@@ -118,8 +122,8 @@ func (t *ScriptFailureTracker) Clear(strategyID string) (bool, int) {
 // scriptFailureTracker is the package-level singleton; resets on restart.
 var scriptFailureTracker = &ScriptFailureTracker{}
 
-// scriptFailureTransientTracker counts consecutive throttle/5xx failures per
-// strategy; cleared on recovery alongside scriptFailureTracker.
+// scriptFailureTransientTracker counts consecutive throttle/5xx/timeout failures
+// per strategy; cleared on recovery alongside scriptFailureTracker.
 var scriptFailureTransientTracker = &ScriptFailureTracker{}
 
 // formatScriptFailureAlert builds the operator message for a failing signal
@@ -141,7 +145,9 @@ func formatScriptRecoveredAlert(sc StrategyConfig, priorCount int) string {
 }
 
 // formatScriptFailureTransientAlert builds the operator message when a strategy
-// has been failing with upstream throttle or HTTP 5xx errors long enough to escalate.
+// has been failing with upstream throttle, HTTP 5xx, or subprocess timeout
+// errors long enough to escalate. Wording stays "upstream error" so a hang is
+// not labeled a script bug.
 func formatScriptFailureTransientAlert(sc StrategyConfig, mode scriptFailureMode, errMsg string, count int) string {
 	return fmt.Sprintf("**SIGNAL SCRIPT FAILING (sustained upstream error)** [%s] %s %s (pid=%d, %s, %d consecutive transient failures): %s",
 		sc.ID, sc.Platform, sc.Script, os.Getpid(), scriptFailureModeLabel(mode), count, errMsg)

--- a/scheduler/script_failure_alerts_test.go
+++ b/scheduler/script_failure_alerts_test.go
@@ -187,6 +187,14 @@ func TestScriptFailureErrorIsTransient(t *testing.T) {
 		{"HTTP 404 Not Found", false},
 		{"(400, 'Bad Request')", false},
 		{"NameError: foo", false},
+		{"script timed out after 30s", true},
+		{"regime bundle hyperliquid/HYPE/30m: script timed out after 30s", true},
+		{"script error: script timed out after 30s (stderr: )", true},
+		{"fatal error: all goroutines are asleep - deadlock!", false},
+		{"NameError: name 'foo' is not defined", false},
+		{"ImportError: No module named 'foo'", false},
+		{"cancelled at phase-budget seal (45s); signature unavailable this cycle", false},
+		{`Post "https://api.hyperliquid.xyz/info": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`, false},
 	}
 	for _, tc := range cases {
 		if got := scriptFailureErrorIsTransient(tc.msg); got != tc.want {
@@ -387,5 +395,101 @@ func TestClearScriptFailure_Clears502TransientTracker(t *testing.T) {
 	_, transientPrior := scriptFailureTransientTracker.Clear(id)
 	if transientPrior != 0 {
 		t.Fatalf("clearScriptFailure must reset 502 transient streak: prior=%d, want 0", transientPrior)
+	}
+}
+
+const wrappedTimeoutErr = "script error: script timed out after 30s (stderr: )"
+const regimeTimeoutErr = "regime bundle hyperliquid/HYPE/30m: script timed out after 30s"
+
+func TestNotifyScriptFailure_WrappedTimeoutSkipsPrimaryStreak(t *testing.T) {
+	id := "regime[hyperliquid/HYPE/30m]"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
+	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "shared_scripts/check_regime.py"}
+	for i := 0; i < scriptFailureAlertThreshold; i++ {
+		notifyScriptFailure(nil, sc, scriptFailureError, wrappedTimeoutErr)
+	}
+	recovered, prior := scriptFailureTracker.Clear(id)
+	if recovered || prior != 0 {
+		t.Fatalf("three wrapped timeouts must not fire primary: recovered=%v prior=%d, want false/0", recovered, prior)
+	}
+	transientRecovered, transientPrior := scriptFailureTransientTracker.Clear(id)
+	if transientRecovered || transientPrior != scriptFailureAlertThreshold {
+		t.Fatalf("wrapped timeout must increment transient tracker only: recovered=%v prior=%d, want false/%d", transientRecovered, transientPrior, scriptFailureAlertThreshold)
+	}
+}
+
+func TestNotifyScriptFailure_SustainedTimeoutAlertsTransient(t *testing.T) {
+	id := "regime[hyperliquid/HYPE/30m]-sustained"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
+	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "shared_scripts/check_regime.py"}
+	for i := 0; i < scriptFailureTransientAlertThreshold; i++ {
+		notifyScriptFailure(nil, sc, scriptFailureError, wrappedTimeoutErr)
+	}
+	recovered, prior := scriptFailureTransientTracker.Clear(id)
+	if !recovered || prior != scriptFailureTransientAlertThreshold {
+		t.Fatalf("sustained timeout: recovered=%v prior=%d, want true/%d", recovered, prior, scriptFailureTransientAlertThreshold)
+	}
+	primaryRecovered, primaryPrior := scriptFailureTracker.Clear(id)
+	if primaryRecovered || primaryPrior != 0 {
+		t.Fatalf("sustained timeout must leave primary at 0: recovered=%v prior=%d", primaryRecovered, primaryPrior)
+	}
+}
+
+func TestNotifyScriptFailure_502ThenTimeoutStaysTransient(t *testing.T) {
+	id := "regime[hyperliquid/HYPE/30m]-mixed"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
+	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "shared_scripts/check_regime.py"}
+	notifyScriptFailure(nil, sc, scriptFailureError, wrapped502BundleErr)
+	notifyScriptFailure(nil, sc, scriptFailureError, wrappedTimeoutErr)
+	recovered, prior := scriptFailureTracker.Clear(id)
+	if recovered || prior != 0 {
+		t.Fatalf("502 then timeout must leave primary at 0: recovered=%v prior=%d", recovered, prior)
+	}
+	_, transientPrior := scriptFailureTransientTracker.Clear(id)
+	if transientPrior != 2 {
+		t.Fatalf("502 then timeout must increment transient only: prior=%d, want 2", transientPrior)
+	}
+}
+
+func TestNotifyScriptFailure_TimeoutThenRealStartsPrimary(t *testing.T) {
+	id := "regime[hyperliquid/HYPE/30m]-handoff"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
+	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "shared_scripts/check_regime.py"}
+	notifyScriptFailure(nil, sc, scriptFailureError, wrappedTimeoutErr)
+	notifyScriptFailure(nil, sc, scriptFailureError, "NameError: foo")
+	recovered, prior := scriptFailureTracker.Clear(id)
+	if recovered || prior != 1 {
+		t.Fatalf("real error after timeout must start primary at 1: recovered=%v prior=%d, want false/1", recovered, prior)
+	}
+}
+
+func TestClearScriptFailure_ClearsTimeoutTransientTracker(t *testing.T) {
+	id := "regime[hyperliquid/HYPE/30m]-clear"
+	defer func() {
+		scriptFailureTracker.Clear(id)
+		scriptFailureTransientTracker.Clear(id)
+	}()
+	sc := StrategyConfig{ID: id, Platform: "hyperliquid", Script: "shared_scripts/check_regime.py"}
+	notifyScriptFailure(nil, sc, scriptFailureError, regimeTimeoutErr)
+	clearScriptFailure(nil, sc)
+	_, transientPrior := scriptFailureTransientTracker.Clear(id)
+	if transientPrior != 0 {
+		t.Fatalf("clearScriptFailure must reset timeout transient streak: prior=%d, want 0", transientPrior)
+	}
+	_, primaryPrior := scriptFailureTracker.Clear(id)
+	if primaryPrior != 0 {
+		t.Fatalf("clearScriptFailure must reset primary streak: prior=%d, want 0", primaryPrior)
 	}
 }


### PR DESCRIPTION
## Plain simple English

When the price-data server hangs for 30 seconds, the bot no longer treats that wait as a broken script. A brief hang stays quiet. Only a long hang sends an alert, and that alert says the server failed.

## Summary

- Append `script timed out after` to the current `scriptFailureTransientRE`. Keep the #1432 429 / 5xx / CloudFront / `bad gateway` tokens. Do not add `<html>` or Go `net/http` timeout strings.
- Three consecutive wrapped timeouts increment the existing 15-strike / 75-minute tracker only (primary stays 0). A later `NameError` still starts the primary tracker at 1. `clearScriptFailure` still clears both.
- CLAUDE.md `#1128` one-liner now names 429 / 5xx / timeout.

Closes #1433.

## Verification

- New classifier and routing tests failed on the unfixed regex (timeout counted as a script bug; three timeouts advanced the primary tracker), then passed after the change.
- `go -C scheduler test -count=1 .` passed (38.2s).
- `go -C scheduler build` passed; `gofmt -l` clean.

---
Created with LLM: Grok 4.6 | high | Harness: Cursor