### PR TITLE
fix(#1454): bring live manual positions inside the kill-switch close and fill chain [C91, ox-alpha, high]

### DIFF
--- a/scheduler/hedge_test.go
+++ b/scheduler/hedge_test.go
@@ -1642,7 +1642,7 @@ func TestEveryHedgeLegCarriesTheHedgeTradeType(t *testing.T) {
 	t.Run("circuit-breaker virtual force-close sweep", func(t *testing.T) {
 		s := hedgeTestState("eth-long")
 		s.Positions["BTC"] = hedgePos(0.4, "short", 10)
-		forceCloseAllPositions(s, map[string]float64{"BTC": 51000}, silentStrategyLogger("eth-long"))
+		forceCloseAllPositions(s, nil, map[string]float64{"BTC": 51000}, silentStrategyLogger("eth-long"))
 		assertAllHedgeRows(t, s, 1)
 	})
 
@@ -2007,7 +2007,7 @@ func TestCircuitBreakerFireWithFailedFetchThenRecoveryClosesBothLegs(t *testing.
 	if !shouldForceCloseAllPositionsOnCircuitBreaker(&sc, assist) {
 		t.Fatal("setup: a sole-owner strategy still force-closes virtually")
 	}
-	forceCloseAllPositions(s, map[string]float64{"ETH": testPrimaryPx, "BTC": testHedgePx}, silentStrategyLogger("eth-long"))
+	forceCloseAllPositions(s, nil, map[string]float64{"ETH": testPrimaryPx, "BTC": testHedgePx}, silentStrategyLogger("eth-long"))
 	if len(s.Positions) != 0 {
 		t.Fatalf("setup: the sweep must clear both virtual legs, got %d", len(s.Positions))
 	}

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1970,6 +1970,12 @@ type HyperliquidLiveCloseReport struct {
 	AlreadyFlat []string
 	// Errors is non-nil so coin-keyed writes don't panic; len() works on nil maps too.
 	Errors map[string]error
+	// #1454: on-chain positions on coins no live HL strategy in the kill-switch
+	// roster (live perps + live type=manual) trades. Surfaced by
+	// planKillSwitchClose as plan.Unconfigured so a MIXED fleet gets the same
+	// CRITICAL line + flat-confirmation block an all-paper fleet already had,
+	// instead of the silent skip that hid manual-only coins.
+	Unconfigured []HLPosition
 }
 
 // ConfirmedFlat reports whether every configured live HL coin reached a
@@ -2030,9 +2036,16 @@ func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLi
 
 	tradedCoins := make(map[string]bool)
 	for _, sc := range hlLiveAll {
-		sym := hyperliquidSymbol(sc.Args)
-		if sym != "" {
-			tradedCoins[sym] = true
+		// #1454: resolve sc.Symbol for type=manual so a coin held only by a
+		// live manual strategy is inside the close scope instead of being
+		// skipped as unowned. Membership is compared CASE-INSENSITIVELY (HL
+		// tickers like kPEPE carry a lower-case prefix; hyperliquidConfiguredCoin's
+		// upper-casing is safe for peer matching but NOT for exchange-side keys),
+		// while report.Fills stays keyed by the RAW on-chain coin.
+		if sym := hyperliquidSymbol(sc.Args); sym != "" {
+			tradedCoins[strings.ToUpper(sym)] = true
+		} else if sc.Type == "manual" && sc.Symbol != "" {
+			tradedCoins[strings.ToUpper(sc.Symbol)] = true
 		}
 	}
 	// #1159: a held hedge leg is exposure this scheduler opened and therefore
@@ -2046,11 +2059,18 @@ func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLi
 	}
 
 	for _, p := range positions {
-		if !tradedCoins[p.Coin] {
+		if !tradedCoins[strings.ToUpper(p.Coin)] {
 			// Unowned position — kill switch only acts on coins this scheduler
 			// is configured to trade. An on-chain leftover from a different
 			// system (manual trade, another bot) is the operator's problem to
 			// reconcile, not the scheduler's to liquidate.
+			// #1454: a NON-ZERO unowned position is reported (report.Unconfigured
+			// → plan.Unconfigured → latch) rather than silently skipped — the
+			// silent skip is what left manual-held exposure running after a
+			// "confirmed flat" kill-switch pass on a mixed fleet.
+			if p.Size != 0 {
+				report.Unconfigured = append(report.Unconfigured, p)
+			}
 			continue
 		}
 		if p.Size == 0 {
@@ -2140,8 +2160,18 @@ func snapshotHyperliquidVirtualQuantities(strategies map[string]*StrategyState, 
 		if ss == nil {
 			continue
 		}
-		if coin := hyperliquidSymbol(sc.Args); coin != "" {
-			if pos := ss.Positions[coin]; pos != nil && pos.Quantity > 0 {
+		// #1454: resolve the coin for type=manual so their virtual quantities
+		// join the same fill-share snapshot as perps; otherwise a shared
+		// perps+manual coin awards the whole fill to the perps side and the
+		// manual leg fails closed into a model-only row. RAW key — this must
+		// match the key applyHyperliquidKillSwitchCloseFill books under.
+		coin := hyperliquidSymbol(sc.Args)
+		if sc.Type == "manual" {
+			coin = sc.Symbol
+		}
+		if coin != "" {
+			pos := hlVirtualPositionFor(ss, sc, coin)
+			if pos != nil && pos.Quantity > 0 {
 				record(coin, sc.ID, pos.Quantity)
 			}
 		}
@@ -2159,6 +2189,26 @@ func snapshotHyperliquidVirtualQuantities(strategies map[string]*StrategyState, 
 		return nil
 	}
 	return out
+}
+
+// hlVirtualPositionFor looks up a strategy's virtual position for a kill-switch
+// coin. The kill-switch chain keys coins through hyperliquidConfiguredCoin
+// (normalized upper-case), while type=manual positions are keyed by the raw
+// configured symbol — the fallback covers an operator-entered lower-case
+// symbol so the normalized fill-share key still finds the virtual leg.
+func hlVirtualPositionFor(ss *StrategyState, sc StrategyConfig, coin string) *Position {
+	if ss == nil {
+		return nil
+	}
+	if pos, ok := ss.Positions[coin]; ok && pos != nil {
+		return pos
+	}
+	if sc.Type == "manual" && sc.Symbol != "" && sc.Symbol != coin {
+		if pos, ok := ss.Positions[sc.Symbol]; ok && pos != nil {
+			return pos
+		}
+	}
+	return nil
 }
 
 // computeHyperliquidCircuitCloseQty returns the unsigned coin quantity for a
@@ -2231,10 +2281,19 @@ func hyperliquidKillSwitchFillShare(sc StrategyConfig, coin string, fillSz, fill
 // share of the portfolio kill-switch fill before generic virtual-state cleanup
 // runs.
 func applyHyperliquidKillSwitchCloseFill(s *StrategyState, sc StrategyConfig, fills map[string]HyperliquidCloseFill, hlLiveAll []StrategyConfig, virtualQty hlVirtualQuantitySnapshot) bool {
-	if s == nil || sc.Platform != "hyperliquid" || sc.Type != "perps" || !hyperliquidIsLive(sc.Args) {
+	// #1454: type=manual joins perps — a live manual strategy must book its
+	// share of the real fill (price/fee/OID) instead of falling through to
+	// forceCloseAllPositions' model-only reconciliation row.
+	if s == nil || sc.Platform != "hyperliquid" || (sc.Type != "perps" && sc.Type != "manual") || !hyperliquidIsLive(sc.Args) {
 		return false
 	}
+	// #1454: resolve sc.Symbol for type=manual (the #1444 precedent) rather
+	// than relying on auto-filled Args. RAW key — report.Fills is keyed by the
+	// raw on-chain coin, and lower-case-prefix tickers (kPEPE) are case-sensitive.
 	coin := hyperliquidSymbol(sc.Args)
+	if sc.Type == "manual" {
+		coin = sc.Symbol
+	}
 	if coin == "" {
 		return false
 	}

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -2041,11 +2041,12 @@ func forceCloseHyperliquidLive(ctx context.Context, positions []HLPosition, hlLi
 		// skipped as unowned. Membership is compared CASE-INSENSITIVELY (HL
 		// tickers like kPEPE carry a lower-case prefix; hyperliquidConfiguredCoin's
 		// upper-casing is safe for peer matching but NOT for exchange-side keys),
-		// while report.Fills stays keyed by the RAW on-chain coin.
-		if sym := hyperliquidSymbol(sc.Args); sym != "" {
+		// while report.Fills stays keyed by the RAW on-chain coin. #1454 review:
+		// the resolver is hyperliquidRawCoin — the SAME symbol-first order the
+		// snapshot/fill/OID sites use, so a hand-written args list whose args[1]
+		// diverges from Symbol cannot split the close scope from the booking key.
+		if sym := hyperliquidRawCoin(sc); sym != "" {
 			tradedCoins[strings.ToUpper(sym)] = true
-		} else if sc.Type == "manual" && sc.Symbol != "" {
-			tradedCoins[strings.ToUpper(sc.Symbol)] = true
 		}
 	}
 	// #1159: a held hedge leg is exposure this scheduler opened and therefore
@@ -2128,16 +2129,25 @@ func hlLiveStrategiesForCoin(coin string, hlLiveAll []StrategyConfig) []Strategy
 // tickers are uppercase by convention and the Python adapter rejects unknown
 // casings on its own, so normalizing here only affects Go-side peer matching.
 func hyperliquidConfiguredCoin(sc StrategyConfig) string {
+	return strings.ToUpper(strings.TrimSpace(hyperliquidRawCoin(sc)))
+}
+
+// hyperliquidRawCoin returns the RAW (case-preserved, un-trimmed) coin ticker
+// a HL kill-switch surface keys on: args[1] for perps, sc.Symbol for manual
+// (the #1444 precedent — LoadConfig synthesizes args=[hold, Symbol, ...] only
+// when Args is empty, so an operator-written args list must never outrank the
+// configured symbol). Every kill-switch consumer of a manual coin — close
+// scope, virtual-quantity snapshot, fill booking, resting-trigger cancel —
+// MUST go through this single resolver so all four name the same coin
+// (#1454 review).
+func hyperliquidRawCoin(sc StrategyConfig) string {
 	if sc.Platform != "hyperliquid" {
 		return ""
 	}
-	var raw string
 	if sc.Type == "manual" {
-		raw = sc.Symbol
-	} else {
-		raw = hyperliquidSymbol(sc.Args)
+		return sc.Symbol
 	}
-	return strings.ToUpper(strings.TrimSpace(raw))
+	return hyperliquidSymbol(sc.Args)
 }
 
 type hlVirtualQuantitySnapshot map[string]map[string]float64
@@ -2165,10 +2175,7 @@ func snapshotHyperliquidVirtualQuantities(strategies map[string]*StrategyState, 
 		// perps+manual coin awards the whole fill to the perps side and the
 		// manual leg fails closed into a model-only row. RAW key — this must
 		// match the key applyHyperliquidKillSwitchCloseFill books under.
-		coin := hyperliquidSymbol(sc.Args)
-		if sc.Type == "manual" {
-			coin = sc.Symbol
-		}
+		coin := hyperliquidRawCoin(sc)
 		if coin != "" {
 			pos := hlVirtualPositionFor(ss, sc, coin)
 			if pos != nil && pos.Quantity > 0 {
@@ -2192,23 +2199,16 @@ func snapshotHyperliquidVirtualQuantities(strategies map[string]*StrategyState, 
 }
 
 // hlVirtualPositionFor looks up a strategy's virtual position for a kill-switch
-// coin. The kill-switch chain keys coins through hyperliquidConfiguredCoin
-// (normalized upper-case), while type=manual positions are keyed by the raw
-// configured symbol — the fallback covers an operator-entered lower-case
-// symbol so the normalized fill-share key still finds the virtual leg.
+// coin. The coin is the RAW (case-preserved) hyperliquidRawCoin value — NOT
+// hyperliquidConfiguredCoin's normalized form — because type=manual positions
+// are keyed by the raw configured symbol and report.Fills by the raw on-chain
+// coin; lower-case-prefix tickers (kPEPE) are case-sensitive, so normalizing
+// either side would silently miss the lookup.
 func hlVirtualPositionFor(ss *StrategyState, sc StrategyConfig, coin string) *Position {
 	if ss == nil {
 		return nil
 	}
-	if pos, ok := ss.Positions[coin]; ok && pos != nil {
-		return pos
-	}
-	if sc.Type == "manual" && sc.Symbol != "" && sc.Symbol != coin {
-		if pos, ok := ss.Positions[sc.Symbol]; ok && pos != nil {
-			return pos
-		}
-	}
-	return nil
+	return ss.Positions[coin]
 }
 
 // computeHyperliquidCircuitCloseQty returns the unsigned coin quantity for a
@@ -2290,10 +2290,7 @@ func applyHyperliquidKillSwitchCloseFill(s *StrategyState, sc StrategyConfig, fi
 	// #1454: resolve sc.Symbol for type=manual (the #1444 precedent) rather
 	// than relying on auto-filled Args. RAW key — report.Fills is keyed by the
 	// raw on-chain coin, and lower-case-prefix tickers (kPEPE) are case-sensitive.
-	coin := hyperliquidSymbol(sc.Args)
-	if sc.Type == "manual" {
-		coin = sc.Symbol
-	}
+	coin := hyperliquidRawCoin(sc)
 	if coin == "" {
 		return false
 	}

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -14,7 +14,14 @@ import (
 type HLNoFillRecoverer func(since time.Time) (*HLUserFillsResult, error)
 
 const (
-	hlKillSwitchNoFillRecoveryLookback = 30 * time.Second
+	// #1454: widened from 30s — an already-flat position whose real fill landed
+	// shortly before the kill switch fired (external close, or an SL fill inside
+	// the fetch-to-submit window) was unrecoverable inside the old window and
+	// its row cleared model-only. Ten minutes bounds the userFills query while
+	// covering every observed incident latency; findUniqueHLFillByCoinQty still
+	// fails closed on ambiguous candidates, so the wider net cannot mis-book a
+	// foreign fill to this close.
+	hlKillSwitchNoFillRecoveryLookback = 10 * time.Minute
 	hlKillSwitchNoFillRecoveryTimeout  = 20 * time.Second
 )
 
@@ -428,6 +435,20 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 			plan.LogLines = append(plan.LogLines,
 				fmt.Sprintf("[CRITICAL] hl-close: %s failed: %v (kill switch will retry next cycle)", coin, plan.CloseReport.Errors[coin]))
 		}
+		// #1454: on-chain positions on coins no live HL strategy (perps OR
+		// manual) trades block flat confirmation in a mixed fleet too. The
+		// detection previously lived only in the empty-roster branch below, so
+		// a fleet with at least one live perps strategy never reached it and a
+		// manual-held coin was skipped without error, report entry, or latch.
+		if len(plan.CloseReport.Unconfigured) > 0 {
+			plan.Unconfigured = append(plan.Unconfigured, plan.CloseReport.Unconfigured...)
+			sort.Slice(plan.Unconfigured, func(i, j int) bool { return plan.Unconfigured[i].Coin < plan.Unconfigured[j].Coin })
+			plan.OnChainConfirmedFlat = false
+			for _, p := range plan.Unconfigured {
+				plan.LogLines = append(plan.LogLines,
+					fmt.Sprintf("[CRITICAL] hl-close: on-chain position for unconfigured coin %s (szi=%.6f) — manual intervention required, kill switch will retry next cycle", p.Coin, p.Size))
+			}
+		}
 
 	case hlStateFetched && len(in.HLLiveAll) == 0:
 		for _, p := range hlPositions {
@@ -621,6 +642,40 @@ func planKillSwitchClose(in KillSwitchCloseInputs) KillSwitchClosePlan {
 
 	plan.DiscordMessage = formatKillSwitchMessage(in.HLAddr, plan, in.PortfolioReason)
 	return plan
+}
+
+// collectHLKillSwitchStopOIDs gathers every resting SL/TP trigger OID held by
+// the kill-switch roster's virtual positions, keyed by coin, so the flatten can
+// cancel them before submitting (#421/#479). Extracted from main.go so the
+// #1454 roster extension to live type=manual strategies — whose resting
+// triggers would otherwise be orphaned on HL's open-order cap — is testable
+// without a running loop.
+func collectHLKillSwitchStopOIDs(strategies map[string]*StrategyState, roster []StrategyConfig) map[string][]int64 {
+	out := map[string][]int64{}
+	for _, sc := range roster {
+		// RAW coin key — forceCloseHyperliquidLive indexes stopLossOIDsByCoin
+		// by the raw on-chain p.Coin (case-sensitive kPEPE-style tickers).
+		sym := hyperliquidSymbol(sc.Args)
+		if sc.Type == "manual" {
+			sym = sc.Symbol
+		}
+		if sym == "" {
+			continue
+		}
+		ss, ok := strategies[sc.ID]
+		if !ok || ss == nil {
+			continue
+		}
+		pos := hlVirtualPositionFor(ss, sc, sym)
+		if pos == nil {
+			continue
+		}
+		out[sym] = appendUniquePositiveStopLossOID(out[sym], pos.StopLossOID)
+		for _, tpOID := range pos.TPOIDs {
+			out[sym] = appendUniquePositiveStopLossOID(out[sym], tpOID)
+		}
+	}
+	return out
 }
 
 // formatKillSwitchMessage builds the Discord notification string from a plan.

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -371,6 +371,73 @@ func recoverHyperliquidAlreadyFlatFills(report *HyperliquidLiveCloseReport, posi
 	return lines
 }
 
+// settledKillSwitchSymbols collects each NON-HL venue's positively-confirmed
+// closed coins, keyed by platform, for applyKillSwitchSettledLegsWhileLatched.
+// HL coins are excluded on purpose: their settled legs book from REAL fills
+// (report.Fills), which is strictly better than a mark estimate.
+func settledKillSwitchSymbols(plan *KillSwitchClosePlan) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+	add := func(platform string, coins []string) {
+		if len(coins) == 0 {
+			return
+		}
+		set := out[platform]
+		if set == nil {
+			set = map[string]bool{}
+			out[platform] = set
+		}
+		for _, c := range coins {
+			if c != "" {
+				set[c] = true
+			}
+		}
+	}
+	add("okx", plan.OKXCloseReport.ClosedCoins)
+	add("robinhood", plan.RHCloseReport.ClosedCoins)
+	add("topstep", plan.TSCloseReport.ClosedCoins)
+	return out
+}
+
+// applyKillSwitchSettledLegsWhileLatched books ONLY what the kill-switch
+// closers POSITIVELY settled while OnChainConfirmedFlat is false — the
+// #1457-review decoupling of "hold the latch" from "book nothing":
+//
+//   - HL legs with a confirmed fill book that fill (price/fee/OID) exactly as
+//     the confirmed-flat sweep would; the #954 same-OID dedupe inside
+//     applyHyperliquidCircuitCloseFill makes re-injection across latched
+//     cycles (already-flat recovery re-finding the same fill) idempotent.
+//   - Non-HL legs whose venue report lists the coin in ClosedCoins book
+//     model-only at the current mark via forceCloseSettledPositions — safe,
+//     because the exchange leg IS flat; waiting for the latch to clear would
+//     leave the virtual book disagreeing with the venue for the whole latch
+//     window.
+//
+// Everything UNSETTLED — an errored close, a foreign Unconfigured coin, an HL
+// coin with no fill this cycle — stays untouched for the retry: closing it
+// here would write an estimate over a live exchange position, which is
+// exactly what the #341 confirmed-flat gate exists to prevent.
+//
+// Caller holds mu. The latch itself (OnChainConfirmedFlat=false → retry next
+// cycle) is untouched — only the booking coupling is relaxed.
+func applyKillSwitchSettledLegsWhileLatched(strategies map[string]*StrategyState, cfgs []StrategyConfig, plan *KillSwitchClosePlan, hlRoster []StrategyConfig, virtualQty hlVirtualQuantitySnapshot, prices map[string]float64, logger *StrategyLogger) {
+	if plan == nil || len(cfgs) == 0 {
+		return
+	}
+	settled := settledKillSwitchSymbols(plan)
+	hasHLFills := len(plan.CloseReport.Fills) > 0
+	for _, sc := range cfgs {
+		s, ok := strategies[sc.ID]
+		if !ok || s == nil {
+			continue
+		}
+		if hasHLFills {
+			applyHyperliquidKillSwitchCloseFill(s, sc, plan.CloseReport.Fills, hlRoster, virtualQty)
+			applyHyperliquidKillSwitchHedgeFill(s, sc, plan.CloseReport.Fills)
+		}
+		forceCloseSettledPositions(s, sc, prices, settled, logger)
+	}
+}
+
 // planKillSwitchClose runs the kill-switch close logic without touching any
 // mutable state — no locks, no virtual state mutation, no Discord delivery.
 // The caller applies mutations based on the returned plan.

--- a/scheduler/kill_switch_close.go
+++ b/scheduler/kill_switch_close.go
@@ -18,9 +18,11 @@ const (
 	// shortly before the kill switch fired (external close, or an SL fill inside
 	// the fetch-to-submit window) was unrecoverable inside the old window and
 	// its row cleared model-only. Ten minutes bounds the userFills query while
-	// covering every observed incident latency; findUniqueHLFillByCoinQty still
-	// fails closed on ambiguous candidates, so the wider net cannot mis-book a
-	// foreign fill to this close.
+	// covering every observed incident latency. #1454 review: uniqueness alone
+	// no longer carries the match — recoverHyperliquidAlreadyFlatFills also
+	// requires a REDUCING fill (non-zero closedPnl, so an opening fill of the
+	// same size can never be adopted) at or after the query's since bound, so a
+	// lone wrong candidate inside the wider net fails closed to model-only.
 	hlKillSwitchNoFillRecoveryLookback = 10 * time.Minute
 	hlKillSwitchNoFillRecoveryTimeout  = 20 * time.Second
 )
@@ -328,10 +330,26 @@ func recoverHyperliquidAlreadyFlatFills(report *HyperliquidLiveCloseReport, posi
 		raws = append(raws, r)
 	}
 	sort.Strings(raws)
+	// #1454 review: restrict candidates to fills that could BE this close —
+	// a reducing fill (Hyperliquid reports closedPnl=0 on opening legs) whose
+	// event time is not before the query's since bound. Matching then stays
+	// unique-by-coin+qty over a pool of plausible closes only; an ambiguous or
+	// empty filtered pool falls back to model-only cleanup, never to booking
+	// an unrelated same-size fill's price/OID/fee into the cash adjustment.
+	candidates := make(map[string]HLFillSummary, len(result.ByOID))
+	for oid, summary := range result.ByOID {
+		if summary.ClosedPnLGross == 0 {
+			continue
+		}
+		if t := hlFillSummaryEventTime(summary); !t.IsZero() && t.Before(since) {
+			continue
+		}
+		candidates[oid] = summary
+	}
 	var lines []string
 	for _, rawCoin := range raws {
 		expected := eligibleByRaw[rawCoin]
-		match, ok, ambiguous := findUniqueHLFillByCoinQty(result.ByOID, rawCoin, expected.qty, true, time.Time{}, 0)
+		match, ok, ambiguous := findUniqueHLFillByCoinQty(candidates, rawCoin, expected.qty, true, time.Time{}, 0)
 		switch {
 		case ok:
 			report.Fills[rawCoin] = HyperliquidCloseFill{
@@ -655,10 +673,9 @@ func collectHLKillSwitchStopOIDs(strategies map[string]*StrategyState, roster []
 	for _, sc := range roster {
 		// RAW coin key — forceCloseHyperliquidLive indexes stopLossOIDsByCoin
 		// by the raw on-chain p.Coin (case-sensitive kPEPE-style tickers).
-		sym := hyperliquidSymbol(sc.Args)
-		if sc.Type == "manual" {
-			sym = sc.Symbol
-		}
+		// #1454 review: single resolver so close scope, fill booking and
+		// trigger cancel can never name different coins for one strategy.
+		sym := hyperliquidRawCoin(sc)
 		if sym == "" {
 			continue
 		}

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -551,8 +551,11 @@ func TestHyperliquidKillSwitchClose_AlreadyFlatSharedLowKCoinAmbiguousFallsBack(
 	in.HLNoFillRecoverer = func(since time.Time) (*HLUserFillsResult, error) {
 		return &HLUserFillsResult{
 			ByOID: map[string]HLFillSummary{
-				"111": {Coin: "kPEPE", Fee: 0.1, Qty: 2.0, Px: 0.00010, LastTimeMS: time.Now().UnixMilli()},
-				"222": {Coin: "kPEPE", Fee: 0.2, Qty: 2.0, Px: 0.00009, LastTimeMS: time.Now().UnixMilli()},
+				// Reducing candidates (non-zero closedPnl) — the #1454-review
+				// filter drops opening fills before uniqueness is judged, so
+				// genuine ambiguity needs closing fills here.
+				"111": {Coin: "kPEPE", Fee: 0.1, Qty: 2.0, Px: 0.00010, ClosedPnLGross: -0.5, LastTimeMS: time.Now().UnixMilli()},
+				"222": {Coin: "kPEPE", Fee: 0.2, Qty: 2.0, Px: 0.00009, ClosedPnLGross: -0.6, LastTimeMS: time.Now().UnixMilli()},
 			},
 		}, nil
 	}
@@ -618,8 +621,8 @@ func TestHyperliquidKillSwitchClose_AlreadyFlatAmbiguousUserFillFallsBack(t *tes
 	in.HLNoFillRecoverer = func(since time.Time) (*HLUserFillsResult, error) {
 		return &HLUserFillsResult{
 			ByOID: map[string]HLFillSummary{
-				"100": {Coin: "ETH", Fee: 0.4, Qty: 1.0, Px: 1990, LastTimeMS: time.Now().UnixMilli()},
-				"101": {Coin: "ETH", Fee: 0.5, Qty: 1.0, Px: 1989, LastTimeMS: time.Now().UnixMilli()},
+				"100": {Coin: "ETH", Fee: 0.4, Qty: 1.0, Px: 1990, ClosedPnLGross: -10, LastTimeMS: time.Now().UnixMilli()},
+				"101": {Coin: "ETH", Fee: 0.5, Qty: 1.0, Px: 1989, ClosedPnLGross: -11, LastTimeMS: time.Now().UnixMilli()},
 			},
 		}, nil
 	}
@@ -633,6 +636,80 @@ func TestHyperliquidKillSwitchClose_AlreadyFlatAmbiguousUserFillFallsBack(t *tes
 	}
 	if !strings.Contains(strings.Join(plan.LogLines, "\n"), "multiple userFills candidates") {
 		t.Fatalf("missing ambiguity warning: %v", plan.LogLines)
+	}
+}
+
+// #1454 review: a lone OPENING fill (closedPnl=0) of the same size inside the
+// widened 10m window must never be booked as the close — uniqueness is judged
+// over plausible closes only.
+func TestHyperliquidKillSwitchClose_AlreadyFlatRecoveryRejectsOpeningFill(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 1.0, EntryPrice: 2000}}
+	closer := func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		return &HyperliquidCloseResult{
+			Close:    &HyperliquidClose{Symbol: symbol, AlreadyFlat: true},
+			Platform: "hyperliquid",
+		}, nil
+	}
+	fetcher, _ := stubHLStateFetcher(nil, nil)
+	in := defaultHLInputs("0xaddr", true, positions, hlLive,
+		"portfolio drawdown 25.0% exceeds limit 20.0%",
+		time.Second, closer, fetcher)
+	in.HLNoFillRecoverer = func(since time.Time) (*HLUserFillsResult, error) {
+		return &HLUserFillsResult{
+			ByOID: map[string]HLFillSummary{
+				"300": {Coin: "ETH", Fee: 0.4, Qty: 1.0, Px: 1990, ClosedPnLGross: 0, LastTimeMS: time.Now().UnixMilli()},
+			},
+		}, nil
+	}
+
+	plan := planKillSwitchClose(in)
+	if _, ok := plan.CloseReport.Fills["ETH"]; ok {
+		t.Fatalf("opening fill must never be adopted as the close: %+v", plan.CloseReport.Fills)
+	}
+	if !strings.Contains(strings.Join(plan.LogLines, "\n"), "no userFills match") {
+		t.Fatalf("expected fail-closed warning, got: %v", plan.LogLines)
+	}
+}
+
+// #1454 review: a reducing candidate whose event time sits BEFORE the query's
+// since bound is outside the recovery window and must be rejected.
+func TestHyperliquidKillSwitchClose_AlreadyFlatRecoveryIgnoresFillBeforeSince(t *testing.T) {
+	hlLive := []StrategyConfig{
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 1.0, EntryPrice: 2000}}
+	closer := func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		return &HyperliquidCloseResult{
+			Close:    &HyperliquidClose{Symbol: symbol, AlreadyFlat: true},
+			Platform: "hyperliquid",
+		}, nil
+	}
+	fetcher, _ := stubHLStateFetcher(nil, nil)
+	var gotSince time.Time
+	in := defaultHLInputs("0xaddr", true, positions, hlLive,
+		"portfolio drawdown 25.0% exceeds limit 20.0%",
+		time.Second, closer, fetcher)
+	in.HLNoFillRecoverer = func(since time.Time) (*HLUserFillsResult, error) {
+		gotSince = since
+		return &HLUserFillsResult{
+			ByOID: map[string]HLFillSummary{
+				"400": {Coin: "ETH", Fee: 0.4, Qty: 1.0, Px: 1990, ClosedPnLGross: -10,
+					LastTimeMS: since.Add(-time.Minute).UnixMilli()},
+			},
+		}, nil
+	}
+
+	plan := planKillSwitchClose(in)
+	if gotSince.IsZero() {
+		t.Fatal("recovery since timestamp must be populated")
+	}
+	if _, ok := plan.CloseReport.Fills["ETH"]; ok {
+		t.Fatalf("fill before the since bound must not be adopted: %+v", plan.CloseReport.Fills)
 	}
 }
 

--- a/scheduler/kill_switch_manual_test.go
+++ b/scheduler/kill_switch_manual_test.go
@@ -313,6 +313,137 @@ func TestPlanKillSwitchClose_DeclaredButFlatHedgeCoinStaysUnowned(t *testing.T) 
 	}
 }
 
+// #1457 review round 2: a HELD latch must not discard what the closers
+// positively settled. HL legs with confirmed fills book the real fill;
+// unsettled legs stay in the book for the retry.
+func TestApplyKillSwitchSettledLegsWhileLatched_BooksConfirmedHLFill(t *testing.T) {
+	cfgs := []StrategyConfig{
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+	}
+	state := &StrategyState{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Cash: 1000,
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 1.0, AvgCost: 2000, Side: "long", Multiplier: 1},
+		},
+	}
+	strategies := map[string]*StrategyState{"hl-eth": state}
+	plan := KillSwitchClosePlan{OnChainConfirmedFlat: false}
+	plan.CloseReport.Fills = map[string]HyperliquidCloseFill{
+		"ETH": {TotalSz: 1.0, AvgPx: 2100, Fee: 0.5, OID: 555},
+	}
+	virtualQty := snapshotHyperliquidVirtualQuantities(strategies, cfgs)
+
+	applyKillSwitchSettledLegsWhileLatched(strategies, cfgs, &plan, cfgs, virtualQty,
+		map[string]float64{"ETH": 2100}, nil)
+
+	if len(state.Positions) != 0 {
+		t.Fatalf("positions after apply = %+v; want flat", state.Positions)
+	}
+	var booked *Trade
+	for i := range state.TradeHistory {
+		tr := &state.TradeHistory[i]
+		if tr.ExchangeOrderID == "555" {
+			booked = tr
+		}
+	}
+	if booked == nil {
+		t.Fatal("confirmed fill must book with its real OID while latched")
+	}
+	if math.Abs(booked.RealizedPnL-100) > 1e-6 || math.Abs(booked.ExchangeFee-0.5) > 1e-9 {
+		t.Errorf("booked fill = PnL %.4f fee %.4f; want 100 / 0.5", booked.RealizedPnL, booked.ExchangeFee)
+	}
+
+	// Re-running on the next latched cycle (already-flat recovery re-finding
+	// the same fill) must be a no-op — no double booking (#954 dedupe).
+	before := len(state.TradeHistory)
+	applyKillSwitchSettledLegsWhileLatched(strategies, cfgs, &plan, cfgs, virtualQty,
+		map[string]float64{"ETH": 2100}, nil)
+	if len(state.TradeHistory) != before {
+		t.Errorf("same-OID re-application must not double-book: %d -> %d rows", before, len(state.TradeHistory))
+	}
+}
+
+func TestApplyKillSwitchSettledLegsWhileLatched_UnsettledLegStays(t *testing.T) {
+	cfgs := []StrategyConfig{
+		{ID: "hl-sol", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "SOL", "1h", "--mode=live"}},
+	}
+	state := &StrategyState{
+		ID: "hl-sol", Type: "perps", Platform: "hyperliquid", Cash: 1000,
+		Positions: map[string]*Position{
+			"SOL": {Symbol: "SOL", Quantity: 2.0, AvgCost: 100, Side: "long", Multiplier: 1},
+		},
+	}
+	strategies := map[string]*StrategyState{"hl-sol": state}
+	plan := KillSwitchClosePlan{OnChainConfirmedFlat: false} // SOL close ERRORED — no fill
+
+	applyKillSwitchSettledLegsWhileLatched(strategies, cfgs, &plan, cfgs, nil,
+		map[string]float64{"SOL": 90}, nil)
+
+	pos := state.Positions["SOL"]
+	if pos == nil || math.Abs(pos.Quantity-2.0) > 1e-9 {
+		t.Fatalf("unsettled leg must stay untouched for the retry, got %+v", state.Positions)
+	}
+	if len(state.TradeHistory) != 0 {
+		t.Errorf("no trade may book over an unsettled live position, got %+v", state.TradeHistory)
+	}
+}
+
+func TestApplyKillSwitchSettledLegsWhileLatched_OKXClosedCoinBooksModelOnly(t *testing.T) {
+	okxCfgs := []StrategyConfig{
+		{ID: "okx-btc", Platform: "okx", Type: "perps",
+			Args: []string{"sma", "BTC-USDT-SWAP", "1h", "--mode=live"}},
+	}
+	hlCfgs := []StrategyConfig{
+		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	okxState := &StrategyState{
+		ID: "okx-btc", Type: "perps", Platform: "okx", Cash: 1000,
+		Positions: map[string]*Position{
+			"BTC": {Symbol: "BTC", Quantity: 1.0, AvgCost: 50000, Side: "long", Multiplier: 1},
+		},
+	}
+	hlState := &StrategyState{
+		ID: "hl-btc", Type: "perps", Platform: "hyperliquid", Cash: 1000,
+		Positions: map[string]*Position{
+			"BTC": {Symbol: "BTC", Quantity: 3.0, AvgCost: 50000, Side: "long", Multiplier: 1},
+		},
+	}
+	strategies := map[string]*StrategyState{"okx-btc": okxState, "hl-btc": hlState}
+	plan := KillSwitchClosePlan{OnChainConfirmedFlat: false}
+	plan.OKXCloseReport.ClosedCoins = []string{"BTC"} // OKX leg settled; HL coin UNRELATED
+
+	applyKillSwitchSettledLegsWhileLatched(strategies, append(append([]StrategyConfig{}, okxCfgs...), hlCfgs...),
+		&plan, nil, nil, map[string]float64{"BTC": 51000}, nil)
+
+	if len(okxState.Positions) != 0 {
+		t.Fatalf("OKX coin the report confirmed closed must book while latched, got %+v", okxState.Positions)
+	}
+	if len(okxState.TradeHistory) != 1 || !okxState.TradeHistory[0].IsClose {
+		t.Fatalf("OKX close row missing: %+v", okxState.TradeHistory)
+	}
+	// Platform gating: the OKX closed-coin set must never touch an HL strategy's
+	// same-named symbol — that leg settles only through its own fill or sweep.
+	if hlState.Positions["BTC"] == nil || math.Abs(hlState.Positions["BTC"].Quantity-3.0) > 1e-9 {
+		t.Errorf("HL position must be untouched by the OKX settled set, got %+v", hlState.Positions)
+	}
+}
+
+func TestSettledKillSwitchSymbols_PlatformKeyed(t *testing.T) {
+	plan := KillSwitchClosePlan{}
+	plan.OKXCloseReport.ClosedCoins = []string{"BTC", ""}
+	plan.TSCloseReport.ClosedCoins = []string{"NQ"}
+	out := settledKillSwitchSymbols(&plan)
+	if len(out) != 2 || !out["okx"]["BTC"] || out["okx"][""] || !out["topstep"]["NQ"] {
+		t.Fatalf("settled = %+v; want okx{BTC}, topstep{NQ}, empty coins dropped", out)
+	}
+	if _, ok := out["robinhood"]; ok {
+		t.Fatalf("platforms with no closes must be absent, got %+v", out)
+	}
+}
+
 // #1454 review: every kill-switch surface must resolve a manual strategy's
 // coin through the ONE symbol-first resolver, so a hand-written args list
 // whose args[1] diverges from Symbol can never split close scope from fill

--- a/scheduler/kill_switch_manual_test.go
+++ b/scheduler/kill_switch_manual_test.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #1454 regression tests: live type=manual strategies join the kill-switch
+// close scope, fill booking, virtual-quantity split, resting-trigger cancel,
+// and unconfigured-coin detection. Before this fix a mixed fleet skipped
+// manual-only coins silently and booked model-only rows for them even when a
+// real exchange fill existed.
+
+func TestPlanKillSwitchClose_ManualOnlyCoinClosedAndBooked(t *testing.T) {
+	roster := []StrategyConfig{
+		{ID: "hl-manual-eth-live", Platform: "hyperliquid", Type: "manual", Symbol: "ETH",
+			Args: []string{"hold", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 2.0, EntryPrice: 3000}}
+	closer := func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		return &HyperliquidCloseResult{
+			Close: &HyperliquidClose{Symbol: symbol,
+				Fill: &HyperliquidCloseFill{TotalSz: 2.0, AvgPx: 2900, Fee: 3.0, OID: 499735101008}},
+			Platform: "hyperliquid",
+		}, nil
+	}
+	fetcher, _ := stubHLStateFetcher(nil, nil)
+
+	plan := planKillSwitchClose(defaultHLInputs("0xaddr", true, positions, roster,
+		"portfolio drawdown 25.0% exceeds limit 20.0%",
+		time.Second, closer, fetcher))
+	if !plan.OnChainConfirmedFlat {
+		t.Fatalf("expected confirmed-flat plan for a closed manual coin, got %+v", plan)
+	}
+
+	s := &StrategyState{
+		ID:       "hl-manual-eth-live",
+		Type:     "manual",
+		Platform: "hyperliquid",
+		Cash:     1000,
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 2.0, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 5},
+		},
+	}
+	forceCloseKillSwitchPositions(s, roster[0], map[string]float64{"ETH": 2800}, plan.CloseReport.Fills, roster, nil, nil)
+
+	if len(s.TradeHistory) != 1 {
+		t.Fatalf("expected exactly 1 trade (the real-fill close), got %d", len(s.TradeHistory))
+	}
+	trade := s.TradeHistory[0]
+	if trade.ExchangeOrderID != "499735101008" {
+		t.Errorf("Trade.ExchangeOrderID = %q; want real fill OID", trade.ExchangeOrderID)
+	}
+	if trade.FeeSource != FeeSourceUserFills {
+		t.Errorf("FeeSource = %q; want %q", trade.FeeSource, FeeSourceUserFills)
+	}
+	if math.Abs(trade.Price-2900) > 1e-9 {
+		t.Errorf("Trade.Price = %.2f; want fill AvgPx 2900, not mark 2800", trade.Price)
+	}
+	wantGross := 2.0 * (2900 - 3000)
+	if math.Abs(trade.RealizedPnL-wantGross) > 1e-9 {
+		t.Errorf("Trade.RealizedPnL = %.4f; want %.4f (fill-derived, gross)", trade.RealizedPnL, wantGross)
+	}
+	if strings.Contains(trade.Details, "model-only") {
+		t.Errorf("trade must not be a model-only row: %s", trade.Details)
+	}
+	wantNet := wantGross - 3.0
+	if len(s.ClosedPositions) != 1 {
+		t.Fatalf("expected one closed position, got %+v", s.ClosedPositions)
+	}
+	if math.Abs(s.ClosedPositions[0].ClosePrice-2900) > 1e-9 || math.Abs(s.ClosedPositions[0].RealizedPnL-wantNet) > 1e-9 {
+		t.Errorf("ClosedPosition = price %.2f pnl %.4f; want 2900 / %.4f",
+			s.ClosedPositions[0].ClosePrice, s.ClosedPositions[0].RealizedPnL, wantNet)
+	}
+	if len(s.Positions) != 0 {
+		t.Errorf("virtual position must be deleted, still has %v", s.Positions)
+	}
+}
+
+func TestPlanKillSwitchClose_ManualOnlyCoinCloseFailureLatches(t *testing.T) {
+	roster := []StrategyConfig{
+		{ID: "hl-manual-eth-live", Platform: "hyperliquid", Type: "manual", Symbol: "ETH",
+			Args: []string{"hold", "ETH", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 2.0, EntryPrice: 3000}}
+	closer := func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		return nil, fmt.Errorf("simulated HL close failure")
+	}
+	// Post-close verification fetch must still show the position open — the
+	// closer failed, so nothing closed it on-chain.
+	fetcher, _ := stubHLStateFetcher(positions, nil)
+
+	plan := planKillSwitchClose(defaultHLInputs("0xaddr", true, positions, roster,
+		"portfolio drawdown 25.0% exceeds limit 20.0%",
+		time.Second, closer, fetcher))
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("a failed close on a manual-held coin must latch (OnChainConfirmedFlat=false)")
+	}
+	if _, ok := plan.CloseReport.Errors["ETH"]; !ok {
+		t.Fatalf("expected Errors[ETH], got %+v", plan.CloseReport.Errors)
+	}
+	joined := strings.Join(plan.LogLines, "\n")
+	if !strings.Contains(joined, "[CRITICAL] hl-close: ETH failed") {
+		t.Errorf("missing CRITICAL failure line, got: %s", joined)
+	}
+	if !strings.Contains(plan.DiscordMessage, "LATCHED") {
+		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
+	}
+}
+
+func TestPlanKillSwitchClose_MixedFleetUnconfiguredCoinBlocksFlat(t *testing.T) {
+	roster := []StrategyConfig{
+		{ID: "hl-perps-btc-live", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "BTC", Size: 1.0}, {Coin: "DOGE", Size: 5000}}
+	closer := func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		return &HyperliquidCloseResult{
+			Close: &HyperliquidClose{Symbol: symbol,
+				Fill: &HyperliquidCloseFill{TotalSz: 1.0, AvgPx: 50000, Fee: 1.0}},
+			Platform: "hyperliquid",
+		}, nil
+	}
+	// Post-close verification fetch must still show the position open — the
+	// closer failed, so nothing closed it on-chain.
+	fetcher, _ := stubHLStateFetcher(positions, nil)
+
+	plan := planKillSwitchClose(defaultHLInputs("0xaddr", true, positions, roster,
+		"portfolio drawdown 25.0% exceeds limit 20.0%",
+		time.Second, closer, fetcher))
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("an on-chain position no configured strategy owns must block flat confirmation even on a mixed fleet")
+	}
+	if len(plan.Unconfigured) != 1 || plan.Unconfigured[0].Coin != "DOGE" {
+		t.Errorf("Unconfigured = %+v; want [DOGE]", plan.Unconfigured)
+	}
+	joined := strings.Join(plan.LogLines, "\n")
+	if !strings.Contains(joined, "unconfigured coin DOGE") {
+		t.Errorf("missing CRITICAL unconfigured-coin line, got: %s", joined)
+	}
+	if !strings.Contains(plan.DiscordMessage, "LATCHED") {
+		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
+	}
+}
+
+func TestHyperliquidKillSwitchShareSplit_PerpsAndManualPeers(t *testing.T) {
+	roster := []StrategyConfig{
+		{ID: "hl-perps-eth-live", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-manual-eth-live", Platform: "hyperliquid", Type: "manual", Symbol: "ETH",
+			Args: []string{"hold", "ETH", "1h", "--mode=live"}},
+	}
+	states := map[string]*StrategyState{
+		"hl-perps-eth-live": {ID: "hl-perps-eth-live", Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 1.5, Side: "long"},
+		}},
+		"hl-manual-eth-live": {ID: "hl-manual-eth-live", Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 0.5, Side: "long"},
+		}},
+	}
+	snap := snapshotHyperliquidVirtualQuantities(states, roster)
+	if snap == nil || snap["ETH"]["hl-perps-eth-live"] != 1.5 || snap["ETH"]["hl-manual-eth-live"] != 0.5 {
+		t.Fatalf("virtual snapshot must include BOTH peers' quantities, got %+v", snap)
+	}
+
+	szPerps, feePerps := hyperliquidKillSwitchFillShare(roster[0], "ETH", 2.0, 10.0, roster, snap)
+	if math.Abs(szPerps-1.5) > 1e-9 || math.Abs(feePerps-7.5) > 1e-9 {
+		t.Errorf("perps share = (%.6f, %.6f); want (1.5, 7.5)", szPerps, feePerps)
+	}
+	szMann, feeMan := hyperliquidKillSwitchFillShare(roster[1], "ETH", 2.0, 10.0, roster, snap)
+	if math.Abs(szMann-0.5) > 1e-9 || math.Abs(feeMan-2.5) > 1e-9 {
+		t.Errorf("manual share = (%.6f, %.6f); want (0.5, 2.5)", szMann, feeMan)
+	}
+}
+
+func TestCollectHLKillSwitchStopOIDs_IncludesManualTriggers(t *testing.T) {
+	strategies := map[string]*StrategyState{
+		"hl-manual-eth-live": {Positions: map[string]*Position{
+			"ETH": {StopLossOID: 111, TPOIDs: []int64{222}},
+		}},
+		"hl-perps-btc-live": {Positions: map[string]*Position{
+			"BTC": {StopLossOID: 333},
+		}},
+	}
+	roster := []StrategyConfig{
+		{ID: "hl-perps-btc-live", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+		{ID: "hl-manual-eth-live", Platform: "hyperliquid", Type: "manual", Symbol: "ETH",
+			Args: []string{"hold", "ETH", "1h", "--mode=live"}},
+	}
+	out := collectHLKillSwitchStopOIDs(strategies, roster)
+	if !reflect.DeepEqual(out["BTC"], []int64{333}) {
+		t.Errorf("BTC OIDs = %v; want [333]", out["BTC"])
+	}
+	if !reflect.DeepEqual(out["ETH"], []int64{111, 222}) {
+		t.Errorf("ETH OIDs = %v; want [111 222] — a manual coin's resting triggers must be cancelled before the flatten", out["ETH"])
+	}
+}
+
+func TestCollectHLKillSwitchStopOIDs_LowerCaseManualSymbolFallsBackToRawKey(t *testing.T) {
+	strategies := map[string]*StrategyState{
+		"hl-manual-sol-live": {Positions: map[string]*Position{
+			"sol": {StopLossOID: 444}, // operator-entered lower-case symbol
+		}},
+	}
+	roster := []StrategyConfig{
+		{ID: "hl-manual-sol-live", Platform: "hyperliquid", Type: "manual", Symbol: "sol",
+			Args: []string{"hold", "sol", "1h", "--mode=live"}},
+	}
+	out := collectHLKillSwitchStopOIDs(strategies, roster)
+	// RAW key: the stop-OID map is consumed by forceCloseHyperliquidLive's
+	// raw on-chain p.Coin lookup.
+	if !reflect.DeepEqual(out["sol"], []int64{444}) {
+		t.Errorf("sol OIDs = %v; want [444] under the raw configured symbol", out["sol"])
+	}
+}
+
+func TestModelOnlyCloseAlert_ThrottledPerStrategySymbol(t *testing.T) {
+	tracker := &modelOnlyCloseTracker{last: make(map[modelOnlyCloseKey]time.Time)}
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+
+	if !tracker.shouldNotify("s-a", "ETH", now) {
+		t.Fatal("first model-only row for a key must notify")
+	}
+	if tracker.shouldNotify("s-a", "ETH", now.Add(time.Minute)) {
+		t.Error("second row inside the window must be throttled")
+	}
+	if !tracker.shouldNotify("s-a", "BTC", now.Add(time.Minute)) {
+		t.Error("an independent (strategy, symbol) key must not be throttled by another key's slot")
+	}
+	if !tracker.shouldNotify("s-b", "ETH", now.Add(time.Minute)) {
+		t.Error("a second strategy's row must not inherit the first strategy's throttle slot")
+	}
+	if !tracker.shouldNotify("s-a", "ETH", now.Add(effectiveAlertThrottleInterval()+time.Second)) {
+		t.Error("a row after the throttle window must notify again")
+	}
+}
+
+func TestQueueModelOnlyCloseAlert_DrainsAndSkipsEmpty(t *testing.T) {
+	drainModelOnlyCloseAlerts() // clear any residue from other tests
+	queueModelOnlyCloseAlert("", "ETH", 1.0)
+	queueModelOnlyCloseAlert("strat", "", 1.0)
+	if got := drainModelOnlyCloseAlerts(); len(got) != 0 {
+		t.Fatalf("empty strategy/symbol must not queue, got %+v", got)
+	}
+
+	// Direct queue path with fresh keys (the shared global throttle may already
+	// hold slots from other tests — use unique IDs).
+	id := "queue-drain-test-strat"
+	queueModelOnlyCloseAlert(id, "UNIQ", 2.5)
+	got := drainModelOnlyCloseAlerts()
+	found := false
+	for _, a := range got {
+		if a.StrategyID == id && a.Symbol == "UNIQ" && math.Abs(a.Quantity-2.5) < 1e-9 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected queued alert for %s/UNIQ, got %+v", id, got)
+	}
+	if again := drainModelOnlyCloseAlerts(); len(again) != 0 {
+		t.Fatalf("drain must empty the queue, got %+v", again)
+	}
+}
+
+func TestPlanKillSwitchClose_DeclaredButFlatHedgeCoinStaysUnowned(t *testing.T) {
+	// #1159 invariant under the #1454 roster: a coin a strategy merely DECLARES
+	// as its hedge — with no held leg — may carry a genuinely foreign position,
+	// so it must stay outside the close scope even though the roster now spans
+	// perps+manual. It must, however, be REPORTED as unowned rather than
+	// silently skipped.
+	roster := []StrategyConfig{
+		{ID: "hl-perps-eth-live", Platform: "hyperliquid", Type: "perps",
+			Args:  []string{"sma", "ETH", "1h", "--mode=live"},
+			Hedge: &HedgeConfig{Enabled: true, Symbol: "SOL"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 1.0}, {Coin: "SOL", Size: 40}}
+	closer := func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		return &HyperliquidCloseResult{
+			Close: &HyperliquidClose{Symbol: symbol,
+				Fill: &HyperliquidCloseFill{TotalSz: 1.0, AvgPx: 3000, Fee: 1.0}},
+			Platform: "hyperliquid",
+		}, nil
+	}
+	fetcher, _ := stubHLStateFetcher(nil, nil)
+
+	in := defaultHLInputs("0xaddr", true, positions, roster,
+		"portfolio drawdown 25.0% exceeds limit 20.0%",
+		time.Second, closer, fetcher)
+	in.HLHedgeCoins = map[string]bool{} // nothing HELD — SOL is declared-but-flat
+	plan := planKillSwitchClose(in)
+
+	if plan.OnChainConfirmedFlat {
+		t.Fatal("a foreign position on a declared-but-flat hedge coin must block flat confirmation")
+	}
+	closed := false
+	for _, c := range plan.CloseReport.ClosedCoins {
+		if c == "SOL" {
+			closed = true
+		}
+	}
+	if closed {
+		t.Error("declared-but-flat hedge coin must NOT be adopted into the close scope")
+	}
+	if len(plan.Unconfigured) != 1 || plan.Unconfigured[0].Coin != "SOL" {
+		t.Errorf("Unconfigured = %+v; want [SOL]", plan.Unconfigured)
+	}
+}

--- a/scheduler/kill_switch_manual_test.go
+++ b/scheduler/kill_switch_manual_test.go
@@ -312,3 +312,146 @@ func TestPlanKillSwitchClose_DeclaredButFlatHedgeCoinStaysUnowned(t *testing.T) 
 		t.Errorf("Unconfigured = %+v; want [SOL]", plan.Unconfigured)
 	}
 }
+
+// #1454 review: every kill-switch surface must resolve a manual strategy's
+// coin through the ONE symbol-first resolver, so a hand-written args list
+// whose args[1] diverges from Symbol can never split close scope from fill
+// booking / trigger cancel.
+func TestHyperliquidRawCoin_ManualSymbolWinsOverArgs(t *testing.T) {
+	sc := StrategyConfig{Platform: "hyperliquid", Type: "manual", Symbol: "ETH",
+		Args: []string{"hold", "BTC", "1h", "--mode=live"}}
+	if got := hyperliquidRawCoin(sc); got != "ETH" {
+		t.Errorf("hyperliquidRawCoin = %q; want ETH (sc.Symbol wins for manual)", got)
+	}
+	if got := hyperliquidConfiguredCoin(sc); got != "ETH" {
+		t.Errorf("hyperliquidConfiguredCoin = %q; want ETH", got)
+	}
+	perps := StrategyConfig{Platform: "hyperliquid", Type: "perps",
+		Args: []string{"sma", "BTC", "1h", "--mode=live"}}
+	if got := hyperliquidRawCoin(perps); got != "BTC" {
+		t.Errorf("hyperliquidRawCoin(perps) = %q; want BTC (args[1])", got)
+	}
+}
+
+func TestForceCloseHyperliquidLive_ManualDivergentArgsStaysInCloseScope(t *testing.T) {
+	// A manual strategy whose hand-written args[1] names a different coin than
+	// its configured symbol must still be closed and booked under sc.Symbol —
+	// the pre-review resolver treated args[1] as authoritative for the close
+	// scope only, leaving the real position unowned while every booking surface
+	// keyed under the symbol.
+	roster := []StrategyConfig{
+		{ID: "hl-manual-eth-live", Platform: "hyperliquid", Type: "manual", Symbol: "ETH",
+			Args: []string{"hold", "BTC", "1h", "--mode=live"}},
+	}
+	positions := []HLPosition{{Coin: "ETH", Size: 2.0, EntryPrice: 2000}}
+	closer := func(symbol string, partialSz *float64, cancelStopLossOIDs []int64) (*HyperliquidCloseResult, error) {
+		return &HyperliquidCloseResult{
+			Close: &HyperliquidClose{Symbol: symbol,
+				Fill: &HyperliquidCloseFill{TotalSz: 2.0, AvgPx: 2100, Fee: 0.5, OID: 777}},
+			Platform: "hyperliquid",
+		}, nil
+	}
+	fetcher, _ := stubHLStateFetcher(nil, nil)
+	in := defaultHLInputs("0xaddr", true, positions, roster,
+		"portfolio drawdown 25.0% exceeds limit 20.0%",
+		time.Second, closer, fetcher)
+	plan := planKillSwitchClose(in)
+
+	if !plan.OnChainConfirmedFlat {
+		t.Fatalf("expected confirmed-flat plan; Unconfigured=%+v errors=%+v", plan.Unconfigured, plan.CloseReport.Errors)
+	}
+	fill, ok := plan.CloseReport.Fills["ETH"]
+	if !ok || fill.TotalSz != 2.0 {
+		t.Fatalf("fills = %+v; want ETH booked under the raw configured symbol", plan.CloseReport.Fills)
+	}
+
+	state := &StrategyState{
+		ID: "hl-manual-eth-live", Type: "manual", Platform: "hyperliquid", Cash: 1000,
+		Positions: map[string]*Position{
+			"ETH": {Symbol: "ETH", Quantity: 2.0, AvgCost: 2000, Side: "long", Multiplier: 1},
+		},
+	}
+	virtualQty := snapshotHyperliquidVirtualQuantities(map[string]*StrategyState{"hl-manual-eth-live": state}, roster)
+	forceCloseKillSwitchPositions(state, roster[0], map[string]float64{"ETH": 2100}, plan.CloseReport.Fills, roster, virtualQty, nil)
+	if len(state.Positions) != 0 {
+		t.Fatalf("positions after apply = %+v; want flat", state.Positions)
+	}
+	var booked *Trade
+	for i := range state.TradeHistory {
+		tr := &state.TradeHistory[i]
+		if tr.ExchangeOrderID != "" {
+			booked = tr
+		}
+	}
+	if booked == nil {
+		t.Fatal("manual leg must book the REAL exchange fill (OID), not fall back to model-only")
+	}
+}
+
+func TestForceCloseAllPositions_ModelOnlyAlertLiveGate(t *testing.T) {
+	drainModelOnlyCloseAlerts()
+	// Unique (strategy, symbol) per sub-case: the global throttle holds slots
+	// for the process lifetime, so shared keys would mask later firings.
+	liveHL := StrategyConfig{ID: "mo-gate-live-hl", Platform: "hyperliquid", Type: "perps",
+		Args: []string{"sma", "MOHLIVE", "1h", "--mode=live"}}
+	paperHL := StrategyConfig{ID: "mo-gate-paper-hl", Platform: "hyperliquid", Type: "perps",
+		Args: []string{"sma", "MOHPAPER", "1h", "--mode=paper"}}
+	okxSpot := StrategyConfig{ID: "mo-gate-live-okx", Platform: "okx", Type: "spot",
+		Args: []string{"sma", "MOOKX", "1h", "--mode=live"}}
+
+	mkState := func(id, sym string, pos *Position) *StrategyState {
+		return &StrategyState{
+			ID: id, Type: "perps", Platform: liveHL.Platform, Cash: 1000,
+			Positions: map[string]*Position{sym: pos},
+		}
+	}
+	long := func(sym string) *Position {
+		return &Position{Symbol: sym, Quantity: 1.0, AvgCost: 100, Side: "long"}
+	}
+
+	// Paper HL perps: model-only row is expected bookkeeping — NO alert.
+	forceCloseAllPositions(mkState(paperHL.ID, "MOHPAPER", long("MOHPAPER")), &paperHL,
+		map[string]float64{"MOHPAPER": 90}, nil)
+	for _, a := range drainModelOnlyCloseAlerts() {
+		if a.StrategyID == paperHL.ID {
+			t.Errorf("paper strategy must never raise the model-only DM, got %+v", a)
+		}
+	}
+
+	// Live OKX spot (no auto-close path): still alerts.
+	forceCloseAllPositions(mkState(okxSpot.ID, "MOOKX", long("MOOKX")), &okxSpot,
+		map[string]float64{"MOOKX": 90}, nil)
+	foundOKX := false
+	for _, a := range drainModelOnlyCloseAlerts() {
+		if a.StrategyID == okxSpot.ID {
+			foundOKX = true
+		}
+	}
+	if !foundOKX {
+		t.Error("live non-HL venue with no auto-close path must still raise the model-only DM")
+	}
+
+	// Live HL perps: alerts.
+	forceCloseAllPositions(mkState(liveHL.ID, "MOHLIVE", long("MOHLIVE")), &liveHL,
+		map[string]float64{"MOHLIVE": 90}, nil)
+	foundHL := false
+	for _, a := range drainModelOnlyCloseAlerts() {
+		if a.StrategyID == liveHL.ID && a.Symbol == "MOHLIVE" {
+			foundHL = true
+		}
+	}
+	if !foundHL {
+		t.Error("live HL perps force-close without a fill must raise the model-only DM")
+	}
+
+	// Corrupt position (qty<=0 OR avgCost<=0): #1009 books a zero-PnL leg with
+	// details set → silent on every mode.
+	corruptPos := &Position{Symbol: "MOCORRUPT", Quantity: -1e-7, AvgCost: 0, Side: "long"}
+	forceCloseAllPositions(mkState(liveHL.ID, "MOCORRUPT", corruptPos), &liveHL,
+		map[string]float64{"MOCORRUPT": 90}, nil)
+	for _, a := range drainModelOnlyCloseAlerts() {
+		if a.StrategyID == liveHL.ID && a.Symbol == "MOCORRUPT" {
+			t.Errorf("corrupt-position close must stay silent, got %+v", a)
+		}
+	}
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1244,12 +1244,12 @@ func main() {
 			// exposure on the same wallet. Built with isHLLiveReconcilable (the
 			// #620 peer-scope precedent) and consumed ONLY by the kill-switch
 			// surfaces below — never by trailing-stop or risk math.
-			var hlKillSwitchAll []StrategyConfig
-			for _, sc := range cfg.Strategies {
-				if isHLLiveReconcilable(sc) {
-					hlKillSwitchAll = append(hlKillSwitchAll, sc)
-				}
-			}
+			// #1454 review: this is the SAME predicate that built hlReconcileAll,
+			// so the roster aliases that slice instead of re-filtering — one list,
+			// never two rosters to keep identical by hand. If a future change
+			// ever needs the kill switch to diverge from reconcile scope, give
+			// hlKillSwitchAll its own named predicate here.
+			hlKillSwitchAll := hlReconcileAll
 
 			// #345: Partition live OKX strategies for the kill-switch close
 			// path. Perps and spot are separated because only perps support
@@ -1727,9 +1727,11 @@ func main() {
 				// coin it trades. Shared coins may have multiple
 				// per-strategy SL triggers, so preserve every OID.
 				mu.RLock()
-				// #1454: the roster includes live manual strategies and the coin
-				// key goes through hyperliquidConfiguredCoin, so a manual coin's
-				// resting SL/TP triggers are cancelled with the rest (#421/#479).
+				// #1454: the roster includes live manual strategies and every
+				// surface keys coins through hyperliquidRawCoin (RAW, case-
+				// preserved — NOT hyperliquidConfiguredCoin's normalized form),
+				// so a manual coin's resting SL/TP triggers are cancelled with
+				// the rest (#421/#479).
 				hlSLOIDs := collectHLKillSwitchStopOIDs(state.Strategies, hlKillSwitchAll)
 				// #1159: hedge coins the scheduler CURRENTLY holds a leg on.
 				// Gated on the held leg, not on config, so the kill switch

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1223,8 +1223,10 @@ func main() {
 			}
 			// Reconcile lists extend hlLive* to include type=manual: manual
 			// positions are real on-chain HL positions that can be closed
-			// externally and must be reconciled. Other hlLiveAll consumers
-			// (kill-switch, trailing-stop, risk math) remain perps-only (#576).
+			// externally and must be reconciled. #1454: the kill switch now
+			// consumes this same perps+manual roster; trailing-stop arming and
+			// risk math remain the perps-only hlLiveAll consumers (#576) — do
+			// NOT widen hlLiveAll itself to reach them.
 			var hlReconcileAll []StrategyConfig
 			for _, sc := range cfg.Strategies {
 				if isHLLiveReconcilable(sc) {
@@ -1782,6 +1784,18 @@ func main() {
 				for _, line := range plan.LogLines {
 					fmt.Println(line)
 				}
+			}
+
+			// #1457 review round 2: a HELD latch (a foreign Unconfigured coin,
+			// one failed close) must not discard what the closers POSITIVELY
+			// settled — confirmed HL fills and non-HL coins the reports list as
+			// closed book immediately; everything unsettled waits for the
+			// retry. The latch itself stays held below (auto-reset and the full
+			// sweep remain gated on OnChainConfirmedFlat).
+			if killSwitchFired && !plan.OnChainConfirmedFlat {
+				mu.Lock()
+				applyKillSwitchSettledLegsWhileLatched(state.Strategies, cfg.Strategies, &plan, hlKillSwitchAll, hlVirtualQty, prices, nil)
+				mu.Unlock()
 			}
 
 			killSwitchAutoReset := false
@@ -4492,8 +4506,9 @@ func hyperliquidSymbol(args []string) string {
 // isHLLiveReconcilable reports whether sc should participate in on-chain
 // reconciliation. Both type=perps and type=manual are live HL positions that
 // can be closed externally; the reconciler is type-agnostic so both are safe.
-// Other consumers of hlLiveAll (kill-switch, trailing-stop arming, risk math)
-// intentionally stay perps-only.
+// #1454: the kill switch consumes this same roster. The perps-only hlLiveAll
+// consumers — trailing-stop arming and risk math — intentionally do NOT use
+// this predicate (#576); keep them on hlLiveAll.
 func isHLLiveReconcilable(sc StrategyConfig) bool {
 	return sc.Platform == "hyperliquid" &&
 		(sc.Type == "perps" || sc.Type == "manual") &&

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -1237,6 +1237,19 @@ func main() {
 					hlReconcileDue = append(hlReconcileDue, sc)
 				}
 			}
+			// #1454: kill-switch roster — live HL perps PLUS live type=manual.
+			// #576 keeps hlLiveAll perps-only because trailing-stop arming and
+			// risk math depend on that meaning, but the kill switch must BOTH
+			// close and book fills for manual positions: they are real leveraged
+			// exposure on the same wallet. Built with isHLLiveReconcilable (the
+			// #620 peer-scope precedent) and consumed ONLY by the kill-switch
+			// surfaces below — never by trailing-stop or risk math.
+			var hlKillSwitchAll []StrategyConfig
+			for _, sc := range cfg.Strategies {
+				if isHLLiveReconcilable(sc) {
+					hlKillSwitchAll = append(hlKillSwitchAll, sc)
+				}
+			}
 
 			// #345: Partition live OKX strategies for the kill-switch close
 			// path. Perps and spot are separated because only perps support
@@ -1713,22 +1726,11 @@ func main() {
 				// Sole-source: every live HL strategy's Position for the
 				// coin it trades. Shared coins may have multiple
 				// per-strategy SL triggers, so preserve every OID.
-				hlSLOIDs := map[string][]int64{}
 				mu.RLock()
-				for _, sc := range hlLiveAll {
-					sym := hyperliquidSymbol(sc.Args)
-					if sym == "" {
-						continue
-					}
-					if ss, ok := state.Strategies[sc.ID]; ok && ss != nil {
-						if pos, pok := ss.Positions[sym]; pok && pos != nil {
-							hlSLOIDs[sym] = appendUniquePositiveStopLossOID(hlSLOIDs[sym], pos.StopLossOID)
-							for _, tpOID := range pos.TPOIDs {
-								hlSLOIDs[sym] = appendUniquePositiveStopLossOID(hlSLOIDs[sym], tpOID)
-							}
-						}
-					}
-				}
+				// #1454: the roster includes live manual strategies and the coin
+				// key goes through hyperliquidConfiguredCoin, so a manual coin's
+				// resting SL/TP triggers are cancelled with the rest (#421/#479).
+				hlSLOIDs := collectHLKillSwitchStopOIDs(state.Strategies, hlKillSwitchAll)
 				// #1159: hedge coins the scheduler CURRENTLY holds a leg on.
 				// Gated on the held leg, not on config, so the kill switch
 				// never liquidates a foreign position sitting on a coin a
@@ -1741,14 +1743,14 @@ func main() {
 						}
 					}
 				}
-				hlVirtualQty = snapshotHyperliquidVirtualQuantities(state.Strategies, hlLiveAll)
+				hlVirtualQty = snapshotHyperliquidVirtualQuantities(state.Strategies, hlKillSwitchAll)
 				mu.RUnlock()
 
 				inputs := KillSwitchCloseInputs{
 					HLAddr:            hlAddr,
 					HLStateFetched:    hlStateFetched,
 					HLPositions:       hlPositions,
-					HLLiveAll:         hlLiveAll,
+					HLLiveAll:         hlKillSwitchAll,
 					HLHedgeCoins:      hlHedgeCoins,
 					HLCloser:          defaultHyperliquidLiveCloser,
 					HLFetcher:         defaultHLStateFetcher,
@@ -1785,7 +1787,7 @@ func main() {
 				mu.Lock()
 				for _, sc := range cfg.Strategies {
 					if s, ok := state.Strategies[sc.ID]; ok {
-						forceCloseKillSwitchPositions(s, sc, prices, plan.CloseReport.Fills, hlLiveAll, hlVirtualQty, nil)
+						forceCloseKillSwitchPositions(s, sc, prices, plan.CloseReport.Fills, hlKillSwitchAll, hlVirtualQty, nil)
 						// Pending HL circuit close was already cleared above
 						// when portfolio kill fired (line ~611); nothing to do
 						// here. The per-strategy pending field is owned by the
@@ -1819,6 +1821,16 @@ func main() {
 					killSwitchMsg = formatKillSwitchAutoResetMessage(killSwitchMsg)
 				}
 				notifier.SendToAllChannels(killSwitchMsg)
+			}
+
+			// #1451 folded alert (#1454): any model-only close row the sweep
+			// just booked reaches the owner here too — a latched fleet may have
+			// no due strategy this cycle, so the per-strategy drain site below
+			// would not run.
+			for _, moAlert := range drainModelOnlyCloseAlerts() {
+				if notifier.HasOwner() {
+					notifier.SendOwnerDM(formatModelOnlyCloseDM(moAlert))
+				}
 			}
 
 			// Warning alert: drawdown approaching kill switch threshold.
@@ -2385,6 +2397,14 @@ func main() {
 					for _, cbAlert := range drainCircuitBreakerSuppressionAlerts() {
 						if notifier.HasOwner() {
 							notifier.SendOwnerDM(formatCircuitBreakerSuppressionDM(cbAlert))
+						}
+					}
+					// #1451 folded alert (#1454): a model-only force-close row is
+					// an estimate standing in for a real exchange close. Drained
+					// unconditionally outside mu, per the same #880 rule.
+					for _, moAlert := range drainModelOnlyCloseAlerts() {
+						if notifier.HasOwner() {
+							notifier.SendOwnerDM(formatModelOnlyCloseDM(moAlert))
 						}
 					}
 					// #1046: a latched per-strategy circuit breaker on an HL perps

--- a/scheduler/model_only_close_alert.go
+++ b/scheduler/model_only_close_alert.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// #1451/#1454 folded alert — throttled owner DM when a model-only close row
+// books.
+//
+// forceCloseAllPositions' generic sweep writes "Circuit breaker close ...
+// (model-only reconciliation adjustment; no exchange fill)" rows whenever no
+// real exchange fill was available: non-HL venues, a missing-fill fallback, a
+// corrupt position, or (before #1454) any manual strategy the kill-switch fill
+// chain ignored. The DB row was the ONLY signal — nothing read it. The repo's
+// convention for a degraded money-accounting path is a throttled owner DM keyed
+// by (strategy_id, symbol) with the alert_throttle_interval floor
+// (missing_mark_alerts, circuit_breaker_suppression_alert), so the same shape
+// lives here.
+//
+// CheckRisk and the kill-switch apply block both run under mu, so the alert is
+// QUEUED there and drained by the main loop outside mu — the #880 rule that no
+// notifier I/O happens under the state lock. Draining is unconditional so an
+// unowned deployment cannot grow the queue without bound.
+
+type modelOnlyCloseAlert struct {
+	StrategyID string
+	Symbol     string
+	Quantity   float64
+}
+
+var modelOnlyCloseAlertQueue struct {
+	mu      sync.Mutex
+	pending []modelOnlyCloseAlert
+}
+
+type modelOnlyCloseKey struct {
+	strategyID string
+	symbol     string
+}
+
+// modelOnlyCloseThrottle is the process-lifetime once-per-window throttle for
+// model-only close DMs. Unlike a clearable live-state tracker this reports a
+// booking event, not an ongoing condition, so slots are never retained/cleared
+// per cycle — the window alone bounds volume.
+type modelOnlyCloseTracker struct {
+	mu   sync.Mutex
+	last map[modelOnlyCloseKey]time.Time
+}
+
+var modelOnlyCloseThrottle = &modelOnlyCloseTracker{last: make(map[modelOnlyCloseKey]time.Time)}
+
+// shouldNotify reports whether a model-only row for (strategyID, symbol) may
+// DM now. Fires when the slot is empty or now.Sub(last) >=
+// effectiveAlertThrottleInterval() (config alert_throttle_interval, empty →
+// 6h). Stamps last under mu when it decides to notify, before the caller sends.
+func (t *modelOnlyCloseTracker) shouldNotify(strategyID, symbol string, now time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	k := modelOnlyCloseKey{strategyID: strategyID, symbol: symbol}
+	if last, ok := t.last[k]; ok && now.Sub(last) < effectiveAlertThrottleInterval() {
+		return false
+	}
+	t.last[k] = now
+	return true
+}
+
+// queueModelOnlyCloseAlert records one model-only close notice for the main
+// loop to send, throttled per (strategy, symbol). Safe to call under mu.
+func queueModelOnlyCloseAlert(strategyID, symbol string, quantity float64) {
+	if strategyID == "" || symbol == "" {
+		return
+	}
+	if !modelOnlyCloseThrottle.shouldNotify(strategyID, symbol, time.Now().UTC()) {
+		return
+	}
+	modelOnlyCloseAlertQueue.mu.Lock()
+	defer modelOnlyCloseAlertQueue.mu.Unlock()
+	modelOnlyCloseAlertQueue.pending = append(modelOnlyCloseAlertQueue.pending,
+		modelOnlyCloseAlert{StrategyID: strategyID, Symbol: symbol, Quantity: quantity})
+}
+
+// drainModelOnlyCloseAlerts removes and returns every queued notice. Always
+// drain, even with no owner configured, so the queue stays bounded.
+func drainModelOnlyCloseAlerts() []modelOnlyCloseAlert {
+	modelOnlyCloseAlertQueue.mu.Lock()
+	defer modelOnlyCloseAlertQueue.mu.Unlock()
+	out := modelOnlyCloseAlertQueue.pending
+	modelOnlyCloseAlertQueue.pending = nil
+	return out
+}
+
+// formatModelOnlyCloseDM renders the owner DM. It states plainly that the row
+// is an estimate without an exchange order behind it, so an operator does not
+// read it as a confirmed close.
+func formatModelOnlyCloseDM(a modelOnlyCloseAlert) string {
+	return fmt.Sprintf("⚠️ **MODEL-ONLY FORCE-CLOSE BOOKED — NO EXCHANGE FILL**\n"+
+		"Strategy `%s`: the circuit-breaker/kill-switch sweep closed %s (qty≈%.6f) as an internal reconciliation row with NO exchange order behind it "+
+		"(detail: \"model-only reconciliation adjustment; no exchange fill\"). Its realized PnL is a mark-derived estimate and may not match what the venue actually did.\n"+
+		"If a real exchange position existed on %s, reconcile it manually. One DM per (strategy, symbol) per alert-throttle window.",
+		a.StrategyID, a.Symbol, a.Quantity, a.Symbol)
+}

--- a/scheduler/regime_alerts_test.go
+++ b/scheduler/regime_alerts_test.go
@@ -294,7 +294,7 @@ func TestRegime_StampedAtProductionCallSites(t *testing.T) {
 	t.Run("risk/forceCloseAllPositions", func(t *testing.T) {
 		s := newState("hyperliquid")
 		s.Positions["BTC"] = &Position{Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "long"}
-		forceCloseAllPositions(s, map[string]float64{"BTC": 51000}, logger)
+		forceCloseAllPositions(s, nil, map[string]float64{"BTC": 51000}, logger)
 		if got := lastRegime(s); got != want {
 			t.Errorf("Regime = %q; want %q", got, want)
 		}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1940,7 +1940,7 @@ func forceCloseKillSwitchPositions(s *StrategyState, sc StrategyConfig, prices m
 	// price/fee rather than the model-only reconciliation adjustment
 	// forceCloseAllPositions would otherwise write.
 	applyHyperliquidKillSwitchHedgeFill(s, sc, hlFills)
-	forceCloseAllPositions(s, prices, logger)
+	forceCloseAllPositions(s, &sc, prices, logger)
 }
 
 // classifyPositionTradeType maps a position to the correct trade_type label
@@ -1981,7 +1981,14 @@ func classifyPositionTradeType(s *StrategyState, pos *Position) string {
 
 // forceCloseAllPositions liquidates all open positions at current prices.
 // Called when any circuit breaker fires.
-func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger *StrategyLogger) {
+//
+// sc carries the strategy's config for the #1454-review live gate on the
+// model-only close DM (nil skips the alert — legacy test callers only); every
+// production caller has it. A PAPER strategy never places exchange orders, so
+// its model-only rows are expected bookkeeping and must not page the owner;
+// a live venue close with no fill behind it is exactly what the alert exists
+// for (#1451/#1454).
+func forceCloseAllPositions(s *StrategyState, sc *StrategyConfig, prices map[string]float64, logger *StrategyLogger) {
 	now := time.Now().UTC()
 
 	for symbol, pos := range s.Positions {
@@ -2036,8 +2043,11 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 			// #1451 folded alert (#1454): a model-only row is an estimate
 			// standing in for a real exchange close. Escalate once per
 			// (strategy, symbol) per throttle window instead of leaving the DB
-			// row as the only signal.
-			queueModelOnlyCloseAlert(s.ID, symbol, pos.Quantity)
+			// row as the only signal. Live-only (#1454 review): paper rows
+			// have no exchange position behind them by construction.
+			if sc != nil && isLiveArgs(sc.Args) {
+				queueModelOnlyCloseAlert(s.ID, symbol, pos.Quantity)
+			}
 		}
 		if logger != nil {
 			logger.Warn("Circuit breaker: force-closing %s %s @ $%.2f (PnL: $%.2f)", pos.Side, symbol, price, pnl)
@@ -2310,7 +2320,7 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 			setTopStepCircuitBreakerPending(sc, s, assist)
 			setOperatorRequiredCircuitBreakerPending(sc, s)
 			if shouldForceCloseAllPositionsOnCircuitBreaker(sc, assist) {
-				forceCloseAllPositions(s, prices, logger)
+				forceCloseAllPositions(s, sc, prices, logger)
 			}
 			return false, fmt.Sprintf("%s (%.1f%% > %.1f%%, portfolio=$%.2f peak=$%.2f, denom=%s=$%.2f)",
 				RiskReasonMaxDrawdownExceeded, r.CurrentDrawdownPct, r.MaxDrawdownPct, portfolioValue, r.PeakValue, denomLabel, denom)
@@ -2334,7 +2344,7 @@ func CheckRisk(sc *StrategyConfig, s *StrategyState, portfolioValue float64, pri
 		setTopStepCircuitBreakerPending(sc, s, assist)
 		setOperatorRequiredCircuitBreakerPending(sc, s)
 		if shouldForceCloseAllPositionsOnCircuitBreaker(sc, assist) {
-			forceCloseAllPositions(s, prices, logger)
+			forceCloseAllPositions(s, sc, prices, logger)
 		}
 		return false, fmt.Sprintf("%s (%d in a row, threshold %d)", RiskReasonConsecutiveLosses, r.ConsecutiveLosses, lossStreakThreshold)
 	}

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -1989,98 +1989,10 @@ func classifyPositionTradeType(s *StrategyState, pos *Position) string {
 // a live venue close with no fill behind it is exactly what the alert exists
 // for (#1451/#1454).
 func forceCloseAllPositions(s *StrategyState, sc *StrategyConfig, prices map[string]float64, logger *StrategyLogger) {
-	now := time.Now().UTC()
-
 	for symbol, pos := range s.Positions {
-		price, ok := prices[symbol]
-		if !ok {
-			price = pos.AvgCost
-		}
-		var pnl, value float64
-		// PnL branch is the same for perps (Multiplier=1) and futures
-		// (Multiplier=contract size) — qty*multiplier*price_delta. Only the
-		// trade_type LABEL differs by venue, classified via
-		// classifyPositionTradeType so perps force-closes carry an accurate
-		// operator-facing label. The label does not feed any ledger sum
-		// (tradeLedgerDeltaSQL ignores trade_type); it is display-only.
-		tradeType := classifyPositionTradeType(s, pos)
-		reason := "circuit_breaker"
-		details := ""
-		// #1009: a force-close must never book PnL off a structurally-corrupt
-		// position. A non-positive quantity (the negative residual a mis-sized
-		// direction reversal used to leave) or a non-positive avg cost (a zeroed
-		// entry that books the full notional as PnL — the ~4884x overstatement
-		// folded in from PR #1008) makes qty*(price-avgCost) meaningless. Clear
-		// it with a zero-PnL leg and leave cash untouched so the booked
-		// realized_pnl reconciles with the closed_positions row.
-		if closePositionIsCorrupt(pos) {
-			reason = "circuit_breaker_corrupt"
-			details = fmt.Sprintf("Circuit breaker close %s (corrupt qty=%.6f avg_cost=%.4f) — zero PnL booked", pos.Side, pos.Quantity, pos.AvgCost)
-			if logger != nil {
-				logger.Warn("Circuit breaker: corrupt %s position %s (qty=%.6f avg_cost=%.4f) — booking zero realized PnL, not qty*(price-avgCost)", pos.Side, symbol, pos.Quantity, pos.AvgCost)
-			}
-		} else if pos.Multiplier > 0 {
-			// Futures/perps: PnL-based (contracts * multiplier * price delta)
-			if pos.Side == "long" {
-				pnl = pos.Quantity * pos.Multiplier * (price - pos.AvgCost)
-			} else {
-				pnl = pos.Quantity * pos.Multiplier * (pos.AvgCost - price)
-			}
-			s.Cash += pnl
-			value = pos.Quantity * pos.Multiplier * price
-		} else if pos.Side == "long" {
-			proceeds := pos.Quantity * price
-			pnl = proceeds - pos.Quantity*pos.AvgCost
-			s.Cash += proceeds
-			value = proceeds
-		} else {
-			pnl = pos.Quantity * (pos.AvgCost - price)
-			s.Cash += pos.Quantity*pos.AvgCost - pos.Quantity*price
-			value = pos.Quantity * price
-		}
-		if details == "" {
-			details = fmt.Sprintf("Circuit breaker close %s, PnL: $%.2f (model-only reconciliation adjustment; no exchange fill)", pos.Side, pnl)
-			// #1451 folded alert (#1454): a model-only row is an estimate
-			// standing in for a real exchange close. Escalate once per
-			// (strategy, symbol) per throttle window instead of leaving the DB
-			// row as the only signal. Live-only (#1454 review): paper rows
-			// have no exchange position behind them by construction.
-			if sc != nil && isLiveArgs(sc.Args) {
-				queueModelOnlyCloseAlert(s.ID, symbol, pos.Quantity)
-			}
-		}
-		if logger != nil {
-			logger.Warn("Circuit breaker: force-closing %s %s @ $%.2f (PnL: $%.2f)", pos.Side, symbol, price, pnl)
-		}
-		positionID := ensurePositionTradeID(s.ID, symbol, pos)
-		trade := Trade{
-			Timestamp:         now,
-			StrategyID:        s.ID,
-			Symbol:            symbol,
-			PositionID:        positionID,
-			Side:              closeTradeSide(pos.Side),
-			Quantity:          absQty(pos.Quantity),
-			Price:             price,
-			Value:             value,
-			TradeType:         tradeType,
-			Details:           details,
-			IsClose:           true,
-			RealizedPnL:       pnl,
-			PnLGross:          true, // model-only adjustment has no exchange fee: gross == net
-			FeeSource:         FeeSourceReconcileAdjustment,
-			Regime:            s.Regime,
-			EntryATR:          pos.EntryATR,
-			StopLossTriggerPx: pos.StopLossTriggerPx,
-			StopLossATRMult:   pos.StopLossATRMult,
-			TPTiersJSON:       pos.TPTiersJSON,
-		}
-		RecordTrade(s, trade)
-		// #1159: a hedge leg's PnL never feeds the loss streak.
-		recordPositionTradeResult(s, pos, pnl)
-		recordClosedPosition(s, pos, price, pnl, reason, now)
-		delete(s.Positions, symbol)
-		clearHLPerpsPositionAlertThrottles(s, symbol)
+		closeVirtualPositionAtMark(s, sc, symbol, pos, prices, logger)
 	}
+	now := time.Now().UTC()
 
 	for id, pos := range s.OptionPositions {
 		var pnl, closePrice float64
@@ -2119,6 +2031,133 @@ func forceCloseAllPositions(s *StrategyState, sc *StrategyConfig, prices map[str
 		RecordTradeResult(&s.RiskState, pnl)
 		recordClosedOptionPosition(s, pos, closePrice, pnl, "circuit_breaker", now)
 		delete(s.OptionPositions, id)
+	}
+}
+
+// closeVirtualPositionAtMark books ONE virtual position's model-only close at
+// the current mark (AvgCost fallback) and removes it from the book. Extracted
+// from forceCloseAllPositions so the kill-switch latched path
+// (applyKillSwitchSettledLegsWhileLatched) can close ONLY positively-settled
+// symbols with the identical booking implementation — never a forked one.
+//
+// sc carries the strategy's config for the #1454-review live gate on the
+// model-only close DM (nil skips the alert — legacy test callers only); every
+// production caller has it. A PAPER strategy never places exchange orders, so
+// its model-only rows are expected bookkeeping and must not page the owner;
+// a live venue close with no fill behind it is exactly what the alert exists
+// for (#1451/#1454).
+func closeVirtualPositionAtMark(s *StrategyState, sc *StrategyConfig, symbol string, pos *Position, prices map[string]float64, logger *StrategyLogger) {
+	now := time.Now().UTC()
+	price, ok := prices[symbol]
+	if !ok {
+		price = pos.AvgCost
+	}
+	var pnl, value float64
+	// PnL branch is the same for perps (Multiplier=1) and futures
+	// (Multiplier=contract size) — qty*multiplier*price_delta. Only the
+	// trade_type LABEL differs by venue, classified via
+	// classifyPositionTradeType so perps force-closes carry an accurate
+	// operator-facing label. The label does not feed any ledger sum
+	// (tradeLedgerDeltaSQL ignores trade_type); it is display-only.
+	tradeType := classifyPositionTradeType(s, pos)
+	reason := "circuit_breaker"
+	details := ""
+	// #1009: a force-close must never book PnL off a structurally-corrupt
+	// position. A non-positive quantity (the negative residual a mis-sized
+	// direction reversal used to leave) or a non-positive avg cost (a zeroed
+	// entry that books the full notional as PnL — the ~4884x overstatement
+	// folded in from PR #1008) makes qty*(price-avgCost) meaningless. Clear
+	// it with a zero-PnL leg and leave cash untouched so the booked
+	// realized_pnl reconciles with the closed_positions row.
+	if closePositionIsCorrupt(pos) {
+		reason = "circuit_breaker_corrupt"
+		details = fmt.Sprintf("Circuit breaker close %s (corrupt qty=%.6f avg_cost=%.4f) — zero PnL booked", pos.Side, pos.Quantity, pos.AvgCost)
+		if logger != nil {
+			logger.Warn("Circuit breaker: corrupt %s position %s (qty=%.6f avg_cost=%.4f) — booking zero realized PnL, not qty*(price-avgCost)", pos.Side, symbol, pos.Quantity, pos.AvgCost)
+		}
+	} else if pos.Multiplier > 0 {
+		// Futures/perps: PnL-based (contracts * multiplier * price delta)
+		if pos.Side == "long" {
+			pnl = pos.Quantity * pos.Multiplier * (price - pos.AvgCost)
+		} else {
+			pnl = pos.Quantity * pos.Multiplier * (pos.AvgCost - price)
+		}
+		s.Cash += pnl
+		value = pos.Quantity * pos.Multiplier * price
+	} else if pos.Side == "long" {
+		proceeds := pos.Quantity * price
+		pnl = proceeds - pos.Quantity*pos.AvgCost
+		s.Cash += proceeds
+		value = proceeds
+	} else {
+		pnl = pos.Quantity * (pos.AvgCost - price)
+		s.Cash += pos.Quantity*pos.AvgCost - pos.Quantity*price
+		value = pos.Quantity * price
+	}
+	if details == "" {
+		details = fmt.Sprintf("Circuit breaker close %s, PnL: $%.2f (model-only reconciliation adjustment; no exchange fill)", pos.Side, pnl)
+		// #1451 folded alert (#1454): a model-only row is an estimate
+		// standing in for a real exchange close. Escalate once per
+		// (strategy, symbol) per throttle window instead of leaving the DB
+		// row as the only signal. Live-only (#1454 review): paper rows
+		// have no exchange position behind them by construction.
+		if sc != nil && isLiveArgs(sc.Args) {
+			queueModelOnlyCloseAlert(s.ID, symbol, pos.Quantity)
+		}
+	}
+	if logger != nil {
+		logger.Warn("Circuit breaker: force-closing %s %s @ $%.2f (PnL: $%.2f)", pos.Side, symbol, price, pnl)
+	}
+	positionID := ensurePositionTradeID(s.ID, symbol, pos)
+	trade := Trade{
+		Timestamp:         now,
+		StrategyID:        s.ID,
+		Symbol:            symbol,
+		PositionID:        positionID,
+		Side:              closeTradeSide(pos.Side),
+		Quantity:          absQty(pos.Quantity),
+		Price:             price,
+		Value:             value,
+		TradeType:         tradeType,
+		Details:           details,
+		IsClose:           true,
+		RealizedPnL:       pnl,
+		PnLGross:          true, // model-only adjustment has no exchange fee: gross == net
+		FeeSource:         FeeSourceReconcileAdjustment,
+		Regime:            s.Regime,
+		EntryATR:          pos.EntryATR,
+		StopLossTriggerPx: pos.StopLossTriggerPx,
+		StopLossATRMult:   pos.StopLossATRMult,
+		TPTiersJSON:       pos.TPTiersJSON,
+	}
+	RecordTrade(s, trade)
+	// #1159: a hedge leg's PnL never feeds the loss streak.
+	recordPositionTradeResult(s, pos, pnl)
+	recordClosedPosition(s, pos, price, pnl, reason, now)
+	delete(s.Positions, symbol)
+	clearHLPerpsPositionAlertThrottles(s, symbol)
+}
+
+// forceCloseSettledPositions model-only-closes ONLY the strategy's positions
+// whose venue leg the kill-switch report POSITIVELY confirmed flat
+// (applyKillSwitchSettledLegsWhileLatched). An unsettled leg — a coin whose
+// close errored or was never attempted — must stay in the book for the retry;
+// closing it here would write an estimate over a live exchange position.
+// settled maps platform → that platform's confirmed-closed coin set.
+func forceCloseSettledPositions(s *StrategyState, sc StrategyConfig, prices map[string]float64, settled map[string]map[string]bool, logger *StrategyLogger) {
+	coins := settled[sc.Platform]
+	if len(coins) == 0 || s == nil {
+		return
+	}
+	var syms []string
+	for sym := range s.Positions {
+		if coins[sym] {
+			syms = append(syms, sym)
+		}
+	}
+	sort.Strings(syms)
+	for _, sym := range syms {
+		closeVirtualPositionAtMark(s, &sc, sym, s.Positions[sym], prices, logger)
 	}
 }
 

--- a/scheduler/risk.go
+++ b/scheduler/risk.go
@@ -2033,6 +2033,11 @@ func forceCloseAllPositions(s *StrategyState, prices map[string]float64, logger 
 		}
 		if details == "" {
 			details = fmt.Sprintf("Circuit breaker close %s, PnL: $%.2f (model-only reconciliation adjustment; no exchange fill)", pos.Side, pnl)
+			// #1451 folded alert (#1454): a model-only row is an estimate
+			// standing in for a real exchange close. Escalate once per
+			// (strategy, symbol) per throttle window instead of leaving the DB
+			// row as the only signal.
+			queueModelOnlyCloseAlert(s.ID, symbol, pos.Quantity)
 		}
 		if logger != nil {
 			logger.Warn("Circuit breaker: force-closing %s %s @ $%.2f (PnL: $%.2f)", pos.Side, symbol, price, pnl)

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -781,7 +781,7 @@ func TestForceCloseAllPositionsRecordsDirectionalTradeSides(t *testing.T) {
 		RiskState:    RiskState{},
 	}
 
-	forceCloseAllPositions(s, map[string]float64{"BTC": 51000, "ETH": 2800}, nil)
+	forceCloseAllPositions(s, nil, map[string]float64{"BTC": 51000, "ETH": 2800}, nil)
 
 	if len(s.TradeHistory) != 4 {
 		t.Fatalf("TradeHistory len = %d, want 4", len(s.TradeHistory))
@@ -842,7 +842,7 @@ func TestForceCloseAllPositions_CorruptPositionBooksZeroPnL(t *testing.T) {
 			// price far from avgCost so a non-zero PnL WOULD be booked if the
 			// corrupt fields were used (e.g. 0.5 * 2150 = 1075, the rowid-54
 			// magnitude). The guard must keep it at zero.
-			forceCloseAllPositions(s, map[string]float64{tc.pos.Symbol: 2150}, nil)
+			forceCloseAllPositions(s, nil, map[string]float64{tc.pos.Symbol: 2150}, nil)
 
 			if len(s.TradeHistory) != 1 {
 				t.Fatalf("TradeHistory len = %d, want 1", len(s.TradeHistory))
@@ -888,7 +888,7 @@ func TestForceCloseAllPositions_HealthyPositionReconciles(t *testing.T) {
 		ClosedPositions: []ClosedPosition{},
 		RiskState:       RiskState{},
 	}
-	forceCloseAllPositions(s, map[string]float64{"ETH": 2100}, nil)
+	forceCloseAllPositions(s, nil, map[string]float64{"ETH": 2100}, nil)
 	if len(s.TradeHistory) != 1 || len(s.ClosedPositions) != 1 {
 		t.Fatalf("history=%d closed=%d, want 1/1", len(s.TradeHistory), len(s.ClosedPositions))
 	}
@@ -914,7 +914,7 @@ func TestForceCloseAllPositions_ResidualRowMarkedReconcileAdjustment(t *testing.
 		ClosedPositions: []ClosedPosition{},
 		RiskState:       RiskState{},
 	}
-	forceCloseAllPositions(s, map[string]float64{"ETH": 2100}, nil)
+	forceCloseAllPositions(s, nil, map[string]float64{"ETH": 2100}, nil)
 	if len(s.TradeHistory) != 1 {
 		t.Fatalf("TradeHistory len = %d, want 1", len(s.TradeHistory))
 	}
@@ -947,7 +947,7 @@ func TestForceCloseAllPositions_OptionRowsMarkedReconcileAdjustment(t *testing.T
 		ClosedPositions: []ClosedPosition{},
 		RiskState:       RiskState{},
 	}
-	forceCloseAllPositions(s, nil, nil)
+	forceCloseAllPositions(s, nil, nil, nil)
 	if len(s.TradeHistory) != 2 {
 		t.Fatalf("TradeHistory len = %d, want 2", len(s.TradeHistory))
 	}
@@ -3550,7 +3550,7 @@ func TestForceCloseAllPositions_TradeType_PerpsVsFutures(t *testing.T) {
 				TradeHistory: []Trade{},
 				RiskState:    RiskState{},
 			}
-			forceCloseAllPositions(s, map[string]float64{"BTC": 51000}, nil)
+			forceCloseAllPositions(s, nil, map[string]float64{"BTC": 51000}, nil)
 			if len(s.TradeHistory) != 1 {
 				t.Fatalf("TradeHistory len = %d, want 1", len(s.TradeHistory))
 			}

--- a/scheduler/trade_protection_snapshot_test.go
+++ b/scheduler/trade_protection_snapshot_test.go
@@ -255,7 +255,7 @@ func TestForceCloseAllPositions_StampsProtectionSnapshot(t *testing.T) {
 		RiskState:    RiskState{},
 	}
 
-	forceCloseAllPositions(s, map[string]float64{"BTC": 51000}, nil)
+	forceCloseAllPositions(s, nil, map[string]float64{"BTC": 51000}, nil)
 
 	if len(s.TradeHistory) != 1 {
 		t.Fatalf("TradeHistory len = %d, want 1", len(s.TradeHistory))


### PR DESCRIPTION
## Plain simple English

The emergency stop could miss positions an operator opened by hand: it closed the automatic ones, reported everything flat, and left hand-opened positions live on the exchange with no warning. Their close rows also recorded estimates instead of real exchange fills. This change brings those positions inside the emergency stop, books their real fills, and alerts the owner when any close still has no exchange order behind it.

## Summary

Implements #1454 (root cause 1 + root cause 3 of umbrella #1451, plus the folded model-only alert).

- **Kill-switch roster** (`hlKillSwitchAll`, main.go): live HL perps + live `type=manual` via `isHLLiveReconcilable` (#620 peer-scope precedent). It replaces `hlLiveAll` across the whole kill-switch fill chain — `KillSwitchCloseInputs.HLLiveAll`, the resting SL/TP trigger-OID cancel snapshot (extracted to testable `collectHLKillSwitchStopOIDs`), `snapshotHyperliquidVirtualQuantities`, the `hyperliquidKillSwitchFillShare` peer set, and `forceCloseKillSwitchPositions`. `hlLiveAll` itself stays perps-only — trailing-stop arming and risk math keep their #576 meaning.
- **Coin keys are RAW, not normalized.** Exchange-side surfaces (`report.Fills`, `stopLossOIDsByCoin`, virtual-position maps) stay keyed by the raw on-chain ticker because HL lower-case-prefix tickers (`kPEPE`) are case-sensitive and `hyperliquidConfiguredCoin` upper-cases. Manual coins resolve via `sc.Symbol` (#1444 precedent). Normalization is used only for traded-coin membership comparison inside `forceCloseHyperliquidLive`. The full suite's three kPEPE already-flat tests pin this.
- **Unowned-coin detection** now lives in `forceCloseHyperliquidLive`: non-zero on-chain positions on coins no roster strategy trades surface as `plan.Unconfigured` with a `[CRITICAL]` line and block `OnChainConfirmedFlat` on a mixed fleet too — previously only an empty perps roster reached that check.
- **No-fill recovery lookback** widened 30s → 10m (`hlKillSwitchNoFillRecoveryLookback`) so a fill that landed just before the switch fired is recovered from userFills rather than clearing model-only; ambiguity still fails closed.
- **Folded #1451 alert**: every model-only close row now queues a throttled owner DM keyed `(strategy_id, symbol)` at the `alert_throttle_interval` floor, drained outside `mu` at two sites.

Preserved invariants: shared-coin virtual-quantity splitting fails closed; #620 perps-CB peer scope untouched; #1159 hedge ownership matrix untouched (declared-but-flat hedge coin stays unowned but is now reported); #576 trailing-stop/risk separation intact; #1448/#1449 latch-ownership arms untouched.

## Verification

- New `scheduler/kill_switch_manual_test.go` (8 tests): manual-only coin closed + booked with real OID/fill-derived PnL (no model-only row); manual close failure latches; mixed-fleet unconfigured coin blocks flat; perps+manual shared coin split by virtual quantity; manual triggers collected for cancellation incl. raw lower-case symbol; declared-but-flat hedge coin unowned-but-reported; model-only DM throttle/drain.
- Red→green: the manual-booking and mixed-fleet tests were run against unfixed `origin/main` and failed there exactly as the issue describes (empty `exchange_order_id`, mark price, `reconcile_adjustment`, confirmed-flat despite the foreign position); they pass with the fix.
- Full scheduler suite green: `go vet ./...`, `gofmt` clean, `go test ./...` (all packages) pass. No Python changes.

Closes #1454. Progress toward umbrella #1451 (root cause 2 is #1455).

---
Created with LLM: ox-alpha | high | Harness: opencode
