### PR TITLE
feat(#1443): screen HYPE from Hyperliquid and harden the cert family [C62, Opus 5, high, fableplan]

### DIFF
--- a/backtest/research/README_1076_directional_premise.md
+++ b/backtest/research/README_1076_directional_premise.md
@@ -116,6 +116,91 @@ using `labels[t]` to trade the move *into* bar `t` — produced impossible Sharp
 committed `_book` decides the side at bar `t` and holds it over `t→t+1`, verified by a
 buy-and-hold book reproducing the asset return exactly.)
 
+## Refreshed run — 2026-08-22, HYPE added (#1443)
+
+The #1085 producer was re-run over the full default universe **plus** HYPE sourced
+from Hyperliquid, in **one invocation**, so the Benjamini-Hochberg family is a
+superset of the previous certify screen. Command:
+
+```bash
+uv run --no-sync python backtest/research/regime_1076_certify.py \
+    --symbols "BTC/USDT,ETH/USDT,SOL/USDT,HYPE/USDC:USDC@hyperliquid" \
+    --n-perm 30000 --seed 0
+```
+
+Full per-cell output: `regime_1443_run_report.json`. Artifact:
+`regime_directional_certifications.json`.
+
+### Verdict — still 0 certified, and this time the arithmetic permits one
+
+**0 of 16 screened cells certify. Every cell fails at the first gate, global BH.**
+
+The important difference from earlier runs is the *resolution*.
+`per_state_significance` reports `p = (ge+1)/(n_perm+1)`, so its smallest possible
+p-value is `1/(n_perm+1)`. At `n_perm=30000` that floor is **3.333e-05**, and the
+rank-1 global-BH critical value over the 1319-row directional family is
+`q/m = 0.05/1319 =` **3.791e-05**. The floor sits *below* the bar, so a single
+genuinely-separating state was arithmetically able to certify. It did not.
+
+This run is therefore a real negative at the tested resolution, and not the
+"could never have passed anyway" artifact a lower `n_perm` would have produced —
+at the previous default of 500, the floor (1.996e-03) sat ~53× **above** the
+rank-1 bar, so no single row could have certified at any effect size.
+
+### The two target cells
+
+| Cell | Verdict | best p | BH bar it needed | Best row | Sign |
+|---|---|---|---|---|---|
+| **(ETH, 1h, composite)** | `fails_global_bh` | 0.002167 | 1.137e-04 (rank 3/1319) | `trending_down_clean` @ `2025H1`, h1, gap **+0.00923** | wrong-signed |
+| **(HYPE, 1h, composite)** | `fails_global_bh` | 0.072631 | 5.004e-03 (rank 132/1319) | `trending_up_clean` @ `oos`, h48, gap **−0.06573** | wrong-signed |
+
+ETH's best row misses its bar by ~19×; HYPE's by ~15×. Both are additionally
+**wrong-signed** — their separation points *against* the side the policy would
+bet — so even a relaxed significance bar would not produce a profitable
+certification for either.
+
+The closest cell in the whole screen was `(HYPE, 4h, adx)` at p=7.000e-04 against
+a rank-2 bar of 7.582e-05 — still ~9× short, and also wrong-signed.
+
+### HYPE window coverage — a hard data-availability limit
+
+Hyperliquid's candle endpoint serves a fixed **5000-candle retention window per
+interval, anchored at *now***; `since` is ignored for anything older. Verified at
+fetch time (repeated requests with `since` at 2023-01-01, 2024-01-01, 2025-01-01
+and 2025-06-10 all returned the same 1h start). The consequence:
+
+| HYPE window | 1h | 4h |
+|---|---|---|
+| `2023` | empty | empty |
+| `2024` | empty | 113 composite bars (Dec only) |
+| `2025H1` | empty | 1039 |
+| `is` | **empty** | 1183 |
+| `oos` | 4955 (from 2026-01-26) | 1353 |
+
+So **(HYPE, 1h, composite) rests entirely on `oos`**, and its `oos` starts
+2026-01-26 rather than the window's nominal 2026-01-01. `oos` is a held-out
+forward window, so the cell was still eligible to certify; it simply is not close.
+Per the issue boundary, no other venue's HYPE series was substituted.
+
+`_load` clips every loaded frame to its eval window before labeling. Without that
+clip, HYPE's empty windows would have ingested the fetch fallback's post-listing
+history under the earlier window's label — a silent statistical corruption, and
+the one place this run could have gone quietly wrong.
+
+### Consequence for the deployed strategies
+
+`certified` stays `[]`, so `regime_directional_policy` resolves to base direction
+on `hl-mr-hype-60`, `hl-vwap-eth-60` and `hl-rmc-eth-live`. The #1085 `[WARN]`
+those three print at config load is the **expected, verified** outcome, not a
+defect — the gate is doing exactly what it exists to do.
+
+The configured policy blocks are left in place (the `keep-with-comment` option in
+the issue's Approach 4) rather than removed. Removing them buys tidier config but
+loses the recorded intent, and re-adding a block is blocked by SIGHUP while a
+position is open — so the safe moment to remove one is from flat, at the
+operator's choosing. That deployment config lives out of tree
+(`/var/lib/go-trader/config.json`); this repo cannot and should not edit it.
+
 ## Action taken (#1076 scope 3)
 
 The premise holds **nowhere** in the tested universe, so the directional-gating surface must

--- a/backtest/research/README_1085_certification.md
+++ b/backtest/research/README_1085_certification.md
@@ -13,6 +13,20 @@ gate proves real, multiplicity-honest directional edge.
 Nothing in the tested universe currently qualifies, so the shipped artifact
 certifies nothing and every `regime_directional_policy` runs default-off.
 
+**Latest run: 2026-08-22 (#1443)** — full default universe plus HYPE sourced from
+Hyperliquid, one invocation, `n_perm=30000`, `seed=0`. 0 of 16 screened cells
+certify; every cell fails at the global-BH gate. At this permutation count the
+p-floor (3.333e-05) sits *below* the rank-1 BH critical value (3.791e-05) over the
+1319-row family, so a single genuinely-separating state was arithmetically able to
+pass — it is a real negative, not a resolution artifact. Per-cell verdicts, the
+HYPE window-coverage limit and the two target cells are written up in
+`README_1076_directional_premise.md` § "Refreshed run — 2026-08-22"; the machine
+-readable form is `regime_1443_run_report.json`.
+
+The `[WARN]` the three configured deployment strategies print at config load is
+therefore the **expected, verified** outcome. The configured policy blocks are
+kept with this record rather than removed; see the same section for why.
+
 ## Single source of truth
 
 The statistical test lives in ONE place — the Python research harness. Go never
@@ -46,9 +60,21 @@ direction only when a directional state for that direction:
 ```json
 {
   "schema_version": 1,
-  "generated_at": "2026-06-19T00:00:00Z",
+  "generated_at": "2026-08-22T00:00:00Z",
   "generator": "backtest/research/regime_1076_certify.py",
-  "criteria": { "global_correction": "benjamini-hochberg", "fdr_q": 0.05, ... },
+  "criteria": {
+    "global_correction": "benjamini-hochberg",
+    "fdr_q": 0.05,
+    "require_sign_aligned": true,
+    "require_held_out_forward": true,
+    "held_out_windows": ["is", "oos"],
+    "screened_family_size": 1319,
+    "n_perm": 30000,
+    "permutation_p_floor": 3.3332e-05,
+    "data_sources": { "BTC/USDT": "binanceus", "HYPE/USDC:USDC": "hyperliquid" },
+    "universe": { "symbols": [...], "timeframes": [...], "windows": [...],
+                  "classifiers": [...], "horizons": [...] }
+  },
   "default_ttl_days": 90,
   "certified": [
     {
@@ -62,16 +88,123 @@ direction only when a directional state for that direction:
 
 `certified` is currently `[]`.
 
+## Per-symbol data sources — `--symbols SYMBOL[@exchange]` (#1443)
+
+The screen loads OHLCV from one default exchange (`eval_windows.PLATFORM`,
+`binanceus`). An asset that does not trade there was previously unreachable, so
+the `--symbols` contract now takes an optional per-symbol source:
+
+```
+BTC/USDT                     -> binanceus (the PLATFORM default)
+HYPE/USDC:USDC@hyperliquid   -> hyperliquid
+```
+
+The spec splits on the **last** `@`, so ccxt symbols carrying `/` and `:` parse
+correctly. An empty symbol or empty exchange raises instead of falling back — a
+typo must never quietly screen the wrong series. Both `regime_1076_certify.py`
+and `regime_1076_directional_premise.py` share the one parser
+(`premise.parse_symbols_arg`).
+
+**`PLATFORM` is never repointed.** The #1315 axis separation pins it because
+every committed regime baseline was computed on that series; a mapped symbol's
+rows cache under its own `exchange_id` namespace in the storage layer, so the
+`binanceus` baselines cannot be disturbed. Boundary decision for HYPE (issue
+Approach 5): the Hyperliquid rows stay a **cert-run cache entry** under
+`exchange_id="hyperliquid"` — not a general storage fixture, and not a new
+platform axis.
+
+**Window clipping.** `load_cached_data`'s empty-cache fallback fetches from
+`since=start_date` and returns the whole fetched history *unsliced*. For an asset
+whose listing post-dates a window, that would screen later data under the earlier
+window's label. `_load` now clips the frame to the window before labeling; on the
+cached path the clip is a no-op, so every already-screened cell is unchanged.
+
+## Family integrity — the narrowed-run refusal (#1443)
+
+`certify()` applies global Benjamini-Hochberg over **only the rows of the current
+invocation**, so the BH family *is* the run's universe. Narrowing any axis
+shrinks the family, and a smaller family resolves a smaller effect — the
+pooled-limit trap #1424 records for the Hurst gate. A run whose universe is not a
+superset of the producer defaults (`DEFAULT_SYMBOLS` × `DEFAULT_TIMEFRAMES` ×
+`DEFAULT_WINDOWS` × `DEFAULT_CLASSIFIERS` × `DEFAULT_HORIZONS`) therefore
+**refuses to write the repo artifact**, before touching any data:
+
+```
+REFUSING to write .../regime_directional_certifications.json: narrowed family: ...
+```
+
+`--allow-narrowed-family` overrides the refusal for research-only artifacts
+written elsewhere; the warning prints either way. Adding symbols is always fine —
+a superset only raises the bar.
+
+Note the producer's default universe (BTC/ETH/SOL × 1h/4h) is narrower than the
+full #1076 battery, which also covered BTC 15m/30m/2h and BNB/XRP 4h through
+`regime_1076_aggregate.py`. The guard pins the *producer's* own default axes; it
+does not reconstruct the aggregate battery.
+
+## Run provenance in `criteria` (#1443)
+
+Every artifact records what the gate actually corrected against:
+
+| Key (inside `criteria`) | Meaning |
+|---|---|
+| `screened_family_size` | directional rows the global BH ran over — computed FROM the rows, never claimed |
+| `data_sources` | `{symbol: exchange_id}` resolved for the run |
+| `universe` | the symbols / timeframes / windows / classifiers / horizons axes |
+| `n_perm` | block-shuffle permutation count |
+| `permutation_p_floor` | `1/(n_perm+1)` — the smallest p-value the test can emit |
+
+A narrowed or mis-sourced artifact is now detectable by inspection: a
+`screened_family_size` far below the full-screen scale is a red flag.
+
+**All of this nests inside `criteria` on purpose.** The Go loader parses with
+`DisallowUnknownFields` and `Criteria` is the only free-form map in the schema, so
+a new **top-level** key would make the live daemon fail closed on a perfectly
+valid artifact. `scheduler/regime_directional_certification_test.go` pins both
+halves of that contract. `schema_version` stays `1`.
+
+### Permutation resolution vs the evidence bar
+
+`per_state_significance` computes `p = (ge+1)/(n_perm+1)`, so its smallest
+possible p-value is `1/(n_perm+1)`. The rank-1 global-BH critical value is
+`q/m`. When the floor sits **above** `q/m`, no single row can certify at any
+effect size, and an empty artifact is not evidence of absence. The producer
+prints both numbers on every run and records them in the run report, so the
+verdict's resolution is stated rather than assumed. The evidence bar itself
+(`q=0.05`) is untouched — raising `n_perm` only sharpens resolution.
+
+## Per-cell run report (#1443)
+
+`--report-out` (default `regime_1443_run_report.json`) writes the verdict for
+**every screened cell**, not only the certified ones, with the first criterion it
+fails in gate order:
+
+`no_directional_rows` → `fails_global_bh` → `wrong_signed` →
+`not_held_out_forward` → `certified`
+
+Each entry carries the cell's best p-value, its BH rank and the critical value it
+needed, plus per-`(symbol, timeframe, window)` coverage and the windows that
+contributed nothing. The artifact schema is unchanged and still lists only
+certified cells.
+
 ## Expiry / refresh
 
 Each certified entry carries `expires_at` (`generated_at + default_ttl_days`,
 default 90). Refresh by re-running the producer:
 
 ```bash
+# Full default universe:
 uv run --no-sync python backtest/research/regime_1076_certify.py
-# narrower universe:
+
+# Full default universe PLUS an HL-sourced asset, one invocation (#1443):
 uv run --no-sync python backtest/research/regime_1076_certify.py \
-    --symbols BTC/USDT,ETH/USDT --timeframes 1h,4h --classifiers adx,composite
+    --symbols "BTC/USDT,ETH/USDT,SOL/USDT,HYPE/USDC:USDC@hyperliquid" \
+    --n-perm 30000 --seed 0
+
+# Research-only, narrowed, written elsewhere:
+uv run --no-sync python backtest/research/regime_1076_certify.py \
+    --symbols BTC/USDT --timeframes 1h --allow-narrowed-family \
+    --out /tmp/research_cert.json
 ```
 
 The live daemon reloads the artifact at startup and on SIGHUP (path overridable

--- a/backtest/research/README_1085_certification.md
+++ b/backtest/research/README_1085_certification.md
@@ -137,6 +137,48 @@ REFUSING to write .../regime_directional_certifications.json: narrowed family: .
 written elsewhere; the warning prints either way. Adding symbols is always fine —
 a superset only raises the bar.
 
+**The refusal covers every repo-tracked output, not just `--out`.** `--report-out`
+defaults to the committed `regime_1443_run_report.json`, which is this issue's
+evidence for the negative result, so a narrowed run that redirects `--out` but
+leaves `--report-out` at its default is refused too, naming the report. Redirect
+both (or pass `--report-out ""` to skip the report) for a research run.
+
+**Baseline sources are checked separately.** `family_is_superset` compares *bare*
+symbols on purpose — a default symbol still covers its axis value whatever venue
+it came from — so it cannot see a default symbol repointed at another exchange.
+`baseline_source_violations` checks that on its own: every `DEFAULT_SYMBOLS` entry
+must resolve to `PLATFORM`, because every committed regime baseline was computed
+on that series (#1315). Symbols *added* beyond the defaults stay free to carry any
+`@exchange`. Same refusal, same `--allow-narrowed-family` override.
+
+**One asset, one series.** `certify()` keys a cell by `normalize_cert_asset`, so
+`BTC/USDT` and `BTC/USDC:USDC@hyperliquid` in one run would blend into a single
+certified entry whose provenance `criteria.data_sources` (keyed by full symbol)
+cannot disentangle. Two `--symbols` entries that normalize to the same asset are
+refused at parse time, as is a repeated symbol string.
+
+## Degenerate runs — the resolution refusal (#1443)
+
+An empty `certified` list is a publishable negative result **only when the run
+could have found something**. Two runs cannot:
+
+| Case | Why it certifies nothing regardless of the data |
+|---|---|
+| `screened_family_size == 0` | no directional rows at all — an unreachable OHLCV cache or windows too short. Nothing was measured. |
+| `permutation_p_floor > fdr_q / m` | the smallest p-value the block-shuffle test can emit sits above the rank-1 BH critical value, so no single row can reject at any effect size. |
+
+Either one **refuses to write a repo-tracked output**, so neither can republish
+"nothing certified" as evidence or erase a future non-empty `certified` list.
+`--allow-degenerate-run` overrides. It is deliberately a **separate** flag from
+`--allow-narrowed-family`: unlocking a narrowed research family must not also
+unlock overwriting the live artifact from a run that measured nothing.
+
+`--n-perm` therefore defaults to **30000**, the resolution the committed artifact
+was produced at. At the full default universe (`m` in the low thousands) the
+rank-1 bar `q/m` is around `4e-05`, while the old `n_perm=500` default floored
+every p-value at `1/501` — about 53x above it, making the documented refresh
+command incapable of certifying anything.
+
 Note the producer's default universe (BTC/ETH/SOL × 1h/4h) is narrower than the
 full #1076 battery, which also covered BTC 15m/30m/2h and BNB/XRP 4h through
 `regime_1076_aggregate.py`. The guard pins the *producer's* own default axes; it
@@ -187,6 +229,25 @@ needed, plus per-`(symbol, timeframe, window)` coverage and the windows that
 contributed nothing. The artifact schema is unchanged and still lists only
 certified cells.
 
+**The reported bar matches the procedure that decided the verdict.** BH is a
+*step-up* procedure: it finds the largest rank `k` with `p_(k) <= q*k/m` and
+rejects every p-value at or below `p_(k)`, so a row can be rejected on a
+higher-ranked survivor's back while missing its own per-rank bar `q*rank/m`.
+Reporting the per-rank bar alone could therefore print `certified` beside a
+p-value that "failed". Each entry now carries all three:
+
+| Field | Meaning |
+|---|---|
+| `bh_rank_threshold` | the row's own per-rank critical value `q*rank/m` |
+| `bh_step_up_cutoff` | the bar the family actually cleared (`q*k_max/m`), `null` when nothing was rejected |
+| `bh_threshold` | the bar the verdict was decided against — the step-up cutoff when there is one, else the per-rank value |
+
+`q*k_max/m` is exactly equivalent to the procedure for every row: no p-value can
+lie in `(p_(k_max), q*k_max/m]`, since one there would satisfy the rank-`k_max+1`
+bar and contradict `k_max`'s maximality. The committed run report is unaffected —
+that family rejected nothing, so `bh_step_up_cutoff` is `null` throughout and
+`bh_threshold` keeps its per-rank values.
+
 ## Expiry / refresh
 
 Each certified entry carries `expires_at` (`generated_at + default_ttl_days`,
@@ -201,10 +262,11 @@ uv run --no-sync python backtest/research/regime_1076_certify.py \
     --symbols "BTC/USDT,ETH/USDT,SOL/USDT,HYPE/USDC:USDC@hyperliquid" \
     --n-perm 30000 --seed 0
 
-# Research-only, narrowed, written elsewhere:
+# Research-only, narrowed, written elsewhere. BOTH outputs must be redirected —
+# --report-out defaults to the committed run report, which is repo-tracked:
 uv run --no-sync python backtest/research/regime_1076_certify.py \
     --symbols BTC/USDT --timeframes 1h --allow-narrowed-family \
-    --out /tmp/research_cert.json
+    --out /tmp/research_cert.json --report-out /tmp/research_report.json
 ```
 
 The live daemon reloads the artifact at startup and on SIGHUP (path overridable

--- a/backtest/research/regime_1076_certify.py
+++ b/backtest/research/regime_1076_certify.py
@@ -28,7 +28,27 @@ Run (needs the OHLCV cache reachable from shared_tools/):
 
     uv run --no-sync python backtest/research/regime_1076_certify.py
     uv run --no-sync python backtest/research/regime_1076_certify.py \
-        --symbols BTC/USDT,ETH/USDT --timeframes 1h,4h --classifiers adx,composite
+        --symbols "BTC/USDT,ETH/USDT,SOL/USDT,HYPE/USDC:USDC@hyperliquid"
+
+#1443 — two hard rules this producer now ENFORCES rather than merely documents:
+
+1. FAMILY INTEGRITY. certify() applies global BH over only the rows of the CURRENT
+   invocation, so a narrowed run (fewer symbols/timeframes/windows/classifiers/horizons)
+   shrinks the correction family and inflates every cell's pass probability — the pooled-
+   limit trap #1424 documents for the Hurst gate. Writing the repo artifact from a run
+   whose universe is not a SUPERSET of the default universe is refused outright
+   (``--allow-narrowed-family`` overrides, and warns loudly either way).
+2. PROVENANCE. The artifact ``criteria`` records the actual screened family size, the
+   per-symbol data sources, the universe axes and the permutation count, so a narrowed or
+   mis-sourced artifact is detectable by inspection after the fact. All new metadata nests
+   INSIDE ``criteria`` on purpose: the Go loader parses with DisallowUnknownFields
+   (scheduler/regime_directional_certification.go), where ``Criteria`` is a free-form map
+   and any NEW top-level key would make the live daemon fail closed on a valid artifact.
+   ``schema_version`` stays 1.
+
+The per-cell verdict surface (cell_verdicts) reports, for every screened cell, the FIRST
+criterion it fails — so "why is (ETH, 1h, composite) not certified?" is answered by the run
+itself instead of being inferred from an empty ``certified`` list.
 """
 from __future__ import annotations
 
@@ -50,6 +70,7 @@ from directional_certification import normalize_cert_asset  # noqa: E402
 import regime_1076_directional_premise as premise  # noqa: E402
 
 DEFAULT_ARTIFACT = os.path.join(_THIS_DIR, "regime_directional_certifications.json")
+DEFAULT_RUN_REPORT = os.path.join(_THIS_DIR, "regime_1443_run_report.json")
 DEFAULT_TTL_DAYS = 90
 HELD_OUT_FORWARD = premise.HELD_OUT_FORWARD
 
@@ -68,8 +89,168 @@ def _policy_direction_label(policy_dir: int) -> str:
     return "long" if policy_dir > 0 else "short"
 
 
+def _bare_symbols(symbols) -> set:
+    """Bare symbol names from either ``"SYM"`` strings, ``"SYM@exchange"`` specs
+    or ``(symbol, exchange)`` pairs."""
+    out = set()
+    for entry in symbols:
+        if isinstance(entry, str):
+            out.add(premise.parse_symbol_spec(entry)[0])
+        else:
+            out.add(str(entry[0]))
+    return out
+
+
+def family_is_superset(symbols, timeframes, windows, classifiers,
+                       horizons=None) -> bool:
+    """True when this run's universe covers the whole default screen.
+
+    certify() corrects across the rows of ONE invocation, so the BH family IS the
+    run's universe. A run that drops any default axis value produces a smaller
+    family, and a smaller family resolves a smaller effect — exactly the
+    pooled-limit trap #1424 records. Certifying a cell from such a run would let
+    a weaker result clear a bar the full screen never lowered. ``horizons`` is
+    checked when supplied: dropping horizons shrinks the family just as dropping
+    symbols does. Pure; unit-tested without data access."""
+    ok = (_bare_symbols(symbols) >= set(premise.DEFAULT_SYMBOLS)
+          and set(timeframes) >= set(premise.DEFAULT_TIMEFRAMES)
+          and set(windows) >= set(premise.DEFAULT_WINDOWS)
+          and set(classifiers) >= set(premise.DEFAULT_CLASSIFIERS))
+    if horizons is not None:
+        ok = ok and set(int(h) for h in horizons) >= set(premise.DEFAULT_HORIZONS)
+    return ok
+
+
+def _bh_ranks(pvals, fdr_q):
+    """``[(rank, critical_value)]`` aligned with ``pvals``: each p-value's 1-based
+    ascending rank in the family and the BH critical value ``fdr_q * rank / m``
+    it had to clear. Ties take the same (lowest) rank so two identical p-values
+    are never reported as passing different bars."""
+    m = len(pvals)
+    if m == 0:
+        return []
+    order = sorted(range(m), key=lambda i: pvals[i])
+    ranks = [0] * m
+    rank = 0
+    prev = None
+    for pos, i in enumerate(order, start=1):
+        if prev is None or pvals[i] > prev:
+            rank = pos
+            prev = pvals[i]
+        ranks[i] = rank
+    return [(ranks[i], fdr_q * ranks[i] / m) for i in range(m)]
+
+
+# Gate order, mirroring certify(): a cell is reported against the FIRST criterion
+# it fails, so the verdict names the binding constraint rather than a downstream one.
+VERDICT_NO_DIRECTIONAL_ROWS = "no_directional_rows"
+VERDICT_FAILS_GLOBAL_BH = "fails_global_bh"
+VERDICT_WRONG_SIGNED = "wrong_signed"
+VERDICT_NOT_HELD_OUT = "not_held_out_forward"
+VERDICT_CERTIFIED = "certified"
+
+
+def cell_verdicts(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD) -> dict:
+    """Per-(asset, timeframe, classifier) verdict over premise-screen rows.
+
+    Reports every SCREENED cell — not only the certified ones — with the first
+    certification criterion it fails, its best (minimum) p-value, and the global
+    BH critical value that p-value had to clear. The artifact still lists only
+    certified cells; this is the run-report surface #1443 requires so a negative
+    verdict states WHY. Pure; unit-tested without data access.
+
+    A cell absent from ``rows`` entirely (no window contributed enough bars) does
+    not appear here — the caller reports those separately against the requested
+    grid."""
+    def _key(r):
+        return (normalize_cert_asset(r["symbol"]), str(r["timeframe"]),
+                str(r["classifier"]).strip().lower())
+
+    n_screened = {}
+    for r in rows:
+        k = _key(r)
+        n_screened[k] = n_screened.get(k, 0) + 1
+
+    # Index-keyed throughout: two rows can compare equal, and a caller may pass the
+    # same dict object twice, so positions in the family — never identity — decide
+    # which p-value maps to which BH rank.
+    directional = [r for r in rows if r.get("policy_dir", 0) != 0]
+    pvals = [float(r["p_value"]) for r in directional]
+    global_bh = benjamini_hochberg(pvals, alpha=fdr_q) if pvals else []
+    ranked = _bh_ranks(pvals, fdr_q)
+    family_size = len(directional)
+    cell_idx: dict = {}
+    for i, r in enumerate(directional):
+        cell_idx.setdefault(_key(r), []).append(i)
+
+    out = {}
+    for key in sorted(n_screened):
+        idxs = cell_idx.get(key, [])
+        entry = {
+            "asset": key[0], "timeframe": key[1], "classifier": key[2],
+            "n_screened_rows": n_screened[key],
+            "n_directional_rows": len(idxs),
+            "global_bh_family_size": family_size,
+            "fdr_q": fdr_q,
+        }
+        if not idxs:
+            entry["verdict"] = VERDICT_NO_DIRECTIONAL_ROWS
+            entry["min_p_value"] = None
+            entry["best_row"] = None
+            entry["bh_rank"] = None
+            entry["bh_threshold"] = None
+            out[key] = entry
+            continue
+
+        best_i = min(idxs, key=lambda i: pvals[i])
+        best = directional[best_i]
+        rank, thresh = ranked[best_i]
+        entry["min_p_value"] = float(best["p_value"])
+        entry["bh_rank"] = int(rank)
+        entry["bh_threshold"] = float(thresh)
+        entry["best_row"] = {
+            "window": str(best["window"]), "horizon": int(best["horizon"]),
+            "state": str(best["state"]), "gap": float(best["gap"]),
+            "p_value": float(best["p_value"]),
+            "policy_dir": int(best["policy_dir"]),
+            "sign_aligned": bool(best.get("sign_aligned")),
+            "source": str(best.get("source", "")),
+        }
+
+        passing = [directional[i] for i in idxs if global_bh[i]]
+        aligned = [r for r in passing if r.get("sign_aligned")]
+        held = [r for r in aligned if r.get("window") in held_out_windows]
+        entry["n_survive_global_bh"] = len(passing)
+        entry["n_survive_and_aligned"] = len(aligned)
+        entry["n_survive_aligned_held_out"] = len(held)
+        if not passing:
+            entry["verdict"] = VERDICT_FAILS_GLOBAL_BH
+        elif not aligned:
+            entry["verdict"] = VERDICT_WRONG_SIGNED
+        elif not held:
+            entry["verdict"] = VERDICT_NOT_HELD_OUT
+        else:
+            entry["verdict"] = VERDICT_CERTIFIED
+            entry["certified_states"] = dict(sorted(
+                (_canonical_trend_label(str(r["state"])),
+                 _policy_direction_label(int(r["policy_dir"]))) for r in held))
+        out[key] = entry
+    return out
+
+
+def permutation_p_floor(n_perm: int) -> float:
+    """``1/(n_perm+1)`` — the smallest p-value the block-shuffle test can emit
+    (regime_diagnostics.per_state_significance). Disclosed next to the rank-1 BH
+    critical value ``fdr_q/m`` because when the floor sits ABOVE that value no
+    single row can certify at any effect size, however real. The run report must
+    say so rather than let an empty artifact read as evidence of absence."""
+    n = max(1, int(n_perm))
+    return 1.0 / (n + 1)
+
+
 def certify(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD,
-            ttl_days=DEFAULT_TTL_DAYS, generated_at=None):
+            ttl_days=DEFAULT_TTL_DAYS, generated_at=None,
+            universe=None, data_sources=None, n_perm=None):
     """Pure certification gate over premise-screen rows. Returns the artifact
     dict. Testable without touching data — pass synthetic rows.
 
@@ -77,6 +258,11 @@ def certify(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD,
     the whole directional family, is sign-aligned, and lands in a held-out
     forward window. Certified cells map each surviving canonical trend label to
     its policy direction.
+
+    ``universe``/``data_sources``/``n_perm`` are optional provenance recorded in
+    ``criteria`` (#1443). ``criteria.screened_family_size`` is always emitted and
+    is computed FROM THE ROWS, so it reports the family the gate actually
+    corrected against — never a claimed one.
     """
     if generated_at is None:
         generated_at = datetime.now(timezone.utc)
@@ -105,6 +291,26 @@ def certify(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD,
         direction = _policy_direction_label(int(r["policy_dir"]))
         cells.setdefault(key, {})[label] = direction
 
+    # #1443 provenance. Everything nests under `criteria` because the Go loader
+    # parses with DisallowUnknownFields and treats `criteria` as a free-form map;
+    # a new TOP-LEVEL key would make the live daemon reject a valid artifact.
+    criteria = {
+        "global_correction": "benjamini-hochberg",
+        "fdr_q": fdr_q,
+        "also_require_bonferroni": False,
+        "require_sign_aligned": True,
+        "require_held_out_forward": True,
+        "held_out_windows": list(held_out_windows),
+        "screened_family_size": len(directional),
+    }
+    if n_perm is not None:
+        criteria["n_perm"] = int(n_perm)
+        criteria["permutation_p_floor"] = permutation_p_floor(n_perm)
+    if data_sources is not None:
+        criteria["data_sources"] = dict(sorted(data_sources.items()))
+    if universe is not None:
+        criteria["universe"] = {k: list(v) for k, v in sorted(universe.items())}
+
     certified = []
     for (asset, timeframe, classifier), states in sorted(cells.items()):
         certified.append({
@@ -121,14 +327,7 @@ def certify(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD,
         "generated_at": gen_iso,
         "generator": "backtest/research/regime_1076_certify.py",
         "source_evidence": "backtest/research/README_1076_directional_premise.md",
-        "criteria": {
-            "global_correction": "benjamini-hochberg",
-            "fdr_q": fdr_q,
-            "also_require_bonferroni": False,
-            "require_sign_aligned": True,
-            "require_held_out_forward": True,
-            "held_out_windows": list(held_out_windows),
-        },
+        "criteria": criteria,
         "default_ttl_days": ttl_days,
         "certified": certified,
     }
@@ -136,7 +335,9 @@ def certify(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD,
 
 def build_parser():
     p = argparse.ArgumentParser(description="#1085 directional-certification producer")
-    p.add_argument("--symbols", default=",".join(premise.DEFAULT_SYMBOLS))
+    p.add_argument("--symbols", default=",".join(premise.DEFAULT_SYMBOLS),
+                   help="comma-separated SYMBOL[@exchange] specs; a bare symbol uses the "
+                        "default data source (#1443). Same contract as the premise script.")
     p.add_argument("--timeframes", default=",".join(premise.DEFAULT_TIMEFRAMES))
     p.add_argument("--windows", default=",".join(premise.DEFAULT_WINDOWS))
     p.add_argument("--horizons", default=",".join(str(h) for h in premise.DEFAULT_HORIZONS))
@@ -147,7 +348,29 @@ def build_parser():
     p.add_argument("--ttl-days", type=int, default=DEFAULT_TTL_DAYS)
     p.add_argument("--out", default=DEFAULT_ARTIFACT,
                    help="artifact path to write (default: the repo artifact)")
+    p.add_argument("--report-out", default=DEFAULT_RUN_REPORT,
+                   help="path for the per-cell run report JSON (empty string to skip)")
+    p.add_argument("--allow-narrowed-family", action="store_true",
+                   help="permit a run whose universe is NOT a superset of the default "
+                        "screen. Narrowing shrinks the BH correction family and inflates "
+                        "every cell's pass probability (#1424); without this flag such a "
+                        "run refuses to write the repo artifact.")
     return p
+
+
+def _format_verdict_line(v) -> str:
+    best = v.get("best_row")
+    head = (f"{v['asset']:6s} {v['timeframe']:4s} {v['classifier']:10s} "
+            f"{v['verdict']:22s}")
+    if not best:
+        return head + f"rows={v['n_screened_rows']} directional=0"
+    return (head
+            + f"min_p={v['min_p_value']:.6g} "
+            + f"needed<={v['bh_threshold']:.3e} (BH rank {v['bh_rank']}/"
+            + f"{v['global_bh_family_size']}) "
+            + f"best={best['state']}@{best['window']}/h{best['horizon']} "
+            + f"gap={best['gap']:+.5f} aligned={'Y' if best['sign_aligned'] else 'N'} "
+            + f"src={best['source']}")
 
 
 def main(argv=None) -> int:
@@ -156,7 +379,10 @@ def main(argv=None) -> int:
 
     args = build_parser().parse_args(argv)
     th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
-    symbols = tuple(s.strip() for s in args.symbols.split(",") if s.strip())
+    try:
+        symbols = premise.parse_symbols_arg(args.symbols)
+    except ValueError as exc:
+        raise SystemExit(f"--symbols: {exc}")
     timeframes = tuple(t.strip() for t in args.timeframes.split(",") if t.strip())
     windows = tuple(w.strip() for w in args.windows.split(",") if w.strip())
     for w in windows:
@@ -165,19 +391,118 @@ def main(argv=None) -> int:
     horizons = tuple(int(h) for h in args.horizons.split(","))
     classifiers = tuple(c.strip() for c in args.classifiers.split(",") if c.strip())
 
-    print(f"# certify universe: {list(symbols)} x {list(timeframes)} x {list(windows)}")
-    print(f"# classifiers={list(classifiers)} n_perm={args.n_perm} platform={PLATFORM}")
+    # FAMILY-INTEGRITY GATE — before any data is touched, so a narrowed run costs
+    # nothing and can never leave a half-written artifact behind.
+    if not family_is_superset(symbols, timeframes, windows, classifiers, horizons):
+        msg = (
+            "narrowed family: this run's universe is NOT a superset of the default "
+            "screen (symbols {s} / timeframes {t} / windows {w} / classifiers {c} / "
+            "horizons {h}). certify() corrects across the rows of ONE invocation, so a "
+            "narrowed run shrinks the Benjamini-Hochberg family and inflates every "
+            "cell's pass probability — the pooled-limit trap #1424 records. Re-run over "
+            "the full default universe (adding symbols is fine), or pass "
+            "--allow-narrowed-family for a research-only artifact."
+        ).format(s=list(premise.DEFAULT_SYMBOLS), t=list(premise.DEFAULT_TIMEFRAMES),
+                 w=list(premise.DEFAULT_WINDOWS), c=list(premise.DEFAULT_CLASSIFIERS),
+                 h=list(premise.DEFAULT_HORIZONS))
+        writes_repo_artifact = (os.path.abspath(args.out)
+                                == os.path.abspath(DEFAULT_ARTIFACT))
+        if writes_repo_artifact and not args.allow_narrowed_family:
+            raise SystemExit(f"REFUSING to write {args.out}: {msg}")
+        print(f"[WARN] {msg}")
+
+    sources = premise.resolve_data_sources(symbols)
+    universe = {"symbols": sorted(sources), "timeframes": list(timeframes),
+                "windows": list(windows), "horizons": [int(h) for h in horizons],
+                "classifiers": list(classifiers)}
+    print(f"# certify universe: {sorted(sources)} x {list(timeframes)} x {list(windows)}")
+    print("# data sources: "
+          + " ".join(f"{sym}={src}" for sym, src in sorted(sources.items())))
+    print(f"# classifiers={list(classifiers)} horizons={list(horizons)} "
+          f"n_perm={args.n_perm} seed={args.seed} default_platform={PLATFORM}")
+
     rows = premise.run(symbols, timeframes, windows, horizons, classifiers, th,
                        args.n_perm, args.seed)
-    artifact = certify(rows, fdr_q=args.fdr_q, ttl_days=args.ttl_days)
+    artifact = certify(rows, fdr_q=args.fdr_q, ttl_days=args.ttl_days,
+                       universe=universe, data_sources=sources, n_perm=args.n_perm)
     with open(args.out, "w") as fh:
         json.dump(artifact, fh, indent=2)
         fh.write("\n")
+
+    family_size = artifact["criteria"]["screened_family_size"]
+    p_floor = permutation_p_floor(args.n_perm)
+    rank1 = args.fdr_q / family_size if family_size else float("nan")
+    coverage = premise.coverage_table(rows)
+    verdicts = cell_verdicts(rows, fdr_q=args.fdr_q)
+
+    print()
+    print("SCREENED COVERAGE — (symbol, tf, window) cells that contributed rows:")
+    for e in coverage:
+        bars = " ".join(f"{c}={n}" for c, n in sorted(e["bars"].items()))
+        print(f"  {e['symbol']:18s} {e['source']:12s} {e['timeframe']:4s} "
+              f"{e['window']:8s} rows={e['rows']:5d}  bars {bars}")
+    present = {(e["symbol"], e["timeframe"], e["window"]) for e in coverage}
+    empty = [(sym, tf, w)
+             for sym, _ex in premise.normalize_symbol_specs(symbols)
+             for tf in timeframes for w in windows
+             if (sym, tf, w) not in present]
+    if empty:
+        print("  windows contributing NO rows (asset not listed yet, or too few bars):")
+        for sym, tf, w in empty:
+            print(f"    {sym:18s} {tf:4s} {w}")
+
+    print()
+    print(f"PERMUTATION RESOLUTION: p-floor 1/(n_perm+1) = {p_floor:.3e} "
+          f"(n_perm={args.n_perm}); rank-1 global-BH critical value q/m = "
+          f"{rank1:.3e} (q={args.fdr_q}, m={family_size}).")
+    if not family_size:
+        print("  ** The screen produced NO directional rows at all — there was nothing "
+              "to correct. This is a coverage failure, not a negative result. **")
+    elif p_floor > rank1:
+        print("  ** The floor sits ABOVE the rank-1 bar: no SINGLE row can certify at "
+              "this n_perm regardless of effect size. An empty artifact from this run "
+              "is NOT evidence of absence. **")
+    else:
+        print("  The floor sits at or below the rank-1 bar: a single true row is "
+              "arithmetically able to certify.")
+
+    print()
+    print("PER-CELL VERDICTS (first failing criterion; the artifact lists only "
+          "certified cells):")
+    for key in sorted(verdicts):
+        print("  " + _format_verdict_line(verdicts[key]))
+
     n = len(artifact["certified"])
+    print()
     print(f"# wrote {n} certified cell(s) -> {args.out}")
     if n == 0:
         print("# nothing survived global correction (#1076 negative result) — "
               "all regime_directional_policy strategies run default-off.")
+
+    if args.report_out:
+        report = {
+            "issue": 1443,
+            "generator": "backtest/research/regime_1076_certify.py",
+            "generated_at": artifact["generated_at"],
+            "universe": universe,
+            "data_sources": dict(sorted(sources.items())),
+            "seed": args.seed,
+            "n_perm": args.n_perm,
+            "fdr_q": args.fdr_q,
+            "screened_family_size": family_size,
+            "permutation_p_floor": p_floor,
+            "global_bh_rank1_threshold": rank1,
+            "single_row_certifiable": bool(family_size and p_floor <= rank1),
+            "coverage": coverage,
+            "empty_windows": [{"symbol": s_, "timeframe": t_, "window": w_}
+                              for s_, t_, w_ in empty],
+            "cell_verdicts": [verdicts[k] for k in sorted(verdicts)],
+            "certified": artifact["certified"],
+        }
+        with open(args.report_out, "w") as fh:
+            json.dump(report, fh, indent=2)
+            fh.write("\n")
+        print(f"# wrote run report ({len(verdicts)} screened cells) -> {args.report_out}")
     return 0
 
 

--- a/backtest/research/regime_1076_certify.py
+++ b/backtest/research/regime_1076_certify.py
@@ -30,14 +30,33 @@ Run (needs the OHLCV cache reachable from shared_tools/):
     uv run --no-sync python backtest/research/regime_1076_certify.py \
         --symbols "BTC/USDT,ETH/USDT,SOL/USDT,HYPE/USDC:USDC@hyperliquid"
 
-#1443 — two hard rules this producer now ENFORCES rather than merely documents:
+#1443 — hard rules this producer now ENFORCES rather than merely documents. Every one
+of them guards the same thing: a REPO-TRACKED output (the artifact the live daemon reads,
+and the committed run report that is this issue's evidence) may only be written by a run
+that was actually capable of certifying, over the baseline universe, on the baseline data.
 
 1. FAMILY INTEGRITY. certify() applies global BH over only the rows of the CURRENT
    invocation, so a narrowed run (fewer symbols/timeframes/windows/classifiers/horizons)
    shrinks the correction family and inflates every cell's pass probability — the pooled-
-   limit trap #1424 documents for the Hurst gate. Writing the repo artifact from a run
+   limit trap #1424 documents for the Hurst gate. Writing a repo-tracked output from a run
    whose universe is not a SUPERSET of the default universe is refused outright
    (``--allow-narrowed-family`` overrides, and warns loudly either way).
+1b. BASELINE SOURCES (review). family_is_superset compares BARE symbols, so it cannot see
+   a DEFAULT symbol repointed at another venue. baseline_source_violations checks that
+   separately: a default symbol must resolve to eval_windows.PLATFORM, because every
+   committed regime baseline was computed on that series (#1315). ADDED symbols stay free
+   to carry any ``@exchange``. Same refusal, same override flag.
+1c. ONE ASSET, ONE SERIES (review). certify() keys a cell by normalize_cert_asset, so two
+   screened symbols reducing to the same asset would blend into ONE certified entry whose
+   provenance ``criteria.data_sources`` (keyed by full symbol) cannot disentangle.
+   Refused at parse time; premise.parse_symbols_arg separately refuses a repeated symbol.
+1d. DEGENERATE RUNS (review). An empty ``certified`` list is a publishable negative result
+   only when the run COULD have found something. A run with no directional rows measured
+   nothing, and a run whose permutation p-floor sits above the rank-1 BH critical value
+   cannot reject at any effect size; either one is refused for repo-tracked outputs
+   (``--allow-degenerate-run`` — deliberately a SEPARATE flag, so unlocking a narrowed
+   research family never also unlocks erasing the live artifact). ``--n-perm`` therefore
+   defaults to 30000, the resolution the committed artifact was produced at.
 2. PROVENANCE. The artifact ``criteria`` records the actual screened family size, the
    per-symbol data sources, the universe axes and the permutation count, so a narrowed or
    mis-sourced artifact is detectable by inspection after the fact. All new metadata nests
@@ -48,7 +67,10 @@ Run (needs the OHLCV cache reachable from shared_tools/):
 
 The per-cell verdict surface (cell_verdicts) reports, for every screened cell, the FIRST
 criterion it fails — so "why is (ETH, 1h, composite) not certified?" is answered by the run
-itself instead of being inferred from an empty ``certified`` list.
+itself instead of being inferred from an empty ``certified`` list. Its ``bh_threshold`` is
+the bar the VERDICT was decided against: BH is a step-up procedure, so once the family
+rejects anything the operative bar is the step-up cutoff, not each row's per-rank critical
+value (both are reported, as ``bh_step_up_cutoff`` and ``bh_rank_threshold``).
 """
 from __future__ import annotations
 
@@ -121,6 +143,39 @@ def family_is_superset(symbols, timeframes, windows, classifiers,
     return ok
 
 
+def baseline_source_violations(sources, platform) -> dict:
+    """``{symbol: exchange}`` for DEFAULT_SYMBOLS entries NOT loaded from the
+    baseline venue.
+
+    #1443 review: family_is_superset compares BARE symbols on purpose (a default
+    symbol still covers its axis value whatever venue it came from), so the width
+    check alone cannot see a repointed baseline. It has to be checked separately,
+    because the repo artifact is what the live daemon reads to enable
+    regime_directional_policy short entries, and every committed regime baseline
+    was computed on the ``eval_windows.PLATFORM`` series (#1315 axis separation).
+    Symbols ADDED beyond the defaults are free to carry any source — that is the
+    whole point of ``SYMBOL[@exchange]``. Pure; unit-tested without data access."""
+    return {sym: src for sym, src in sorted(sources.items())
+            if sym in set(premise.DEFAULT_SYMBOLS) and src != platform}
+
+
+def cert_asset_collisions(symbols) -> dict:
+    """``{cert_asset: [symbol, ...]}`` for normalized assets backed by more than
+    one screened symbol.
+
+    #1443 review: certify() keys a cell by ``normalize_cert_asset(symbol)``, so
+    ``BTC/USDT`` and ``BTC/USDC:USDC@hyperliquid`` collapse into ONE certified
+    entry whose rows come from two venues, while ``criteria.data_sources`` (keyed
+    by full symbol) cannot say which venue backed which state. Screening the same
+    asset from two venues in one run is therefore refused at parse time rather
+    than silently blended. Pure; unit-tested without data access."""
+    by_asset: dict = {}
+    for symbol, _exchange in premise.normalize_symbol_specs(symbols):
+        by_asset.setdefault(normalize_cert_asset(symbol), []).append(symbol)
+    return {asset: sorted(syms) for asset, syms in sorted(by_asset.items())
+            if len(syms) > 1}
+
+
 def _bh_ranks(pvals, fdr_q):
     """``[(rank, critical_value)]`` aligned with ``pvals``: each p-value's 1-based
     ascending rank in the family and the BH critical value ``fdr_q * rank / m``
@@ -139,6 +194,34 @@ def _bh_ranks(pvals, fdr_q):
             prev = pvals[i]
         ranks[i] = rank
     return [(ranks[i], fdr_q * ranks[i] / m) for i in range(m)]
+
+
+def bh_step_up_cutoff(pvals, fdr_q):
+    """The critical value the family ACTUALLY cleared, or ``None`` when the
+    procedure rejected nothing.
+
+    #1443 review: Benjamini-Hochberg is a STEP-UP procedure
+    (backtest/regime_stats.py) — it finds the largest rank k with
+    ``p_(k) <= q*k/m`` and rejects every p-value at or below ``p_(k)``. So a row
+    whose OWN per-rank bar ``q*rank/m`` it missed can still be rejected on the
+    back of a higher-ranked survivor. Reporting the per-rank bar as "the bar it
+    needed" can therefore contradict the verdict beside it.
+
+    ``q*k_max/m`` is exactly equivalent to the procedure for every row in the
+    family: no p-value can lie in ``(p_(k_max), q*k_max/m]`` — one there would
+    itself satisfy the rank-``k_max+1`` bar and contradict k_max's maximality.
+    Pure; unit-tested without data access."""
+    m = len(pvals)
+    if m == 0:
+        return None
+    ordered = sorted(float(p) for p in pvals)
+    k_max = 0
+    for k, p in enumerate(ordered, start=1):
+        if p <= fdr_q * k / m:
+            k_max = k
+    if not k_max:
+        return None
+    return fdr_q * k_max / m
 
 
 # Gate order, mirroring certify(): a cell is reported against the FIRST criterion
@@ -178,6 +261,7 @@ def cell_verdicts(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD) -> dict:
     pvals = [float(r["p_value"]) for r in directional]
     global_bh = benjamini_hochberg(pvals, alpha=fdr_q) if pvals else []
     ranked = _bh_ranks(pvals, fdr_q)
+    step_up = bh_step_up_cutoff(pvals, fdr_q)
     family_size = len(directional)
     cell_idx: dict = {}
     for i, r in enumerate(directional):
@@ -199,6 +283,9 @@ def cell_verdicts(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD) -> dict:
             entry["best_row"] = None
             entry["bh_rank"] = None
             entry["bh_threshold"] = None
+            entry["bh_rank_threshold"] = None
+            entry["bh_step_up_cutoff"] = (
+                None if step_up is None else float(step_up))
             out[key] = entry
             continue
 
@@ -207,7 +294,14 @@ def cell_verdicts(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD) -> dict:
         rank, thresh = ranked[best_i]
         entry["min_p_value"] = float(best["p_value"])
         entry["bh_rank"] = int(rank)
-        entry["bh_threshold"] = float(thresh)
+        # #1443 review: `bh_threshold` is the bar the VERDICT was decided against,
+        # so it must be the step-up cutoff whenever the family rejected anything —
+        # a row can be rejected on a higher-ranked survivor's back while missing
+        # its own per-rank bar. With nothing rejected there is no cutoff, and the
+        # row's own per-rank bar is the honest "how far short did it fall".
+        entry["bh_rank_threshold"] = float(thresh)
+        entry["bh_step_up_cutoff"] = None if step_up is None else float(step_up)
+        entry["bh_threshold"] = float(thresh if step_up is None else step_up)
         entry["best_row"] = {
             "window": str(best["window"]), "horizon": int(best["horizon"]),
             "state": str(best["state"]), "gap": float(best["gap"]),
@@ -342,7 +436,12 @@ def build_parser():
     p.add_argument("--windows", default=",".join(premise.DEFAULT_WINDOWS))
     p.add_argument("--horizons", default=",".join(str(h) for h in premise.DEFAULT_HORIZONS))
     p.add_argument("--classifiers", default=",".join(premise.DEFAULT_CLASSIFIERS))
-    p.add_argument("--n-perm", type=int, default=500)
+    # #1443 review: the default matches the committed artifact's run. At the full
+    # default universe (m in the low thousands) the rank-1 BH bar q/m sits around
+    # 4e-05, while n_perm=500 floors every p-value at 1/501 ~ 2e-03 — ~53x ABOVE
+    # it. The old default therefore made the documented refresh command incapable
+    # of certifying anything at any effect size.
+    p.add_argument("--n-perm", type=int, default=30000)
     p.add_argument("--seed", type=int, default=0)
     p.add_argument("--fdr-q", type=float, default=0.05)
     p.add_argument("--ttl-days", type=int, default=DEFAULT_TTL_DAYS)
@@ -352,9 +451,19 @@ def build_parser():
                    help="path for the per-cell run report JSON (empty string to skip)")
     p.add_argument("--allow-narrowed-family", action="store_true",
                    help="permit a run whose universe is NOT a superset of the default "
-                        "screen. Narrowing shrinks the BH correction family and inflates "
-                        "every cell's pass probability (#1424); without this flag such a "
-                        "run refuses to write the repo artifact.")
+                        "screen, or whose baseline symbols are sourced off-PLATFORM. "
+                        "Narrowing shrinks the BH correction family and inflates every "
+                        "cell's pass probability (#1424); a repointed baseline screens a "
+                        "series no committed baseline used. Without this flag such a run "
+                        "refuses to write ANY repo-tracked output.")
+    p.add_argument("--allow-degenerate-run", action="store_true",
+                   help="permit a run that is structurally incapable of certifying "
+                        "anything — no directional rows screened at all, or a permutation "
+                        "p-floor above the rank-1 BH critical value — to overwrite a "
+                        "repo-tracked output. Deliberately SEPARATE from "
+                        "--allow-narrowed-family: narrowing a research family must not "
+                        "also unlock the erasure of a live artifact from a run that "
+                        "measured nothing.")
     return p
 
 
@@ -364,10 +473,12 @@ def _format_verdict_line(v) -> str:
             f"{v['verdict']:22s}")
     if not best:
         return head + f"rows={v['n_screened_rows']} directional=0"
+    bar_kind = "step-up cutoff" if v.get("bh_step_up_cutoff") is not None \
+        else "per-rank bar"
     return (head
             + f"min_p={v['min_p_value']:.6g} "
-            + f"needed<={v['bh_threshold']:.3e} (BH rank {v['bh_rank']}/"
-            + f"{v['global_bh_family_size']}) "
+            + f"needed<={v['bh_threshold']:.3e} ({bar_kind}; BH rank "
+            + f"{v['bh_rank']}/{v['global_bh_family_size']}) "
             + f"best={best['state']}@{best['window']}/h{best['horizon']} "
             + f"gap={best['gap']:+.5f} aligned={'Y' if best['sign_aligned'] else 'N'} "
             + f"src={best['source']}")
@@ -391,27 +502,61 @@ def main(argv=None) -> int:
     horizons = tuple(int(h) for h in args.horizons.split(","))
     classifiers = tuple(c.strip() for c in args.classifiers.split(",") if c.strip())
 
-    # FAMILY-INTEGRITY GATE — before any data is touched, so a narrowed run costs
-    # nothing and can never leave a half-written artifact behind.
+    # ONE-ASSET-ONE-SERIES GATE (#1443 review). certify() keys a cell by the
+    # NORMALIZED asset, so two symbols reducing to the same asset blend into one
+    # certified entry whose provenance cannot be told apart. Refuse before any
+    # data is touched.
+    collisions = cert_asset_collisions(symbols)
+    if collisions:
+        detail = "; ".join(f"{asset} <- {syms}" for asset, syms in collisions.items())
+        raise SystemExit(
+            f"--symbols: two screened symbols normalize to the same certification "
+            f"asset ({detail}). certify() keys a cell by the normalized asset, so their "
+            "rows would blend into ONE certified entry while criteria.data_sources "
+            "(keyed by full symbol) could not say which venue backed which state. "
+            "Screen one series per asset per run.")
+
+    sources = premise.resolve_data_sources(symbols)
+
+    # REPO-OUTPUT INTEGRITY GATE — before any data is touched, so a refused run
+    # costs nothing and can never leave a half-written file behind. EVERY
+    # repo-tracked output the producer can write is protected, not just --out:
+    # the run report is this issue's committed evidence for the negative result.
+    repo_targets = []
+    if os.path.abspath(args.out) == os.path.abspath(DEFAULT_ARTIFACT):
+        repo_targets.append(args.out)
+    if args.report_out and (os.path.abspath(args.report_out)
+                            == os.path.abspath(DEFAULT_RUN_REPORT)):
+        repo_targets.append(args.report_out)
+
+    integrity_problems = []
     if not family_is_superset(symbols, timeframes, windows, classifiers, horizons):
-        msg = (
+        integrity_problems.append((
             "narrowed family: this run's universe is NOT a superset of the default "
             "screen (symbols {s} / timeframes {t} / windows {w} / classifiers {c} / "
             "horizons {h}). certify() corrects across the rows of ONE invocation, so a "
             "narrowed run shrinks the Benjamini-Hochberg family and inflates every "
-            "cell's pass probability — the pooled-limit trap #1424 records. Re-run over "
-            "the full default universe (adding symbols is fine), or pass "
-            "--allow-narrowed-family for a research-only artifact."
+            "cell's pass probability — the pooled-limit trap #1424 records."
         ).format(s=list(premise.DEFAULT_SYMBOLS), t=list(premise.DEFAULT_TIMEFRAMES),
                  w=list(premise.DEFAULT_WINDOWS), c=list(premise.DEFAULT_CLASSIFIERS),
-                 h=list(premise.DEFAULT_HORIZONS))
-        writes_repo_artifact = (os.path.abspath(args.out)
-                                == os.path.abspath(DEFAULT_ARTIFACT))
-        if writes_repo_artifact and not args.allow_narrowed_family:
-            raise SystemExit(f"REFUSING to write {args.out}: {msg}")
+                 h=list(premise.DEFAULT_HORIZONS)))
+    repointed = baseline_source_violations(sources, PLATFORM)
+    if repointed:
+        integrity_problems.append(
+            "repointed baseline: default symbols "
+            + ", ".join(f"{sym}@{src}" for sym, src in repointed.items())
+            + f" are not loaded from the baseline venue {PLATFORM!r}. Every committed "
+            "regime baseline was computed on that series (#1315 axis separation), so a "
+            "substituted source screens a series no baseline used. Adding NEW symbols "
+            "from any venue stays free.")
+    if integrity_problems:
+        msg = " ALSO: ".join(integrity_problems) + (
+            " Re-run over the full default universe on the baseline sources (adding "
+            "symbols is fine), or pass --allow-narrowed-family and write elsewhere.")
+        if repo_targets and not args.allow_narrowed_family:
+            raise SystemExit(
+                f"REFUSING to write repo-tracked output {repo_targets}: {msg}")
         print(f"[WARN] {msg}")
-
-    sources = premise.resolve_data_sources(symbols)
     universe = {"symbols": sorted(sources), "timeframes": list(timeframes),
                 "windows": list(windows), "horizons": [int(h) for h in horizons],
                 "classifiers": list(classifiers)}
@@ -423,11 +568,10 @@ def main(argv=None) -> int:
 
     rows = premise.run(symbols, timeframes, windows, horizons, classifiers, th,
                        args.n_perm, args.seed)
+    # certify() is pure — nothing is written until the degenerate-run gate below
+    # has passed, so a refusal leaves every existing file byte-identical.
     artifact = certify(rows, fdr_q=args.fdr_q, ttl_days=args.ttl_days,
                        universe=universe, data_sources=sources, n_perm=args.n_perm)
-    with open(args.out, "w") as fh:
-        json.dump(artifact, fh, indent=2)
-        fh.write("\n")
 
     family_size = artifact["criteria"]["screened_family_size"]
     p_floor = permutation_p_floor(args.n_perm)
@@ -471,6 +615,37 @@ def main(argv=None) -> int:
           "certified cells):")
     for key in sorted(verdicts):
         print("  " + _format_verdict_line(verdicts[key]))
+
+    # DEGENERATE-RUN GATE (#1443 review). An empty ``certified`` list is a
+    # publishable negative result ONLY when the run could have found something.
+    # A run with no directional rows measured nothing, and a run whose p-floor
+    # sits above the rank-1 BH bar cannot reject at any effect size — either one
+    # overwriting a repo-tracked file republishes "nothing certified" as evidence
+    # and would silently erase a future non-empty certified list.
+    degenerate = []
+    if not family_size:
+        degenerate.append(
+            "the screen produced NO directional rows at all, so there was nothing to "
+            "correct — a coverage failure (unreachable OHLCV cache, or every window "
+            "too short), not a negative result")
+    elif p_floor > rank1:
+        degenerate.append(
+            f"the permutation p-floor {p_floor:.3e} (n_perm={args.n_perm}) sits ABOVE "
+            f"the rank-1 global-BH critical value {rank1:.3e} (q={args.fdr_q}, "
+            f"m={family_size}), so no single row can certify at any effect size — an "
+            "empty artifact from this run is not evidence of absence. Raise --n-perm")
+    if degenerate and repo_targets and not args.allow_degenerate_run:
+        raise SystemExit(
+            f"REFUSING to write repo-tracked output {repo_targets}: "
+            + "; ".join(degenerate)
+            + ". Pass --allow-degenerate-run to overwrite anyway, or write elsewhere "
+              "with --out/--report-out.")
+    if degenerate:
+        print(f"[WARN] degenerate run: {'; '.join(degenerate)}")
+
+    with open(args.out, "w") as fh:
+        json.dump(artifact, fh, indent=2)
+        fh.write("\n")
 
     n = len(artifact["certified"])
     print()

--- a/backtest/research/regime_1076_certify.py
+++ b/backtest/research/regime_1076_certify.py
@@ -232,6 +232,20 @@ VERDICT_WRONG_SIGNED = "wrong_signed"
 VERDICT_NOT_HELD_OUT = "not_held_out_forward"
 VERDICT_CERTIFIED = "certified"
 
+# #1443 review round 2: which tier of rows the displayed `best_row` was drawn
+# from. The verdict is decided by a LADDER of nested filters (directional ->
+# survived global BH -> sign-aligned -> held-out forward), and each verdict
+# names the deepest tier the cell reached. Picking the displayed row from the
+# whole directional set let a CERTIFIED cell print evidence that itself reads as
+# a miss (`sign_aligned: false`, or a historical window) whenever the cell's
+# globally lowest-p row was not one of the rows that actually passed. The row
+# shown is therefore always a member of the set the verdict is ABOUT, and this
+# field says which set that is so the diagnostic explains its own reasoning.
+BASIS_ALL_DIRECTIONAL = "all_directional_rows"
+BASIS_SURVIVED_BH = "survived_global_bh"
+BASIS_SURVIVED_ALIGNED = "survived_and_aligned"
+BASIS_CERTIFIED_HELD_OUT = "certified_held_out_forward"
+
 
 def cell_verdicts(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD) -> dict:
     """Per-(asset, timeframe, classifier) verdict over premise-screen rows.
@@ -281,6 +295,7 @@ def cell_verdicts(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD) -> dict:
             entry["verdict"] = VERDICT_NO_DIRECTIONAL_ROWS
             entry["min_p_value"] = None
             entry["best_row"] = None
+            entry["best_row_basis"] = None
             entry["bh_rank"] = None
             entry["bh_threshold"] = None
             entry["bh_rank_threshold"] = None
@@ -289,10 +304,13 @@ def cell_verdicts(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD) -> dict:
             out[key] = entry
             continue
 
-        best_i = min(idxs, key=lambda i: pvals[i])
-        best = directional[best_i]
-        rank, thresh = ranked[best_i]
-        entry["min_p_value"] = float(best["p_value"])
+        # `min_p_value` and the BH fields stay anchored to the cell's globally
+        # lowest-p directional row: that is literally the minimum, and for a cell
+        # that failed it is the honest "how far short did it fall". The DISPLAYED
+        # row is chosen separately, below, from the tier the verdict names.
+        min_i = min(idxs, key=lambda i: pvals[i])
+        rank, thresh = ranked[min_i]
+        entry["min_p_value"] = float(pvals[min_i])
         entry["bh_rank"] = int(rank)
         # #1443 review: `bh_threshold` is the bar the VERDICT was decided against,
         # so it must be the step-up cutoff whenever the family rejected anything —
@@ -302,6 +320,37 @@ def cell_verdicts(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD) -> dict:
         entry["bh_rank_threshold"] = float(thresh)
         entry["bh_step_up_cutoff"] = None if step_up is None else float(step_up)
         entry["bh_threshold"] = float(thresh if step_up is None else step_up)
+        # Placed here so the emitted key order is stable across the reordering
+        # this fix required; the values are filled once the verdict is known.
+        entry["best_row"] = None
+        entry["best_row_basis"] = None
+
+        passing_idxs = [i for i in idxs if global_bh[i]]
+        aligned_idxs = [i for i in passing_idxs
+                        if directional[i].get("sign_aligned")]
+        held_idxs = [i for i in aligned_idxs
+                     if directional[i].get("window") in held_out_windows]
+        entry["n_survive_global_bh"] = len(passing_idxs)
+        entry["n_survive_and_aligned"] = len(aligned_idxs)
+        entry["n_survive_aligned_held_out"] = len(held_idxs)
+        if not passing_idxs:
+            entry["verdict"] = VERDICT_FAILS_GLOBAL_BH
+            evidence_idxs, basis = idxs, BASIS_ALL_DIRECTIONAL
+        elif not aligned_idxs:
+            entry["verdict"] = VERDICT_WRONG_SIGNED
+            evidence_idxs, basis = passing_idxs, BASIS_SURVIVED_BH
+        elif not held_idxs:
+            entry["verdict"] = VERDICT_NOT_HELD_OUT
+            evidence_idxs, basis = aligned_idxs, BASIS_SURVIVED_ALIGNED
+        else:
+            entry["verdict"] = VERDICT_CERTIFIED
+            evidence_idxs, basis = held_idxs, BASIS_CERTIFIED_HELD_OUT
+            entry["certified_states"] = dict(sorted(
+                (_canonical_trend_label(str(directional[i]["state"])),
+                 _policy_direction_label(int(directional[i]["policy_dir"])))
+                for i in held_idxs))
+
+        best = directional[min(evidence_idxs, key=lambda i: pvals[i])]
         entry["best_row"] = {
             "window": str(best["window"]), "horizon": int(best["horizon"]),
             "state": str(best["state"]), "gap": float(best["gap"]),
@@ -310,24 +359,7 @@ def cell_verdicts(rows, fdr_q=0.05, held_out_windows=HELD_OUT_FORWARD) -> dict:
             "sign_aligned": bool(best.get("sign_aligned")),
             "source": str(best.get("source", "")),
         }
-
-        passing = [directional[i] for i in idxs if global_bh[i]]
-        aligned = [r for r in passing if r.get("sign_aligned")]
-        held = [r for r in aligned if r.get("window") in held_out_windows]
-        entry["n_survive_global_bh"] = len(passing)
-        entry["n_survive_and_aligned"] = len(aligned)
-        entry["n_survive_aligned_held_out"] = len(held)
-        if not passing:
-            entry["verdict"] = VERDICT_FAILS_GLOBAL_BH
-        elif not aligned:
-            entry["verdict"] = VERDICT_WRONG_SIGNED
-        elif not held:
-            entry["verdict"] = VERDICT_NOT_HELD_OUT
-        else:
-            entry["verdict"] = VERDICT_CERTIFIED
-            entry["certified_states"] = dict(sorted(
-                (_canonical_trend_label(str(r["state"])),
-                 _policy_direction_label(int(r["policy_dir"]))) for r in held))
+        entry["best_row_basis"] = basis
         out[key] = entry
     return out
 
@@ -475,13 +507,22 @@ def _format_verdict_line(v) -> str:
         return head + f"rows={v['n_screened_rows']} directional=0"
     bar_kind = "step-up cutoff" if v.get("bh_step_up_cutoff") is not None \
         else "per-rank bar"
+    # The displayed row is the verdict's own evidence, so it is not always the
+    # cell minimum. Say so on the line rather than letting `min_p=` be read as
+    # the shown row's p-value.
+    best_p = ("" if best["p_value"] == v["min_p_value"]
+              else f"p={best['p_value']:.6g} ")
+    basis = ("" if v.get("best_row_basis") in (None, BASIS_ALL_DIRECTIONAL)
+             else f" basis={v['best_row_basis']}")
     return (head
             + f"min_p={v['min_p_value']:.6g} "
             + f"needed<={v['bh_threshold']:.3e} ({bar_kind}; BH rank "
             + f"{v['bh_rank']}/{v['global_bh_family_size']}) "
             + f"best={best['state']}@{best['window']}/h{best['horizon']} "
+            + best_p
             + f"gap={best['gap']:+.5f} aligned={'Y' if best['sign_aligned'] else 'N'} "
-            + f"src={best['source']}")
+            + f"src={best['source']}"
+            + basis)
 
 
 def main(argv=None) -> int:

--- a/backtest/research/regime_1076_directional_premise.py
+++ b/backtest/research/regime_1076_directional_premise.py
@@ -110,11 +110,28 @@ def parse_symbol_spec(spec: str) -> tuple[str, str | None]:
 def parse_symbols_arg(raw: str) -> tuple[tuple[str, str | None], ...]:
     """Parse a comma-separated ``--symbols`` value into ``(symbol, exchange)``
     pairs. Shared by this script and regime_1076_certify.py so both CLIs honor
-    one contract."""
+    one contract.
+
+    #1443 review: a repeated symbol STRING is rejected outright. Every
+    symbol-keyed surface downstream is a dict — resolve_data_sources keeps only
+    the last exchange for a repeated key, coverage_table blends both series into
+    one (symbol, timeframe, window) cell — so the same symbol listed twice under
+    two exchanges would double the correction family while recording the
+    provenance of only one of them. Refusing at parse time is the only place the
+    two entries are still distinguishable."""
     specs = tuple(parse_symbol_spec(part) for part in (raw or "").split(",")
                   if part.strip())
     if not specs:
         raise ValueError("--symbols resolved to no symbols")
+    seen: dict = {}
+    for symbol, exchange in specs:
+        if symbol in seen:
+            raise ValueError(
+                f"duplicate symbol {symbol!r} in --symbols (sources "
+                f"{seen[symbol] or 'default'} and {exchange or 'default'}); "
+                "every symbol-keyed surface downstream is a dict, so the two "
+                "entries would merge into one recorded series")
+        seen[symbol] = exchange
     return specs
 
 

--- a/backtest/research/regime_1076_directional_premise.py
+++ b/backtest/research/regime_1076_directional_premise.py
@@ -30,6 +30,16 @@ Run (needs the trading_bot.db OHLCV cache reachable from shared_tools/):
     uv run --no-sync python backtest/research/regime_1076_directional_premise.py
     uv run --no-sync python backtest/research/regime_1076_directional_premise.py \
         --symbols BTC/USDT,ETH/USDT,SOL/USDT --timeframes 1h,4h --classifiers adx,composite
+
+#1443: ``--symbols`` accepts an optional per-symbol data source, ``SYMBOL[@exchange]``.
+A bare symbol keeps the ``eval_windows.PLATFORM`` default ("binanceus"); an ``@exchange``
+suffix loads that symbol's OHLCV from that exchange's cache namespace instead. This exists
+because assets that do not trade on the default venue (HYPE, an HL perp) are otherwise
+unreachable by the screen. ``PLATFORM`` itself is NEVER repointed — the #1315 axis
+separation pins it, because every committed regime baseline was computed on that series.
+
+    uv run --no-sync python backtest/research/regime_1076_directional_premise.py \
+        --symbols "BTC/USDT,ETH/USDT,SOL/USDT,HYPE/USDC:USDC@hyperliquid"
 """
 from __future__ import annotations
 import os
@@ -43,6 +53,7 @@ for _p in (_BACKTEST, _ROOT, os.path.join(_ROOT, "shared_tools")):
         sys.path.insert(0, _p)
 
 import numpy as np
+import pandas as pd
 
 from regime import (
     compute_regime,
@@ -72,6 +83,106 @@ ADX_PERIOD = 14              # Wilder standard for the 3-state directional class
 ADX_THRESHOLD = 20.0         # compute_regime / _normalize_spec default
 
 
+def parse_symbol_spec(spec: str) -> tuple[str, str | None]:
+    """Split a ``SYMBOL[@exchange]`` CLI spec into ``(symbol, exchange_or_None)``.
+
+    Splits on the LAST ``@`` so ccxt symbols carrying ``/`` and ``:`` parse
+    correctly: ``"HYPE/USDC:USDC@hyperliquid"`` -> ``("HYPE/USDC:USDC",
+    "hyperliquid")``. A bare symbol returns ``(symbol, None)``, meaning "use the
+    PLATFORM default". An empty symbol or an empty exchange raises loudly rather
+    than silently falling back — a typo must never quietly screen the wrong
+    series. Pure; unit-tested without data access."""
+    raw = (spec or "").strip()
+    if not raw:
+        raise ValueError("empty symbol spec")
+    head, sep, tail = raw.rpartition("@")
+    if not sep:
+        return (raw, None)
+    symbol = head.strip()
+    exchange = tail.strip()
+    if not symbol:
+        raise ValueError(f"symbol spec {spec!r} has an empty symbol before '@'")
+    if not exchange:
+        raise ValueError(f"symbol spec {spec!r} has an empty exchange after '@'")
+    return (symbol, exchange)
+
+
+def parse_symbols_arg(raw: str) -> tuple[tuple[str, str | None], ...]:
+    """Parse a comma-separated ``--symbols`` value into ``(symbol, exchange)``
+    pairs. Shared by this script and regime_1076_certify.py so both CLIs honor
+    one contract."""
+    specs = tuple(parse_symbol_spec(part) for part in (raw or "").split(",")
+                  if part.strip())
+    if not specs:
+        raise ValueError("--symbols resolved to no symbols")
+    return specs
+
+
+def normalize_symbol_specs(symbols) -> tuple[tuple[str, str | None], ...]:
+    """Accept either bare symbol strings or ``(symbol, exchange)`` pairs and
+    return pairs. A bare ``str`` entry is NOT re-parsed for ``@`` — callers that
+    want spec parsing use parse_symbols_arg; run() stays tolerant of the plain
+    tuple-of-strings form its existing callers and tests pass."""
+    out = []
+    for entry in symbols:
+        if isinstance(entry, str):
+            out.append((entry, None))
+            continue
+        symbol, exchange = entry
+        out.append((str(symbol), None if exchange is None else str(exchange)))
+    return tuple(out)
+
+
+def resolve_data_sources(symbols) -> dict:
+    """``{symbol: exchange_id}`` for the resolved run, PLATFORM where unset.
+    Recorded in the run banner, the ``--out`` dump and (via the certify
+    producer) the artifact ``criteria`` so a screen's data provenance is
+    inspectable after the fact."""
+    return {symbol: (exchange or PLATFORM)
+            for symbol, exchange in normalize_symbol_specs(symbols)}
+
+
+def _clip_window(df, start, end):
+    """Clip a loaded OHLCV frame to the eval window on its datetime index.
+
+    load_cached_data's CACHED path already filters to [start, end], but its
+    empty-cache fallback fetches from ``since=start_date`` and returns the whole
+    fetched history UNSLICED (shared_tools/data_fetcher.py). For an asset whose
+    listing post-dates a window (HYPE, listed Nov 2024, against the "2023"
+    window) that fallback would hand back later data mislabeled as the requested
+    window — a silent statistical corruption. Clipping here defuses it and is a
+    no-op on the cached path, so every already-screened cell stays identical.
+    End is inclusive, matching storage.load_ohlcv's ``timestamp <= end_ts``.
+    Pure; unit-tested without data access."""
+    if df is None or len(df) == 0:
+        return df
+    if not isinstance(df.index, pd.DatetimeIndex):
+        raise ValueError(
+            "OHLCV frame must carry a DatetimeIndex to clip to an eval window; "
+            f"got {type(df.index).__name__}")
+    if start is not None:
+        df = df[df.index >= pd.Timestamp(start)]
+    if end is not None:
+        df = df[df.index <= pd.Timestamp(end)]
+    return df
+
+
+def coverage_table(rows) -> list:
+    """Per-(symbol, timeframe, window) screened coverage derived purely from
+    result rows: which windows actually contributed, from which source, with how
+    many labeled bars. #1443 requires the run itself to state this for a newly
+    added asset whose history starts mid-universe."""
+    agg: dict = {}
+    for r in rows:
+        key = (str(r["symbol"]), str(r["timeframe"]), str(r["window"]))
+        e = agg.setdefault(key, {"symbol": key[0], "timeframe": key[1],
+                                 "window": key[2], "source": str(r.get("source", "")),
+                                 "rows": 0, "bars": {}})
+        e["rows"] += 1
+        e["bars"][str(r["classifier"])] = int(r.get("n_bars", 0) or 0)
+    return [agg[k] for k in sorted(agg)]
+
+
 def _policy_direction(label: str) -> int:
     """The side regime_directional_policy bets for a state: +1 long, -1 short, 0 neutral."""
     if label.startswith("trending_up"):
@@ -98,10 +209,11 @@ def _label_stream(close_df, classifier, th):
     return close_df["close"].to_numpy(), labels, valid
 
 
-def _load(symbol, timeframe, window, classifier, th):
+def _load(symbol, timeframe, window, classifier, th, exchange=None):
     start, end = WINDOWS[window]
-    df = load_cached_data(symbol, timeframe, exchange_id=PLATFORM,
+    df = load_cached_data(symbol, timeframe, exchange_id=(exchange or PLATFORM),
                           start_date=start, end_date=end)
+    df = _clip_window(df, start, end)
     if len(df) <= max(COMPOSITE_PERIOD, ADX_PERIOD) + 5:
         return None
     close, labels, valid = _label_stream(df, classifier, th)
@@ -109,17 +221,24 @@ def _load(symbol, timeframe, window, classifier, th):
     st = stability(vlabels)
     mean_dwell = (float(np.mean(list(st["mean_dwell"].values())))
                   if st["mean_dwell"] else 1.0)
-    return {"close": close, "valid": valid, "vlabels": vlabels, "mean_dwell": mean_dwell}
+    return {"close": close, "valid": valid, "vlabels": vlabels,
+            "mean_dwell": mean_dwell, "n_bars": int(np.count_nonzero(valid))}
 
 
 def run(symbols, timeframes, windows, horizons, classifiers, th, n_perm, seed):
-    """Returns a flat list of per-(classifier,symbol,tf,window,horizon,state) result rows."""
+    """Returns a flat list of per-(classifier,symbol,tf,window,horizon,state) result rows.
+
+    ``symbols`` accepts bare symbol strings (loaded from PLATFORM) or
+    ``(symbol, exchange)`` pairs from parse_symbols_arg (#1443)."""
     rows = []
+    specs = normalize_symbol_specs(symbols)
     for classifier in classifiers:
-        for symbol in symbols:
+        for symbol, exchange in specs:
+            source = exchange or PLATFORM
             for timeframe in timeframes:
                 for window in windows:
-                    d = _load(symbol, timeframe, window, classifier, th)
+                    d = _load(symbol, timeframe, window, classifier, th,
+                              exchange=exchange)
                     if d is None:
                         continue
                     for h in horizons:
@@ -138,6 +257,7 @@ def run(symbols, timeframes, windows, horizons, classifiers, th, n_perm, seed):
                             aligned = bool(pol != 0 and np.sign(gap) == pol)
                             rows.append({
                                 "classifier": classifier, "symbol": symbol,
+                                "source": source, "n_bars": int(d["n_bars"]),
                                 "timeframe": timeframe, "window": window, "horizon": int(h),
                                 "state": str(state), "gap": gap,
                                 "mean_fwd": float(sep.get(state, {}).get("mean", float("nan"))),
@@ -149,7 +269,39 @@ def run(symbols, timeframes, windows, horizons, classifiers, th, n_perm, seed):
     return rows
 
 
-def report(rows, classifiers):
+def _report_coverage(rows, symbols=None, timeframes=None, windows=None):
+    """Print which (symbol, timeframe, window) cells actually contributed rows.
+
+    #1443: a symbol whose listing post-dates part of the window grid contributes
+    nothing for the earlier windows, and the run must say so instead of leaving
+    the reader to infer it from a row count. The empty-cell enumeration reads the
+    REQUESTED axes, never the axes present in the results — a timeframe that
+    produced no rows for any symbol must still be named as empty."""
+    cov = coverage_table(rows)
+    print("SCREENED COVERAGE — (symbol, tf, window) cells that contributed rows:")
+    print(f"{'symbol':18s} {'source':12s} {'tf':4s} {'window':8s} {'rows':>5s}  labeled bars")
+    print("-" * 78)
+    for e in cov:
+        bars = " ".join(f"{c}={n}" for c, n in sorted(e["bars"].items()))
+        print(f"{e['symbol']:18s} {e['source']:12s} {e['timeframe']:4s} "
+              f"{e['window']:8s} {e['rows']:5d}  {bars}")
+    if symbols is not None and timeframes is not None and windows is not None:
+        present = {(e["symbol"], e["timeframe"], e["window"]) for e in cov}
+        missing = []
+        for symbol, _exchange in normalize_symbol_specs(symbols):
+            for tf in timeframes:
+                for w in windows:
+                    if (symbol, tf, w) not in present:
+                        missing.append((symbol, tf, w))
+        if missing:
+            print("\nWindows that contributed NO rows (too few bars after clipping "
+                  "to the window — e.g. the asset was not listed yet):")
+            for symbol, tf, w in missing:
+                print(f"  {symbol:18s} {tf:4s} {w}")
+    print()
+
+
+def report(rows, classifiers, symbols=None, timeframes=None, windows=None):
     directional = [r for r in rows if r["policy_dir"] != 0]   # trending_* states only
     n_dir = len(directional)
     n_fdr = sum(r["fdr_reject"] for r in directional)
@@ -162,6 +314,8 @@ def report(rows, classifiers):
     print(f"  FDR-significant (any sign):                {n_fdr}")
     print(f"  FDR-significant AND policy-sign-aligned:   {len(candidates)}  <- candidate edges")
     print()
+
+    _report_coverage(rows, symbols, timeframes, windows)
 
     # per-classifier breakdown
     for c in classifiers:
@@ -226,7 +380,12 @@ def report(rows, classifiers):
 def build_parser():
     import argparse
     p = argparse.ArgumentParser(description="#1076 scope-1: regime->direction premise screen")
-    p.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
+    p.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS),
+                   help="comma-separated SYMBOL[@exchange] specs. A bare symbol loads "
+                        f"from the default data source ({PLATFORM}); an @exchange suffix "
+                        "loads that symbol from that exchange's cache namespace instead "
+                        "(#1443, e.g. HYPE/USDC:USDC@hyperliquid). The default source is "
+                        "never repointed (#1315 axis separation).")
     p.add_argument("--timeframes", default=",".join(DEFAULT_TIMEFRAMES))
     p.add_argument("--windows", default=",".join(DEFAULT_WINDOWS),
                    help=f"comma-separated; known: {', '.join(WINDOWS)}")
@@ -242,7 +401,10 @@ def build_parser():
 def main(argv=None) -> int:
     args = build_parser().parse_args(argv)
     th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
-    symbols = tuple(s.strip() for s in args.symbols.split(",") if s.strip())
+    try:
+        symbols = parse_symbols_arg(args.symbols)
+    except ValueError as exc:
+        raise SystemExit(f"--symbols: {exc}")
     timeframes = tuple(t.strip() for t in args.timeframes.split(",") if t.strip())
     windows = tuple(w.strip() for w in args.windows.split(",") if w.strip())
     for w in windows:
@@ -251,19 +413,27 @@ def main(argv=None) -> int:
     horizons = tuple(int(h) for h in args.horizons.split(","))
     classifiers = tuple(c.strip() for c in args.classifiers.split(",") if c.strip())
 
-    print(f"# universe: {list(symbols)} x {list(timeframes)} x {list(windows)}")
+    sources = resolve_data_sources(symbols)
+    print(f"# universe: {sorted(sources)} x {list(timeframes)} x {list(windows)}")
+    print("# data sources: "
+          + " ".join(f"{sym}={src}" for sym, src in sorted(sources.items())))
     print(f"# classifiers={list(classifiers)} horizons={list(horizons)} "
-          f"n_perm={args.n_perm} platform={PLATFORM}\n")
+          f"n_perm={args.n_perm} default_platform={PLATFORM}\n")
     rows = run(symbols, timeframes, windows, horizons, classifiers, th,
                args.n_perm, args.seed)
-    report(rows, classifiers)
+    report(rows, classifiers, symbols=symbols, timeframes=timeframes,
+           windows=windows)
     if args.out:
         import json
         with open(args.out, "w") as fh:
-            json.dump({"universe": {"symbols": list(symbols), "timeframes": list(timeframes),
+            json.dump({"universe": {"symbols": sorted(sources),
+                                    "timeframes": list(timeframes),
                                     "windows": list(windows), "horizons": list(horizons),
                                     "classifiers": list(classifiers), "n_perm": args.n_perm,
-                                    "platform": PLATFORM}, "rows": rows}, fh, indent=2)
+                                    "default_platform": PLATFORM,
+                                    "data_sources": sources},
+                       "coverage": coverage_table(rows),
+                       "rows": rows}, fh, indent=2)
         print(f"# wrote {len(rows)} rows -> {args.out}")
     return 0
 

--- a/backtest/research/regime_1443_run_report.json
+++ b/backtest/research/regime_1443_run_report.json
@@ -485,6 +485,7 @@
         "sign_aligned": true,
         "source": "binanceus"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -513,6 +514,7 @@
         "sign_aligned": true,
         "source": "binanceus"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -541,6 +543,7 @@
         "sign_aligned": false,
         "source": "binanceus"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -569,6 +572,7 @@
         "sign_aligned": true,
         "source": "binanceus"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -597,6 +601,7 @@
         "sign_aligned": true,
         "source": "binanceus"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -625,6 +630,7 @@
         "sign_aligned": false,
         "source": "binanceus"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -653,6 +659,7 @@
         "sign_aligned": true,
         "source": "binanceus"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -681,6 +688,7 @@
         "sign_aligned": false,
         "source": "binanceus"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -709,6 +717,7 @@
         "sign_aligned": false,
         "source": "hyperliquid"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -737,6 +746,7 @@
         "sign_aligned": false,
         "source": "hyperliquid"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -765,6 +775,7 @@
         "sign_aligned": false,
         "source": "hyperliquid"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -793,6 +804,7 @@
         "sign_aligned": false,
         "source": "hyperliquid"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -821,6 +833,7 @@
         "sign_aligned": true,
         "source": "binanceus"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -849,6 +862,7 @@
         "sign_aligned": false,
         "source": "binanceus"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -877,6 +891,7 @@
         "sign_aligned": true,
         "source": "binanceus"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,
@@ -905,6 +920,7 @@
         "sign_aligned": true,
         "source": "binanceus"
       },
+      "best_row_basis": "all_directional_rows",
       "n_survive_global_bh": 0,
       "n_survive_and_aligned": 0,
       "n_survive_aligned_held_out": 0,

--- a/backtest/research/regime_1443_run_report.json
+++ b/backtest/research/regime_1443_run_report.json
@@ -472,6 +472,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.0037998733375554147,
       "bh_rank": 8,
+      "bh_rank_threshold": 0.00030326004548900684,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.00030326004548900684,
       "best_row": {
         "window": "2023",
@@ -498,6 +500,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.006966434452184927,
       "bh_rank": 13,
+      "bh_rank_threshold": 0.0004927975739196361,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.0004927975739196361,
       "best_row": {
         "window": "2024",
@@ -524,6 +528,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.020132662244591846,
       "bh_rank": 43,
+      "bh_rank_threshold": 0.0016300227445034117,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.0016300227445034117,
       "best_row": {
         "window": "is",
@@ -550,6 +556,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.006433118896036798,
       "bh_rank": 10,
+      "bh_rank_threshold": 0.0003790750568612585,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.0003790750568612585,
       "best_row": {
         "window": "oos",
@@ -576,6 +584,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.028765707809739676,
       "bh_rank": 62,
+      "bh_rank_threshold": 0.002350265352539803,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.002350265352539803,
       "best_row": {
         "window": "oos",
@@ -602,6 +612,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.0021665944468517717,
       "bh_rank": 3,
+      "bh_rank_threshold": 0.00011372251705837758,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.00011372251705837758,
       "best_row": {
         "window": "2025H1",
@@ -628,6 +640,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.06276457451418287,
       "bh_rank": 119,
+      "bh_rank_threshold": 0.004510993176648976,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.004510993176648976,
       "best_row": {
         "window": "oos",
@@ -654,6 +668,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.0028332388920369322,
       "bh_rank": 6,
+      "bh_rank_threshold": 0.00022744503411675516,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.00022744503411675516,
       "best_row": {
         "window": "2024",
@@ -680,6 +696,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.16822772574247524,
       "bh_rank": 261,
+      "bh_rank_threshold": 0.009893858984078848,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.009893858984078848,
       "best_row": {
         "window": "oos",
@@ -706,6 +724,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.07263091230292323,
       "bh_rank": 132,
+      "bh_rank_threshold": 0.005003790750568613,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.005003790750568613,
       "best_row": {
         "window": "oos",
@@ -732,6 +752,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.0006999766674444185,
       "bh_rank": 2,
+      "bh_rank_threshold": 7.581501137225171e-05,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 7.581501137225171e-05,
       "best_row": {
         "window": "2025H1",
@@ -758,6 +780,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.006899770007666411,
       "bh_rank": 11,
+      "bh_rank_threshold": 0.0004169825625473844,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.0004169825625473844,
       "best_row": {
         "window": "is",
@@ -784,6 +808,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.03366554448185061,
       "bh_rank": 69,
+      "bh_rank_threshold": 0.002615617892342684,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.002615617892342684,
       "best_row": {
         "window": "2023",
@@ -810,6 +836,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.0005333155561481284,
       "bh_rank": 1,
+      "bh_rank_threshold": 3.7907505686125855e-05,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 3.7907505686125855e-05,
       "best_row": {
         "window": "2024",
@@ -836,6 +864,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.014132862237925403,
       "bh_rank": 30,
+      "bh_rank_threshold": 0.0011372251705837756,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.0011372251705837756,
       "best_row": {
         "window": "2023",
@@ -862,6 +892,8 @@
       "fdr_q": 0.05,
       "min_p_value": 0.009066364454518182,
       "bh_rank": 17,
+      "bh_rank_threshold": 0.0006444275966641396,
+      "bh_step_up_cutoff": null,
       "bh_threshold": 0.0006444275966641396,
       "best_row": {
         "window": "2023",

--- a/backtest/research/regime_1443_run_report.json
+++ b/backtest/research/regime_1443_run_report.json
@@ -1,0 +1,883 @@
+{
+  "issue": 1443,
+  "generator": "backtest/research/regime_1076_certify.py",
+  "generated_at": "2026-08-22T10:06:41Z",
+  "universe": {
+    "symbols": [
+      "BTC/USDT",
+      "ETH/USDT",
+      "HYPE/USDC:USDC",
+      "SOL/USDT"
+    ],
+    "timeframes": [
+      "1h",
+      "4h"
+    ],
+    "windows": [
+      "is",
+      "oos",
+      "2023",
+      "2024",
+      "2025H1"
+    ],
+    "horizons": [
+      1,
+      4,
+      8,
+      12,
+      24,
+      48,
+      72
+    ],
+    "classifiers": [
+      "adx",
+      "composite"
+    ]
+  },
+  "data_sources": {
+    "BTC/USDT": "binanceus",
+    "ETH/USDT": "binanceus",
+    "HYPE/USDC:USDC": "hyperliquid",
+    "SOL/USDT": "binanceus"
+  },
+  "seed": 0,
+  "n_perm": 30000,
+  "fdr_q": 0.05,
+  "screened_family_size": 1319,
+  "permutation_p_floor": 3.333222225925803e-05,
+  "global_bh_rank1_threshold": 3.7907505686125855e-05,
+  "single_row_certifiable": true,
+  "coverage": [
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "1h",
+      "window": "2023",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 8740,
+        "composite": 8706
+      }
+    },
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "1h",
+      "window": "2024",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 8771,
+        "composite": 8737
+      }
+    },
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "1h",
+      "window": "2025H1",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 4331,
+        "composite": 4297
+      }
+    },
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "1h",
+      "window": "is",
+      "source": "binanceus",
+      "rows": 63,
+      "bars": {
+        "adx": 4907,
+        "composite": 4873
+      }
+    },
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "1h",
+      "window": "oos",
+      "source": "binanceus",
+      "rows": 63,
+      "bars": {
+        "adx": 3683,
+        "composite": 3649
+      }
+    },
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "4h",
+      "window": "2023",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 2176,
+        "composite": 2142
+      }
+    },
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "4h",
+      "window": "2024",
+      "source": "binanceus",
+      "rows": 63,
+      "bars": {
+        "adx": 2183,
+        "composite": 2149
+      }
+    },
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "4h",
+      "window": "2025H1",
+      "source": "binanceus",
+      "rows": 56,
+      "bars": {
+        "adx": 1073,
+        "composite": 1039
+      }
+    },
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "4h",
+      "window": "is",
+      "source": "binanceus",
+      "rows": 63,
+      "bars": {
+        "adx": 1217,
+        "composite": 1183
+      }
+    },
+    {
+      "symbol": "BTC/USDT",
+      "timeframe": "4h",
+      "window": "oos",
+      "source": "binanceus",
+      "rows": 63,
+      "bars": {
+        "adx": 914,
+        "composite": 880
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "1h",
+      "window": "2023",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 8740,
+        "composite": 8706
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "1h",
+      "window": "2024",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 8771,
+        "composite": 8737
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "1h",
+      "window": "2025H1",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 4331,
+        "composite": 4297
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "1h",
+      "window": "is",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 4907,
+        "composite": 4873
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "1h",
+      "window": "oos",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 3894,
+        "composite": 3860
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "4h",
+      "window": "2023",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 2176,
+        "composite": 2142
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "4h",
+      "window": "2024",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 2183,
+        "composite": 2149
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "4h",
+      "window": "2025H1",
+      "source": "binanceus",
+      "rows": 63,
+      "bars": {
+        "adx": 1073,
+        "composite": 1039
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "4h",
+      "window": "is",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 1217,
+        "composite": 1183
+      }
+    },
+    {
+      "symbol": "ETH/USDT",
+      "timeframe": "4h",
+      "window": "oos",
+      "source": "binanceus",
+      "rows": 63,
+      "bars": {
+        "adx": 914,
+        "composite": 880
+      }
+    },
+    {
+      "symbol": "HYPE/USDC:USDC",
+      "timeframe": "1h",
+      "window": "oos",
+      "source": "hyperliquid",
+      "rows": 77,
+      "bars": {
+        "adx": 4988,
+        "composite": 4955
+      }
+    },
+    {
+      "symbol": "HYPE/USDC:USDC",
+      "timeframe": "4h",
+      "window": "2024",
+      "source": "hyperliquid",
+      "rows": 43,
+      "bars": {
+        "adx": 147,
+        "composite": 113
+      }
+    },
+    {
+      "symbol": "HYPE/USDC:USDC",
+      "timeframe": "4h",
+      "window": "2025H1",
+      "source": "hyperliquid",
+      "rows": 56,
+      "bars": {
+        "adx": 1073,
+        "composite": 1039
+      }
+    },
+    {
+      "symbol": "HYPE/USDC:USDC",
+      "timeframe": "4h",
+      "window": "is",
+      "source": "hyperliquid",
+      "rows": 63,
+      "bars": {
+        "adx": 1217,
+        "composite": 1183
+      }
+    },
+    {
+      "symbol": "HYPE/USDC:USDC",
+      "timeframe": "4h",
+      "window": "oos",
+      "source": "hyperliquid",
+      "rows": 63,
+      "bars": {
+        "adx": 1386,
+        "composite": 1353
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "1h",
+      "window": "2023",
+      "source": "binanceus",
+      "rows": 77,
+      "bars": {
+        "adx": 8740,
+        "composite": 8706
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "1h",
+      "window": "2024",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 8771,
+        "composite": 8737
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "1h",
+      "window": "2025H1",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 4331,
+        "composite": 4297
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "1h",
+      "window": "is",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 4907,
+        "composite": 4873
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "1h",
+      "window": "oos",
+      "source": "binanceus",
+      "rows": 77,
+      "bars": {
+        "adx": 3894,
+        "composite": 3860
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "4h",
+      "window": "2023",
+      "source": "binanceus",
+      "rows": 63,
+      "bars": {
+        "adx": 2176,
+        "composite": 2142
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "4h",
+      "window": "2024",
+      "source": "binanceus",
+      "rows": 56,
+      "bars": {
+        "adx": 2183,
+        "composite": 2149
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "4h",
+      "window": "2025H1",
+      "source": "binanceus",
+      "rows": 63,
+      "bars": {
+        "adx": 1073,
+        "composite": 1039
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "4h",
+      "window": "is",
+      "source": "binanceus",
+      "rows": 63,
+      "bars": {
+        "adx": 1217,
+        "composite": 1183
+      }
+    },
+    {
+      "symbol": "SOL/USDT",
+      "timeframe": "4h",
+      "window": "oos",
+      "source": "binanceus",
+      "rows": 70,
+      "bars": {
+        "adx": 914,
+        "composite": 880
+      }
+    }
+  ],
+  "empty_windows": [
+    {
+      "symbol": "HYPE/USDC:USDC",
+      "timeframe": "1h",
+      "window": "is"
+    },
+    {
+      "symbol": "HYPE/USDC:USDC",
+      "timeframe": "1h",
+      "window": "2023"
+    },
+    {
+      "symbol": "HYPE/USDC:USDC",
+      "timeframe": "1h",
+      "window": "2024"
+    },
+    {
+      "symbol": "HYPE/USDC:USDC",
+      "timeframe": "1h",
+      "window": "2025H1"
+    },
+    {
+      "symbol": "HYPE/USDC:USDC",
+      "timeframe": "4h",
+      "window": "2023"
+    }
+  ],
+  "cell_verdicts": [
+    {
+      "asset": "BTC",
+      "timeframe": "1h",
+      "classifier": "adx",
+      "n_screened_rows": 105,
+      "n_directional_rows": 70,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.0037998733375554147,
+      "bh_rank": 8,
+      "bh_threshold": 0.00030326004548900684,
+      "best_row": {
+        "window": "2023",
+        "horizon": 72,
+        "state": "trending_up",
+        "gap": 0.012189507593874514,
+        "p_value": 0.0037998733375554147,
+        "policy_dir": 1,
+        "sign_aligned": true,
+        "source": "binanceus"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "BTC",
+      "timeframe": "1h",
+      "classifier": "composite",
+      "n_screened_rows": 231,
+      "n_directional_rows": 126,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.006966434452184927,
+      "bh_rank": 13,
+      "bh_threshold": 0.0004927975739196361,
+      "best_row": {
+        "window": "2024",
+        "horizon": 24,
+        "state": "trending_up_choppy",
+        "gap": 0.005127412241029497,
+        "p_value": 0.006966434452184927,
+        "policy_dir": 1,
+        "sign_aligned": true,
+        "source": "binanceus"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "BTC",
+      "timeframe": "4h",
+      "classifier": "adx",
+      "n_screened_rows": 105,
+      "n_directional_rows": 70,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.020132662244591846,
+      "bh_rank": 43,
+      "bh_threshold": 0.0016300227445034117,
+      "best_row": {
+        "window": "is",
+        "horizon": 72,
+        "state": "trending_up",
+        "gap": -0.03915440383233747,
+        "p_value": 0.020132662244591846,
+        "policy_dir": 1,
+        "sign_aligned": false,
+        "source": "binanceus"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "BTC",
+      "timeframe": "4h",
+      "classifier": "composite",
+      "n_screened_rows": 210,
+      "n_directional_rows": 105,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.006433118896036798,
+      "bh_rank": 10,
+      "bh_threshold": 0.0003790750568612585,
+      "best_row": {
+        "window": "oos",
+        "horizon": 1,
+        "state": "trending_down_clean",
+        "gap": -0.006466346099703586,
+        "p_value": 0.006433118896036798,
+        "policy_dir": -1,
+        "sign_aligned": true,
+        "source": "binanceus"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "ETH",
+      "timeframe": "1h",
+      "classifier": "adx",
+      "n_screened_rows": 105,
+      "n_directional_rows": 70,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.028765707809739676,
+      "bh_rank": 62,
+      "bh_threshold": 0.002350265352539803,
+      "best_row": {
+        "window": "oos",
+        "horizon": 8,
+        "state": "trending_down",
+        "gap": -0.0035237425568513656,
+        "p_value": 0.028765707809739676,
+        "policy_dir": -1,
+        "sign_aligned": true,
+        "source": "binanceus"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "ETH",
+      "timeframe": "1h",
+      "classifier": "composite",
+      "n_screened_rows": 245,
+      "n_directional_rows": 140,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.0021665944468517717,
+      "bh_rank": 3,
+      "bh_threshold": 0.00011372251705837758,
+      "best_row": {
+        "window": "2025H1",
+        "horizon": 1,
+        "state": "trending_down_clean",
+        "gap": 0.009231095213637103,
+        "p_value": 0.0021665944468517717,
+        "policy_dir": -1,
+        "sign_aligned": false,
+        "source": "binanceus"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "ETH",
+      "timeframe": "4h",
+      "classifier": "adx",
+      "n_screened_rows": 105,
+      "n_directional_rows": 70,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.06276457451418287,
+      "bh_rank": 119,
+      "bh_threshold": 0.004510993176648976,
+      "best_row": {
+        "window": "oos",
+        "horizon": 1,
+        "state": "trending_down",
+        "gap": -0.001698825849144466,
+        "p_value": 0.06276457451418287,
+        "policy_dir": -1,
+        "sign_aligned": true,
+        "source": "binanceus"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "ETH",
+      "timeframe": "4h",
+      "classifier": "composite",
+      "n_screened_rows": 231,
+      "n_directional_rows": 126,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.0028332388920369322,
+      "bh_rank": 6,
+      "bh_threshold": 0.00022744503411675516,
+      "best_row": {
+        "window": "2024",
+        "horizon": 1,
+        "state": "trending_down_clean",
+        "gap": 0.022842698267352878,
+        "p_value": 0.0028332388920369322,
+        "policy_dir": -1,
+        "sign_aligned": false,
+        "source": "binanceus"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "HYPE",
+      "timeframe": "1h",
+      "classifier": "adx",
+      "n_screened_rows": 21,
+      "n_directional_rows": 14,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.16822772574247524,
+      "bh_rank": 261,
+      "bh_threshold": 0.009893858984078848,
+      "best_row": {
+        "window": "oos",
+        "horizon": 72,
+        "state": "trending_down",
+        "gap": 0.01356913774259042,
+        "p_value": 0.16822772574247524,
+        "policy_dir": -1,
+        "sign_aligned": false,
+        "source": "hyperliquid"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "HYPE",
+      "timeframe": "1h",
+      "classifier": "composite",
+      "n_screened_rows": 56,
+      "n_directional_rows": 28,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.07263091230292323,
+      "bh_rank": 132,
+      "bh_threshold": 0.005003790750568613,
+      "best_row": {
+        "window": "oos",
+        "horizon": 48,
+        "state": "trending_up_clean",
+        "gap": -0.06573183132992963,
+        "p_value": 0.07263091230292323,
+        "policy_dir": 1,
+        "sign_aligned": false,
+        "source": "hyperliquid"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "HYPE",
+      "timeframe": "4h",
+      "classifier": "adx",
+      "n_screened_rows": 84,
+      "n_directional_rows": 56,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.0006999766674444185,
+      "bh_rank": 2,
+      "bh_threshold": 7.581501137225171e-05,
+      "best_row": {
+        "window": "2025H1",
+        "horizon": 1,
+        "state": "trending_up",
+        "gap": -0.006130564157924708,
+        "p_value": 0.0006999766674444185,
+        "policy_dir": 1,
+        "sign_aligned": false,
+        "source": "hyperliquid"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "HYPE",
+      "timeframe": "4h",
+      "classifier": "composite",
+      "n_screened_rows": 141,
+      "n_directional_rows": 66,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.006899770007666411,
+      "bh_rank": 11,
+      "bh_threshold": 0.0004169825625473844,
+      "best_row": {
+        "window": "is",
+        "horizon": 1,
+        "state": "trending_down_clean",
+        "gap": 0.06325226122582024,
+        "p_value": 0.006899770007666411,
+        "policy_dir": -1,
+        "sign_aligned": false,
+        "source": "hyperliquid"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "SOL",
+      "timeframe": "1h",
+      "classifier": "adx",
+      "n_screened_rows": 105,
+      "n_directional_rows": 70,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.03366554448185061,
+      "bh_rank": 69,
+      "bh_threshold": 0.002615617892342684,
+      "best_row": {
+        "window": "2023",
+        "horizon": 72,
+        "state": "trending_down",
+        "gap": -0.018606247563357,
+        "p_value": 0.03366554448185061,
+        "policy_dir": -1,
+        "sign_aligned": true,
+        "source": "binanceus"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "SOL",
+      "timeframe": "1h",
+      "classifier": "composite",
+      "n_screened_rows": 259,
+      "n_directional_rows": 140,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.0005333155561481284,
+      "bh_rank": 1,
+      "bh_threshold": 3.7907505686125855e-05,
+      "best_row": {
+        "window": "2024",
+        "horizon": 1,
+        "state": "trending_down_clean",
+        "gap": 0.03569811073271726,
+        "p_value": 0.0005333155561481284,
+        "policy_dir": -1,
+        "sign_aligned": false,
+        "source": "binanceus"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "SOL",
+      "timeframe": "4h",
+      "classifier": "adx",
+      "n_screened_rows": 105,
+      "n_directional_rows": 70,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.014132862237925403,
+      "bh_rank": 30,
+      "bh_threshold": 0.0011372251705837756,
+      "best_row": {
+        "window": "2023",
+        "horizon": 12,
+        "state": "trending_up",
+        "gap": 0.02363288979185363,
+        "p_value": 0.014132862237925403,
+        "policy_dir": 1,
+        "sign_aligned": true,
+        "source": "binanceus"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    },
+    {
+      "asset": "SOL",
+      "timeframe": "4h",
+      "classifier": "composite",
+      "n_screened_rows": 210,
+      "n_directional_rows": 98,
+      "global_bh_family_size": 1319,
+      "fdr_q": 0.05,
+      "min_p_value": 0.009066364454518182,
+      "bh_rank": 17,
+      "bh_threshold": 0.0006444275966641396,
+      "best_row": {
+        "window": "2023",
+        "horizon": 12,
+        "state": "trending_up_choppy",
+        "gap": 0.023600006915014626,
+        "p_value": 0.009066364454518182,
+        "policy_dir": 1,
+        "sign_aligned": true,
+        "source": "binanceus"
+      },
+      "n_survive_global_bh": 0,
+      "n_survive_and_aligned": 0,
+      "n_survive_aligned_held_out": 0,
+      "verdict": "fails_global_bh"
+    }
+  ],
+  "certified": []
+}

--- a/backtest/research/regime_directional_certifications.json
+++ b/backtest/research/regime_directional_certifications.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-06-19T00:00:00Z",
+  "generated_at": "2026-08-22T10:06:41Z",
   "generator": "backtest/research/regime_1076_certify.py",
   "source_evidence": "backtest/research/README_1076_directional_premise.md",
   "criteria": {
@@ -9,8 +9,51 @@
     "also_require_bonferroni": false,
     "require_sign_aligned": true,
     "require_held_out_forward": true,
-    "held_out_windows": ["is", "oos"],
-    "n_perm": 500
+    "held_out_windows": [
+      "is",
+      "oos"
+    ],
+    "screened_family_size": 1319,
+    "n_perm": 30000,
+    "permutation_p_floor": 3.333222225925803e-05,
+    "data_sources": {
+      "BTC/USDT": "binanceus",
+      "ETH/USDT": "binanceus",
+      "HYPE/USDC:USDC": "hyperliquid",
+      "SOL/USDT": "binanceus"
+    },
+    "universe": {
+      "classifiers": [
+        "adx",
+        "composite"
+      ],
+      "horizons": [
+        1,
+        4,
+        8,
+        12,
+        24,
+        48,
+        72
+      ],
+      "symbols": [
+        "BTC/USDT",
+        "ETH/USDT",
+        "HYPE/USDC:USDC",
+        "SOL/USDT"
+      ],
+      "timeframes": [
+        "1h",
+        "4h"
+      ],
+      "windows": [
+        "is",
+        "oos",
+        "2023",
+        "2024",
+        "2025H1"
+      ]
+    }
   },
   "default_ttl_days": 90,
   "certified": []

--- a/backtest/tests/test_regime_1076_certify.py
+++ b/backtest/tests/test_regime_1076_certify.py
@@ -2,6 +2,7 @@
 
 Tests the global-correction + sign-alignment + held-out-forward gate over
 synthetic premise-screen rows — no data access."""
+import json
 import os
 import sys
 from datetime import datetime, timezone
@@ -63,3 +64,226 @@ def test_composite_sublabel_maps_to_canonical():
         [_row(state="trending_down_strong", policy_dir=-1)], generated_at=GEN_AT)
     assert len(art["certified"]) == 1
     assert art["certified"][0]["states"] == {"trending_down": "short"}
+
+
+# ==========================================================================
+# #1443 — criteria provenance, family integrity, per-cell verdicts
+# ==========================================================================
+import pytest  # noqa: E402
+
+import regime_1076_directional_premise as premise_mod  # noqa: E402
+
+FULL_UNIVERSE = dict(
+    symbols=premise_mod.DEFAULT_SYMBOLS,
+    timeframes=premise_mod.DEFAULT_TIMEFRAMES,
+    windows=premise_mod.DEFAULT_WINDOWS,
+    classifiers=premise_mod.DEFAULT_CLASSIFIERS,
+    horizons=premise_mod.DEFAULT_HORIZONS,
+)
+
+
+# -------------------------------------------------------------- criteria
+def test_screened_family_size_counts_directional_rows_only():
+    # A ranging row is not part of the directional BH family and must not
+    # inflate the recorded family size.
+    rows = [_row(), _row(symbol="ETH/USDT"),
+            _row(state="ranging", policy_dir=0, sign_aligned=False)]
+    art = certify_mod.certify(rows, generated_at=GEN_AT)
+    assert art["criteria"]["screened_family_size"] == 2
+
+
+def test_screened_family_size_is_emitted_even_for_an_empty_screen():
+    art = certify_mod.certify([], generated_at=GEN_AT)
+    assert art["criteria"]["screened_family_size"] == 0
+
+
+def test_provenance_keys_are_absent_when_not_supplied():
+    c = certify_mod.certify([_row()], generated_at=GEN_AT)["criteria"]
+    for key in ("universe", "data_sources", "n_perm", "permutation_p_floor"):
+        assert key not in c
+
+
+def test_provenance_keys_pass_through_and_nest_under_criteria():
+    sources = {"HYPE/USDC:USDC": "hyperliquid", "BTC/USDT": "binanceus"}
+    art = certify_mod.certify(
+        [_row()], generated_at=GEN_AT, universe=FULL_UNIVERSE,
+        data_sources=sources, n_perm=30000)
+    c = art["criteria"]
+    assert c["data_sources"] == sources
+    assert c["n_perm"] == 30000
+    assert c["permutation_p_floor"] == pytest.approx(1 / 30001)
+    assert c["universe"]["symbols"] == list(premise_mod.DEFAULT_SYMBOLS)
+    assert c["universe"]["horizons"] == list(premise_mod.DEFAULT_HORIZONS)
+    # The Go loader parses with DisallowUnknownFields and only `criteria` is a
+    # free-form map, so NO new key may appear at the top level.
+    assert set(art) == {"schema_version", "generated_at", "generator",
+                        "source_evidence", "criteria", "default_ttl_days",
+                        "certified"}
+    assert art["schema_version"] == 1
+
+
+def test_permutation_p_floor_arithmetic():
+    assert certify_mod.permutation_p_floor(500) == pytest.approx(1 / 501)
+    assert certify_mod.permutation_p_floor(30000) == pytest.approx(1 / 30001)
+
+
+# ------------------------------------------------------- family integrity
+def test_family_is_superset_true_for_the_default_universe():
+    assert certify_mod.family_is_superset(**FULL_UNIVERSE)
+
+
+def test_family_is_superset_true_when_a_symbol_is_added():
+    assert certify_mod.family_is_superset(
+        symbols=premise_mod.parse_symbols_arg(
+            "BTC/USDT,ETH/USDT,SOL/USDT,HYPE/USDC:USDC@hyperliquid"),
+        timeframes=premise_mod.DEFAULT_TIMEFRAMES,
+        windows=premise_mod.DEFAULT_WINDOWS,
+        classifiers=premise_mod.DEFAULT_CLASSIFIERS,
+        horizons=premise_mod.DEFAULT_HORIZONS)
+
+
+def test_family_is_superset_ignores_the_exchange_suffix():
+    # Sourcing a default symbol elsewhere still covers that axis value.
+    assert certify_mod.family_is_superset(
+        symbols=("BTC/USDT@kraken", "ETH/USDT", "SOL/USDT"),
+        timeframes=premise_mod.DEFAULT_TIMEFRAMES,
+        windows=premise_mod.DEFAULT_WINDOWS,
+        classifiers=premise_mod.DEFAULT_CLASSIFIERS,
+        horizons=premise_mod.DEFAULT_HORIZONS)
+
+
+@pytest.mark.parametrize("axis", ["symbols", "timeframes", "windows",
+                                  "classifiers", "horizons"])
+def test_family_is_superset_false_when_any_axis_is_narrowed(axis):
+    kwargs = dict(FULL_UNIVERSE)
+    kwargs[axis] = tuple(kwargs[axis])[:-1]
+    assert not certify_mod.family_is_superset(**kwargs)
+
+
+def test_family_is_superset_skips_horizons_when_not_supplied():
+    kwargs = dict(FULL_UNIVERSE)
+    kwargs["horizons"] = None
+    assert certify_mod.family_is_superset(**kwargs)
+
+
+def test_narrowed_run_refuses_to_write_the_repo_artifact():
+    # The gate fires BEFORE any data access, so this never touches the cache.
+    with pytest.raises(SystemExit) as exc:
+        certify_mod.main(["--symbols", "ETH/USDT", "--timeframes", "1h",
+                          "--classifiers", "composite"])
+    assert "narrowed family" in str(exc.value)
+
+
+def test_narrowed_run_may_write_a_research_artifact_elsewhere(tmp_path, monkeypatch):
+    # Same narrowed universe, but writing OUTSIDE the repo artifact: allowed,
+    # with the narrowing warned about and recorded. premise.run is substituted so
+    # this stays a pure test.
+    monkeypatch.setattr(premise_mod, "run", lambda *a, **k: [_row(symbol="ETH/USDT")])
+    out = tmp_path / "research_artifact.json"
+    report = tmp_path / "research_report.json"
+    rc = certify_mod.main(["--symbols", "ETH/USDT", "--timeframes", "1h",
+                           "--classifiers", "composite", "--windows", "oos",
+                           "--horizons", "4", "--n-perm", "1",
+                           "--out", str(out), "--report-out", str(report)])
+    assert rc == 0
+    art = json.loads(out.read_text())
+    assert art["schema_version"] == 1
+    # Narrowed on purpose: the recorded universe makes that inspectable later.
+    assert art["criteria"]["universe"]["symbols"] == ["ETH/USDT"]
+    assert art["criteria"]["screened_family_size"] == 1
+    assert json.loads(report.read_text())["cell_verdicts"][0]["verdict"] == (
+        certify_mod.VERDICT_CERTIFIED)
+
+
+def test_repo_artifact_run_over_the_full_family_is_allowed(tmp_path, monkeypatch):
+    # The inverse of the refusal above: a superset universe writing the repo
+    # artifact path proceeds. Guards against a guard that refuses everything.
+    monkeypatch.setattr(premise_mod, "run", lambda *a, **k: [])
+    monkeypatch.setattr(certify_mod, "DEFAULT_ARTIFACT", str(tmp_path / "art.json"))
+    rc = certify_mod.main([
+        "--symbols", "BTC/USDT,ETH/USDT,SOL/USDT,HYPE/USDC:USDC@hyperliquid",
+        "--out", str(tmp_path / "art.json"),
+        "--report-out", str(tmp_path / "rep.json")])
+    assert rc == 0
+    assert json.loads((tmp_path / "art.json").read_text())["certified"] == []
+
+
+# ---------------------------------------------------------- cell verdicts
+def test_cell_verdict_certified_matches_the_artifact():
+    rows = [_row()]
+    v = certify_mod.cell_verdicts(rows)[("BTC", "1h", "composite")]
+    assert v["verdict"] == certify_mod.VERDICT_CERTIFIED
+    assert v["certified_states"] == {"trending_up": "long"}
+    assert v["global_bh_family_size"] == 1
+    assert v["bh_rank"] == 1
+
+
+def test_cell_verdict_reports_the_bh_bar_it_missed():
+    # 200 weak rows: the best one is nowhere near the rank-1 critical value.
+    rows = [_row(symbol="ETH/USDT", p=0.30 + i * 0.001) for i in range(200)]
+    v = certify_mod.cell_verdicts(rows)[("ETH", "1h", "composite")]
+    assert v["verdict"] == certify_mod.VERDICT_FAILS_GLOBAL_BH
+    assert v["min_p_value"] == pytest.approx(0.30)
+    assert v["bh_rank"] == 1
+    assert v["bh_threshold"] == pytest.approx(0.05 / 200)
+    assert v["n_survive_global_bh"] == 0
+
+
+def test_cell_verdict_wrong_signed_outranks_the_held_out_check():
+    # Strong and BH-surviving, but the separation points against the policy bet:
+    # the binding failure is the sign, not the window.
+    rows = [_row(sign_aligned=False, window="2024")]
+    v = certify_mod.cell_verdicts(rows)[("BTC", "1h", "composite")]
+    assert v["verdict"] == certify_mod.VERDICT_WRONG_SIGNED
+
+
+def test_cell_verdict_not_held_out_forward():
+    v = certify_mod.cell_verdicts([_row(window="2024")])[("BTC", "1h", "composite")]
+    assert v["verdict"] == certify_mod.VERDICT_NOT_HELD_OUT
+    assert v["n_survive_and_aligned"] == 1
+    assert v["n_survive_aligned_held_out"] == 0
+
+
+def test_cell_verdict_no_directional_rows():
+    v = certify_mod.cell_verdicts(
+        [_row(state="ranging", policy_dir=0, sign_aligned=False)]
+    )[("BTC", "1h", "composite")]
+    assert v["verdict"] == certify_mod.VERDICT_NO_DIRECTIONAL_ROWS
+    assert v["n_directional_rows"] == 0
+    assert v["min_p_value"] is None
+
+
+def test_cell_verdicts_cover_every_screened_cell_not_only_certified_ones():
+    rows = [_row(symbol="BTC/USDT"), _row(symbol="ETH/USDT", p=0.9),
+            _row(symbol="HYPE/USDC:USDC", p=0.9, window="is")]
+    v = certify_mod.cell_verdicts(rows)
+    assert set(v) == {("BTC", "1h", "composite"), ("ETH", "1h", "composite"),
+                      ("HYPE", "1h", "composite")}
+    # The BH family is the whole run, so every cell reports the same denominator.
+    assert {e["global_bh_family_size"] for e in v.values()} == {3}
+
+
+def test_cell_verdict_best_row_records_the_data_source():
+    rows = [dict(_row(symbol="HYPE/USDC:USDC", window="is"),
+                 source="hyperliquid")]
+    v = certify_mod.cell_verdicts(rows)[("HYPE", "1h", "composite")]
+    assert v["best_row"]["source"] == "hyperliquid"
+
+
+def test_cell_verdicts_handle_repeated_and_equal_row_objects():
+    # Rows are matched to BH ranks by POSITION in the family. Equal-valued rows —
+    # or literally the same dict passed twice — must each occupy their own slot,
+    # otherwise a cell's reported bar belongs to a different hypothesis.
+    shared = _row(symbol="ETH/USDT", p=0.4)
+    rows = [shared, shared, _row(symbol="ETH/USDT", p=0.4), _row(p=0.001)]
+    v = certify_mod.cell_verdicts(rows)
+    eth = v[("ETH", "1h", "composite")]
+    assert eth["n_directional_rows"] == 3
+    assert eth["global_bh_family_size"] == 4
+    assert eth["min_p_value"] == pytest.approx(0.4)
+
+
+def test_bh_ranks_give_tied_p_values_the_same_bar():
+    ranks = certify_mod._bh_ranks([0.2, 0.1, 0.2], 0.05)
+    assert [r for r, _ in ranks] == [2, 1, 2]
+    assert ranks[1][1] == pytest.approx(0.05 * 1 / 3)

--- a/backtest/tests/test_regime_1076_certify.py
+++ b/backtest/tests/test_regime_1076_certify.py
@@ -198,7 +198,10 @@ def test_narrowed_run_may_write_a_research_artifact_elsewhere(tmp_path, monkeypa
 def test_repo_artifact_run_over_the_full_family_is_allowed(tmp_path, monkeypatch):
     # The inverse of the refusal above: a superset universe writing the repo
     # artifact path proceeds. Guards against a guard that refuses everything.
-    monkeypatch.setattr(premise_mod, "run", lambda *a, **k: [])
+    # The screen returns a directional row that FAILS the gate, so the run is a
+    # legitimate negative result rather than a degenerate one (see the
+    # zero-coverage test below) and must still write with exit 0.
+    monkeypatch.setattr(premise_mod, "run", lambda *a, **k: [_row(p=0.9)])
     monkeypatch.setattr(certify_mod, "DEFAULT_ARTIFACT", str(tmp_path / "art.json"))
     rc = certify_mod.main([
         "--symbols", "BTC/USDT,ETH/USDT,SOL/USDT,HYPE/USDC:USDC@hyperliquid",
@@ -287,3 +290,202 @@ def test_bh_ranks_give_tied_p_values_the_same_bar():
     ranks = certify_mod._bh_ranks([0.2, 0.1, 0.2], 0.05)
     assert [r for r, _ in ranks] == [2, 1, 2]
     assert ranks[1][1] == pytest.approx(0.05 * 1 / 3)
+
+
+# ------------------------------------------- baseline data sources (review)
+def test_baseline_source_violations_is_empty_on_the_baseline_venue():
+    # Explicitly naming the baseline venue is the SAME source, so it must pass.
+    sources = {"BTC/USDT": "binanceus", "ETH/USDT": "binanceus",
+               "SOL/USDT": "binanceus"}
+    assert certify_mod.baseline_source_violations(sources, "binanceus") == {}
+
+
+def test_baseline_source_violations_ignores_added_symbols():
+    # An ADDED symbol carrying its own venue is the whole point of SYMBOL@exchange.
+    sources = {"BTC/USDT": "binanceus", "ETH/USDT": "binanceus",
+               "SOL/USDT": "binanceus", "HYPE/USDC:USDC": "hyperliquid"}
+    assert certify_mod.baseline_source_violations(sources, "binanceus") == {}
+
+
+def test_baseline_source_violations_reports_every_repointed_default():
+    # Two at once: the guard must name both, not stop at the first it finds.
+    sources = {"BTC/USDT": "kraken", "ETH/USDT": "coinbase",
+               "SOL/USDT": "binanceus"}
+    assert certify_mod.baseline_source_violations(sources, "binanceus") == {
+        "BTC/USDT": "kraken", "ETH/USDT": "coinbase"}
+
+
+def test_repointed_baseline_refuses_to_write_the_repo_artifact(monkeypatch):
+    # Full-width family, so ONLY the source check can be refusing here.
+    with pytest.raises(SystemExit) as exc:
+        certify_mod.main(["--symbols", "BTC/USDT@kraken,ETH/USDT,SOL/USDT"])
+    assert "repointed baseline" in str(exc.value)
+    assert "BTC/USDT@kraken" in str(exc.value)
+
+
+def test_repointed_baseline_may_be_written_elsewhere(tmp_path, monkeypatch):
+    monkeypatch.setattr(premise_mod, "run", lambda *a, **k: [_row(p=0.9)])
+    out = tmp_path / "art.json"
+    rc = certify_mod.main(["--symbols", "BTC/USDT@kraken,ETH/USDT,SOL/USDT",
+                           "--out", str(out), "--report-out", ""])
+    assert rc == 0
+    assert json.loads(out.read_text())["criteria"]["data_sources"]["BTC/USDT"] == "kraken"
+
+
+# --------------------------------------------- repo run report (review)
+def test_narrowed_run_refuses_when_only_the_report_targets_the_repo(monkeypatch):
+    # --out is redirected but --report-out still defaults to the COMMITTED run
+    # report, which is this issue's evidence for the negative result.
+    with pytest.raises(SystemExit) as exc:
+        certify_mod.main(["--symbols", "BTC/USDT", "--timeframes", "1h",
+                          "--classifiers", "composite",
+                          "--out", "/tmp/research_cert.json"])
+    assert "narrowed family" in str(exc.value)
+    assert "regime_1443_run_report.json" in str(exc.value)
+
+
+def test_empty_report_out_skips_cleanly_instead_of_refusing(tmp_path, monkeypatch):
+    monkeypatch.setattr(premise_mod, "run", lambda *a, **k: [_row(symbol="ETH/USDT")])
+    out = tmp_path / "research.json"
+    rc = certify_mod.main(["--symbols", "ETH/USDT", "--timeframes", "1h",
+                           "--classifiers", "composite", "--windows", "oos",
+                           "--horizons", "4", "--n-perm", "1",
+                           "--out", str(out), "--report-out", ""])
+    assert rc == 0
+    assert out.exists()
+
+
+def test_full_width_run_writes_both_repo_defaults(tmp_path, monkeypatch):
+    monkeypatch.setattr(premise_mod, "run", lambda *a, **k: [_row(p=0.9)])
+    art, rep = tmp_path / "art.json", tmp_path / "rep.json"
+    monkeypatch.setattr(certify_mod, "DEFAULT_ARTIFACT", str(art))
+    monkeypatch.setattr(certify_mod, "DEFAULT_RUN_REPORT", str(rep))
+    rc = certify_mod.main(["--symbols", ",".join(premise_mod.DEFAULT_SYMBOLS)])
+    assert rc == 0
+    assert art.exists() and rep.exists()
+
+
+# ------------------------------------------------ degenerate runs (review)
+def test_zero_coverage_run_refuses_and_leaves_the_artifact_untouched(tmp_path, monkeypatch):
+    monkeypatch.setattr(premise_mod, "run", lambda *a, **k: [])
+    art = tmp_path / "art.json"
+    art.write_text('{"sentinel": true}\n')
+    monkeypatch.setattr(certify_mod, "DEFAULT_ARTIFACT", str(art))
+    with pytest.raises(SystemExit) as exc:
+        certify_mod.main(["--symbols", ",".join(premise_mod.DEFAULT_SYMBOLS),
+                          "--report-out", ""])
+    assert "NO directional rows" in str(exc.value)
+    # A refusal must never half-write: the pre-existing file is byte-identical.
+    assert json.loads(art.read_text()) == {"sentinel": True}
+
+
+def test_under_resolved_run_refuses_the_repo_artifact(tmp_path, monkeypatch):
+    # 400 directional rows at n_perm=500: p-floor 1/501 sits far above q/400.
+    monkeypatch.setattr(premise_mod, "run",
+                        lambda *a, **k: [_row(p=0.5) for _ in range(400)])
+    monkeypatch.setattr(certify_mod, "DEFAULT_ARTIFACT", str(tmp_path / "art.json"))
+    with pytest.raises(SystemExit) as exc:
+        certify_mod.main(["--symbols", ",".join(premise_mod.DEFAULT_SYMBOLS),
+                          "--n-perm", "500", "--report-out", ""])
+    assert "p-floor" in str(exc.value)
+    assert not (tmp_path / "art.json").exists()
+
+
+def test_degenerate_research_run_written_elsewhere_is_allowed(tmp_path, monkeypatch):
+    # Nothing repo-tracked is targeted, so research stays free.
+    monkeypatch.setattr(premise_mod, "run", lambda *a, **k: [])
+    out = tmp_path / "research.json"
+    rc = certify_mod.main(["--symbols", "BTC/USDT", "--timeframes", "1h",
+                           "--classifiers", "composite", "--windows", "oos",
+                           "--horizons", "4", "--allow-narrowed-family",
+                           "--out", str(out), "--report-out", str(tmp_path / "r.json")])
+    assert rc == 0
+    assert json.loads(out.read_text())["certified"] == []
+
+
+def test_allow_degenerate_run_is_separate_from_allow_narrowed_family(tmp_path, monkeypatch):
+    # Narrowing must NOT also unlock overwriting the live artifact from a run
+    # that measured nothing.
+    monkeypatch.setattr(premise_mod, "run", lambda *a, **k: [])
+    monkeypatch.setattr(certify_mod, "DEFAULT_ARTIFACT", str(tmp_path / "art.json"))
+    with pytest.raises(SystemExit) as exc:
+        certify_mod.main(["--symbols", "BTC/USDT", "--timeframes", "1h",
+                          "--classifiers", "composite", "--windows", "oos",
+                          "--horizons", "4", "--allow-narrowed-family",
+                          "--report-out", ""])
+    assert "NO directional rows" in str(exc.value)
+    rc = certify_mod.main(["--symbols", "BTC/USDT", "--timeframes", "1h",
+                           "--classifiers", "composite", "--windows", "oos",
+                           "--horizons", "4", "--allow-narrowed-family",
+                           "--allow-degenerate-run", "--report-out", ""])
+    assert rc == 0
+    assert json.loads((tmp_path / "art.json").read_text())["certified"] == []
+
+
+def test_n_perm_default_resolves_the_full_screen():
+    # The default must be able to certify at full-screen family sizes.
+    n_perm = certify_mod.build_parser().parse_args([]).n_perm
+    assert certify_mod.permutation_p_floor(n_perm) <= 0.05 / 1319
+
+
+# ---------------------------------------------- one asset, one series (review)
+def test_cert_asset_collisions_flags_two_venues_for_one_asset():
+    got = certify_mod.cert_asset_collisions(
+        premise_mod.parse_symbols_arg("BTC/USDT,BTC/USDC:USDC@hyperliquid"))
+    assert got == {"BTC": ["BTC/USDC:USDC", "BTC/USDT"]}
+
+
+def test_cert_asset_collisions_accepts_distinct_assets():
+    assert certify_mod.cert_asset_collisions(premise_mod.parse_symbols_arg(
+        "BTC/USDT,ETH/USDT,SOL/USDT,HYPE/USDC:USDC@hyperliquid")) == {}
+
+
+def test_colliding_assets_refuse_before_any_data_access():
+    with pytest.raises(SystemExit) as exc:
+        certify_mod.main(["--symbols",
+                          "BTC/USDT,ETH/USDT,SOL/USDT,BTC/USDC:USDC@hyperliquid"])
+    assert "normalize to the same certification asset" in str(exc.value)
+
+
+# ------------------------------------------- BH step-up consistency (review)
+def test_step_up_cutoff_is_none_when_the_family_rejects_nothing():
+    assert certify_mod.bh_step_up_cutoff([0.3, 0.4, 0.5], 0.05) is None
+    assert certify_mod.bh_step_up_cutoff([], 0.05) is None
+
+
+def test_step_up_cutoff_reports_the_bar_the_family_cleared():
+    # m=2, q=0.05: per-rank bars are 0.025 and 0.05. Rank 1 (0.04) misses its own
+    # bar, rank 2 (0.041) clears 0.05, so BH steps up and rejects BOTH.
+    assert certify_mod.bh_step_up_cutoff([0.04, 0.041], 0.05) == pytest.approx(0.05)
+
+
+def test_reported_bar_never_contradicts_the_verdict():
+    # The defect this fixes: certified cells whose min_p exceeded the printed bar.
+    rows = [_row(symbol="BTC/USDT", p=0.04), _row(symbol="ETH/USDT", p=0.041)]
+    v = certify_mod.cell_verdicts(rows, fdr_q=0.05)
+    for entry in v.values():
+        assert entry["verdict"] == certify_mod.VERDICT_CERTIFIED
+        assert entry["min_p_value"] <= entry["bh_threshold"]
+    btc = v[("BTC", "1h", "composite")]
+    assert btc["bh_rank_threshold"] == pytest.approx(0.025)   # its own per-rank bar
+    assert btc["bh_step_up_cutoff"] == pytest.approx(0.05)    # what BH actually applied
+
+
+def test_tied_p_values_straddling_the_cut_report_one_consistent_bar():
+    rows = [_row(symbol=s, p=0.03) for s in ("BTC/USDT", "ETH/USDT", "SOL/USDT")]
+    v = certify_mod.cell_verdicts(rows, fdr_q=0.05)
+    assert {e["verdict"] for e in v.values()} == {certify_mod.VERDICT_CERTIFIED}
+    bars = [e["bh_threshold"] for e in v.values()]
+    assert bars == [pytest.approx(0.05)] * 3
+    for e in v.values():
+        assert e["min_p_value"] <= e["bh_threshold"]
+
+
+def test_failing_family_keeps_the_per_rank_bar():
+    # Must-survive: with nothing rejected there is no cutoff, so the honest
+    # "how far short did it fall" stays each row's own per-rank critical value.
+    rows = [_row(symbol="ETH/USDT", p=0.30 + i * 0.001) for i in range(200)]
+    v = certify_mod.cell_verdicts(rows)[("ETH", "1h", "composite")]
+    assert v["bh_step_up_cutoff"] is None
+    assert v["bh_threshold"] == pytest.approx(0.05 / 200)
+    assert v["bh_threshold"] == v["bh_rank_threshold"]

--- a/backtest/tests/test_regime_1076_certify.py
+++ b/backtest/tests/test_regime_1076_certify.py
@@ -489,3 +489,86 @@ def test_failing_family_keeps_the_per_rank_bar():
     assert v["bh_step_up_cutoff"] is None
     assert v["bh_threshold"] == pytest.approx(0.05 / 200)
     assert v["bh_threshold"] == v["bh_rank_threshold"]
+
+
+# --- #1443 review round 2: the displayed best_row must not contradict its own
+# verdict. The verdict is decided by nested filters; the row shown as its
+# evidence is drawn from the deepest tier the cell reached, never from the whole
+# directional set. Every case below puts the cell's globally lowest-p row in a
+# SHALLOWER tier than the one the verdict names.
+
+def test_certified_cell_does_not_display_a_wrong_signed_best_row():
+    rows = [_row(p=1e-6, sign_aligned=False), _row(p=1e-5, sign_aligned=True)]
+    v = certify_mod.cell_verdicts(rows)[("BTC", "1h", "composite")]
+    assert v["verdict"] == certify_mod.VERDICT_CERTIFIED
+    assert v["best_row"]["sign_aligned"] is True
+    assert v["best_row"]["p_value"] == 1e-5
+    assert v["best_row_basis"] == certify_mod.BASIS_CERTIFIED_HELD_OUT
+    # The cell minimum keeps its literal meaning — it is not the displayed row.
+    assert v["min_p_value"] == 1e-6
+
+
+def test_certified_cell_does_not_display_a_historical_window_best_row():
+    rows = [_row(p=1e-6, window="2024"), _row(p=1e-5, window="oos")]
+    v = certify_mod.cell_verdicts(rows)[("BTC", "1h", "composite")]
+    assert v["verdict"] == certify_mod.VERDICT_CERTIFIED
+    assert v["best_row"]["window"] == "oos"
+    assert v["best_row_basis"] == certify_mod.BASIS_CERTIFIED_HELD_OUT
+
+
+def test_not_held_out_cell_displays_an_aligned_row():
+    # Verdict says the cell survived BH and alignment but missed held-out
+    # forward; showing the wrong-signed minimum as its evidence contradicts that.
+    rows = [_row(p=1e-6, window="2024", sign_aligned=False),
+            _row(p=1e-5, window="2024", sign_aligned=True)]
+    v = certify_mod.cell_verdicts(rows)[("BTC", "1h", "composite")]
+    assert v["verdict"] == certify_mod.VERDICT_NOT_HELD_OUT
+    assert v["best_row"]["sign_aligned"] is True
+    assert v["best_row_basis"] == certify_mod.BASIS_SURVIVED_ALIGNED
+
+
+def test_wrong_signed_cell_displays_a_surviving_row():
+    rows = [_row(p=1e-6, sign_aligned=False), _row(p=1e-5, sign_aligned=False)]
+    v = certify_mod.cell_verdicts(rows)[("BTC", "1h", "composite")]
+    assert v["verdict"] == certify_mod.VERDICT_WRONG_SIGNED
+    assert v["best_row"]["p_value"] == 1e-6
+    assert v["best_row_basis"] == certify_mod.BASIS_SURVIVED_BH
+
+
+def test_single_row_cells_display_that_row_unchanged():
+    # The pre-existing shape: one directional row per cell, at every verdict.
+    for row, verdict in ((_row(p=1e-6), certify_mod.VERDICT_CERTIFIED),
+                         (_row(p=1e-6, window="2024"),
+                          certify_mod.VERDICT_NOT_HELD_OUT),
+                         (_row(p=1e-6, sign_aligned=False),
+                          certify_mod.VERDICT_WRONG_SIGNED),
+                         (_row(p=0.9), certify_mod.VERDICT_FAILS_GLOBAL_BH)):
+        v = certify_mod.cell_verdicts([row])[("BTC", "1h", "composite")]
+        assert v["verdict"] == verdict
+        assert v["best_row"]["p_value"] == row["p_value"] == v["min_p_value"]
+
+
+def test_failing_cell_still_displays_its_globally_lowest_p_row():
+    # Nothing passed, so "how far short did it fall" is the whole directional
+    # set — the reported basis and the committed run report both say so.
+    rows = [_row(p=0.5), _row(p=0.9)]
+    v = certify_mod.cell_verdicts(rows)[("BTC", "1h", "composite")]
+    assert v["verdict"] == certify_mod.VERDICT_FAILS_GLOBAL_BH
+    assert v["best_row"]["p_value"] == 0.5 == v["min_p_value"]
+    assert v["best_row_basis"] == certify_mod.BASIS_ALL_DIRECTIONAL
+
+
+def test_verdict_line_names_the_displayed_row_when_it_is_not_the_minimum():
+    rows = [_row(p=1e-6, sign_aligned=False), _row(p=1e-5, sign_aligned=True)]
+    v = certify_mod.cell_verdicts(rows)[("BTC", "1h", "composite")]
+    line = certify_mod._format_verdict_line(v)
+    assert "min_p=1e-06" in line
+    assert "p=1e-05" in line
+    assert f"basis={certify_mod.BASIS_CERTIFIED_HELD_OUT}" in line
+
+
+def test_verdict_line_is_unchanged_when_the_displayed_row_is_the_minimum():
+    v = certify_mod.cell_verdicts([_row(p=0.5)])[("BTC", "1h", "composite")]
+    line = certify_mod._format_verdict_line(v)
+    assert " p=" not in line
+    assert "basis=" not in line

--- a/backtest/tests/test_regime_1076_premise.py
+++ b/backtest/tests/test_regime_1076_premise.py
@@ -226,3 +226,21 @@ def test_coverage_table_omits_windows_that_contributed_nothing():
     # report diffs the table against the requested grid to name it.
     cov = premise.coverage_table([_row(window="oos")])
     assert [e["window"] for e in cov] == ["oos"]
+
+
+def test_parse_symbols_arg_rejects_a_repeated_symbol():
+    # Every symbol-keyed surface downstream is a dict, so the two entries would
+    # merge — resolve_data_sources keeping only the last exchange, coverage_table
+    # blending both series into one cell — while both still inflate the family.
+    with pytest.raises(ValueError, match="duplicate symbol"):
+        premise.parse_symbols_arg("BTC/USDT,ETH/USDT,BTC/USDT@kraken")
+
+
+def test_parse_symbols_arg_rejects_an_exact_repeat():
+    with pytest.raises(ValueError, match="duplicate symbol"):
+        premise.parse_symbols_arg("BTC/USDT,BTC/USDT")
+
+
+def test_parse_symbols_arg_allows_distinct_symbols_on_one_venue():
+    assert premise.parse_symbols_arg("BTC/USDT@kraken,ETH/USDT@kraken") == (
+        ("BTC/USDT", "kraken"), ("ETH/USDT", "kraken"))

--- a/backtest/tests/test_regime_1076_premise.py
+++ b/backtest/tests/test_regime_1076_premise.py
@@ -1,0 +1,228 @@
+"""#1443: the premise screen's pure symbol-spec / window-clip / coverage helpers.
+
+No data access: the one test that exercises ``_load`` substitutes a fake loader
+so the fetch-fallback overflow it guards against is reproducible offline."""
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "research")))
+
+import regime_1076_directional_premise as premise  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# parse_symbol_spec / parse_symbols_arg
+# --------------------------------------------------------------------------
+def test_bare_symbol_has_no_exchange():
+    assert premise.parse_symbol_spec("BTC/USDT") == ("BTC/USDT", None)
+
+
+def test_ccxt_perp_symbol_splits_on_the_last_at():
+    # The symbol itself carries "/" and ":"; only the trailing @ is the source.
+    assert premise.parse_symbol_spec("HYPE/USDC:USDC@hyperliquid") == (
+        "HYPE/USDC:USDC", "hyperliquid")
+
+
+def test_spec_whitespace_is_trimmed():
+    assert premise.parse_symbol_spec("  ETH/USDT @ binanceus ") == (
+        "ETH/USDT", "binanceus")
+
+
+@pytest.mark.parametrize("spec", ["", "   ", "@hyperliquid", "BTC/USDT@", "BTC/USDT@   "])
+def test_malformed_specs_raise(spec):
+    # A typo must never silently fall back to the default source: a screen run on
+    # the wrong series would look completely normal in the output.
+    with pytest.raises(ValueError):
+        premise.parse_symbol_spec(spec)
+
+
+def test_parse_symbols_arg_mixed_defaults_and_mapped_symbol():
+    specs = premise.parse_symbols_arg(
+        "BTC/USDT,ETH/USDT,SOL/USDT,HYPE/USDC:USDC@hyperliquid")
+    assert specs == (("BTC/USDT", None), ("ETH/USDT", None), ("SOL/USDT", None),
+                     ("HYPE/USDC:USDC", "hyperliquid"))
+
+
+def test_parse_symbols_arg_skips_blank_entries():
+    assert premise.parse_symbols_arg("BTC/USDT, ,ETH/USDT") == (
+        ("BTC/USDT", None), ("ETH/USDT", None))
+
+
+def test_parse_symbols_arg_rejects_an_empty_universe():
+    with pytest.raises(ValueError):
+        premise.parse_symbols_arg("  ,  ")
+
+
+def test_normalize_symbol_specs_accepts_both_forms():
+    assert premise.normalize_symbol_specs(
+        ["BTC/USDT", ("HYPE/USDC:USDC", "hyperliquid")]) == (
+            ("BTC/USDT", None), ("HYPE/USDC:USDC", "hyperliquid"))
+
+
+def test_normalize_symbol_specs_does_not_reparse_bare_strings():
+    # run() takes plain strings from existing callers; an "@" inside one of those
+    # is part of the symbol, not a source override.
+    assert premise.normalize_symbol_specs(["A@B"]) == (("A@B", None),)
+
+
+def test_resolve_data_sources_fills_platform_for_unmapped_symbols():
+    sources = premise.resolve_data_sources(
+        premise.parse_symbols_arg("BTC/USDT,HYPE/USDC:USDC@hyperliquid"))
+    assert sources == {"BTC/USDT": premise.PLATFORM,
+                       "HYPE/USDC:USDC": "hyperliquid"}
+
+
+# --------------------------------------------------------------------------
+# _clip_window
+# --------------------------------------------------------------------------
+def _frame(start, periods, freq="1h"):
+    idx = pd.date_range(start, periods=periods, freq=freq)
+    return pd.DataFrame({"open": 1.0, "high": 1.0, "low": 1.0,
+                         "close": 1.0, "volume": 1.0}, index=idx)
+
+
+def test_clip_window_trims_both_ends_inclusive_of_end():
+    df = _frame("2023-12-30", 120)          # 2023-12-30 .. 2024-01-03
+    out = premise._clip_window(df, "2023-01-01", "2024-01-01")
+    assert out.index.min() == pd.Timestamp("2023-12-30")
+    # end is inclusive, matching storage.load_ohlcv's `timestamp <= end_ts`
+    assert out.index.max() == pd.Timestamp("2024-01-01 00:00:00")
+
+
+def test_clip_window_open_ended_when_end_is_none():
+    df = _frame("2026-01-01", 48)
+    out = premise._clip_window(df, "2026-01-01", None)
+    assert len(out) == 48
+
+
+def test_clip_window_drops_everything_before_the_window():
+    df = _frame("2024-11-01", 100)
+    out = premise._clip_window(df, "2023-01-01", "2024-01-01")
+    assert len(out) == 0
+
+
+def test_clip_window_passes_empty_frames_through():
+    empty = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+    assert len(premise._clip_window(empty, "2023-01-01", "2024-01-01")) == 0
+
+
+def test_clip_window_rejects_a_non_datetime_index():
+    df = pd.DataFrame({"close": [1.0, 2.0]})
+    with pytest.raises(ValueError):
+        premise._clip_window(df, "2023-01-01", "2024-01-01")
+
+
+# --------------------------------------------------------------------------
+# _load — the regression this guard exists for
+# --------------------------------------------------------------------------
+def _price_frame(start, periods):
+    """A wandering price series long enough to clear the composite warmup."""
+    rng = np.random.default_rng(7)
+    idx = pd.date_range(start, periods=periods, freq="1h")
+    close = 100.0 * np.exp(np.cumsum(rng.normal(0, 0.002, periods)))
+    return pd.DataFrame({"open": close, "high": close * 1.001,
+                         "low": close * 0.999, "close": close,
+                         "volume": 1.0}, index=idx)
+
+
+def test_load_clips_a_fetch_fallback_frame_to_the_requested_window(monkeypatch):
+    """load_cached_data's empty-cache fallback fetches from ``since=start_date``
+    and returns the WHOLE history unsliced. For an asset listed after a window
+    (HYPE against "2023") that would screen later data under the earlier
+    window's label. Without the clip in _load this test sees the full frame."""
+    start, end = premise.WINDOWS["2023"]
+    # Listing starts inside 2023 but the frame runs two years past the window end.
+    full = _price_frame("2023-11-01", 24 * 400)
+    assert full.index.max() > pd.Timestamp(end)
+    monkeypatch.setattr(premise, "load_cached_data",
+                        lambda *a, **k: full.copy())
+
+    d = premise._load("HYPE/USDC:USDC", "1h", "2023", "composite",
+                      dict(premise._DEFAULT_COMPOSITE_THRESHOLDS),
+                      exchange="hyperliquid")
+    assert d is not None
+    in_window = int(((full.index >= pd.Timestamp(start))
+                     & (full.index <= pd.Timestamp(end))).sum())
+    assert in_window < len(full)                 # the overflow is real
+    assert d["n_bars"] <= in_window              # only in-window bars were labeled
+    assert len(d["close"]) == in_window
+
+
+def test_load_passes_the_mapped_exchange_to_the_loader(monkeypatch):
+    seen = {}
+
+    def fake(symbol, timeframe, exchange_id=None, start_date=None, end_date=None):
+        seen["exchange_id"] = exchange_id
+        return _price_frame("2025-01-01", 24 * 120)
+
+    monkeypatch.setattr(premise, "load_cached_data", fake)
+    premise._load("HYPE/USDC:USDC", "1h", "2025H1", "composite",
+                  dict(premise._DEFAULT_COMPOSITE_THRESHOLDS),
+                  exchange="hyperliquid")
+    assert seen["exchange_id"] == "hyperliquid"
+
+
+def test_load_defaults_to_platform_when_no_exchange_is_mapped(monkeypatch):
+    seen = {}
+
+    def fake(symbol, timeframe, exchange_id=None, start_date=None, end_date=None):
+        seen["exchange_id"] = exchange_id
+        return _price_frame("2025-01-01", 24 * 120)
+
+    monkeypatch.setattr(premise, "load_cached_data", fake)
+    premise._load("BTC/USDT", "1h", "2025H1", "composite",
+                  dict(premise._DEFAULT_COMPOSITE_THRESHOLDS))
+    assert seen["exchange_id"] == premise.PLATFORM
+
+
+def test_load_returns_none_for_a_window_the_asset_predates(monkeypatch):
+    # HYPE against "2023": the fetch fallback hands back post-listing data, the
+    # clip empties it, and the existing bar-count guard drops the cell.
+    monkeypatch.setattr(premise, "load_cached_data",
+                        lambda *a, **k: _price_frame("2024-11-01", 24 * 300))
+    assert premise._load("HYPE/USDC:USDC", "1h", "2023", "composite",
+                         dict(premise._DEFAULT_COMPOSITE_THRESHOLDS),
+                         exchange="hyperliquid") is None
+
+
+# --------------------------------------------------------------------------
+# coverage_table
+# --------------------------------------------------------------------------
+def _row(symbol="HYPE/USDC:USDC", timeframe="1h", window="oos",
+         classifier="composite", source="hyperliquid", n_bars=1200):
+    return {"classifier": classifier, "symbol": symbol, "source": source,
+            "n_bars": n_bars, "timeframe": timeframe, "window": window,
+            "horizon": 4, "state": "trending_up", "gap": 0.01, "mean_fwd": 0.01,
+            "p_value": 0.5, "fdr_reject": False, "policy_dir": 1,
+            "sign_aligned": True, "candidate_edge": False}
+
+
+def test_coverage_table_counts_rows_and_bars_per_classifier():
+    rows = [_row(), _row(), _row(classifier="adx", n_bars=1234)]
+    cov = premise.coverage_table(rows)
+    assert len(cov) == 1
+    e = cov[0]
+    assert e["symbol"] == "HYPE/USDC:USDC"
+    assert e["source"] == "hyperliquid"
+    assert e["rows"] == 3
+    assert e["bars"] == {"composite": 1200, "adx": 1234}
+
+
+def test_coverage_table_is_sorted_and_splits_windows():
+    rows = [_row(window="oos"), _row(window="is"), _row(symbol="BTC/USDT",
+                                                        source="binanceus")]
+    cov = premise.coverage_table(rows)
+    assert [(e["symbol"], e["window"]) for e in cov] == [
+        ("BTC/USDT", "oos"), ("HYPE/USDC:USDC", "is"), ("HYPE/USDC:USDC", "oos")]
+
+
+def test_coverage_table_omits_windows_that_contributed_nothing():
+    # The absence IS the signal: a window with no rows never appears, and the
+    # report diffs the table against the requested grid to name it.
+    cov = premise.coverage_table([_row(window="oos")])
+    assert [e["window"] for e in cov] == ["oos"]

--- a/docs/backtesting-registry.md
+++ b/docs/backtesting-registry.md
@@ -62,14 +62,14 @@ its row here in the same PR. A new row is part of the change, not a follow-up.
 | `directional_certification.py` | Evidence-gated directional-certification backtest consumer — parity mirror of the Go path. | active | #1085 |
 | `research/regime_1081_economic_gate.py` | Economic walk-forward gate for regime-conditioned ATR sizing (money-side complement to separation gates). | active | #1081 |
 | `research/regime_1083_multi_asset_gate.py` | Multi-asset breadth gate orchestrating the single-cell separation/economic gates. | active | #1083 |
-| `research/regime_1076_certify.py` | Producer for the directional-certification artifact (SSoT for the regime→direction gate). | active | #1085 |
+| `research/regime_1076_certify.py` | Producer for the directional-certification artifact (SSoT for the regime→direction gate). Refuses to write the repo artifact from a narrowed BH family; records run provenance in `criteria` and per-cell verdicts in `--report-out` (#1443). | active | #1085 |
 
 ## Research one-shots (reproducible evidence, tied to a closed issue)
 
 | File | Purpose | Status | Origin |
 |------|---------|--------|--------|
 | `research/regime_1073_directional_negative_result.py` | Evidence the 7-state composite has no real forward-*return* separation (but strong forward-vol). | one-shot | #1073 |
-| `research/regime_1076_directional_premise.py` | Scope-1: does the regime label predict forward *direction*? | one-shot | #1076 |
+| `research/regime_1076_directional_premise.py` | Scope-1: does the regime label predict forward *direction*? Also the screen re-run by the #1085 producer; `--symbols` takes an optional per-symbol data source (`SYMBOL[@exchange]`, #1443). | one-shot | #1076 |
 | `research/regime_1076_economic_sim.py` | Scope-2: does picking trade side by regime label earn risk-adjusted PnL over base? | one-shot | #1076 |
 | `research/regime_1076_aggregate.py` | Aggregates the #1076 battery under one global multiple-comparisons correction. | one-shot | #1076 |
 | `research/regime_1080_unsupervised_vol_model.py` | Evidence run for the unsupervised vol-state bake-off. | one-shot | #1080 |

--- a/scheduler/regime_directional_certification_test.go
+++ b/scheduler/regime_directional_certification_test.go
@@ -104,6 +104,68 @@ func TestParseRejectsBadDirectionAndSchema(t *testing.T) {
 	}
 }
 
+// #1443: the producer records run provenance (screened family size, per-symbol
+// data sources, universe axes, permutation count) so a narrowed or mis-sourced
+// artifact is detectable by inspection. parseDirectionalCertSet uses
+// DisallowUnknownFields, and Criteria is the ONLY free-form map in the schema —
+// so that metadata must nest inside `criteria`. These two cases pin both halves
+// of that contract; no production Go change is involved.
+func TestParseToleratesNestedCriteriaProvenance(t *testing.T) {
+	art := []byte(`{
+		"schema_version": 1,
+		"generated_at": "2026-08-22T00:00:00Z",
+		"generator": "backtest/research/regime_1076_certify.py",
+		"source_evidence": "backtest/research/README_1076_directional_premise.md",
+		"criteria": {
+			"global_correction": "benjamini-hochberg",
+			"fdr_q": 0.05,
+			"held_out_windows": ["is", "oos"],
+			"screened_family_size": 2436,
+			"n_perm": 30000,
+			"permutation_p_floor": 3.333e-05,
+			"data_sources": {"BTC/USDT": "binanceus", "HYPE/USDC:USDC": "hyperliquid"},
+			"universe": {
+				"symbols": ["BTC/USDT", "ETH/USDT", "SOL/USDT", "HYPE/USDC:USDC"],
+				"timeframes": ["1h", "4h"],
+				"windows": ["is", "oos", "2023", "2024", "2025H1"],
+				"classifiers": ["adx", "composite"],
+				"horizons": [1, 4, 8, 12, 24, 48, 72]
+			}
+		},
+		"default_ttl_days": 90,
+		"certified": [
+			{"asset":"HYPE","timeframe":"1h","classifier":"composite",
+			 "generated_at":"2026-08-22T00:00:00Z","expires_at":"2026-11-20T00:00:00Z",
+			 "states":{"trending_down":"short"}}]}`)
+	set, err := parseDirectionalCertSet(art)
+	if err != nil {
+		t.Fatalf("nested criteria provenance must parse, got %v", err)
+	}
+	if got := set.Criteria["screened_family_size"]; got != float64(2436) {
+		t.Fatalf("screened_family_size not preserved: %v", got)
+	}
+	entry, ok := set.Certified("HYPE/USDC:USDC", "1h", "composite",
+		time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC))
+	if !ok {
+		t.Fatal("HYPE cell must certify through the normalized asset key")
+	}
+	if entry["trending_down"] != DirectionShort {
+		t.Fatalf("unexpected states: %v", entry)
+	}
+}
+
+func TestParseRejectsProvenanceAtTopLevel(t *testing.T) {
+	// The same metadata one level up. DisallowUnknownFields rejects it, which is
+	// exactly why the producer must never promote these keys out of `criteria`:
+	// doing so would make the live daemon fail closed on a valid screen.
+	for _, key := range []string{"screened_family_size", "data_sources", "universe", "n_perm"} {
+		art := []byte(`{"schema_version":1,"` + key + `":{},"certified":[]}`)
+		if _, err := parseDirectionalCertSet(art); err == nil {
+			t.Fatalf("top-level %q must be rejected by DisallowUnknownFields", key)
+		}
+	}
+}
+
 func TestLoadFailClosedOnMissingAndMalformed(t *testing.T) {
 	// Missing file -> empty set, no warn, no error.
 	set, err := LoadDirectionalCertSet("/nonexistent/regime_directional_certifications.json")


### PR DESCRIPTION
## Plain simple English

Some live strategies can trade short when the market trends down. A safety gate keeps this off until statistics prove the edge is real. The proof tool could not read data for one coin, HYPE, so the gate could never open for it. This work connects that data and reruns the proof. The result is negative: no edge, gate stays closed.

## Summary

Closes #1443.

The certification screen loaded every symbol from one exchange (`eval_windows.PLATFORM`, `binanceus`), so HYPE — a Hyperliquid perp — was unreachable and the `regime_directional_policy` configured on `hl-mr-hype-60` could never become evidence-backed. `--symbols` now accepts an optional per-symbol data source, `SYMBOL[@exchange]`.

`PLATFORM` itself is never repointed: mapped rows cache under their own `exchange_id` namespace, so the #1315 axis separation and every committed `binanceus` baseline are untouched. Verified: zero HYPE rows exist under the `binanceus` namespace after the run.

### Three hardenings

1. **Window clipping in `_load`.** `load_cached_data`'s empty-cache fallback fetches from `since=start_date` and returns the whole history **unsliced**, so an asset listed after a window would have later data screened under the earlier window's label. The clip is a no-op on the cached path, so every already-screened cell is unchanged. This is the one place the run could have gone silently wrong.

2. **Family-integrity refusal.** `certify()` corrects across the rows of ONE invocation, so the BH family *is* the run's universe. A narrowed run shrinks it and inflates every cell's pass probability — the pooled-limit trap #1424 records. Writing the repo artifact from a non-superset universe is now refused **before any data is touched**. `--allow-narrowed-family` overrides for research artifacts written elsewhere.

3. **Provenance and per-cell verdicts.** The artifact `criteria` records the actual screened family size (computed from the rows, never claimed), the per-symbol data sources, the universe axes, `n_perm` and the permutation p-floor. A new run report gives every screened cell its **first failing criterion**, best p-value, and the BH critical value it needed. All new metadata nests inside `criteria` because the Go loader parses with `DisallowUnknownFields` — a new top-level key would make the live daemon fail closed on a valid artifact. `schema_version` stays 1; no production Go change.

## Result of the regenerated screen

One invocation over the full default universe plus HYPE, `--n-perm 30000 --seed 0` (per the maintainer sign-off on the plan's decision point 1):

**0 of 16 screened cells certify. Every cell fails at the global-BH gate.**

The resolution caveat does **not** apply here. The p-floor `1/(n_perm+1)` = **3.333e-05** sits *below* the rank-1 BH critical value `q/m` = **3.791e-05** over the 1319-row family, so a single genuinely-separating state was arithmetically able to pass. It did not. At the previous default of `n_perm=500` the floor would have sat ~53× above that bar, where no single row could certify at any effect size.

| Target cell | Verdict | best p | bar it needed | best row | sign |
|---|---|---|---|---|---|
| (ETH, 1h, composite) | `fails_global_bh` | 0.002167 | 1.137e-04 (rank 3/1319) | `trending_down_clean` @ `2025H1` h1, gap +0.00923 | wrong-signed |
| (HYPE, 1h, composite) | `fails_global_bh` | 0.072631 | 5.004e-03 (rank 132/1319) | `trending_up_clean` @ `oos` h48, gap −0.06573 | wrong-signed |

Both miss by more than an order of magnitude and are additionally wrong-signed, so a relaxed bar would not yield a profitable certification either. Closest cell overall was (HYPE, 4h, adx) at p=7.000e-04 against a 7.582e-05 bar — still ~9× short, also wrong-signed.

`certified` stays `[]`, so the #1085 `[WARN]` printed by `hl-mr-hype-60`, `hl-vwap-eth-60` and `hl-rmc-eth-live` is the **expected, verified** outcome.

### HYPE data-availability limit (issue decision point 2)

Hyperliquid's candle endpoint serves a fixed **5000-candle retention window per interval, anchored at now**; `since` is ignored beyond it. Verified at fetch time — requests with `since` at 2023-01-01, 2024-01-01, 2025-01-01 and 2025-06-10 all returned the same 1h start.

| HYPE window | 1h | 4h |
|---|---|---|
| `2023` | empty | empty |
| `2024` | empty | 113 composite bars (Dec only) |
| `2025H1` | empty | 1039 |
| `is` | **empty** | 1183 |
| `oos` | 4955 (from 2026-01-26) | 1353 |

(HYPE, 1h, composite) therefore rests entirely on `oos`. That is a held-out-forward window, so the cell was still eligible to certify. **No other venue's HYPE series was substituted**, per the issue boundary — the shortfall is recorded in the coverage table and run report instead.

## Verification

- `go -C scheduler test . -count=1` → `ok` (full package); `gofmt -l scheduler/` clean
- `uv run --no-sync python -m pytest shared_strategies/ shared_tools/ platforms/ backtest/ -q -n auto` → **3409 passed, 1 skipped**
- The clip regression test was proven **red → green**: against the unfixed `_load`, a HYPE `2023` request labels 7152 post-listing bars as 2023, and both clip tests fail
- Narrowed run to the default `--out` exits 1 before touching data, leaving the artifact unmodified
- Regenerated artifact parses through `parseDirectionalCertSet` (Go) and `load_certifications` (Python) with no warning; index is empty because `certified` is empty
- `sqlite3` check: 0 HYPE rows under the `binanceus` namespace

## Adopted plan

Built to the Fable 5 plan posted on the issue (https://github.com/richkuo/go-trader/issues/1443#issuecomment-5379028890) and the maintainer's follow-up sign-off fixing `--n-perm 30000` (https://github.com/richkuo/go-trader/issues/1443#issuecomment-5379041270). Deviations, both additive:

1. **`family_is_superset` also checks `horizons`.** The plan named four axes (symbols/timeframes/windows/classifiers). Dropping horizons shrinks the BH family exactly as dropping symbols does, so leaving it unchecked would leave the guard bypassable by the narrowing it exists to prevent. The parameter is optional, so the plan's four-axis call shape still works.
2. **`cell_verdicts` keys rows by family position, not `id()`.** The plan did not specify the lookup mechanism; identity keying misbehaves if a caller passes the same row object twice, which would attach a cell's reported bar to a different hypothesis. Regression-tested.

Also added beyond the plan's literal text: an explicit branch for a zero-row family (a coverage failure, which must not print as a negative result), and the empty-window enumeration reads the *requested* axes rather than the axes present in the results.

## Follow-on work — unfiled

- Removing or keeping the `regime_directional_policy` blocks on the three deployment strategies is recorded as **keep-with-comment** in `README_1076_directional_premise.md`, with the reasoning. That config lives out of tree (`/var/lib/go-trader/config.json`) and is an operator action, not a repo change.
- Live-flip validation (deploy + SIGHUP + `DirectionCertifiedStatesAtOpen`) is moot while nothing certifies; it stays an operator runbook item for the day a cert appears.

---
Created with LLM: Opus 5 | high | Harness: Claude Code
