### PR TITLE
test(#1485): merge and prune the Go protected-core test suite, phase A [C68, Fable 5, high]

### DIFF
--- a/scheduler/config_migration_test.go
+++ b/scheduler/config_migration_test.go
@@ -23,6 +23,9 @@ func TestNewFieldsSince(t *testing.T) {
 			if f.Version <= version {
 				t.Errorf("NewFieldsSince(%d) returned field %q with version %d", version, f.JSONPath, f.Version)
 			}
+			if f.JSONPath == "" || f.Description == "" || f.FieldType == "" || f.Version <= 0 {
+				t.Errorf("NewFieldsSince(%d) returned malformed field %+v", version, f)
+			}
 		}
 	}
 }
@@ -36,185 +39,86 @@ func TestMinSupportedConfigVersionFloor(t *testing.T) {
 	}
 }
 
-func TestNewFieldsSinceFieldProperties(t *testing.T) {
-	fields := NewFieldsSince(0)
-	for _, f := range fields {
-		if f.JSONPath == "" {
-			t.Error("field has empty JSONPath")
+func TestMigrateConfigWritesValues(t *testing.T) {
+	cases := []struct {
+		name   string
+		values map[string]string
+		check  func(t *testing.T, updated map[string]interface{})
+	}{
+		{
+			name:   "stamps_version_and_sets_value",
+			values: map[string]string{"discord.owner_id": "12345"},
+			check: func(t *testing.T, updated map[string]interface{}) {
+				discord, ok := updated["discord"].(map[string]interface{})
+				if !ok {
+					t.Fatal("discord section missing")
+				}
+				if discord["owner_id"] != "12345" {
+					t.Errorf("discord.owner_id = %v, want %q", discord["owner_id"], "12345")
+				}
+				if updated["interval_seconds"].(float64) != 300 {
+					t.Error("interval_seconds should be preserved")
+				}
+				if _, ok := updated["default_stop_loss_atr_mult"]; ok {
+					t.Error("default_stop_loss_atr_mult should no longer be backfilled on disk (#1285)")
+				}
+			},
+		},
+		{
+			name:   "creates_nested_paths",
+			values: map[string]string{"discord.dm_channels.hyperliquid": "999888777"},
+			check: func(t *testing.T, updated map[string]interface{}) {
+				discord := updated["discord"].(map[string]interface{})
+				dmCh := discord["dm_channels"].(map[string]interface{})
+				if dmCh["hyperliquid"] != "999888777" {
+					t.Errorf("discord.dm_channels.hyperliquid = %v, want %q", dmCh["hyperliquid"], "999888777")
+				}
+			},
+		},
+		{
+			name:   "nil_values_still_stamp_version",
+			values: nil,
+			check:  func(t *testing.T, updated map[string]interface{}) {},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.json")
+			writeRawConfig(t, path, map[string]interface{}{
+				"interval_seconds": 300,
+				"strategies":       []interface{}{},
+			})
+			if err := MigrateConfig(path, tc.values, nil); err != nil {
+				t.Fatalf("MigrateConfig failed: %v", err)
+			}
+			if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+				t.Error("temp file should not exist after migration")
+			}
+			updated := readRawConfig(t, path)
+			if version := int(updated["config_version"].(float64)); version != CurrentConfigVersion {
+				t.Errorf("config_version = %d, want %d", version, CurrentConfigVersion)
+			}
+			tc.check(t, updated)
+		})
+	}
+}
+
+func TestMigrateConfigRejectsUnreadableInput(t *testing.T) {
+	t.Run("missing_file", func(t *testing.T) {
+		if err := MigrateConfig("/nonexistent/config.json", nil, nil); err == nil {
+			t.Error("expected error for missing file")
 		}
-		if f.Description == "" {
-			t.Errorf("field %q has empty Description", f.JSONPath)
+	})
+	t.Run("invalid_json", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.json")
+		if err := os.WriteFile(path, []byte("not json"), 0600); err != nil {
+			t.Fatal(err)
 		}
-		if f.FieldType == "" {
-			t.Errorf("field %q has empty FieldType", f.JSONPath)
+		if err := MigrateConfig(path, nil, nil); err == nil {
+			t.Error("expected error for invalid JSON")
 		}
-		if f.Version <= 0 {
-			t.Errorf("field %q has invalid version %d", f.JSONPath, f.Version)
-		}
-	}
-}
-
-func TestMigrateConfigBasic(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-
-	original := map[string]interface{}{
-		"interval_seconds": 300,
-		"strategies":       []interface{}{},
-	}
-	data, err := json.MarshalIndent(original, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	values := map[string]string{
-		"discord.owner_id": "12345",
-	}
-	if err := MigrateConfig(path, values, nil); err != nil {
-		t.Fatalf("MigrateConfig failed: %v", err)
-	}
-
-	result, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var updated map[string]interface{}
-	if err := json.Unmarshal(result, &updated); err != nil {
-		t.Fatal(err)
-	}
-
-	version := int(updated["config_version"].(float64))
-	if version != CurrentConfigVersion {
-		t.Errorf("config_version = %d, want %d", version, CurrentConfigVersion)
-	}
-
-	discord, ok := updated["discord"].(map[string]interface{})
-	if !ok {
-		t.Fatal("discord section missing")
-	}
-	if discord["owner_id"] != "12345" {
-		t.Errorf("discord.owner_id = %v, want %q", discord["owner_id"], "12345")
-	}
-
-	if updated["interval_seconds"].(float64) != 300 {
-		t.Error("interval_seconds should be preserved")
-	}
-	if _, ok := updated["default_stop_loss_atr_mult"]; ok {
-		t.Error("default_stop_loss_atr_mult should no longer be backfilled on disk (#1285)")
-	}
-}
-
-func TestMigrateConfigCreatesNestedPaths(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-
-	original := map[string]interface{}{"interval_seconds": 300}
-	data, err := json.MarshalIndent(original, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	values := map[string]string{
-		"discord.dm_channels.hyperliquid": "999888777",
-	}
-	if err := MigrateConfig(path, values, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var updated map[string]interface{}
-	if err := json.Unmarshal(result, &updated); err != nil {
-		t.Fatal(err)
-	}
-
-	discord := updated["discord"].(map[string]interface{})
-	dmCh := discord["dm_channels"].(map[string]interface{})
-	if dmCh["hyperliquid"] != "999888777" {
-		t.Errorf("discord.dm_channels.hyperliquid = %v, want %q", dmCh["hyperliquid"], "999888777")
-	}
-}
-
-func TestMigrateConfigNilValues(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-
-	original := map[string]interface{}{"interval_seconds": 300}
-	data, err := json.MarshalIndent(original, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := MigrateConfig(path, nil, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var updated map[string]interface{}
-	if err := json.Unmarshal(result, &updated); err != nil {
-		t.Fatal(err)
-	}
-
-	version := int(updated["config_version"].(float64))
-	if version != CurrentConfigVersion {
-		t.Errorf("config_version = %d, want %d", version, CurrentConfigVersion)
-	}
-}
-
-func TestMigrateConfigAtomicWrite(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-
-	original := map[string]interface{}{"interval_seconds": 300}
-	data, err := json.MarshalIndent(original, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := MigrateConfig(path, nil, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
-		t.Error("temp file should not exist after migration")
-	}
-}
-
-func TestMigrateConfigMissingFile(t *testing.T) {
-	err := MigrateConfig("/nonexistent/config.json", nil, nil)
-	if err == nil {
-		t.Error("expected error for missing file")
-	}
-}
-
-func TestMigrateConfigInvalidJSON(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-	if err := os.WriteFile(path, []byte("not json"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	err := MigrateConfig(path, nil, nil)
-	if err == nil {
-		t.Error("expected error for invalid JSON")
-	}
+	})
 }
 
 func TestSetNestedField(t *testing.T) {
@@ -348,39 +252,6 @@ func TestMigrateConfigRejectsPreFloorVersions(t *testing.T) {
 	}
 }
 
-func TestMigrateConfigAtFloorNeverStripsLegacyNames(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-	writeRawConfig(t, path, map[string]interface{}{
-		"config_version": MinSupportedConfigVersion,
-		"discord": map[string]interface{}{
-			"channel_paper_trades": true,
-			"channel_live_trades":  true,
-			"spot_summary_freq":    "hourly",
-		},
-	})
-	if err := MigrateConfig(path, nil, nil); err != nil {
-		t.Fatalf("MigrateConfig failed: %v", err)
-	}
-	result, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var updated map[string]interface{}
-	if err := json.Unmarshal(result, &updated); err != nil {
-		t.Fatal(err)
-	}
-	if v := int(updated["config_version"].(float64)); v != CurrentConfigVersion {
-		t.Errorf("config_version = %d, want %d", v, CurrentConfigVersion)
-	}
-	discord := updated["discord"].(map[string]interface{})
-	for _, key := range []string{"channel_paper_trades", "channel_live_trades", "spot_summary_freq"} {
-		if _, ok := discord[key]; !ok {
-			t.Errorf("discord.%s should NOT be removed for a supported config", key)
-		}
-	}
-}
-
 func assertVersionlessDMKeyError(t *testing.T, err error, key, path string, original []byte) {
 	t.Helper()
 	if err == nil {
@@ -492,71 +363,69 @@ func TestVersionlessConfigRemovedTranslationKeyAcceptance(t *testing.T) {
 	}
 }
 
-func TestVersionlessConfigWithInertPreFloorKeysMigrates(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-	writeRawConfig(t, path, map[string]interface{}{
-		"interval_seconds": 3600,
-		"strategies":       []interface{}{},
-		"discord": map[string]interface{}{
-			"owner_id":             "disc-owner",
-			"channel_paper_trades": true,
-			"channel_live_trades":  true,
-			"spot_summary_freq":    "hourly",
+func TestMigrateConfigRetainsInertLegacyDiscordKeys(t *testing.T) {
+	inert := map[string]interface{}{
+		"channel_paper_trades": true,
+		"channel_live_trades":  true,
+		"spot_summary_freq":    "hourly",
+	}
+	cases := []struct {
+		name string
+		obj  map[string]interface{}
+	}{
+		{
+			name: "at_floor_version",
+			obj: map[string]interface{}{
+				"config_version": MinSupportedConfigVersion,
+				"discord":        inert,
+			},
 		},
-	})
-	if err := MigrateConfig(path, nil, nil); err != nil {
-		t.Fatalf("MigrateConfig rejected a version-less config with inert pre-floor keys: %v", err)
-	}
-	after, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var updated map[string]interface{}
-	if err := json.Unmarshal(after, &updated); err != nil {
-		t.Fatal(err)
-	}
-	if v := int(updated["config_version"].(float64)); v != CurrentConfigVersion {
-		t.Errorf("config_version = %d, want %d", v, CurrentConfigVersion)
-	}
-	discord := updated["discord"].(map[string]interface{})
-	for _, key := range []string{"channel_paper_trades", "channel_live_trades", "spot_summary_freq"} {
-		if _, ok := discord[key]; !ok {
-			t.Errorf("discord.%s should be retained (inert) for a version-less config", key)
-		}
-	}
-}
-
-func TestMigrateConfigV8PreservesFieldsAtCurrentVersion(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-	original := map[string]interface{}{
-		"config_version": CurrentConfigVersion,
-		"discord": map[string]interface{}{
-			"spot_summary_freq": "hourly",
+		{
+			name: "versionless",
+			obj: map[string]interface{}{
+				"interval_seconds": 3600,
+				"strategies":       []interface{}{},
+				"discord": map[string]interface{}{
+					"owner_id":             "disc-owner",
+					"channel_paper_trades": true,
+					"channel_live_trades":  true,
+					"spot_summary_freq":    "hourly",
+				},
+			},
+		},
+		{
+			name: "versionless_without_strategies",
+			obj: map[string]interface{}{
+				"interval_seconds": 3600,
+				"discord":          inert,
+			},
+		},
+		{
+			name: "at_current_version",
+			obj: map[string]interface{}{
+				"config_version": CurrentConfigVersion,
+				"discord":        inert,
+			},
 		},
 	}
-	data, err := json.MarshalIndent(original, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		t.Fatal(err)
-	}
-	if err := MigrateConfig(path, nil, nil); err != nil {
-		t.Fatal(err)
-	}
-	result, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var updated map[string]interface{}
-	if err := json.Unmarshal(result, &updated); err != nil {
-		t.Fatal(err)
-	}
-	discord := updated["discord"].(map[string]interface{})
-	if _, ok := discord["spot_summary_freq"]; !ok {
-		t.Error("discord.spot_summary_freq should NOT be removed when already at CurrentConfigVersion")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.json")
+			writeRawConfig(t, path, tc.obj)
+			if err := MigrateConfig(path, nil, nil); err != nil {
+				t.Fatalf("MigrateConfig failed: %v", err)
+			}
+			updated := readRawConfig(t, path)
+			if v := int(updated["config_version"].(float64)); v != CurrentConfigVersion {
+				t.Errorf("config_version = %d, want %d", v, CurrentConfigVersion)
+			}
+			discord := updated["discord"].(map[string]interface{})
+			for _, key := range []string{"channel_paper_trades", "channel_live_trades", "spot_summary_freq"} {
+				if _, ok := discord[key]; !ok {
+					t.Errorf("discord.%s should NOT be removed (inert) for a supported config", key)
+				}
+			}
+		})
 	}
 }
 
@@ -1161,129 +1030,113 @@ func TestLoadConfig_V14_TranslatesAllowShortsToDirection(t *testing.T) {
 	}
 }
 
-func TestMigrateConfigV16UserDefaultsAliases(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-	raw := map[string]interface{}{
-		"config_version": 15,
-		"user_close_defaults": map[string]interface{}{
-			"trailing_tp_ratchet": map[string]interface{}{
-				"tp_tiers": []interface{}{map[string]interface{}{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}},
-			},
-			"regime_atr": map[string]interface{}{
-				"stop_loss_atr_regime": map[string]interface{}{"use_defaults": true},
-			},
-		},
-		"manual_defaults": map[string]interface{}{
-			"margin_usd":         125.0,
-			"stop_loss_atr_mult": 2.25,
-			"side":               "short",
-		},
-	}
-	writeMigrationJSON(t, path, raw)
-
-	if err := MigrateConfig(path, nil, nil); err != nil {
-		t.Fatalf("MigrateConfig: %v", err)
-	}
-	updated := readMigrationJSON(t, path)
-	if int(updated["config_version"].(float64)) != CurrentConfigVersion {
-		t.Fatalf("config_version = %v, want %d", updated["config_version"], CurrentConfigVersion)
-	}
-	if _, ok := updated["user_close_defaults"]; ok {
-		t.Fatal("legacy user_close_defaults key was not removed")
-	}
-	if _, ok := updated["manual_defaults"]; ok {
-		t.Fatal("legacy manual_defaults key was not removed")
-	}
-	userDefaults := updated["user_defaults"].(map[string]interface{})
-	closeDefaults := userDefaults["close"].(map[string]interface{})
-	if _, ok := closeDefaults["regime_atr"]; ok {
-		t.Fatal("regime_atr stayed inside user_defaults.close")
-	}
-	if _, ok := closeDefaults["trailing_tp_ratchet"]; !ok {
-		t.Fatalf("trailing_tp_ratchet missing from user_defaults.close: %+v", closeDefaults)
-	}
-	regimeATR := userDefaults["regime_atr"].(map[string]interface{})
-	if _, ok := regimeATR["stop_loss_atr_mult_regime"]; !ok {
-		t.Fatalf("stop_loss_atr_mult_regime missing from user_defaults.regime_atr: %+v", regimeATR)
-	}
-	manual := userDefaults["manual"].(map[string]interface{})
-	if manual["margin_usd"].(float64) != 125.0 || manual["side"].(string) != "short" {
-		t.Fatalf("manual defaults not migrated: %+v", manual)
-	}
-}
-
-func TestMigrateConfigV16UserDefaultsEquivalentAliases(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
+func TestMigrateConfigV16UserDefaults(t *testing.T) {
 	closeDefaults := map[string]interface{}{
 		"tiered_tp_atr": map[string]interface{}{
 			"tp_tiers": []interface{}{map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0}},
 		},
 	}
-	raw := map[string]interface{}{
-		"config_version":             16,
-		"user_close_defaults":        closeDefaults,
-		"user_defaults":              map[string]interface{}{"close": closeDefaults},
-		"interval_seconds":           600,
-		"default_stop_loss_atr_mult": 1.0,
-	}
-	writeMigrationJSON(t, path, raw)
-
-	if err := MigrateConfig(path, nil, nil); err != nil {
-		t.Fatalf("MigrateConfig accepted equivalent legacy/canonical aliases: %v", err)
-	}
-	updated := readMigrationJSON(t, path)
-	if _, ok := updated["user_close_defaults"]; ok {
-		t.Fatal("equivalent legacy user_close_defaults key was not removed")
-	}
-	userDefaults := updated["user_defaults"].(map[string]interface{})
-	if !reflect.DeepEqual(userDefaults["close"], closeDefaults) {
-		t.Fatalf("canonical close defaults changed: %+v", userDefaults["close"])
-	}
-}
-
-func TestMigrateConfigV16UserDefaultsConflictRejects(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-	raw := map[string]interface{}{
-		"config_version": 16,
-		"user_defaults": map[string]interface{}{
-			"manual": map[string]interface{}{"side": "long"},
+	cases := []struct {
+		name    string
+		raw     map[string]interface{}
+		wantErr string
+		check   func(t *testing.T, updated map[string]interface{})
+	}{
+		{
+			name: "legacy_aliases_move_into_user_defaults",
+			raw: map[string]interface{}{
+				"config_version": 15,
+				"user_close_defaults": map[string]interface{}{
+					"trailing_tp_ratchet": map[string]interface{}{
+						"tp_tiers": []interface{}{map[string]interface{}{"atr_multiple": 1.0, "trailing_mult_after": 1.0, "close_fraction": 0.0}},
+					},
+					"regime_atr": map[string]interface{}{
+						"stop_loss_atr_regime": map[string]interface{}{"use_defaults": true},
+					},
+				},
+				"manual_defaults": map[string]interface{}{
+					"margin_usd":         125.0,
+					"stop_loss_atr_mult": 2.25,
+					"side":               "short",
+				},
+			},
+			check: func(t *testing.T, updated map[string]interface{}) {
+				if int(updated["config_version"].(float64)) != CurrentConfigVersion {
+					t.Fatalf("config_version = %v, want %d", updated["config_version"], CurrentConfigVersion)
+				}
+				if _, ok := updated["user_close_defaults"]; ok {
+					t.Fatal("legacy user_close_defaults key was not removed")
+				}
+				if _, ok := updated["manual_defaults"]; ok {
+					t.Fatal("legacy manual_defaults key was not removed")
+				}
+				userDefaults := updated["user_defaults"].(map[string]interface{})
+				closes := userDefaults["close"].(map[string]interface{})
+				if _, ok := closes["regime_atr"]; ok {
+					t.Fatal("regime_atr stayed inside user_defaults.close")
+				}
+				if _, ok := closes["trailing_tp_ratchet"]; !ok {
+					t.Fatalf("trailing_tp_ratchet missing from user_defaults.close: %+v", closes)
+				}
+				regimeATR := userDefaults["regime_atr"].(map[string]interface{})
+				if _, ok := regimeATR["stop_loss_atr_mult_regime"]; !ok {
+					t.Fatalf("stop_loss_atr_mult_regime missing from user_defaults.regime_atr: %+v", regimeATR)
+				}
+				manual := userDefaults["manual"].(map[string]interface{})
+				if manual["margin_usd"].(float64) != 125.0 || manual["side"].(string) != "short" {
+					t.Fatalf("manual defaults not migrated: %+v", manual)
+				}
+			},
 		},
-		"manual_defaults": map[string]interface{}{"side": "short"},
+		{
+			name: "equivalent_aliases_accepted_and_legacy_dropped",
+			raw: map[string]interface{}{
+				"config_version":             16,
+				"user_close_defaults":        closeDefaults,
+				"user_defaults":              map[string]interface{}{"close": closeDefaults},
+				"interval_seconds":           600,
+				"default_stop_loss_atr_mult": 1.0,
+			},
+			check: func(t *testing.T, updated map[string]interface{}) {
+				if _, ok := updated["user_close_defaults"]; ok {
+					t.Fatal("equivalent legacy user_close_defaults key was not removed")
+				}
+				userDefaults := updated["user_defaults"].(map[string]interface{})
+				if !reflect.DeepEqual(userDefaults["close"], closeDefaults) {
+					t.Fatalf("canonical close defaults changed: %+v", userDefaults["close"])
+				}
+			},
+		},
+		{
+			name: "conflicting_aliases_rejected",
+			raw: map[string]interface{}{
+				"config_version": 16,
+				"user_defaults": map[string]interface{}{
+					"manual": map[string]interface{}{"side": "long"},
+				},
+				"manual_defaults": map[string]interface{}{"side": "short"},
+			},
+			wantErr: "conflicts",
+		},
 	}
-	writeMigrationJSON(t, path, raw)
-
-	err := MigrateConfig(path, nil, nil)
-	if err == nil {
-		t.Fatal("MigrateConfig accepted conflicting user_defaults.manual/manual_defaults")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.json")
+			writeRawConfig(t, path, tc.raw)
+			err := MigrateConfig(path, nil, nil)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatal("MigrateConfig accepted conflicting user_defaults.manual/manual_defaults")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not mention %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("MigrateConfig: %v", err)
+			}
+			tc.check(t, readRawConfig(t, path))
+		})
 	}
-	if !bytes.Contains([]byte(err.Error()), []byte("conflicts")) {
-		t.Fatalf("error %q does not mention conflict", err)
-	}
-}
-
-func writeMigrationJSON(t *testing.T, path string, raw map[string]interface{}) {
-	t.Helper()
-	data, err := json.MarshalIndent(raw, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func readMigrationJSON(t *testing.T, path string) map[string]interface{} {
-	t.Helper()
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var raw map[string]interface{}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatal(err)
-	}
-	return raw
 }

--- a/scheduler/config_migration_v15_test.go
+++ b/scheduler/config_migration_v15_test.go
@@ -8,169 +8,213 @@ import (
 	"testing"
 )
 
-func TestMigrateV15CloseKeys_TPAtPct(t *testing.T) {
-	raw := map[string]interface{}{
-		"config_version": 14,
-		"strategies": []interface{}{
-			map[string]interface{}{
-				"id": "s1",
-				"close_strategy": map[string]interface{}{
-					"name":   "tp_at_pct",
-					"params": map[string]interface{}{"pct": 0.05},
+func TestMigrateV15CloseKeys(t *testing.T) {
+	strategyOf := func(t *testing.T, raw map[string]interface{}) map[string]interface{} {
+		t.Helper()
+		return raw["strategies"].([]interface{})[0].(map[string]interface{})
+	}
+	closeParamsOf := func(t *testing.T, raw map[string]interface{}) map[string]interface{} {
+		t.Helper()
+		return strategyOf(t, raw)["close_strategy"].(map[string]interface{})["params"].(map[string]interface{})
+	}
+	regimeTier := func(frac, up, ranging, down float64) map[string]interface{} {
+		return map[string]interface{}{
+			"close_fraction": frac,
+			"trend_regime": map[string]interface{}{
+				"trending_up":   map[string]interface{}{"atr": up},
+				"ranging":       map[string]interface{}{"atr": ranging},
+				"trending_down": map[string]interface{}{"atr": down},
+			},
+		}
+	}
+	cases := []struct {
+		name  string
+		raw   map[string]interface{}
+		check func(t *testing.T, raw map[string]interface{})
+	}{
+		{
+			name: "tp_at_pct_becomes_single_tier_tiered_tp_pct",
+			raw: map[string]interface{}{
+				"config_version": 14,
+				"strategies": []interface{}{
+					map[string]interface{}{
+						"id": "s1",
+						"close_strategy": map[string]interface{}{
+							"name":   "tp_at_pct",
+							"params": map[string]interface{}{"pct": 0.05},
+						},
+					},
 				},
 			},
+			check: func(t *testing.T, raw map[string]interface{}) {
+				ref := strategyOf(t, raw)["close_strategy"].(map[string]interface{})
+				if ref["name"] != "tiered_tp_pct" {
+					t.Fatalf("name = %v, want tiered_tp_pct", ref["name"])
+				}
+				tier0 := closeParamsOf(t, raw)["tp_tiers"].([]interface{})[0].(map[string]interface{})
+				if tier0["profit_pct"].(float64) != 0.05 {
+					t.Errorf("profit_pct = %v, want 0.05", tier0["profit_pct"])
+				}
+				if tier0["close_fraction"].(float64) != 1.0 {
+					t.Errorf("close_fraction = %v, want 1.0", tier0["close_fraction"])
+				}
+			},
 		},
-	}
-	migrateV15CloseKeys(raw)
-	ref := raw["strategies"].([]interface{})[0].(map[string]interface{})["close_strategy"].(map[string]interface{})
-	if ref["name"] != "tiered_tp_pct" {
-		t.Fatalf("name = %v, want tiered_tp_pct", ref["name"])
-	}
-	params := ref["params"].(map[string]interface{})
-	tiers := params["tp_tiers"].([]interface{})
-	tier0 := tiers[0].(map[string]interface{})
-	if tier0["profit_pct"].(float64) != 0.05 {
-		t.Errorf("profit_pct = %v, want 0.05", tier0["profit_pct"])
-	}
-	if tier0["close_fraction"].(float64) != 1.0 {
-		t.Errorf("close_fraction = %v, want 1.0", tier0["close_fraction"])
-	}
-}
-
-func TestMigrateV15CloseKeys_CanonicalizeTierKeys(t *testing.T) {
-	raw := map[string]interface{}{
-		"strategies": []interface{}{
-			map[string]interface{}{
-				"id": "s1",
-				"close_strategy": map[string]interface{}{
-					"name": "tiered_tp_atr",
-					"params": map[string]interface{}{
-						"tiers": []interface{}{
-							map[string]interface{}{
-								"atr":      1.0,
-								"fraction": 0.5,
-							},
-							map[string]interface{}{
-								"multiple":       2.0,
-								"close_fraction": 1.0,
+		{
+			name: "canonicalizes_tier_keys",
+			raw: map[string]interface{}{
+				"strategies": []interface{}{
+					map[string]interface{}{
+						"id": "s1",
+						"close_strategy": map[string]interface{}{
+							"name": "tiered_tp_atr",
+							"params": map[string]interface{}{
+								"tiers": []interface{}{
+									map[string]interface{}{"atr": 1.0, "fraction": 0.5},
+									map[string]interface{}{"multiple": 2.0, "close_fraction": 1.0},
+								},
 							},
 						},
 					},
 				},
 			},
+			check: func(t *testing.T, raw map[string]interface{}) {
+				params := closeParamsOf(t, raw)
+				tiers, ok := params["tp_tiers"].([]interface{})
+				if !ok {
+					t.Fatalf("params = %#v, want tp_tiers list", params)
+				}
+				t0 := tiers[0].(map[string]interface{})
+				if t0["atr_multiple"].(float64) != 1.0 || t0["close_fraction"].(float64) != 0.5 {
+					t.Errorf("tier[0] = %#v", t0)
+				}
+			},
 		},
-	}
-	migrateV15CloseKeys(raw)
-	ref := raw["strategies"].([]interface{})[0].(map[string]interface{})["close_strategy"].(map[string]interface{})
-	params := ref["params"].(map[string]interface{})
-	tiers, ok := params["tp_tiers"].([]interface{})
-	if !ok {
-		t.Fatalf("params = %#v, want tp_tiers list", params)
-	}
-	t0 := tiers[0].(map[string]interface{})
-	if t0["atr_multiple"].(float64) != 1.0 || t0["close_fraction"].(float64) != 0.5 {
-		t.Errorf("tier[0] = %#v", t0)
-	}
-}
-
-func TestMigrateV15CloseKeys_LiftLegacyRegime(t *testing.T) {
-	tier0 := map[string]interface{}{
-		"close_fraction": 0.5,
-		"trend_regime": map[string]interface{}{
-			"trending_up":   map[string]interface{}{"atr": 2.0},
-			"ranging":       map[string]interface{}{"atr": 1.0},
-			"trending_down": map[string]interface{}{"atr": 2.0},
-		},
-	}
-	tier1 := map[string]interface{}{
-		"close_fraction": 1.0,
-		"trend_regime": map[string]interface{}{
-			"trending_up":   map[string]interface{}{"atr": 4.0},
-			"ranging":       map[string]interface{}{"atr": 2.0},
-			"trending_down": map[string]interface{}{"atr": 4.0},
-		},
-	}
-	raw := map[string]interface{}{
-		"default_stop_loss_atr_mult": 1.5,
-		"strategies": []interface{}{
-			map[string]interface{}{
-				"id": "hl-test",
-				"stop_loss_atr_regime": map[string]interface{}{
-					"trend_regime": map[string]interface{}{
-						"trending_up":   map[string]interface{}{"atr": 1.5},
-						"ranging":       map[string]interface{}{"atr": 0.8},
-						"trending_down": map[string]interface{}{"atr": 1.5},
-					},
-				},
-				"close_strategy": map[string]interface{}{
-					"name": "tiered_tp_atr_regime",
-					"params": map[string]interface{}{
-						"tiers": []interface{}{tier0, tier1},
+		{
+			name: "lifts_legacy_regime_into_unified_close",
+			raw: map[string]interface{}{
+				"default_stop_loss_atr_mult": 1.5,
+				"strategies": []interface{}{
+					map[string]interface{}{
+						"id": "hl-test",
+						"stop_loss_atr_regime": map[string]interface{}{
+							"trend_regime": map[string]interface{}{
+								"trending_up":   map[string]interface{}{"atr": 1.5},
+								"ranging":       map[string]interface{}{"atr": 0.8},
+								"trending_down": map[string]interface{}{"atr": 1.5},
+							},
+						},
+						"close_strategy": map[string]interface{}{
+							"name": "tiered_tp_atr_regime",
+							"params": map[string]interface{}{
+								"tiers": []interface{}{regimeTier(0.5, 2.0, 1.0, 2.0), regimeTier(1.0, 4.0, 2.0, 4.0)},
+							},
+						},
 					},
 				},
 			},
+			check: func(t *testing.T, raw map[string]interface{}) {
+				sc := strategyOf(t, raw)
+				if _, ok := sc["stop_loss_atr_regime"]; ok {
+					t.Error("stop_loss_atr_regime should be removed after fold")
+				}
+				if _, ok := sc["stop_loss_atr_mult"]; ok {
+					t.Error("stop_loss_atr_mult should be removed after fold")
+				}
+				params := closeParamsOf(t, raw)
+				if !closeParamsAreUnifiedRegime(params) {
+					t.Fatalf("params not unified: %#v", params)
+				}
+				up := params["trend_regime"].(map[string]interface{})["trending_up"].(map[string]interface{})
+				if up["stop_loss_atr"].(float64) != 1.5 {
+					t.Errorf("trending_up stop_loss_atr = %v, want 1.5", up["stop_loss_atr"])
+				}
+				tiers := up["tp_tiers"].([]interface{})
+				if len(tiers) != 2 {
+					t.Fatalf("trending_up tp_tiers len = %d, want 2", len(tiers))
+				}
+				t0 := tiers[0].(map[string]interface{})
+				if t0["atr_multiple"].(float64) != 2.0 || t0["close_fraction"].(float64) != 0.5 {
+					t.Errorf("tier[0] = %#v", t0)
+				}
+			},
 		},
-	}
-	migrateV15CloseKeys(raw)
-	sc := raw["strategies"].([]interface{})[0].(map[string]interface{})
-	if _, ok := sc["stop_loss_atr_regime"]; ok {
-		t.Error("stop_loss_atr_regime should be removed after fold")
-	}
-	if _, ok := sc["stop_loss_atr_mult"]; ok {
-		t.Error("stop_loss_atr_mult should be removed after fold")
-	}
-	ref := sc["close_strategy"].(map[string]interface{})
-	params := ref["params"].(map[string]interface{})
-	if !closeParamsAreUnifiedRegime(params) {
-		t.Fatalf("params not unified: %#v", params)
-	}
-	tr := params["trend_regime"].(map[string]interface{})
-	up := tr["trending_up"].(map[string]interface{})
-	if up["stop_loss_atr"].(float64) != 1.5 {
-		t.Errorf("trending_up stop_loss_atr = %v, want 1.5", up["stop_loss_atr"])
-	}
-	tiers := up["tp_tiers"].([]interface{})
-	if len(tiers) != 2 {
-		t.Fatalf("trending_up tp_tiers len = %d, want 2", len(tiers))
-	}
-	t0 := tiers[0].(map[string]interface{})
-	if t0["atr_multiple"].(float64) != 2.0 || t0["close_fraction"].(float64) != 0.5 {
-		t.Errorf("tier[0] = %#v", t0)
-	}
-}
-
-func TestMigrateV15CloseKeys_LiftLegacyRegime_StripsScalarStopLoss(t *testing.T) {
-	tier0 := map[string]interface{}{
-		"close_fraction": 0.5,
-		"trend_regime": map[string]interface{}{
-			"trending_up":   map[string]interface{}{"atr": 2.0},
-			"ranging":       map[string]interface{}{"atr": 1.0},
-			"trending_down": map[string]interface{}{"atr": 2.0},
-		},
-	}
-	raw := map[string]interface{}{
-		"strategies": []interface{}{
-			map[string]interface{}{
-				"id":                 "hl-test",
-				"stop_loss_atr_mult": 1.5,
-				"close_strategy": map[string]interface{}{
-					"name": "tiered_tp_atr_regime",
-					"params": map[string]interface{}{
-						"tiers": []interface{}{tier0},
+		{
+			name: "lift_legacy_regime_strips_scalar_stop_loss_into_fold",
+			raw: map[string]interface{}{
+				"strategies": []interface{}{
+					map[string]interface{}{
+						"id":                 "hl-test",
+						"stop_loss_atr_mult": 1.5,
+						"close_strategy": map[string]interface{}{
+							"name": "tiered_tp_atr_regime",
+							"params": map[string]interface{}{
+								"tiers": []interface{}{regimeTier(0.5, 2.0, 1.0, 2.0)},
+							},
+						},
 					},
 				},
 			},
+			check: func(t *testing.T, raw map[string]interface{}) {
+				sc := strategyOf(t, raw)
+				if _, ok := sc["stop_loss_atr_mult"]; ok {
+					t.Fatal("stop_loss_atr_mult should be stripped after unified fold")
+				}
+				up := closeParamsOf(t, raw)["trend_regime"].(map[string]interface{})["trending_up"].(map[string]interface{})
+				if up["stop_loss_atr"].(float64) != 1.5 {
+					t.Errorf("trending_up stop_loss_atr = %v, want 1.5 from scalar fallback", up["stop_loss_atr"])
+				}
+			},
+		},
+		{
+			name: "trailing_tp_ratchet_regime_table_canonicalized_per_regime",
+			raw: map[string]interface{}{
+				"config_version": 14,
+				"strategies": []interface{}{
+					map[string]interface{}{
+						"id":       "s1",
+						"type":     "perps",
+						"platform": "hyperliquid",
+						"close_strategy": map[string]interface{}{
+							"name": "trailing_tp_ratchet_regime",
+							"params": map[string]interface{}{
+								"tp_tiers": map[string]interface{}{
+									"trending_up": []interface{}{
+										map[string]interface{}{"atr": 1.5, "fraction": 0.0, "trailing_mult_after": 2.0},
+									},
+									"trending_down": []interface{}{
+										map[string]interface{}{"multiple": 1.0, "close_fraction": 0.25, "trailing_mult_after": 1.5},
+									},
+									"ranging": []interface{}{
+										map[string]interface{}{"atr_multiple": 1.0, "close_fraction": 0.0, "trailing_mult_after": 2.5},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, raw map[string]interface{}) {
+				params := closeParamsOf(t, raw)
+				table, ok := params["tp_tiers"].(map[string]interface{})
+				if !ok {
+					t.Fatalf("tp_tiers = %#v, want regime-keyed map", params["tp_tiers"])
+				}
+				up := table["trending_up"].([]interface{})[0].(map[string]interface{})
+				if up["atr_multiple"].(float64) != 1.5 || up["close_fraction"].(float64) != 0 {
+					t.Errorf("trending_up tier = %#v", up)
+				}
+				if up["trailing_mult_after"].(float64) != 2.0 {
+					t.Errorf("trailing_mult_after = %v", up["trailing_mult_after"])
+				}
+			},
 		},
 	}
-	migrateV15CloseKeys(raw)
-	sc := raw["strategies"].([]interface{})[0].(map[string]interface{})
-	if _, ok := sc["stop_loss_atr_mult"]; ok {
-		t.Fatal("stop_loss_atr_mult should be stripped after unified fold")
-	}
-	params := sc["close_strategy"].(map[string]interface{})["params"].(map[string]interface{})
-	up := params["trend_regime"].(map[string]interface{})["trending_up"].(map[string]interface{})
-	if up["stop_loss_atr"].(float64) != 1.5 {
-		t.Errorf("trending_up stop_loss_atr = %v, want 1.5 from scalar fallback", up["stop_loss_atr"])
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			migrateV15CloseKeys(tc.raw)
+			tc.check(t, tc.raw)
+		})
 	}
 }
 
@@ -301,60 +345,5 @@ func TestLoadConfig_V15_MigratesCloseKeysOnDisk(t *testing.T) {
 	}
 	if !reflect.DeepEqual(tiersRaw, want) {
 		t.Errorf("tp_tiers = %#v, want %#v", tiersRaw, want)
-	}
-}
-
-func TestMigrateV15CloseKeys_TrailingTPRatchetRegimeTable(t *testing.T) {
-	raw := map[string]interface{}{
-		"config_version": 14,
-		"strategies": []interface{}{
-			map[string]interface{}{
-				"id":       "s1",
-				"type":     "perps",
-				"platform": "hyperliquid",
-				"close_strategy": map[string]interface{}{
-					"name": "trailing_tp_ratchet_regime",
-					"params": map[string]interface{}{
-						"tp_tiers": map[string]interface{}{
-							"trending_up": []interface{}{
-								map[string]interface{}{
-									"atr":                 1.5,
-									"fraction":            0.0,
-									"trailing_mult_after": 2.0,
-								},
-							},
-							"trending_down": []interface{}{
-								map[string]interface{}{
-									"multiple":            1.0,
-									"close_fraction":      0.25,
-									"trailing_mult_after": 1.5,
-								},
-							},
-							"ranging": []interface{}{
-								map[string]interface{}{
-									"atr_multiple":        1.0,
-									"close_fraction":      0.0,
-									"trailing_mult_after": 2.5,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	migrateV15CloseKeys(raw)
-	ref := raw["strategies"].([]interface{})[0].(map[string]interface{})["close_strategy"].(map[string]interface{})
-	params := ref["params"].(map[string]interface{})
-	table, ok := params["tp_tiers"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("tp_tiers = %#v, want regime-keyed map", params["tp_tiers"])
-	}
-	up := table["trending_up"].([]interface{})[0].(map[string]interface{})
-	if up["atr_multiple"].(float64) != 1.5 || up["close_fraction"].(float64) != 0 {
-		t.Errorf("trending_up tier = %#v", up)
-	}
-	if up["trailing_mult_after"].(float64) != 2.0 {
-		t.Errorf("trailing_mult_after = %v", up["trailing_mult_after"])
 	}
 }

--- a/scheduler/config_migration_v18_test.go
+++ b/scheduler/config_migration_v18_test.go
@@ -182,56 +182,65 @@ func TestLoadConfigV18MigratesLegacyUserDefaultKeys(t *testing.T) {
 	}
 }
 
-func TestMigrateV18RejectsConflictingTrailKeys(t *testing.T) {
-	raw := map[string]interface{}{
-		"strategies": []interface{}{
-			map[string]interface{}{
-				"id":                        "hl-eth",
-				legacyTrailStopATRRegimeKey: map[string]interface{}{"use_defaults": true},
-				trailStopATRRegimeKey:       map[string]interface{}{"trend_regime": map[string]interface{}{"ranging": map[string]interface{}{"atr_multiple": 1.0}}},
+func TestMigrateV18TrailStopATRRegimeKey(t *testing.T) {
+	t.Run("conflicting_blocks_rejected_naming_both_keys", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"strategies": []interface{}{
+				map[string]interface{}{
+					"id":                        "hl-eth",
+					legacyTrailStopATRRegimeKey: map[string]interface{}{"use_defaults": true},
+					trailStopATRRegimeKey:       map[string]interface{}{"trend_regime": map[string]interface{}{"ranging": map[string]interface{}{"atr_multiple": 1.0}}},
+				},
 			},
-		},
-	}
-	err := migrateV18TrailStopATRRegimeKey(raw)
-	if err == nil {
-		t.Fatal("expected conflict error when both spellings carry different blocks")
-	}
-	if !strings.Contains(err.Error(), legacyTrailStopATRRegimeKey) || !strings.Contains(err.Error(), trailStopATRRegimeKey) {
-		t.Errorf("conflict error should name both keys, got: %v", err)
-	}
+		}
+		err := migrateV18TrailStopATRRegimeKey(raw)
+		if err == nil {
+			t.Fatal("expected conflict error when both spellings carry different blocks")
+		}
+		if !strings.Contains(err.Error(), legacyTrailStopATRRegimeKey) || !strings.Contains(err.Error(), trailStopATRRegimeKey) {
+			t.Errorf("conflict error should name both keys, got: %v", err)
+		}
+	})
+	t.Run("identical_blocks_drop_redundant_legacy_key", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"strategies": []interface{}{
+				map[string]interface{}{
+					"id":                        "hl-eth",
+					legacyTrailStopATRRegimeKey: map[string]interface{}{"use_defaults": true},
+					trailStopATRRegimeKey:       map[string]interface{}{"use_defaults": true},
+				},
+			},
+		}
+		if err := migrateV18TrailStopATRRegimeKey(raw); err != nil {
+			t.Fatalf("identical blocks should migrate cleanly, got: %v", err)
+		}
+		sc := raw["strategies"].([]interface{})[0].(map[string]interface{})
+		if _, present := sc[legacyTrailStopATRRegimeKey]; present {
+			t.Error("redundant legacy key was not removed")
+		}
+		if got := sc[trailStopATRRegimeKey]; got == nil {
+			t.Error("canonical key was dropped")
+		}
+	})
 }
 
-func TestMigrateV18DropsRedundantLegacyTrailKey(t *testing.T) {
-	block := map[string]interface{}{"use_defaults": true}
-	raw := map[string]interface{}{
-		"strategies": []interface{}{
-			map[string]interface{}{
-				"id":                        "hl-eth",
-				legacyTrailStopATRRegimeKey: map[string]interface{}{"use_defaults": true},
-				trailStopATRRegimeKey:       block,
-			},
-		},
+func TestNeedsV18TrailStopKeyMigration(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{"v18_stamped_still_carrying_legacy_key", `{"config_version": 18, "strategies": [{"id": "a", "trailing_stop_atr_regime": {"use_defaults": true}}]}`, true},
+		{"v18_stamped_on_canonical_key", `{"config_version": 18, "strategies": [{"id": "a", "trail_stop_atr_regime": {"use_defaults": true}}]}`, false},
+		{"sub_v18_with_no_legacy_key", v18CleanStrategyConfigJSON, false},
+		{"sub_v18_carrying_legacy_key", v18LegacyStrategyConfigJSON, true},
 	}
-	if err := migrateV18TrailStopATRRegimeKey(raw); err != nil {
-		t.Fatalf("identical blocks should migrate cleanly, got: %v", err)
-	}
-	sc := raw["strategies"].([]interface{})[0].(map[string]interface{})
-	if _, present := sc[legacyTrailStopATRRegimeKey]; present {
-		t.Error("redundant legacy key was not removed")
-	}
-	if got := sc[trailStopATRRegimeKey]; got == nil {
-		t.Error("canonical key was dropped")
-	}
-}
-
-func TestNeedsV18TrailStopKeyMigrationDetectsLegacyKeyAtCurrentVersion(t *testing.T) {
-	current := []byte(`{"config_version": 18, "strategies": [{"id": "a", "trailing_stop_atr_regime": {"use_defaults": true}}]}`)
-	if !needsV18TrailStopKeyMigration(current) {
-		t.Error("a v18-stamped config still carrying the legacy key must migrate")
-	}
-	clean := []byte(`{"config_version": 18, "strategies": [{"id": "a", "trail_stop_atr_regime": {"use_defaults": true}}]}`)
-	if needsV18TrailStopKeyMigration(clean) {
-		t.Error("a v18 config on the canonical key must not migrate again")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := needsV18TrailStopKeyMigration([]byte(tc.data)); got != tc.want {
+				t.Errorf("needsV18TrailStopKeyMigration = %v, want %v (keyed on the legacy key, never the version)", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -448,14 +457,5 @@ func TestLoadConfigLegacyKeyStillFailsLoudWhenItCannotBeRewritten(t *testing.T) 
 	path := readOnlyConfigDir(t, v18LegacyStrategyConfigJSON)
 	if _, err := LoadConfig(path); err == nil {
 		t.Fatal("a config carrying the legacy key must fail the load when the rename cannot be persisted — loading it would leave the on-disk key contradicting the running shape")
-	}
-}
-
-func TestNeedsV18MigrationIsKeyedOnTheLegacyKeyNotTheVersion(t *testing.T) {
-	if needsV18TrailStopKeyMigration([]byte(v18CleanStrategyConfigJSON)) {
-		t.Error("a sub-v18 config with no legacy key must not trigger a load-time rewrite")
-	}
-	if !needsV18TrailStopKeyMigration([]byte(v18LegacyStrategyConfigJSON)) {
-		t.Error("a config carrying the legacy key must trigger the rename")
 	}
 }

--- a/scheduler/config_migration_v19_test.go
+++ b/scheduler/config_migration_v19_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -199,138 +198,148 @@ func TestLoadConfigV19MigratesUserDefaultKeys(t *testing.T) {
 	}
 }
 
-func TestMigrateV19RejectsConflictingKeys(t *testing.T) {
-	raw := `{
-		"strategies": [{
-			"id": "hl-eth-conflict",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"trail_stop_atr_regime": {
-				"trend_regime": {"ranging": {"atr_multiple": 1.0}}
+func TestMigrateV19AtrMultRegimeKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr []string
+		check   func(t *testing.T, sc map[string]interface{})
+	}{
+		{
+			name: "conflicting_blocks_rejected_naming_legacy_key",
+			raw: `{
+				"strategies": [{
+					"id": "hl-eth-conflict",
+					"type": "perps",
+					"platform": "hyperliquid",
+					"trail_stop_atr_regime": {
+						"trend_regime": {"ranging": {"atr_multiple": 1.0}}
+					},
+					"trailing_stop_atr_mult_regime": {
+						"trend_regime": {"ranging": {"atr_multiple": 2.0}}
+					}
+				}]
+			}`,
+			wantErr: []string{"conflicts", `"trail_stop_atr_regime"`},
+		},
+		{
+			name: "identical_blocks_drop_redundant_legacy_key",
+			raw: `{
+				"strategies": [{
+					"id": "hl-eth-redundant",
+					"type": "perps",
+					"platform": "hyperliquid",
+					"trail_stop_atr_regime": {
+						"trend_regime": {"ranging": {"atr_multiple": 2.0}}
+					},
+					"trailing_stop_atr_mult_regime": {
+						"trend_regime": {"ranging": {"atr_multiple": 2.0}}
+					}
+				}]
+			}`,
+			check: func(t *testing.T, sc map[string]interface{}) {
+				if _, present := sc["trail_stop_atr_regime"]; present {
+					t.Fatalf("legacy key should be dropped after identical-block merge")
+				}
+				canon, present := sc["trailing_stop_atr_mult_regime"]
+				if !present {
+					t.Fatalf("canonical key should remain")
+				}
+				canonMap, ok := canon.(map[string]interface{})
+				if !ok {
+					t.Fatalf("canonical block should be an object, got %T", canon)
+				}
+				trend, ok := canonMap["trend_regime"].(map[string]interface{})["ranging"].(map[string]interface{})["atr_multiple"]
+				if !ok || trend != 2.0 {
+					t.Fatalf("canonical atr_multiple = %v, want 2.0", trend)
+				}
 			},
-			"trailing_stop_atr_mult_regime": {
-				"trend_regime": {"ranging": {"atr_multiple": 2.0}}
-			}
-		}]
-	}`
-	var data map[string]interface{}
-	if err := json.Unmarshal([]byte(raw), &data); err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	err := migrateV19AtrMultRegimeKey(data)
-	if err == nil {
-		t.Fatalf("expected conflict error, got nil")
-	}
-	if !strings.Contains(err.Error(), "conflicts") {
-		t.Fatalf("expected conflict error, got %q", err)
-	}
-	if !strings.Contains(err.Error(), `"trail_stop_atr_regime"`) {
-		t.Fatalf("conflict error should name the legacy key, got %q", err)
-	}
-}
-
-func TestMigrateV19DropsRedundantLegacyKeyWhenCanonicalMatches(t *testing.T) {
-	raw := `{
-		"strategies": [{
-			"id": "hl-eth-redundant",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"trail_stop_atr_regime": {
-				"trend_regime": {"ranging": {"atr_multiple": 2.0}}
+		},
+		{
+			name: "rename_leaves_trailing_stop_pct_untouched",
+			raw: `{
+				"strategies": [{
+					"id": "hl-eth-pct",
+					"type": "perps",
+					"platform": "hyperliquid",
+					"trailing_stop_pct": 1.5,
+					"trail_stop_atr_regime": {
+						"trend_regime": {"ranging": {"atr_multiple": 1.0}}
+					}
+				}]
+			}`,
+			check: func(t *testing.T, sc map[string]interface{}) {
+				if pct, ok := sc["trailing_stop_pct"].(float64); !ok || pct != 1.5 {
+					t.Fatalf("trailing_stop_pct should be untouched, got %v", sc["trailing_stop_pct"])
+				}
+				if _, present := sc["trail_stop_atr_regime"]; present {
+					t.Fatalf("legacy key should be renamed away")
+				}
+				if _, present := sc["trailing_stop_atr_mult_regime"]; !present {
+					t.Fatalf("canonical key missing after rename")
+				}
 			},
-			"trailing_stop_atr_mult_regime": {
-				"trend_regime": {"ranging": {"atr_multiple": 2.0}}
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := v19ParseRawConfig(t, tc.raw)
+			err := migrateV19AtrMultRegimeKey(data)
+			if len(tc.wantErr) > 0 {
+				if err == nil {
+					t.Fatalf("expected conflict error, got nil")
+				}
+				for _, want := range tc.wantErr {
+					if !strings.Contains(err.Error(), want) {
+						t.Fatalf("error %q missing %q", err, want)
+					}
+				}
+				return
 			}
-		}]
-	}`
-	var data map[string]interface{}
-	if err := json.Unmarshal([]byte(raw), &data); err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	if err := migrateV19AtrMultRegimeKey(data); err != nil {
-		t.Fatalf("redundant migration should succeed, got %v", err)
-	}
-	sc := data["strategies"].([]interface{})[0].(map[string]interface{})
-	if _, present := sc["trail_stop_atr_regime"]; present {
-		t.Fatalf("legacy key should be dropped after identical-block merge")
-	}
-	canon, present := sc["trailing_stop_atr_mult_regime"]
-	if !present {
-		t.Fatalf("canonical key should remain")
-	}
-	canonMap, ok := canon.(map[string]interface{})
-	if !ok {
-		t.Fatalf("canonical block should be an object, got %T", canon)
-	}
-	trend, ok := canonMap["trend_regime"].(map[string]interface{})["ranging"].(map[string]interface{})["atr_multiple"]
-	if !ok || trend != 2.0 {
-		t.Fatalf("canonical atr_multiple = %v, want 2.0", trend)
-	}
-}
-
-func TestNeedsV19AtrMultRegimeRenameDetectsLegacyKey(t *testing.T) {
-	data := v19ParseRawConfig(t, v19LegacyStrategyConfigJSON)
-	if !hasLegacyV19AtrMultRegimeKey(data) {
-		t.Fatalf("legacy strategy config should be flagged for v19 rename")
-	}
-	if !needsV19AtrMultRegimeRename([]byte(v19LegacyStrategyConfigJSON)) {
-		t.Fatalf("needsV19AtrMultRegimeRename should flag legacy key in raw bytes")
-	}
-}
-
-func TestNeedsV19AtrMultRegimeRenameIgnoresCanonicalConfig(t *testing.T) {
-	data := v19ParseRawConfig(t, v19CanonicalStrategyConfigJSON)
-	if hasLegacyV19AtrMultRegimeKey(data) {
-		t.Fatalf("canonical v19 config should not be flagged for rename")
-	}
-	if needsV19AtrMultRegimeRename([]byte(v19CanonicalStrategyConfigJSON)) {
-		t.Fatalf("needsV19AtrMultRegimeRename should ignore canonical v19 config")
-	}
-}
-
-func TestV19RenameKeepsTrailingStopPctUnaffected(t *testing.T) {
-	raw := `{
-		"strategies": [{
-			"id": "hl-eth-pct",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"trailing_stop_pct": 1.5,
-			"trail_stop_atr_regime": {
-				"trend_regime": {"ranging": {"atr_multiple": 1.0}}
+			if err != nil {
+				t.Fatalf("v19 migration failed: %v", err)
 			}
-		}]
-	}`
-	var data map[string]interface{}
-	if err := json.Unmarshal([]byte(raw), &data); err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	if err := migrateV19AtrMultRegimeKey(data); err != nil {
-		t.Fatalf("v19 migration failed: %v", err)
-	}
-	sc := data["strategies"].([]interface{})[0].(map[string]interface{})
-	if pct, ok := sc["trailing_stop_pct"].(float64); !ok || pct != 1.5 {
-		t.Fatalf("trailing_stop_pct should be untouched, got %v", sc["trailing_stop_pct"])
+			tc.check(t, v19StrategyBlock(t, data))
+		})
 	}
 }
 
-func TestV19AtomicRenameSitesListsEveryMutationSite(t *testing.T) {
-	expected := []string{
-		"strategies[]",
-		"user_defaults.regime_atr",
-		"user_defaults.manual",
-		"user_defaults.close[]",
+func TestNeedsV19AtrMultRegimeRename(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"legacy_v18_canonical_key_flagged", v19LegacyStrategyConfigJSON, true},
+		{"v19_canonical_key_ignored", v19CanonicalStrategyConfigJSON, false},
 	}
-	if len(v19AtomicRenameSites) != len(expected) {
-		t.Fatalf("v19AtomicRenameSites has %d entries, want %d", len(v19AtomicRenameSites), len(expected))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasLegacyV19AtrMultRegimeKey(v19ParseRawConfig(t, tc.raw)); got != tc.want {
+				t.Errorf("hasLegacyV19AtrMultRegimeKey = %v, want %v", got, tc.want)
+			}
+			if got := needsV19AtrMultRegimeRename([]byte(tc.raw)); got != tc.want {
+				t.Errorf("needsV19AtrMultRegimeRename = %v, want %v", got, tc.want)
+			}
+		})
 	}
-	for i, want := range expected {
-		if v19AtomicRenameSites[i] != want {
-			t.Fatalf("v19AtomicRenameSites[%d] = %q, want %q", i, v19AtomicRenameSites[i], want)
+}
+
+func TestV19RenameMap(t *testing.T) {
+	seen := map[string]bool{}
+	for _, pair := range v19RenameMap {
+		if seen[pair.LegacyKey] {
+			t.Fatalf("duplicate legacy key in v19 rename map: %q", pair.LegacyKey)
+		}
+		seen[pair.LegacyKey] = true
+		if pair.LegacyKey == pair.CanonKey {
+			t.Fatalf("rename pair maps a key to itself: %q", pair.LegacyKey)
 		}
 	}
-}
+	if len(seen) != 2 {
+		t.Fatalf("expected 2 rename pairs, got %d (%v)", len(seen), seen)
+	}
 
-func TestSortedV19RenameMapReturnsStableOrder(t *testing.T) {
 	a := sortedV19RenameMap()
 	b := sortedV19RenameMap()
 	if len(a) != len(v19RenameMap) {
@@ -338,14 +347,12 @@ func TestSortedV19RenameMapReturnsStableOrder(t *testing.T) {
 	}
 	for i := range a {
 		if a[i].LegacyKey != b[i].LegacyKey {
-			t.Fatalf("sortedV19RenameMap not deterministic at index %d: %q vs %q",
-				i, a[i].LegacyKey, b[i].LegacyKey)
+			t.Fatalf("sortedV19RenameMap not deterministic at index %d: %q vs %q", i, a[i].LegacyKey, b[i].LegacyKey)
 		}
 	}
 	for i := 1; i < len(a); i++ {
 		if a[i-1].LegacyKey >= a[i].LegacyKey {
-			t.Fatalf("sortedV19RenameMap not sorted: %q >= %q",
-				a[i-1].LegacyKey, a[i].LegacyKey)
+			t.Fatalf("sortedV19RenameMap not sorted: %q >= %q", a[i-1].LegacyKey, a[i].LegacyKey)
 		}
 	}
 }
@@ -473,21 +480,8 @@ func TestLoadConfigV19ReadOnlyCleanConfigDoesNotWrite(t *testing.T) {
 }
 
 func TestLoadConfigV19ReadOnlyLegacyKeyStillAttemptsRewrite(t *testing.T) {
-
-	if os.Getuid() == 0 {
-		t.Skip("root bypasses POSIX read-only enforcement; verified on Linux CI non-root")
-	}
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-	if err := os.WriteFile(path, []byte(v19LegacyStrategyConfigJSON), 0o644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	if err := os.Chmod(dir, 0o555); err != nil {
-		t.Fatalf("chmod read-only: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
-	_, err := LoadConfigForProbe(path)
-	if err == nil {
+	path := readOnlyConfigDir(t, v19LegacyStrategyConfigJSON)
+	if _, err := LoadConfigForProbe(path); err == nil {
 		t.Fatalf("expected an error when read-only path blocks the v19 migration write")
 	}
 }
@@ -498,37 +492,6 @@ func keysOf(m map[string]interface{}) []string {
 		out = append(out, k)
 	}
 	return out
-}
-
-func TestRenameMapIsSortedByLegacyKey(t *testing.T) {
-	seen := map[string]bool{}
-	for _, pair := range v19RenameMap {
-		if seen[pair.LegacyKey] {
-			t.Fatalf("duplicate legacy key in v19 rename map: %q", pair.LegacyKey)
-		}
-		seen[pair.LegacyKey] = true
-		if pair.LegacyKey == pair.CanonKey {
-			t.Fatalf("rename pair maps a key to itself: %q", pair.LegacyKey)
-		}
-	}
-	if len(seen) != 2 {
-		t.Fatalf("expected 2 rename pairs, got %d (%v)", len(seen), seen)
-	}
-}
-
-func TestV19NoticeMentionsBothRenames(t *testing.T) {
-	if !strings.Contains(v19AtrMultRenameNotice, "stop_loss_atr_mult_regime") {
-		t.Fatalf("v19 notice should mention stop_loss_atr_mult_regime")
-	}
-	if !strings.Contains(v19AtrMultRenameNotice, "trailing_stop_atr_mult_regime") {
-		t.Fatalf("v19 notice should mention trailing_stop_atr_mult_regime")
-	}
-	if !strings.Contains(v19AtrMultRenameNotice, "stop_loss_atr_regime") {
-		t.Fatalf("v19 notice should mention the legacy stop_loss_atr_regime key")
-	}
-	if !strings.Contains(v19AtrMultRenameNotice, "trail_stop_atr_regime") {
-		t.Fatalf("v19 notice should mention the legacy trail_stop_atr_regime key")
-	}
 }
 
 func TestV19RenamePreservesPreExistingUnrelatedKeys(t *testing.T) {
@@ -577,5 +540,3 @@ func TestV19RenamePreservesPreExistingUnrelatedKeys(t *testing.T) {
 		t.Fatalf("margin_mode should be preserved, got %q", sc.MarginMode)
 	}
 }
-
-var _ = fmt.Sprintf

--- a/scheduler/config_regime_directional_warn_test.go
+++ b/scheduler/config_regime_directional_warn_test.go
@@ -6,6 +6,26 @@ import (
 )
 
 func TestRegimeDirectionalPolicyWarnings(t *testing.T) {
+	t.Run("nil config yields no warnings", func(t *testing.T) {
+		if got := regimeDirectionalPolicyWarnings(nil); got != nil {
+			t.Errorf("nil config must yield no warnings, got %v", got)
+		}
+	})
+	t.Run("strategies without the policy yield no warnings", func(t *testing.T) {
+		empty := &Config{Strategies: []StrategyConfig{{ID: "a"}, {ID: "b"}}}
+		if got := regimeDirectionalPolicyWarnings(empty); len(got) != 0 {
+			t.Errorf("strategies without the policy must yield no warnings, got %v", got)
+		}
+	})
+	t.Run("single-label policy yields one warning", func(t *testing.T) {
+		one := &Config{Strategies: []StrategyConfig{{ID: "x", RegimeDirectionalPolicy: &RegimeDirectionalPolicy{
+			TrendRegime: map[string]RegimeDirectionalEntry{"trending_up": {Direction: "long"}},
+		}}}}
+		if got := regimeDirectionalPolicyWarnings(one); len(got) != 1 {
+			t.Fatalf("configured policy must yield 1 warning, got %d", len(got))
+		}
+	})
+
 	cfg := &Config{Strategies: []StrategyConfig{
 		{ID: "plain-long"},
 		{ID: "dir-policy", RegimeDirectionalPolicy: &RegimeDirectionalPolicy{
@@ -32,21 +52,5 @@ func TestRegimeDirectionalPolicyWarnings(t *testing.T) {
 	}
 	if !strings.HasPrefix(w, "[WARN]") {
 		t.Errorf("warning must use the [WARN] operator prefix; got %q", w)
-	}
-}
-
-func TestRegimeDirectionalPolicyWarningsEdgeCases(t *testing.T) {
-	if got := regimeDirectionalPolicyWarnings(nil); got != nil {
-		t.Errorf("nil config must yield no warnings, got %v", got)
-	}
-	empty := &Config{Strategies: []StrategyConfig{{ID: "a"}, {ID: "b"}}}
-	if got := regimeDirectionalPolicyWarnings(empty); len(got) != 0 {
-		t.Errorf("strategies without the policy must yield no warnings, got %v", got)
-	}
-	one := &Config{Strategies: []StrategyConfig{{ID: "x", RegimeDirectionalPolicy: &RegimeDirectionalPolicy{
-		TrendRegime: map[string]RegimeDirectionalEntry{"trending_up": {Direction: "long"}},
-	}}}}
-	if got := regimeDirectionalPolicyWarnings(one); len(got) != 1 {
-		t.Fatalf("configured policy must yield 1 warning, got %d", len(got))
 	}
 }

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -227,11 +227,15 @@ func TestApplyHotReloadConfigOpenPositionGuards(t *testing.T) {
 		}
 		return out
 	}
-	twoTiers := tiers(
-		map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
-		map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
-	)
-	oneTier := tiers(map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0})
+	twoTiers := func() []interface{} {
+		return tiers(
+			map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
+			map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+		)
+	}
+	oneTier := func() []interface{} {
+		return tiers(map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0})
+	}
 	slAfterRegime := func(ranging float64) map[string]interface{} {
 		return map[string]interface{}{
 			"trend_regime": map[string]interface{}{
@@ -498,25 +502,25 @@ func TestApplyHotReloadConfigOpenPositionGuards(t *testing.T) {
 		},
 		{
 			name: "rejects sl_after add with open position",
-			cfg:  func() *Config { return hlReloadConfig(withSL(map[string]interface{}{"tp_tiers": twoTiers})) },
+			cfg:  func() *Config { return hlReloadConfig(withSL(map[string]interface{}{"tp_tiers": twoTiers()})) },
 			next: func() *Config {
-				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": "breakeven", "tp_tiers": twoTiers}))
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": "breakeven", "tp_tiers": twoTiers()}))
 			},
 			state:   openETH,
 			wantErr: "sl_after rules changed with open positions",
 		},
 		{
 			name: "allows sl_after add when flat",
-			cfg:  func() *Config { return hlReloadConfig(withSL(map[string]interface{}{"tp_tiers": oneTier})) },
+			cfg:  func() *Config { return hlReloadConfig(withSL(map[string]interface{}{"tp_tiers": oneTier()})) },
 			next: func() *Config {
-				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": "breakeven", "tp_tiers": oneTier}))
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": "breakeven", "tp_tiers": oneTier()}))
 			},
 			state: flatETHReloadState,
 		},
 		{
 			name: "rejects sl_after mode switch (breakeven -> trail_from_here) with open position",
 			cfg: func() *Config {
-				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": "breakeven", "tp_tiers": oneTier}))
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": "breakeven", "tp_tiers": oneTier()}))
 			},
 			next: func() *Config {
 				return hlReloadConfig(withSL(map[string]interface{}{
@@ -524,7 +528,7 @@ func TestApplyHotReloadConfigOpenPositionGuards(t *testing.T) {
 						"kind":            "trail_from_here",
 						"trail_from_here": map[string]interface{}{"atr_mult": 1.0},
 					},
-					"tp_tiers": oneTier,
+					"tp_tiers": oneTier(),
 				}))
 			},
 			state:   openETH,
@@ -533,10 +537,10 @@ func TestApplyHotReloadConfigOpenPositionGuards(t *testing.T) {
 		{
 			name: "rejects sl_after scalar -> regime shape change with open position",
 			cfg: func() *Config {
-				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": map[string]interface{}{"atr_mult": 0.25}, "tp_tiers": oneTier}))
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": map[string]interface{}{"atr_mult": 0.25}, "tp_tiers": oneTier()}))
 			},
 			next: func() *Config {
-				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(0.0), "tp_tiers": oneTier}))
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(0.0), "tp_tiers": oneTier()}))
 			},
 			state:   openETH,
 			wantErr: "sl_after rules changed with open positions",
@@ -544,10 +548,10 @@ func TestApplyHotReloadConfigOpenPositionGuards(t *testing.T) {
 		{
 			name: "rejects sl_after regime value change with open position",
 			cfg: func() *Config {
-				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(0.0), "tp_tiers": oneTier}))
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(0.0), "tp_tiers": oneTier()}))
 			},
 			next: func() *Config {
-				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(-0.5), "tp_tiers": oneTier}))
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(-0.5), "tp_tiers": oneTier()}))
 			},
 			state:   openETH,
 			wantErr: "sl_after rules changed with open positions",
@@ -555,10 +559,10 @@ func TestApplyHotReloadConfigOpenPositionGuards(t *testing.T) {
 		{
 			name: "allows identical sl_after regime block with open position",
 			cfg: func() *Config {
-				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(0.0), "tp_tiers": oneTier}))
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(0.0), "tp_tiers": oneTier()}))
 			},
 			next: func() *Config {
-				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(0.0), "tp_tiers": oneTier}))
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(0.0), "tp_tiers": oneTier()}))
 			},
 			state: openETH,
 		},

--- a/scheduler/config_reload_test.go
+++ b/scheduler/config_reload_test.go
@@ -179,282 +179,6 @@ func TestApplyHotReloadConfigAppliesAllowedFields(t *testing.T) {
 	}
 }
 
-func TestApplyHotReloadConfigRejectsStrategySetChange(t *testing.T) {
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "s1", Type: "spot", Platform: "binanceus", Script: "x.py", Capital: 100, MaxDrawdownPct: 10,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "s1", Type: "spot", Platform: "binanceus", Script: "x.py", Capital: 200, MaxDrawdownPct: 10,
-	}, {
-		ID: "s2", Type: "spot", Platform: "binanceus", Script: "x.py", Capital: 100, MaxDrawdownPct: 10,
-	}})
-
-	_, err := applyHotReloadConfig(cfg, next, NewAppState(), nil, nil)
-	if err == nil {
-		t.Fatal("expected strategy set change to be rejected")
-	}
-	if !strings.Contains(err.Error(), "strategy set changed") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.Strategies[0].Capital != 100 {
-		t.Errorf("current config mutated after rejected reload: %+v", cfg.Strategies[0])
-	}
-}
-
-func TestApplyHotReloadConfigRejectsNonReloadableStrategyField(t *testing.T) {
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "s1", Type: "spot", Platform: "binanceus", Script: "x.py", Args: []string{"a"}, Capital: 100, MaxDrawdownPct: 10,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "s1", Type: "spot", Platform: "binanceus", Script: "y.py", Args: []string{"a"}, Capital: 200, MaxDrawdownPct: 10,
-	}})
-
-	_, err := applyHotReloadConfig(cfg, next, NewAppState(), nil, nil)
-	if err == nil {
-		t.Fatal("expected script change to be rejected")
-	}
-	if !strings.Contains(err.Error(), "non-hot-reloadable") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.Strategies[0].Capital != 100 {
-		t.Errorf("current config mutated after rejected reload: %+v", cfg.Strategies[0])
-	}
-}
-
-func TestApplyHotReloadConfigAllowsOpenCloseStrategyChanges(t *testing.T) {
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "s1", Type: "spot", Platform: "binanceus", Script: "x.py",
-		Args: []string{"triple_ema", "BTC/USDT", "1h"}, Capital: 100, MaxDrawdownPct: 10,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "s1", Type: "spot", Platform: "binanceus", Script: "x.py",
-		Args: []string{"triple_ema", "BTC/USDT", "1h"}, Capital: 100, MaxDrawdownPct: 10,
-		OpenStrategy: StrategyRef{Name: "triple_ema"}, CloseStrategy: &StrategyRef{Name: "tp_at_pct"},
-	}})
-
-	changes, err := applyHotReloadConfig(cfg, next, NewAppState(), nil, nil)
-	if err != nil {
-		t.Fatalf("applyHotReloadConfig returned error: %v", err)
-	}
-	joined := strings.Join(changes, "\n")
-	for _, want := range []string{
-		"strategy[s1].open_strategy:",
-		"strategy[s1].close_strategy:",
-	} {
-		if !strings.Contains(joined, want) {
-			t.Fatalf("changes missing %q:\n%s", want, joined)
-		}
-	}
-	if cfg.Strategies[0].OpenStrategy.Name != "triple_ema" {
-		t.Fatalf("OpenStrategy.Name = %q, want triple_ema", cfg.Strategies[0].OpenStrategy.Name)
-	}
-	if cfg.Strategies[0].CloseStrategy == nil || cfg.Strategies[0].CloseStrategy.Name != "tp_at_pct" {
-		t.Fatalf("CloseStrategy = %#v, want tp_at_pct", cfg.Strategies[0].CloseStrategy)
-	}
-}
-
-func TestApplyHotReloadConfigRejectsLeverageChangeWithOpenPerpsPosition(t *testing.T) {
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1200, MaxDrawdownPct: 12, Leverage: 5,
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {
-			ID: "hl-eth", Cash: 900,
-			RiskState: RiskState{MaxDrawdownPct: 10},
-			Positions: map[string]*Position{
-				"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 3000, Leverage: 2},
-			},
-		},
-	}}
-
-	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
-	if err == nil {
-		t.Fatal("expected open perps leverage change to be rejected")
-	}
-	if !strings.Contains(err.Error(), "leverage changed with open positions") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.Strategies[0].Capital != 1000 || cfg.Strategies[0].MaxDrawdownPct != 10 || cfg.Strategies[0].Leverage != 2 {
-		t.Fatalf("current config mutated after rejected reload: %+v", cfg.Strategies[0])
-	}
-	if state.Strategies["hl-eth"].Cash != 900 || state.Strategies["hl-eth"].RiskState.MaxDrawdownPct != 10 {
-		t.Fatalf("state mutated after rejected reload: %+v", state.Strategies["hl-eth"])
-	}
-	if state.Strategies["hl-eth"].Positions["ETH"].Leverage != 2 {
-		t.Fatalf("position leverage mutated after rejected reload: %+v", state.Strategies["hl-eth"].Positions["ETH"])
-	}
-}
-
-func TestApplyHotReloadConfigRejectsMarginModeChangeWithOpenPerpsPosition(t *testing.T) {
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, MarginMode: "isolated",
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, MarginMode: "cross",
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {
-			ID: "hl-eth", Cash: 900,
-			RiskState: RiskState{MaxDrawdownPct: 10},
-			Positions: map[string]*Position{
-				"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 3000, Leverage: 2},
-			},
-		},
-	}}
-
-	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
-	if err == nil {
-		t.Fatal("expected margin_mode change with open position to be rejected")
-	}
-	if !strings.Contains(err.Error(), "margin_mode changed with open positions") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.Strategies[0].MarginMode != "isolated" {
-		t.Fatalf("current config mutated after rejected reload: %+v", cfg.Strategies[0])
-	}
-}
-
-func TestApplyHotReloadConfigAllowsMarginModeChangeWhenFlat(t *testing.T) {
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, MarginMode: "isolated",
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, MarginMode: "cross",
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Cash: 1000, Positions: map[string]*Position{}},
-	}}
-
-	if _, err := applyHotReloadConfig(cfg, next, state, nil, nil); err != nil {
-		t.Fatalf("expected margin_mode change to succeed when flat, got: %v", err)
-	}
-	if cfg.Strategies[0].MarginMode != "cross" {
-		t.Fatalf("MarginMode = %q, want %q", cfg.Strategies[0].MarginMode, "cross")
-	}
-}
-
-func TestApplyHotReloadConfigPreservesRuntimeCapitalPctCapital(t *testing.T) {
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "s1", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "BTC", "1h"}, Capital: 2500, CapitalPct: 0.5, MaxDrawdownPct: 10, Leverage: 2,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "s1", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "BTC", "1h"}, Capital: 100, CapitalPct: 0.5, MaxDrawdownPct: 12, Leverage: 2,
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"s1": {ID: "s1", Cash: 2400, RiskState: RiskState{MaxDrawdownPct: 10}},
-	}}
-
-	changes, err := applyHotReloadConfig(cfg, next, state, nil, nil)
-	if err != nil {
-		t.Fatalf("applyHotReloadConfig returned error: %v", err)
-	}
-	if cfg.Strategies[0].Capital != 2500 {
-		t.Errorf("runtime capital_pct capital = %g, want preserved 2500", cfg.Strategies[0].Capital)
-	}
-	if state.Strategies["s1"].Cash != 2400 {
-		t.Errorf("cash = %g, want preserved 2400", state.Strategies["s1"].Cash)
-	}
-	joined := strings.Join(changes, "\n")
-	if strings.Contains(joined, ".capital:") {
-		t.Fatalf("capital_pct fallback capital should not be hot-applied, changes:\n%s", joined)
-	}
-	if cfg.Strategies[0].MaxDrawdownPct != 12 || state.Strategies["s1"].RiskState.MaxDrawdownPct != 12 {
-		t.Fatalf("other hot-reloadable fields should still apply, cfg=%+v state=%+v", cfg.Strategies[0], state.Strategies["s1"].RiskState)
-	}
-}
-
-func TestApplyHotReloadConfigRejectsHLPeerMismatchOnReload(t *testing.T) {
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth-a", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 5, MarginMode: "isolated",
-	}, {
-		ID: "hl-eth-b", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"b", "ETH", "1h"}, Capital: 500, MaxDrawdownPct: 10, Leverage: 5, MarginMode: "isolated",
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth-a", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 5, MarginMode: "isolated",
-	}, {
-		ID: "hl-eth-b", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"b", "ETH", "1h"}, Capital: 500, MaxDrawdownPct: 10, Leverage: 10, MarginMode: "isolated",
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth-a": {ID: "hl-eth-a", Cash: 1000},
-		"hl-eth-b": {ID: "hl-eth-b", Cash: 500},
-	}}
-
-	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
-	if err == nil {
-		t.Fatal("expected hot reload to reject peer leverage mismatch")
-	}
-	if !strings.Contains(err.Error(), "disagree on leverage") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestApplyHotReloadConfigAllowsTrailingStopPctChangeWithOpenPosition(t *testing.T) {
-	oldTrail := 3.0
-	newTrail := 4.0
-	oldMinMove := 0.5
-	newMinMove := 0.25
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", TrailingStopPct: &oldTrail, TrailingStopMinMovePct: &oldMinMove,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", TrailingStopPct: &newTrail, TrailingStopMinMovePct: &newMinMove,
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
-		}},
-	}}
-
-	changes, err := applyHotReloadConfig(cfg, next, state, nil, nil)
-	if err != nil {
-		t.Fatalf("applyHotReloadConfig: %v", err)
-	}
-	if cfg.Strategies[0].TrailingStopPct == nil || *cfg.Strategies[0].TrailingStopPct != 4 {
-		t.Fatalf("TrailingStopPct=%v, want 4", cfg.Strategies[0].TrailingStopPct)
-	}
-	if cfg.Strategies[0].TrailingStopMinMovePct == nil || *cfg.Strategies[0].TrailingStopMinMovePct != 0.25 {
-		t.Fatalf("TrailingStopMinMovePct=%v, want 0.25", cfg.Strategies[0].TrailingStopMinMovePct)
-	}
-	joined := strings.Join(changes, "\n")
-	if !strings.Contains(joined, "trailing_stop_pct") || !strings.Contains(joined, "trailing_stop_min_move_pct") {
-		t.Fatalf("changes=%v, want trailing_stop_pct and trailing_stop_min_move_pct entries", changes)
-	}
-}
-
-func TestApplyHotReloadConfigRejectsFixedToTrailingWithOpenPosition(t *testing.T) {
-	trail := 3.0
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated",
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", TrailingStopPct: &trail,
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
-		}},
-	}}
-
-	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
-	if err == nil {
-		t.Fatal("expected hot reload to reject fixed-to-trailing mode switch")
-	}
-	if !strings.Contains(err.Error(), "trailing_stop_pct mode changed") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
 func minimalReloadConfig(strategies []StrategyConfig) *Config {
 	return &Config{
 		IntervalSeconds: 600,
@@ -466,416 +190,418 @@ func minimalReloadConfig(strategies []StrategyConfig) *Config {
 	}
 }
 
-func TestApplyHotReloadConfigRejectsDirectionChangeWithOpenPerpsPosition(t *testing.T) {
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, Direction: DirectionLong,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, Direction: DirectionShort,
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {
-			ID: "hl-eth", Cash: 900,
-			RiskState: RiskState{MaxDrawdownPct: 10},
-			Positions: map[string]*Position{
-				"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 3000, Leverage: 2},
-			},
-		},
-	}}
-
-	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
-	if err == nil {
-		t.Fatal("expected direction change with open position to be rejected")
+func hlReloadStrategy(mut func(*StrategyConfig)) StrategyConfig {
+	sc := StrategyConfig{
+		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
+		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
+		Leverage: 5, MarginMode: "isolated",
 	}
-	if !strings.Contains(err.Error(), "direction changed with open positions") {
-		t.Fatalf("unexpected error: %v", err)
+	if mut != nil {
+		mut(&sc)
 	}
-	if cfg.Strategies[0].Direction != DirectionLong {
-		t.Fatalf("current config mutated after rejected reload: %+v", cfg.Strategies[0])
-	}
+	return sc
 }
 
-func TestApplyHotReloadConfigRejectsSLAfterAddWithOpenPosition(t *testing.T) {
-	tieredOpen := &StrategyRef{
-		Name: "tiered_tp_atr",
-		Params: map[string]interface{}{
-			"tp_tiers": []interface{}{
-				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
-				map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
-			},
-		},
-	}
-	tieredWithSLAfter := &StrategyRef{
-		Name: "tiered_tp_atr",
-		Params: map[string]interface{}{
-			"sl_after": "breakeven",
-			"tp_tiers": []interface{}{
-				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
-				map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
-			},
-		},
-	}
-	slMult := 1.5
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: tieredOpen,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: tieredWithSLAfter,
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
-		}},
-	}}
-
-	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
-	if err == nil {
-		t.Fatal("expected hot reload to reject sl_after addition with open position")
-	}
-	if !strings.Contains(err.Error(), "sl_after rules changed with open positions") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+func hlReloadConfig(mut func(*StrategyConfig)) *Config {
+	return minimalReloadConfig([]StrategyConfig{hlReloadStrategy(mut)})
 }
 
-func TestApplyHotReloadConfigAllowsSLAfterAddWhenFlat(t *testing.T) {
-	tieredOpen := &StrategyRef{
-		Name: "tiered_tp_atr",
-		Params: map[string]interface{}{
-			"tp_tiers": []interface{}{
-				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
-			},
-		},
-	}
-	tieredWithSLAfter := &StrategyRef{
-		Name: "tiered_tp_atr",
-		Params: map[string]interface{}{
-			"sl_after": "breakeven",
-			"tp_tiers": []interface{}{
-				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
-			},
-		},
-	}
-	slMult := 1.5
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: tieredOpen,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: tieredWithSLAfter,
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
+func flatETHReloadState() *AppState {
+	return &AppState{Strategies: map[string]*StrategyState{
 		"hl-eth": {ID: "hl-eth", Cash: 1000, Positions: map[string]*Position{}},
 	}}
-
-	if _, err := applyHotReloadConfig(cfg, next, state, nil, nil); err != nil {
-		t.Fatalf("expected sl_after change to be allowed when flat, got: %v", err)
-	}
 }
 
-func TestApplyHotReloadConfigRejectsSLAfterModeChangeWithOpenPosition(t *testing.T) {
-	tierWithBreakeven := &StrategyRef{
-		Name: "tiered_tp_atr",
-		Params: map[string]interface{}{
-			"sl_after": "breakeven",
-			"tp_tiers": []interface{}{
-				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
-			},
-		},
-	}
-	tierWithTrail := &StrategyRef{
-		Name: "tiered_tp_atr",
-		Params: map[string]interface{}{
-			"sl_after": map[string]interface{}{
-				"kind":            "trail_from_here",
-				"trail_from_here": map[string]interface{}{"atr_mult": 1.0},
-			},
-			"tp_tiers": []interface{}{
-				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
-			},
-		},
-	}
-	slMult := 1.5
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: tierWithBreakeven,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: tierWithTrail,
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
-		}},
-	}}
-
-	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
-	if err == nil {
-		t.Fatal("expected hot reload to reject sl_after mode switch")
-	}
-	if !strings.Contains(err.Error(), "sl_after rules changed with open positions") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+func tieredATRRef(params map[string]interface{}) *StrategyRef {
+	return &StrategyRef{Name: "tiered_tp_atr", Params: params}
 }
 
-func TestApplyHotReloadConfigRejectsSLAfterScalarToRegimeWithOpenPosition(t *testing.T) {
-	tierScalar := &StrategyRef{
-		Name: "tiered_tp_atr",
-		Params: map[string]interface{}{
-			"sl_after": map[string]interface{}{"atr_mult": 0.25},
-			"tp_tiers": []interface{}{
-				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
-			},
-		},
+func TestApplyHotReloadConfigOpenPositionGuards(t *testing.T) {
+	spotStrategy := func(script string, capital float64) StrategyConfig {
+		return StrategyConfig{ID: "s1", Type: "spot", Platform: "binanceus", Script: script, Args: []string{"a"}, Capital: capital, MaxDrawdownPct: 10}
 	}
-	tierRegime := &StrategyRef{
-		Name: "tiered_tp_atr",
-		Params: map[string]interface{}{
-			"sl_after": map[string]interface{}{
-				"trend_regime": map[string]interface{}{
-					"trending_up":   map[string]interface{}{"atr_multiple": 0.25},
-					"trending_down": map[string]interface{}{"atr_multiple": 0.25},
-					"ranging":       map[string]interface{}{"atr_multiple": 0.0},
-				},
-			},
-			"tp_tiers": []interface{}{
-				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
-			},
-		},
+	tiers := func(entries ...map[string]interface{}) []interface{} {
+		out := make([]interface{}, 0, len(entries))
+		for _, e := range entries {
+			out = append(out, e)
+		}
+		return out
 	}
-	slMult := 1.5
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: tierScalar,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: tierRegime,
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
-		}},
-	}}
-
-	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
-	if err == nil {
-		t.Fatal("expected hot reload to reject sl_after scalar→regime shape change with open position")
-	}
-	if !strings.Contains(err.Error(), "sl_after rules changed with open positions") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestApplyHotReloadConfigRejectsSLAfterRegimeValueChangeWithOpenPosition(t *testing.T) {
-	makeRef := func(ranging float64) *StrategyRef {
-		return &StrategyRef{
-			Name: "tiered_tp_atr",
-			Params: map[string]interface{}{
-				"sl_after": map[string]interface{}{
-					"trend_regime": map[string]interface{}{
-						"trending_up":   map[string]interface{}{"atr_multiple": 0.25},
-						"trending_down": map[string]interface{}{"atr_multiple": 0.25},
-						"ranging":       map[string]interface{}{"atr_multiple": ranging},
-					},
-				},
-				"tp_tiers": []interface{}{
-					map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
-				},
+	twoTiers := tiers(
+		map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 0.5},
+		map[string]interface{}{"atr_multiple": 3.0, "close_fraction": 1.0},
+	)
+	oneTier := tiers(map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0})
+	slAfterRegime := func(ranging float64) map[string]interface{} {
+		return map[string]interface{}{
+			"trend_regime": map[string]interface{}{
+				"trending_up":   map[string]interface{}{"atr_multiple": 0.25},
+				"trending_down": map[string]interface{}{"atr_multiple": 0.25},
+				"ranging":       map[string]interface{}{"atr_multiple": ranging},
 			},
 		}
 	}
-	slMult := 1.5
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: makeRef(0.0),
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: makeRef(-0.5),
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
-		}},
-	}}
-
-	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
-	if err == nil {
-		t.Fatal("expected hot reload to reject sl_after regime value change with open position")
+	withSL := func(params map[string]interface{}) func(*StrategyConfig) {
+		return func(sc *StrategyConfig) {
+			sc.StopLossATRMult = floatPtr(1.5)
+			sc.CloseStrategy = tieredATRRef(params)
+		}
 	}
-	if !strings.Contains(err.Error(), "sl_after rules changed with open positions") {
-		t.Fatalf("unexpected error: %v", err)
+	regimeTierRef := func(rangingATR float64, slAfter bool) func(*StrategyConfig) {
+		tier0 := map[string]interface{}{
+			"trend_regime": map[string]interface{}{
+				"trending_up":   map[string]interface{}{"atr_multiple": 2.0},
+				"trending_down": map[string]interface{}{"atr_multiple": 2.0},
+				"ranging":       map[string]interface{}{"atr_multiple": rangingATR},
+			},
+			"close_fraction": 0.5,
+		}
+		if slAfter {
+			tier0["sl_after"] = map[string]interface{}{
+				"trail_from_here": map[string]interface{}{"tp_atr_fraction": 0.5},
+			}
+		}
+		return func(sc *StrategyConfig) {
+			sc.StopLossATRMult = floatPtr(1.5)
+			sc.CloseStrategy = &StrategyRef{
+				Name: "tiered_tp_atr_regime",
+				Params: map[string]interface{}{
+					"tp_tiers": []interface{}{
+						tier0,
+						map[string]interface{}{
+							"trend_regime": map[string]interface{}{
+								"trending_up":   map[string]interface{}{"atr_multiple": 4.0},
+								"trending_down": map[string]interface{}{"atr_multiple": 4.0},
+								"ranging":       map[string]interface{}{"atr_multiple": 3.0},
+							},
+							"close_fraction": 1.0,
+						},
+					},
+				},
+			}
+		}
 	}
-}
-
-func TestApplyHotReloadConfigAllowsSLAfterRegimeIdentical(t *testing.T) {
-	tierRegime := &StrategyRef{
-		Name: "tiered_tp_atr",
-		Params: map[string]interface{}{
-			"sl_after": map[string]interface{}{
-				"trend_regime": map[string]interface{}{
-					"trending_up":   map[string]interface{}{"atr_multiple": 0.25},
-					"trending_down": map[string]interface{}{"atr_multiple": 0.25},
-					"ranging":       map[string]interface{}{"atr_multiple": 0.0},
+	openRangingState := func() *AppState {
+		return &AppState{Strategies: map[string]*StrategyState{
+			"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
+				"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long", Regime: "ranging"},
+			}},
+		}}
+	}
+	openLeveredState := func() *AppState {
+		return &AppState{Strategies: map[string]*StrategyState{
+			"hl-eth": {
+				ID: "hl-eth", Cash: 900,
+				RiskState: RiskState{MaxDrawdownPct: 10},
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 3000, Leverage: 2},
 				},
 			},
-			"tp_tiers": []interface{}{
-				map[string]interface{}{"atr_multiple": 2.0, "close_fraction": 1.0},
+		}}
+	}
+	openETH := func() *AppState { return openETHReloadState("hl-eth") }
+
+	cases := []struct {
+		name    string
+		cfg     func() *Config
+		next    func() *Config
+		state   func() *AppState
+		wantErr string
+		check   func(t *testing.T, cfg *Config, state *AppState, changes []string)
+	}{
+		{
+			name: "rejects strategy set change",
+			cfg:  func() *Config { return minimalReloadConfig([]StrategyConfig{spotStrategy("x.py", 100)}) },
+			next: func() *Config {
+				return minimalReloadConfig([]StrategyConfig{spotStrategy("x.py", 200), {ID: "s2", Type: "spot", Platform: "binanceus", Script: "x.py", Capital: 100, MaxDrawdownPct: 10}})
+			},
+			state:   NewAppState,
+			wantErr: "strategy set changed",
+		},
+		{
+			name:    "rejects non-hot-reloadable strategy field (script)",
+			cfg:     func() *Config { return minimalReloadConfig([]StrategyConfig{spotStrategy("x.py", 100)}) },
+			next:    func() *Config { return minimalReloadConfig([]StrategyConfig{spotStrategy("y.py", 200)}) },
+			state:   NewAppState,
+			wantErr: "non-hot-reloadable",
+		},
+		{
+			name: "allows open/close strategy ref changes",
+			cfg: func() *Config {
+				return minimalReloadConfig([]StrategyConfig{{ID: "s1", Type: "spot", Platform: "binanceus", Script: "x.py", Args: []string{"triple_ema", "BTC/USDT", "1h"}, Capital: 100, MaxDrawdownPct: 10}})
+			},
+			next: func() *Config {
+				return minimalReloadConfig([]StrategyConfig{{ID: "s1", Type: "spot", Platform: "binanceus", Script: "x.py", Args: []string{"triple_ema", "BTC/USDT", "1h"}, Capital: 100, MaxDrawdownPct: 10,
+					OpenStrategy: StrategyRef{Name: "triple_ema"}, CloseStrategy: &StrategyRef{Name: "tp_at_pct"}}})
+			},
+			state: NewAppState,
+			check: func(t *testing.T, cfg *Config, _ *AppState, changes []string) {
+				joined := strings.Join(changes, "\n")
+				for _, want := range []string{"strategy[s1].open_strategy:", "strategy[s1].close_strategy:"} {
+					if !strings.Contains(joined, want) {
+						t.Fatalf("changes missing %q:\n%s", want, joined)
+					}
+				}
+				if cfg.Strategies[0].OpenStrategy.Name != "triple_ema" {
+					t.Fatalf("OpenStrategy.Name = %q, want triple_ema", cfg.Strategies[0].OpenStrategy.Name)
+				}
+				if cfg.Strategies[0].CloseStrategy == nil || cfg.Strategies[0].CloseStrategy.Name != "tp_at_pct" {
+					t.Fatalf("CloseStrategy = %#v, want tp_at_pct", cfg.Strategies[0].CloseStrategy)
+				}
 			},
 		},
-	}
-	slMult := 1.5
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: tierRegime,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: tierRegime,
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
-		}},
-	}}
-
-	if _, err := applyHotReloadConfig(cfg, next, state, nil, nil); err != nil {
-		t.Fatalf("identical sl_after regime configs should reload cleanly with open position, got: %v", err)
-	}
-}
-
-func TestApplyHotReloadConfigRejectsRegimeTierMultipleChangeWithTPATRFraction(t *testing.T) {
-	makeRef := func(rangingATR float64) *StrategyRef {
-		return &StrategyRef{
-			Name: "tiered_tp_atr_regime",
-			Params: map[string]interface{}{
-				"tp_tiers": []interface{}{
-					map[string]interface{}{
-						"trend_regime": map[string]interface{}{
-							"trending_up":   map[string]interface{}{"atr_multiple": 2.0},
-							"trending_down": map[string]interface{}{"atr_multiple": 2.0},
-							"ranging":       map[string]interface{}{"atr_multiple": rangingATR},
-						},
-						"close_fraction": 0.5,
-						"sl_after": map[string]interface{}{
-							"trail_from_here": map[string]interface{}{"tp_atr_fraction": 0.5},
-						},
-					},
-					map[string]interface{}{
-						"trend_regime": map[string]interface{}{
-							"trending_up":   map[string]interface{}{"atr_multiple": 4.0},
-							"trending_down": map[string]interface{}{"atr_multiple": 4.0},
-							"ranging":       map[string]interface{}{"atr_multiple": 3.0},
-						},
-						"close_fraction": 1.0,
-					},
-				},
+		{
+			name: "rejects leverage change with open perps position",
+			cfg: func() *Config {
+				return hlReloadConfig(func(sc *StrategyConfig) { sc.Leverage = 2; sc.MarginMode = "" })
 			},
-		}
-	}
-	slMult := 1.5
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: makeRef(1.5),
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: makeRef(2.5),
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long", Regime: "ranging"},
-		}},
-	}}
-
-	_, err := applyHotReloadConfig(cfg, next, state, nil, nil)
-	if err == nil {
-		t.Fatal("expected hot reload to reject regime tier multiple change with open position")
-	}
-	if !strings.Contains(err.Error(), "sl_after rules changed with open positions") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestApplyHotReloadConfigAllowsRegimeTierMultipleChangeWithoutSLAfter(t *testing.T) {
-	makeRef := func(rangingATR float64) *StrategyRef {
-		return &StrategyRef{
-			Name: "tiered_tp_atr_regime",
-			Params: map[string]interface{}{
-				"tp_tiers": []interface{}{
-					map[string]interface{}{
-						"trend_regime": map[string]interface{}{
-							"trending_up":   map[string]interface{}{"atr_multiple": 2.0},
-							"trending_down": map[string]interface{}{"atr_multiple": 2.0},
-							"ranging":       map[string]interface{}{"atr_multiple": rangingATR},
-						},
-						"close_fraction": 0.5,
-					},
-					map[string]interface{}{
-						"trend_regime": map[string]interface{}{
-							"trending_up":   map[string]interface{}{"atr_multiple": 4.0},
-							"trending_down": map[string]interface{}{"atr_multiple": 4.0},
-							"ranging":       map[string]interface{}{"atr_multiple": 3.0},
-						},
-						"close_fraction": 1.0,
-					},
-				},
+			next: func() *Config {
+				return hlReloadConfig(func(sc *StrategyConfig) {
+					sc.Leverage = 5
+					sc.MarginMode = ""
+					sc.Capital = 1200
+					sc.MaxDrawdownPct = 12
+				})
 			},
-		}
+			state:   openLeveredState,
+			wantErr: "leverage changed with open positions",
+		},
+		{
+			name: "rejects margin_mode change with open perps position",
+			cfg:  func() *Config { return hlReloadConfig(func(sc *StrategyConfig) { sc.Leverage = 2 }) },
+			next: func() *Config {
+				return hlReloadConfig(func(sc *StrategyConfig) { sc.Leverage = 2; sc.MarginMode = "cross" })
+			},
+			state:   openLeveredState,
+			wantErr: "margin_mode changed with open positions",
+		},
+		{
+			name: "allows margin_mode change when flat",
+			cfg:  func() *Config { return hlReloadConfig(func(sc *StrategyConfig) { sc.Leverage = 2 }) },
+			next: func() *Config {
+				return hlReloadConfig(func(sc *StrategyConfig) { sc.Leverage = 2; sc.MarginMode = "cross" })
+			},
+			state: flatETHReloadState,
+			check: func(t *testing.T, cfg *Config, _ *AppState, _ []string) {
+				if cfg.Strategies[0].MarginMode != "cross" {
+					t.Fatalf("MarginMode = %q, want %q", cfg.Strategies[0].MarginMode, "cross")
+				}
+			},
+		},
+		{
+			name: "preserves runtime capital_pct capital while applying other fields",
+			cfg: func() *Config {
+				return minimalReloadConfig([]StrategyConfig{{ID: "s1", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "BTC", "1h"}, Capital: 2500, CapitalPct: 0.5, MaxDrawdownPct: 10, Leverage: 2}})
+			},
+			next: func() *Config {
+				return minimalReloadConfig([]StrategyConfig{{ID: "s1", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "BTC", "1h"}, Capital: 100, CapitalPct: 0.5, MaxDrawdownPct: 12, Leverage: 2}})
+			},
+			state: func() *AppState {
+				return &AppState{Strategies: map[string]*StrategyState{"s1": {ID: "s1", Cash: 2400, RiskState: RiskState{MaxDrawdownPct: 10}}}}
+			},
+			check: func(t *testing.T, cfg *Config, state *AppState, changes []string) {
+				if cfg.Strategies[0].Capital != 2500 {
+					t.Errorf("runtime capital_pct capital = %g, want preserved 2500", cfg.Strategies[0].Capital)
+				}
+				if state.Strategies["s1"].Cash != 2400 {
+					t.Errorf("cash = %g, want preserved 2400", state.Strategies["s1"].Cash)
+				}
+				if joined := strings.Join(changes, "\n"); strings.Contains(joined, ".capital:") {
+					t.Fatalf("capital_pct fallback capital should not be hot-applied, changes:\n%s", joined)
+				}
+				if cfg.Strategies[0].MaxDrawdownPct != 12 || state.Strategies["s1"].RiskState.MaxDrawdownPct != 12 {
+					t.Fatalf("other hot-reloadable fields should still apply, cfg=%+v state=%+v", cfg.Strategies[0], state.Strategies["s1"].RiskState)
+				}
+			},
+		},
+		{
+			name: "rejects HL peer leverage mismatch in next",
+			cfg: func() *Config {
+				return minimalReloadConfig([]StrategyConfig{
+					hlReloadStrategy(func(sc *StrategyConfig) { sc.ID = "hl-eth-a" }),
+					hlReloadStrategy(func(sc *StrategyConfig) { sc.ID = "hl-eth-b"; sc.Args = []string{"b", "ETH", "1h"}; sc.Capital = 500 }),
+				})
+			},
+			next: func() *Config {
+				return minimalReloadConfig([]StrategyConfig{
+					hlReloadStrategy(func(sc *StrategyConfig) { sc.ID = "hl-eth-a" }),
+					hlReloadStrategy(func(sc *StrategyConfig) {
+						sc.ID = "hl-eth-b"
+						sc.Args = []string{"b", "ETH", "1h"}
+						sc.Capital = 500
+						sc.Leverage = 10
+					}),
+				})
+			},
+			state: func() *AppState {
+				return &AppState{Strategies: map[string]*StrategyState{
+					"hl-eth-a": {ID: "hl-eth-a", Cash: 1000},
+					"hl-eth-b": {ID: "hl-eth-b", Cash: 500},
+				}}
+			},
+			wantErr: "disagree on leverage",
+		},
+		{
+			name: "allows trailing_stop_pct value change with open position",
+			cfg: func() *Config {
+				return hlReloadConfig(func(sc *StrategyConfig) { sc.TrailingStopPct = floatPtr(3); sc.TrailingStopMinMovePct = floatPtr(0.5) })
+			},
+			next: func() *Config {
+				return hlReloadConfig(func(sc *StrategyConfig) { sc.TrailingStopPct = floatPtr(4); sc.TrailingStopMinMovePct = floatPtr(0.25) })
+			},
+			state: openETH,
+			check: func(t *testing.T, cfg *Config, _ *AppState, changes []string) {
+				if cfg.Strategies[0].TrailingStopPct == nil || *cfg.Strategies[0].TrailingStopPct != 4 {
+					t.Fatalf("TrailingStopPct=%v, want 4", cfg.Strategies[0].TrailingStopPct)
+				}
+				if cfg.Strategies[0].TrailingStopMinMovePct == nil || *cfg.Strategies[0].TrailingStopMinMovePct != 0.25 {
+					t.Fatalf("TrailingStopMinMovePct=%v, want 0.25", cfg.Strategies[0].TrailingStopMinMovePct)
+				}
+				joined := strings.Join(changes, "\n")
+				if !strings.Contains(joined, "trailing_stop_pct") || !strings.Contains(joined, "trailing_stop_min_move_pct") {
+					t.Fatalf("changes=%v, want trailing_stop_pct and trailing_stop_min_move_pct entries", changes)
+				}
+			},
+		},
+		{
+			name:    "rejects fixed-to-trailing stop mode switch with open position",
+			cfg:     func() *Config { return hlReloadConfig(nil) },
+			next:    func() *Config { return hlReloadConfig(func(sc *StrategyConfig) { sc.TrailingStopPct = floatPtr(3) }) },
+			state:   openETH,
+			wantErr: "trailing_stop_pct mode changed",
+		},
+		{
+			name: "rejects direction change with open perps position",
+			cfg: func() *Config {
+				return hlReloadConfig(func(sc *StrategyConfig) { sc.Leverage = 2; sc.MarginMode = ""; sc.Direction = DirectionLong })
+			},
+			next: func() *Config {
+				return hlReloadConfig(func(sc *StrategyConfig) { sc.Leverage = 2; sc.MarginMode = ""; sc.Direction = DirectionShort })
+			},
+			state:   openLeveredState,
+			wantErr: "direction changed with open positions",
+		},
+		{
+			name: "allows direction change when flat",
+			cfg: func() *Config {
+				return hlReloadConfig(func(sc *StrategyConfig) { sc.Leverage = 2; sc.MarginMode = ""; sc.Direction = DirectionLong })
+			},
+			next: func() *Config {
+				return hlReloadConfig(func(sc *StrategyConfig) { sc.Leverage = 2; sc.MarginMode = ""; sc.Direction = DirectionShort })
+			},
+			state: flatETHReloadState,
+			check: func(t *testing.T, cfg *Config, _ *AppState, _ []string) {
+				if cfg.Strategies[0].Direction != DirectionShort {
+					t.Errorf("Direction = %q, want %q after applied reload", cfg.Strategies[0].Direction, DirectionShort)
+				}
+			},
+		},
+		{
+			name: "rejects sl_after add with open position",
+			cfg:  func() *Config { return hlReloadConfig(withSL(map[string]interface{}{"tp_tiers": twoTiers})) },
+			next: func() *Config {
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": "breakeven", "tp_tiers": twoTiers}))
+			},
+			state:   openETH,
+			wantErr: "sl_after rules changed with open positions",
+		},
+		{
+			name: "allows sl_after add when flat",
+			cfg:  func() *Config { return hlReloadConfig(withSL(map[string]interface{}{"tp_tiers": oneTier})) },
+			next: func() *Config {
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": "breakeven", "tp_tiers": oneTier}))
+			},
+			state: flatETHReloadState,
+		},
+		{
+			name: "rejects sl_after mode switch (breakeven -> trail_from_here) with open position",
+			cfg: func() *Config {
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": "breakeven", "tp_tiers": oneTier}))
+			},
+			next: func() *Config {
+				return hlReloadConfig(withSL(map[string]interface{}{
+					"sl_after": map[string]interface{}{
+						"kind":            "trail_from_here",
+						"trail_from_here": map[string]interface{}{"atr_mult": 1.0},
+					},
+					"tp_tiers": oneTier,
+				}))
+			},
+			state:   openETH,
+			wantErr: "sl_after rules changed with open positions",
+		},
+		{
+			name: "rejects sl_after scalar -> regime shape change with open position",
+			cfg: func() *Config {
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": map[string]interface{}{"atr_mult": 0.25}, "tp_tiers": oneTier}))
+			},
+			next: func() *Config {
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(0.0), "tp_tiers": oneTier}))
+			},
+			state:   openETH,
+			wantErr: "sl_after rules changed with open positions",
+		},
+		{
+			name: "rejects sl_after regime value change with open position",
+			cfg: func() *Config {
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(0.0), "tp_tiers": oneTier}))
+			},
+			next: func() *Config {
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(-0.5), "tp_tiers": oneTier}))
+			},
+			state:   openETH,
+			wantErr: "sl_after rules changed with open positions",
+		},
+		{
+			name: "allows identical sl_after regime block with open position",
+			cfg: func() *Config {
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(0.0), "tp_tiers": oneTier}))
+			},
+			next: func() *Config {
+				return hlReloadConfig(withSL(map[string]interface{}{"sl_after": slAfterRegime(0.0), "tp_tiers": oneTier}))
+			},
+			state: openETH,
+		},
+		{
+			name:    "rejects regime tier multiple change when sl_after uses tp_atr_fraction",
+			cfg:     func() *Config { return hlReloadConfig(regimeTierRef(1.5, true)) },
+			next:    func() *Config { return hlReloadConfig(regimeTierRef(2.5, true)) },
+			state:   openRangingState,
+			wantErr: "sl_after rules changed with open positions",
+		},
+		{
+			name:  "allows regime tier multiple change without sl_after",
+			cfg:   func() *Config { return hlReloadConfig(regimeTierRef(1.5, false)) },
+			next:  func() *Config { return hlReloadConfig(regimeTierRef(2.5, false)) },
+			state: openRangingState,
+		},
 	}
-	slMult := 1.5
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: makeRef(1.5),
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-		Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-		Leverage: 5, MarginMode: "isolated", StopLossATRMult: &slMult,
-		CloseStrategy: makeRef(2.5),
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long", Regime: "ranging"},
-		}},
-	}}
-
-	if _, err := applyHotReloadConfig(cfg, next, state, nil, nil); err != nil {
-		t.Fatalf("tier changes without sl_after should not trip sl_after reload guard, got: %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, state := tc.cfg(), tc.state()
+			changes, err := applyHotReloadConfig(cfg, tc.next(), state, nil, nil)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected reload to be rejected with %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if want := tc.cfg(); !reflect.DeepEqual(cfg, want) {
+					t.Fatalf("current config mutated after rejected reload:\n got %+v\nwant %+v", cfg.Strategies, want.Strategies)
+				}
+				if want := tc.state(); !reflect.DeepEqual(state, want) {
+					t.Fatalf("state mutated after rejected reload:\n got %+v\nwant %+v", state.Strategies, want.Strategies)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("applyHotReloadConfig: %v", err)
+			}
+			if tc.check != nil {
+				tc.check(t, cfg, state, changes)
+			}
+		})
 	}
 }
 
@@ -1121,25 +847,6 @@ func TestApplyHotReloadConfigRegimeTimeframe(t *testing.T) {
 	})
 }
 
-func TestApplyHotReloadConfigAllowsDirectionChangeWhenFlat(t *testing.T) {
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, Direction: DirectionLong,
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py", Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, Direction: DirectionShort,
-	}})
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Cash: 1000, Positions: map[string]*Position{}},
-	}}
-
-	if _, err := applyHotReloadConfig(cfg, next, state, nil, nil); err != nil {
-		t.Fatalf("expected direction change to be allowed when flat, got: %v", err)
-	}
-	if cfg.Strategies[0].Direction != DirectionShort {
-		t.Errorf("Direction = %q, want %q after applied reload", cfg.Strategies[0].Direction, DirectionShort)
-	}
-}
-
 func TestValidateHotReloadCompatible(t *testing.T) {
 	baseStrategy := StrategyConfig{
 		ID:             "spot-btc",
@@ -1216,6 +923,8 @@ func TestValidateHotReloadCompatible(t *testing.T) {
 				},
 			}
 		}, "leverage"},
+		{"regime_gate_window only change returns nil", func(c *Config) { c.Strategies[0].RegimeGateWindow = "medium" }, ""},
+		{"shared-wallet pool budgeting mode change requires restart", func(c *Config) { c.Strategies[0].sharedWalletPoolBudget = true }, "shared-wallet pool budgeting mode changed"},
 		{"identical configs returns nil", func(*Config) {}, ""},
 	}
 
@@ -1235,72 +944,6 @@ func TestValidateHotReloadCompatible(t *testing.T) {
 				} else if !strings.Contains(err.Error(), tc.wantErr) {
 					t.Errorf("expected error containing %q, got: %v", tc.wantErr, err)
 				}
-			}
-		})
-	}
-}
-
-func TestFormatFloatPtr(t *testing.T) {
-	v1 := float64(3.14)
-	v2 := float64(0)
-	cases := []struct {
-		name string
-		in   *float64
-		want string
-	}{
-		{"nil", nil, "<nil>"},
-		{"positive", &v1, "3.14"},
-		{"zero", &v2, "0"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := formatFloatPtr(tc.in)
-			if got != tc.want {
-				t.Errorf("formatFloatPtr(%v) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestFormatFloatPtrUSD(t *testing.T) {
-	v1 := float64(12.5)
-	v2 := float64(0)
-	cases := []struct {
-		name string
-		in   *float64
-		want string
-	}{
-		{"nil", nil, "<nil>"},
-		{"positive", &v1, "$12.50"},
-		{"zero", &v2, "$0.00"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := formatFloatPtrUSD(tc.in)
-			if got != tc.want {
-				t.Errorf("formatFloatPtrUSD(%v) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestFormatFloatPtrPct(t *testing.T) {
-	v1 := float64(12.5)
-	v2 := float64(0)
-	cases := []struct {
-		name string
-		in   *float64
-		want string
-	}{
-		{"nil", nil, "<nil>"},
-		{"positive", &v1, "12.50%"},
-		{"zero", &v2, "0.00%"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := formatFloatPtrPct(tc.in)
-			if got != tc.want {
-				t.Errorf("formatFloatPtrPct(%v) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
 	}
@@ -1389,41 +1032,24 @@ func TestStrategyHasOpenPositions(t *testing.T) {
 	})
 }
 
-func TestPortfolioRiskMaxDrawdown(t *testing.T) {
+func TestPortfolioRiskAccessorsNilSafe(t *testing.T) {
 	cases := []struct {
-		name string
-		in   *PortfolioRiskConfig
-		want float64
+		name     string
+		in       *PortfolioRiskConfig
+		wantDD   float64
+		wantWarn float64
 	}{
-		{"nil", nil, 0},
-		{"populated", &PortfolioRiskConfig{MaxDrawdownPct: 15.5}, 15.5},
-		{"zero value", &PortfolioRiskConfig{}, 0},
+		{"nil", nil, 0, 0},
+		{"populated", &PortfolioRiskConfig{MaxDrawdownPct: 15.5, WarnThresholdPct: 60.0}, 15.5, 60.0},
+		{"zero value", &PortfolioRiskConfig{}, 0, 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := portfolioRiskMaxDrawdown(tc.in)
-			if got != tc.want {
-				t.Errorf("portfolioRiskMaxDrawdown(%v) = %v, want %v", tc.in, got, tc.want)
+			if got := portfolioRiskMaxDrawdown(tc.in); got != tc.wantDD {
+				t.Errorf("portfolioRiskMaxDrawdown(%v) = %v, want %v", tc.in, got, tc.wantDD)
 			}
-		})
-	}
-}
-
-func TestPortfolioRiskWarnThreshold(t *testing.T) {
-	cases := []struct {
-		name string
-		in   *PortfolioRiskConfig
-		want float64
-	}{
-		{"nil", nil, 0},
-		{"populated", &PortfolioRiskConfig{WarnThresholdPct: 60.0}, 60.0},
-		{"zero value", &PortfolioRiskConfig{}, 0},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := portfolioRiskWarnThreshold(tc.in)
-			if got != tc.want {
-				t.Errorf("portfolioRiskWarnThreshold(%v) = %v, want %v", tc.in, got, tc.want)
+			if got := portfolioRiskWarnThreshold(tc.in); got != tc.wantWarn {
+				t.Errorf("portfolioRiskWarnThreshold(%v) = %v, want %v", tc.in, got, tc.wantWarn)
 			}
 		})
 	}
@@ -1798,57 +1424,6 @@ func TestLoadConfigManualDefaultsRejectsEmptyTPTiersArray(t *testing.T) {
 	}
 }
 
-func TestStrategyRestartShape_RegimeWindowOnlyChange(t *testing.T) {
-	a := StrategyConfig{ID: "hl-a", RegimeGateWindow: "short", RegimeATRWindow: "medium"}
-	b := StrategyConfig{ID: "hl-a", RegimeGateWindow: "long", RegimeATRWindow: "short"}
-	if !reflect.DeepEqual(strategyRestartShape(a), strategyRestartShape(b)) {
-		t.Fatal("regime_*_window-only change should not affect restart shape")
-	}
-}
-
-func TestValidateHotReloadCompatible_RegimeWindowOnlyChange(t *testing.T) {
-	cfg := minimalReloadConfig([]StrategyConfig{{
-		ID:               "hl-a",
-		Type:             "perps",
-		Platform:         "hyperliquid",
-		Script:           "shared_scripts/check_hyperliquid.py",
-		Args:             []string{"momentum", "BTC", "1h", "--mode=paper"},
-		Capital:          1000,
-		MaxDrawdownPct:   10,
-		RegimeGateWindow: "short",
-	}})
-	next := minimalReloadConfig([]StrategyConfig{{
-		ID:               "hl-a",
-		Type:             "perps",
-		Platform:         "hyperliquid",
-		Script:           "shared_scripts/check_hyperliquid.py",
-		Args:             []string{"momentum", "BTC", "1h", "--mode=paper"},
-		Capital:          1000,
-		MaxDrawdownPct:   10,
-		RegimeGateWindow: "medium",
-	}})
-	if err := validateHotReloadCompatible(cfg, next); err != nil {
-		t.Fatalf("pure regime_gate_window change should be hot-reloadable: %v", err)
-	}
-}
-
-func TestValidateHotReloadCompatible_SharedWalletPoolModeRequiresRestart(t *testing.T) {
-	base := StrategyConfig{
-		ID: "hl-a", Type: "perps", Platform: "hyperliquid",
-		Script: "shared_scripts/check_hyperliquid.py",
-		Args:   []string{"momentum", "BTC", "1h", "--mode=live"},
-	}
-	nextStrategy := base
-	nextStrategy.sharedWalletPoolBudget = true
-
-	cfg := minimalReloadConfig([]StrategyConfig{base})
-	next := minimalReloadConfig([]StrategyConfig{nextStrategy})
-	err := validateHotReloadCompatible(cfg, next)
-	if err == nil || !strings.Contains(err.Error(), "shared-wallet pool budgeting mode changed") {
-		t.Fatalf("expected pool-mode restart requirement, got %v", err)
-	}
-}
-
 func TestApplyHotReloadConfigPreservesDeferredPoolTransitionManageOnlyLatch(t *testing.T) {
 	strategy := StrategyConfig{
 		ID: "hl-a", Type: "perps", Platform: "hyperliquid",
@@ -1872,55 +1447,33 @@ func TestApplyHotReloadConfigPreservesDeferredPoolTransitionManageOnlyLatch(t *t
 	}
 }
 
-func TestApplyHotReloadConfig_CircuitBreakerToggleWhileOpen(t *testing.T) {
-	falseVal, trueVal := false, true
-	base := func(cb *bool) []StrategyConfig {
-		return []StrategyConfig{{
-			ID: "hl-eth", Type: "perps", Platform: "hyperliquid",
-			Script:  "shared_scripts/check_hyperliquid.py",
-			Args:    []string{"momentum", "ETH", "1h", "--mode=paper"},
-			Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, Direction: DirectionLong,
-			CircuitBreaker: cb,
-		}}
+func TestStrategyRestartShapeIgnoresHotReloadableFields(t *testing.T) {
+	on, off := true, false
+	dd, th, lc := 720, 3, 30
+	cases := []struct {
+		name string
+		a, b StrategyConfig
+	}{
+		{"regime_*_window only change", StrategyConfig{ID: "hl-a", RegimeGateWindow: "short", RegimeATRWindow: "medium"}, StrategyConfig{ID: "hl-a", RegimeGateWindow: "long", RegimeATRWindow: "short"}},
+		{"cb_* override set-vs-nil", StrategyConfig{ID: "hl-a"}, StrategyConfig{ID: "hl-a", CBDrawdownCooldownMinutes: &dd, CBLossStreakThreshold: &th, CBLossStreakCooldownMinutes: &lc}},
+		{"circuit_breaker on/off", StrategyConfig{ID: "hl-a", CircuitBreaker: &on}, StrategyConfig{ID: "hl-a", CircuitBreaker: &off}},
+		{"circuit_breaker set-vs-nil", StrategyConfig{ID: "hl-a", CircuitBreaker: &on}, StrategyConfig{ID: "hl-a", CircuitBreaker: nil}},
+		{"notify_ratchet_triggers on/off", StrategyConfig{ID: "hl-a", NotifyRatchetTriggers: &on}, StrategyConfig{ID: "hl-a", NotifyRatchetTriggers: &off}},
+		{"notify_ratchet_triggers set-vs-nil", StrategyConfig{ID: "hl-a", NotifyRatchetTriggers: &on}, StrategyConfig{ID: "hl-a", NotifyRatchetTriggers: nil}},
 	}
-	openState := func() *AppState {
-		return &AppState{Strategies: map[string]*StrategyState{
-			"hl-eth": {
-				ID: "hl-eth", Cash: 900,
-				RiskState: RiskState{MaxDrawdownPct: 10},
-				Positions: map[string]*Position{
-					"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 3000, Leverage: 2},
-				},
-			},
-		}}
-	}
-
-	cfg := minimalReloadConfig(base(nil))
-	next := minimalReloadConfig(base(&falseVal))
-	changes, err := applyHotReloadConfig(cfg, next, openState(), nil, nil)
-	if err != nil {
-		t.Fatalf("circuit_breaker on->off while open should be hot-reloadable: %v", err)
-	}
-	if cfg.Strategies[0].CircuitBreakerEnabled() {
-		t.Fatal("expected circuit breaker disabled after reload")
-	}
-	if !strings.Contains(strings.Join(changes, "\n"), "circuit_breaker") {
-		t.Fatalf("expected a circuit_breaker change entry, got %v", changes)
-	}
-
-	cfg = minimalReloadConfig(base(&falseVal))
-	next = minimalReloadConfig(base(&trueVal))
-	if _, err := applyHotReloadConfig(cfg, next, openState(), nil, nil); err != nil {
-		t.Fatalf("circuit_breaker off->on while open should be hot-reloadable: %v", err)
-	}
-	if !cfg.Strategies[0].CircuitBreakerEnabled() {
-		t.Fatal("expected circuit breaker re-enabled after reload")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !reflect.DeepEqual(strategyRestartShape(tc.a), strategyRestartShape(tc.b)) {
+				t.Fatalf("%s should not affect restart shape", tc.name)
+			}
+		})
 	}
 }
 
-func TestApplyHotReloadConfig_CBOverridesWhileOpen(t *testing.T) {
+func TestApplyHotReloadConfigTogglesWhileOpen(t *testing.T) {
+	falseVal, trueVal := false, true
 	intp := func(v int) *int { return &v }
-	base := func(mut func(*StrategyConfig)) []StrategyConfig {
+	base := func(mut func(*StrategyConfig)) *Config {
 		sc := StrategyConfig{
 			ID: "hl-eth", Type: "perps", Platform: "hyperliquid",
 			Script:  "shared_scripts/check_hyperliquid.py",
@@ -1930,7 +1483,7 @@ func TestApplyHotReloadConfig_CBOverridesWhileOpen(t *testing.T) {
 		if mut != nil {
 			mut(&sc)
 		}
-		return []StrategyConfig{sc}
+		return minimalReloadConfig([]StrategyConfig{sc})
 	}
 	openState := func() *AppState {
 		return &AppState{Strategies: map[string]*StrategyState{
@@ -1948,143 +1501,101 @@ func TestApplyHotReloadConfig_CBOverridesWhileOpen(t *testing.T) {
 		sc.CBLossStreakThreshold = intp(3)
 		sc.CBLossStreakCooldownMinutes = intp(30)
 	}
-
-	cfg := minimalReloadConfig(base(nil))
-	next := minimalReloadConfig(base(setOverrides))
-	changes, err := applyHotReloadConfig(cfg, next, openState(), nil, nil)
-	if err != nil {
-		t.Fatalf("cb_* overrides while open should be hot-reloadable: %v", err)
-	}
-	sc := &cfg.Strategies[0]
-	if got := sc.CircuitBreakerDrawdownCooldown(); got != 12*time.Hour {
-		t.Fatalf("drawdown cooldown after reload = %v, want 12h", got)
-	}
-	if got := sc.CircuitBreakerLossStreakThreshold(); got != 3 {
-		t.Fatalf("loss-streak threshold after reload = %d, want 3", got)
-	}
-	if got := sc.CircuitBreakerLossStreakCooldown(); got != 30*time.Minute {
-		t.Fatalf("loss-streak cooldown after reload = %v, want 30m", got)
-	}
-	joined := strings.Join(changes, "\n")
-	for _, want := range []string{"cb_drawdown_cooldown_minutes", "cb_loss_streak_threshold", "cb_loss_streak_cooldown_minutes"} {
-		if !strings.Contains(joined, want) {
-			t.Fatalf("expected a %s change entry, got %v", want, changes)
-		}
-	}
-
-	cfg = minimalReloadConfig(base(setOverrides))
-	next = minimalReloadConfig(base(nil))
-	if _, err := applyHotReloadConfig(cfg, next, openState(), nil, nil); err != nil {
-		t.Fatalf("clearing cb_* overrides while open should be hot-reloadable: %v", err)
-	}
-	sc = &cfg.Strategies[0]
-	if sc.CircuitBreakerDrawdownCooldown() != 24*time.Hour || sc.CircuitBreakerLossStreakThreshold() != 5 || sc.CircuitBreakerLossStreakCooldown() != time.Hour {
-		t.Fatal("cleared overrides should fall back to the historical defaults")
-	}
-}
-
-func TestStrategyRestartShape_CBOverrideOnlyChange(t *testing.T) {
-	dd, th, lc := 720, 3, 30
-	a := StrategyConfig{ID: "hl-a"}
-	b := StrategyConfig{ID: "hl-a", CBDrawdownCooldownMinutes: &dd, CBLossStreakThreshold: &th, CBLossStreakCooldownMinutes: &lc}
-	if !reflect.DeepEqual(strategyRestartShape(a), strategyRestartShape(b)) {
-		t.Fatal("cb_* override set-vs-nil should not affect restart shape")
-	}
-}
-
-func TestStrategyRestartShape_CircuitBreakerOnlyChange(t *testing.T) {
-	on, off := true, false
-	a := StrategyConfig{ID: "hl-a", CircuitBreaker: &on}
-	b := StrategyConfig{ID: "hl-a", CircuitBreaker: &off}
-	c := StrategyConfig{ID: "hl-a", CircuitBreaker: nil}
-	if !reflect.DeepEqual(strategyRestartShape(a), strategyRestartShape(b)) {
-		t.Fatal("circuit_breaker on/off change should not affect restart shape")
-	}
-	if !reflect.DeepEqual(strategyRestartShape(a), strategyRestartShape(c)) {
-		t.Fatal("circuit_breaker set-vs-nil should not affect restart shape")
-	}
-}
-
-func TestApplyHotReloadConfig_NotifyRatchetTriggersWhileOpen(t *testing.T) {
-	falseVal, trueVal := false, true
-	base := func(nrt *bool) []StrategyConfig {
-		return []StrategyConfig{{
-			ID: "hl-eth", Type: "perps", Platform: "hyperliquid",
-			Script:  "shared_scripts/check_hyperliquid.py",
-			Args:    []string{"momentum", "ETH", "1h", "--mode=paper"},
-			Capital: 1000, MaxDrawdownPct: 10, Leverage: 2, Direction: DirectionLong,
-			NotifyRatchetTriggers: nrt,
-		}}
-	}
-	openState := func() *AppState {
-		return &AppState{Strategies: map[string]*StrategyState{
-			"hl-eth": {
-				ID: "hl-eth", Cash: 900,
-				RiskState: RiskState{MaxDrawdownPct: 10},
-				Positions: map[string]*Position{
-					"ETH": {Symbol: "ETH", Quantity: 1, Side: "long", AvgCost: 3000, Leverage: 2},
-				},
+	cases := []struct {
+		name        string
+		old, new    func(*StrategyConfig)
+		wantChanges []string
+		check       func(t *testing.T, sc *StrategyConfig)
+	}{
+		{
+			name: "circuit_breaker nil->off",
+			old:  nil, new: func(sc *StrategyConfig) { sc.CircuitBreaker = &falseVal },
+			wantChanges: []string{"circuit_breaker"},
+			check: func(t *testing.T, sc *StrategyConfig) {
+				if sc.CircuitBreakerEnabled() {
+					t.Fatal("expected circuit breaker disabled after reload")
+				}
 			},
-		}}
+		},
+		{
+			name: "circuit_breaker off->on",
+			old:  func(sc *StrategyConfig) { sc.CircuitBreaker = &falseVal },
+			new:  func(sc *StrategyConfig) { sc.CircuitBreaker = &trueVal },
+			check: func(t *testing.T, sc *StrategyConfig) {
+				if !sc.CircuitBreakerEnabled() {
+					t.Fatal("expected circuit breaker re-enabled after reload")
+				}
+			},
+		},
+		{
+			name: "cb_* overrides set",
+			old:  nil, new: setOverrides,
+			wantChanges: []string{"cb_drawdown_cooldown_minutes", "cb_loss_streak_threshold", "cb_loss_streak_cooldown_minutes"},
+			check: func(t *testing.T, sc *StrategyConfig) {
+				if got := sc.CircuitBreakerDrawdownCooldown(); got != 12*time.Hour {
+					t.Fatalf("drawdown cooldown after reload = %v, want 12h", got)
+				}
+				if got := sc.CircuitBreakerLossStreakThreshold(); got != 3 {
+					t.Fatalf("loss-streak threshold after reload = %d, want 3", got)
+				}
+				if got := sc.CircuitBreakerLossStreakCooldown(); got != 30*time.Minute {
+					t.Fatalf("loss-streak cooldown after reload = %v, want 30m", got)
+				}
+			},
+		},
+		{
+			name: "cb_* overrides cleared fall back to historical defaults",
+			old:  setOverrides, new: nil,
+			check: func(t *testing.T, sc *StrategyConfig) {
+				if sc.CircuitBreakerDrawdownCooldown() != 24*time.Hour || sc.CircuitBreakerLossStreakThreshold() != 5 || sc.CircuitBreakerLossStreakCooldown() != time.Hour {
+					t.Fatal("cleared overrides should fall back to the historical defaults")
+				}
+			},
+		},
+		{
+			name: "notify_ratchet_triggers nil->off",
+			old:  nil, new: func(sc *StrategyConfig) { sc.NotifyRatchetTriggers = &falseVal },
+			wantChanges: []string{"notify_ratchet_triggers"},
+			check: func(t *testing.T, sc *StrategyConfig) {
+				if sc.NotifyRatchetTriggers == nil || *sc.NotifyRatchetTriggers {
+					t.Fatal("expected notify_ratchet_triggers=false after reload")
+				}
+			},
+		},
+		{
+			name: "notify_ratchet_triggers off->on",
+			old:  func(sc *StrategyConfig) { sc.NotifyRatchetTriggers = &falseVal },
+			new:  func(sc *StrategyConfig) { sc.NotifyRatchetTriggers = &trueVal },
+			check: func(t *testing.T, sc *StrategyConfig) {
+				if sc.NotifyRatchetTriggers == nil || !*sc.NotifyRatchetTriggers {
+					t.Fatal("expected notify_ratchet_triggers=true after reload")
+				}
+			},
+		},
 	}
-
-	cfg := minimalReloadConfig(base(nil))
-	next := minimalReloadConfig(base(&falseVal))
-	changes, err := applyHotReloadConfig(cfg, next, openState(), nil, nil)
-	if err != nil {
-		t.Fatalf("notify_ratchet_triggers nil->off while open should be hot-reloadable: %v", err)
-	}
-	if cfg.Strategies[0].NotifyRatchetTriggers == nil || *cfg.Strategies[0].NotifyRatchetTriggers {
-		t.Fatal("expected notify_ratchet_triggers=false after reload")
-	}
-	if !strings.Contains(strings.Join(changes, "\n"), "notify_ratchet_triggers") {
-		t.Fatalf("expected a notify_ratchet_triggers change entry, got %v", changes)
-	}
-
-	cfg = minimalReloadConfig(base(&falseVal))
-	next = minimalReloadConfig(base(&trueVal))
-	if _, err := applyHotReloadConfig(cfg, next, openState(), nil, nil); err != nil {
-		t.Fatalf("notify_ratchet_triggers off->on while open should be hot-reloadable: %v", err)
-	}
-	if cfg.Strategies[0].NotifyRatchetTriggers == nil || !*cfg.Strategies[0].NotifyRatchetTriggers {
-		t.Fatal("expected notify_ratchet_triggers=true after reload")
-	}
-}
-
-func TestStrategyRestartShape_NotifyRatchetTriggersOnlyChange(t *testing.T) {
-	on, off := true, false
-	a := StrategyConfig{ID: "hl-a", NotifyRatchetTriggers: &on}
-	b := StrategyConfig{ID: "hl-a", NotifyRatchetTriggers: &off}
-	c := StrategyConfig{ID: "hl-a", NotifyRatchetTriggers: nil}
-	if !reflect.DeepEqual(strategyRestartShape(a), strategyRestartShape(b)) {
-		t.Fatal("notify_ratchet_triggers on/off change should not affect restart shape")
-	}
-	if !reflect.DeepEqual(strategyRestartShape(a), strategyRestartShape(c)) {
-		t.Fatal("notify_ratchet_triggers set-vs-nil should not affect restart shape")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base(tc.old)
+			changes, err := applyHotReloadConfig(cfg, base(tc.new), openState(), nil, nil)
+			if err != nil {
+				t.Fatalf("%s while open should be hot-reloadable: %v", tc.name, err)
+			}
+			joined := strings.Join(changes, "\n")
+			for _, want := range tc.wantChanges {
+				if !strings.Contains(joined, want) {
+					t.Fatalf("expected a %s change entry, got %v", want, changes)
+				}
+			}
+			tc.check(t, &cfg.Strategies[0])
+		})
 	}
 }
 
 func TestValidateHotReloadStateCompatible_StopOwnerModeToggles(t *testing.T) {
-	pf := func(v float64) *float64 { return &v }
-	mkCfg := func(mutate func(sc *StrategyConfig)) *Config {
-		sc := StrategyConfig{
-			ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
-			Args: []string{"a", "ETH", "1h"}, Capital: 1000, MaxDrawdownPct: 10,
-			Leverage: 5, MarginMode: "isolated",
-		}
-		if mutate != nil {
-			mutate(&sc)
-		}
-		return minimalReloadConfig([]StrategyConfig{sc})
-	}
-	openState := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long"},
-		}},
-	}}
-	flatState := &AppState{Strategies: map[string]*StrategyState{
-		"hl-eth": {ID: "hl-eth", Positions: map[string]*Position{}},
-	}}
+	pf := floatPtr
+	mkCfg := hlReloadConfig
+	openState := openETHReloadState("hl-eth")
+	flatState := flatETHReloadState()
 	regimeBlock := func(sc *StrategyConfig, trailing bool) {
 		b := &RegimeATRBlock{TrendRegime: map[string]RegimeATREntry{"trending": {ATR: 2}}}
 		if trailing {
@@ -2133,6 +1644,35 @@ func TestValidateHotReloadStateCompatible_StopOwnerModeToggles(t *testing.T) {
 			}
 			if err := validateHotReloadStateCompatible(mkCfg(tc.old), mkCfg(tc.new), flatState); err != nil {
 				t.Fatalf("flat: same toggle must be accepted, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestFormatFloatPtrVariants(t *testing.T) {
+	v1 := float64(12.5)
+	v2 := float64(0)
+	v3 := float64(3.14)
+	cases := []struct {
+		name string
+		fn   func(*float64) string
+		in   *float64
+		want string
+	}{
+		{"plain nil", formatFloatPtr, nil, "<nil>"},
+		{"plain positive", formatFloatPtr, &v3, "3.14"},
+		{"plain zero", formatFloatPtr, &v2, "0"},
+		{"usd nil", formatFloatPtrUSD, nil, "<nil>"},
+		{"usd positive", formatFloatPtrUSD, &v1, "$12.50"},
+		{"usd zero", formatFloatPtrUSD, &v2, "$0.00"},
+		{"pct nil", formatFloatPtrPct, nil, "<nil>"},
+		{"pct positive", formatFloatPtrPct, &v1, "12.50%"},
+		{"pct zero", formatFloatPtrPct, &v2, "0.00%"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.fn(tc.in); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -789,198 +790,6 @@ func TestLoadConfigInitialCapital(t *testing.T) {
 	}
 }
 
-func TestLoadConfigPerpsLeverageDefault(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-test-eth",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-	sc := cfg.Strategies[0]
-	if sc.Leverage != 1 {
-		t.Errorf("Leverage = %g, want 1 (default)", sc.Leverage)
-	}
-}
-
-func TestLoadConfigPerpsLeverageExplicit(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-test-eth",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"leverage": 10
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-	if cfg.Strategies[0].Leverage != 10 {
-		t.Errorf("Leverage = %g, want 10", cfg.Strategies[0].Leverage)
-	}
-	if cfg.Strategies[0].SizingLeverage != 10 {
-		t.Errorf("SizingLeverage = %g, want 10 (defaults to leverage)", cfg.Strategies[0].SizingLeverage)
-	}
-}
-
-func TestLoadConfigPerpsSizingLeverageExplicit(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-test-eth",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"leverage": 20,
-			"sizing_leverage": 2
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-	sc := cfg.Strategies[0]
-	if got := EffectiveExchangeLeverage(sc); got != 20 {
-		t.Errorf("EffectiveExchangeLeverage = %g, want 20", got)
-	}
-	if got := EffectiveSizingLeverage(sc); got != 2 {
-		t.Errorf("EffectiveSizingLeverage = %g, want 2", got)
-	}
-}
-
-func TestLoadConfigLeverageRejectsSpot(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "test-spot",
-			"type": "spot",
-			"script": "shared_scripts/check_strategy.py",
-			"args": ["sma_crossover", "BTC/USDT", "1h"],
-			"capital": 1000,
-			"leverage": 5
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for leverage on spot strategy")
-	}
-	if !strings.Contains(err.Error(), "leverage is only supported for perps") {
-		t.Errorf("error = %v, want 'leverage is only supported for perps'", err)
-	}
-}
-
-func TestLoadConfigLeverageRejectsOutOfRange(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-test-eth",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"leverage": 150
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for leverage=150")
-	}
-	if !strings.Contains(err.Error(), "leverage must be in") {
-		t.Errorf("error = %v, want 'leverage must be in'", err)
-	}
-}
-
-func TestLoadConfigSizingLeverageRejectsSpot(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "test-spot",
-			"type": "spot",
-			"script": "shared_scripts/check_strategy.py",
-			"args": ["sma_crossover", "BTC/USDT", "1h"],
-			"capital": 1000,
-			"sizing_leverage": 2
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for sizing_leverage on spot strategy")
-	}
-	if !strings.Contains(err.Error(), "sizing_leverage is only supported for perps") {
-		t.Errorf("error = %v, want 'sizing_leverage is only supported for perps'", err)
-	}
-}
-
-func TestLoadConfigSizingLeverageAcceptsFractional(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-test-eth",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"leverage": 20,
-			"sizing_leverage": 0.5
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig with sizing_leverage=0.5 failed: %v", err)
-	}
-	if got := cfg.Strategies[0].SizingLeverage; got != 0.5 {
-		t.Errorf("SizingLeverage = %g, want 0.5", got)
-	}
-}
-
-func TestLoadConfigSizingLeverageRejectsOutOfRange(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-test-eth",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"leverage": 20,
-			"sizing_leverage": 200
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for sizing_leverage=200")
-	}
-	if !strings.Contains(err.Error(), "sizing_leverage must be in") {
-		t.Errorf("error = %v, want 'sizing_leverage must be in'", err)
-	}
-}
-
 func TestLoadConfigMarginPerTradeUSDAccepted(t *testing.T) {
 	dir := t.TempDir()
 	cfgJSON := `{
@@ -1012,52 +821,6 @@ func TestLoadConfigMarginPerTradeUSDAccepted(t *testing.T) {
 	}
 }
 
-func TestLoadConfigMarginPerTradeUSDRejectsSpot(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "test-spot",
-			"type": "spot",
-			"script": "shared_scripts/check_strategy.py",
-			"args": ["sma_crossover", "BTC/USDT", "1h"],
-			"capital": 1000,
-			"margin_per_trade_usd": 100
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for margin_per_trade_usd on spot strategy")
-	}
-	if !strings.Contains(err.Error(), "margin_per_trade_usd is only supported for perps") {
-		t.Errorf("error = %v, want 'margin_per_trade_usd is only supported for perps'", err)
-	}
-}
-
-func TestLoadConfigMarginPerTradeUSDRejectsNonPositive(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-test-eth",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"leverage": 20,
-			"margin_per_trade_usd": 0
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for margin_per_trade_usd=0")
-	}
-	if !strings.Contains(err.Error(), "margin_per_trade_usd must be positive") {
-		t.Errorf("error = %v, want 'margin_per_trade_usd must be positive'", err)
-	}
-}
-
 func TestEffectiveMarginPerTradeUSDOmittedReturnsZero(t *testing.T) {
 	sc := StrategyConfig{Type: "perps", Leverage: 20, SizingLeverage: 1}
 	if got := EffectiveMarginPerTradeUSD(sc); got != 0 {
@@ -1065,28 +828,6 @@ func TestEffectiveMarginPerTradeUSDOmittedReturnsZero(t *testing.T) {
 	}
 	if got := ComputePerpsOpenNotional(sc, 1000); got != 1000 {
 		t.Errorf("ComputePerpsOpenNotional with omitted margin_per_trade_usd = %g, want 1000 (cash × sizing_leverage)", got)
-	}
-}
-
-func TestLoadConfigHLPerpsDefaultsToIsolatedMargin(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-test-eth",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-	if cfg.Strategies[0].MarginMode != "isolated" {
-		t.Errorf("MarginMode = %q, want %q (default)", cfg.Strategies[0].MarginMode, "isolated")
 	}
 }
 
@@ -1118,144 +859,6 @@ func TestLoadConfigHLPerpsSingleStrategyAutoDerivesStopLoss(t *testing.T) {
 	}
 	if got := EffectiveStopLossPct(sc); got != 0 {
 		t.Errorf("EffectiveStopLossPct = %g, want 0 (deferred until EntryATR is stamped)", got)
-	}
-}
-
-func TestLoadConfigManualDefaultsStopLossATRMultTo2Point0(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-manual-eth-live",
-			"type": "manual",
-			"platform": "hyperliquid",
-			"symbol": "ETH",
-			"timeframe": "1h",
-			"capital": 1000,
-			"leverage": 20,
-			"max_drawdown_pct": 20
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-	sc := cfg.Strategies[0]
-	if sc.StopLossATRMult == nil {
-		t.Fatal("StopLossATRMult = nil, want 2.0 default applied")
-	}
-	if got := *sc.StopLossATRMult; got != defaultManualStopLossATRMult {
-		t.Errorf("StopLossATRMult = %g, want %g", got, defaultManualStopLossATRMult)
-	}
-}
-
-func TestLoadConfigManualOptsOutWhenGlobalDefaultIsZero(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"default_stop_loss_atr_mult": 0,
-		"strategies": [{
-			"id": "hl-manual-eth-live",
-			"type": "manual",
-			"platform": "hyperliquid",
-			"symbol": "ETH",
-			"timeframe": "1h",
-			"capital": 1000,
-			"leverage": 20,
-			"max_drawdown_pct": 20
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-	sc := cfg.Strategies[0]
-	if sc.StopLossATRMult != nil {
-		t.Errorf("StopLossATRMult = %v, want nil (default_stop_loss_atr_mult=0 is the global opt-out)", *sc.StopLossATRMult)
-	}
-}
-
-func TestLoadConfigManualExplicitATRMultPreserved(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-manual-eth-live",
-			"type": "manual",
-			"platform": "hyperliquid",
-			"symbol": "ETH",
-			"timeframe": "1h",
-			"capital": 1000,
-			"leverage": 20,
-			"max_drawdown_pct": 20,
-			"stop_loss_atr_mult": 2.5
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-	sc := cfg.Strategies[0]
-	if sc.StopLossATRMult == nil {
-		t.Fatal("StopLossATRMult = nil, want explicit 2.5 preserved")
-	}
-	if got := *sc.StopLossATRMult; got != 2.5 {
-		t.Errorf("StopLossATRMult = %g, want 2.5 (explicit value)", got)
-	}
-}
-
-func TestLoadConfigManualDefaultsStopLossATRMultOverride(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"user_defaults": {"manual": {"stop_loss_atr_mult": 2.25}},
-		"strategies": [{
-			"id": "hl-manual-eth-live",
-			"type": "manual",
-			"platform": "hyperliquid",
-			"symbol": "ETH",
-			"timeframe": "1h",
-			"capital": 1000,
-			"leverage": 20,
-			"max_drawdown_pct": 20
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-	sc := cfg.Strategies[0]
-	if sc.StopLossATRMult == nil {
-		t.Fatal("StopLossATRMult = nil, want 2.25 from user_defaults.manual")
-	}
-	if got := *sc.StopLossATRMult; got != 2.25 {
-		t.Errorf("StopLossATRMult = %g, want 2.25 (user_defaults.manual override)", got)
-	}
-}
-
-func TestLoadConfigManualDefaultsStopLossATRMultZeroOptsOut(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"user_defaults": {"manual": {"stop_loss_atr_mult": 0}},
-		"strategies": [{
-			"id": "hl-manual-eth-live",
-			"type": "manual",
-			"platform": "hyperliquid",
-			"symbol": "ETH",
-			"timeframe": "1h",
-			"capital": 1000,
-			"leverage": 20,
-			"max_drawdown_pct": 20
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-	sc := cfg.Strategies[0]
-	if sc.StopLossATRMult != nil {
-		t.Errorf("StopLossATRMult = %v, want nil (user_defaults.manual.stop_loss_atr_mult=0 opts manual strategies out)", *sc.StopLossATRMult)
 	}
 }
 
@@ -1501,531 +1104,6 @@ func TestConfigResolveManualRatchetFallbackIgnoresZeroScalarOptOut(t *testing.T)
 	}
 	if got := cfg.resolveManualRatchetFallbackATRMult(); got != defaultManualStopLossATRMult {
 		t.Errorf("resolveManualRatchetFallbackATRMult = %g, want %g no-naked fallback", got, defaultManualStopLossATRMult)
-	}
-}
-
-func TestLoadConfigHLPerpsExplicitCross(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-test-eth",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"margin_mode": "cross"
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-	if cfg.Strategies[0].MarginMode != "cross" {
-		t.Errorf("MarginMode = %q, want %q", cfg.Strategies[0].MarginMode, "cross")
-	}
-}
-
-func TestLoadConfigMarginModeRejectsInvalidValue(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-test-eth",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"margin_mode": "portfolio"
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for margin_mode=portfolio")
-	}
-	if !strings.Contains(err.Error(), "margin_mode must be") {
-		t.Errorf("error = %v, want 'margin_mode must be'", err)
-	}
-}
-
-func TestLoadConfigMarginModeRejectsSpot(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "test-spot",
-			"type": "spot",
-			"script": "shared_scripts/check_strategy.py",
-			"args": ["sma_crossover", "BTC/USDT", "1h"],
-			"capital": 1000,
-			"margin_mode": "isolated"
-		}]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for margin_mode on spot")
-	}
-	if !strings.Contains(err.Error(), "margin_mode is only supported for HL perps") {
-		t.Errorf("error = %v, want 'margin_mode is only supported for HL perps'", err)
-	}
-}
-
-func TestLoadConfigHLPerpsPeersOnSameCoinMatching(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [
-			{
-				"id": "hl-eth-trend",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-				"capital": 1000,
-				"leverage": 5,
-				"margin_mode": "isolated"
-			},
-			{
-				"id": "hl-eth-breakout",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
-				"capital": 500,
-				"leverage": 5,
-				"margin_mode": "isolated"
-			}
-		]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-	if len(cfg.Strategies) != 2 {
-		t.Fatalf("expected 2 strategies, got %d", len(cfg.Strategies))
-	}
-	for _, sc := range cfg.Strategies {
-		if got := EffectiveStopLossPct(sc); got != 0 {
-			t.Errorf("%s EffectiveStopLossPct = %g, want 0 for omitted same-coin peer", sc.ID, got)
-		}
-	}
-}
-
-func TestLoadConfigHLPerpsPeersMismatchedMarginMode(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [
-			{
-				"id": "hl-eth-trend",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-				"capital": 1000,
-				"leverage": 5,
-				"margin_mode": "isolated"
-			},
-			{
-				"id": "hl-eth-breakout",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
-				"capital": 500,
-				"leverage": 5,
-				"margin_mode": "cross"
-			}
-		]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for mismatched margin_mode on peers")
-	}
-	if !strings.Contains(err.Error(), "disagree on margin_mode") {
-		t.Errorf("error = %v, want 'disagree on margin_mode'", err)
-	}
-	if !strings.Contains(err.Error(), "ETH") {
-		t.Errorf("error = %v, want mention of coin ETH", err)
-	}
-}
-
-func TestLoadConfigHLPerpsPeersMismatchedLeverage(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [
-			{
-				"id": "hl-eth-trend",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-				"capital": 1000,
-				"leverage": 5,
-				"margin_mode": "isolated"
-			},
-			{
-				"id": "hl-eth-breakout",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
-				"capital": 500,
-				"leverage": 10,
-				"margin_mode": "isolated"
-			}
-		]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for mismatched leverage on peers")
-	}
-	if !strings.Contains(err.Error(), "disagree on leverage") {
-		t.Errorf("error = %v, want 'disagree on leverage'", err)
-	}
-}
-
-func TestLoadConfigHLPerpsPeersMultipleStopLossAllowed(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [
-			{
-				"id": "hl-eth-trend",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-				"capital": 1000,
-				"leverage": 5,
-				"margin_mode": "isolated",
-				"stop_loss_pct": 3.0
-			},
-			{
-				"id": "hl-eth-breakout",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
-				"capital": 500,
-				"leverage": 5,
-				"margin_mode": "isolated",
-				"stop_loss_pct": 5.0
-			}
-		]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-}
-
-func TestLoadConfigHLPerpsPeersSingleStopLossAllowed(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [
-			{
-				"id": "hl-eth-trend",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-				"capital": 1000,
-				"leverage": 5,
-				"margin_mode": "isolated",
-				"stop_loss_pct": 3.0
-			},
-			{
-				"id": "hl-eth-breakout",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
-				"capital": 500,
-				"leverage": 5,
-				"margin_mode": "isolated"
-			}
-		]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-	got := map[string]float64{}
-	for _, sc := range cfg.Strategies {
-		got[sc.ID] = EffectiveStopLossPct(sc)
-	}
-	if got["hl-eth-trend"] != 3 {
-		t.Errorf("explicit owner EffectiveStopLossPct = %g, want 3", got["hl-eth-trend"])
-	}
-	if got["hl-eth-breakout"] != 0 {
-		t.Errorf("omitted peer EffectiveStopLossPct = %g, want 0", got["hl-eth-breakout"])
-	}
-}
-
-func TestLoadConfigHLPerpsPeersDifferentCoinsIndependent(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [
-			{
-				"id": "hl-eth-trend",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-				"capital": 1000,
-				"leverage": 5,
-				"margin_mode": "isolated"
-			},
-			{
-				"id": "hl-btc-trend",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["sma_crossover", "BTC", "1h", "--mode=paper"],
-				"capital": 1000,
-				"leverage": 10,
-				"margin_mode": "cross"
-			}
-		]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	if _, err := LoadConfig(path); err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-}
-
-func TestLoadConfigHLPerpsPeersNoStopLossAllowed(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [
-			{
-				"id": "hl-eth-trend",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-				"capital": 1000,
-				"leverage": 5,
-				"margin_mode": "isolated",
-				"stop_loss_pct": 0
-			},
-			{
-				"id": "hl-eth-breakout",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
-				"capital": 500,
-				"leverage": 5,
-				"margin_mode": "isolated",
-				"stop_loss_pct": 0
-			}
-		]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	if _, err := LoadConfig(path); err != nil {
-		t.Fatalf("LoadConfig failed for two peers with stop_loss_pct:0: %v", err)
-	}
-}
-
-func TestLoadConfigHLPerpsPeersDefaultedMarginModeMatches(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [
-			{
-				"id": "hl-eth-trend",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-				"capital": 1000,
-				"leverage": 5
-			},
-			{
-				"id": "hl-eth-breakout",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
-				"capital": 500,
-				"leverage": 5,
-				"margin_mode": "isolated"
-			}
-		]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed for defaulted vs explicit margin_mode peers: %v", err)
-	}
-	for _, sc := range cfg.Strategies {
-		if sc.MarginMode != "isolated" {
-			t.Errorf("strategy %s margin_mode = %q, want %q", sc.ID, sc.MarginMode, "isolated")
-		}
-	}
-}
-
-func TestLoadConfigHLPerpsPeersOmittedStopLossDoesNotConflict(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [
-			{
-				"id": "hl-eth-trend",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-				"capital": 1000,
-				"leverage": 5,
-				"margin_mode": "isolated"
-			},
-			{
-				"id": "hl-eth-breakout",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["donchian_breakout", "ETH", "4h", "--mode=paper"],
-				"capital": 500,
-				"leverage": 5,
-				"margin_mode": "isolated"
-			}
-		]
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	cfg, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig failed for omitted same-coin stop_loss_* peers: %v", err)
-	}
-	for _, sc := range cfg.Strategies {
-		if got := EffectiveStopLossPct(sc); got != 0 {
-			t.Errorf("%s EffectiveStopLossPct = %g, want 0", sc.ID, got)
-		}
-	}
-}
-
-func TestConfigValidationDMChannelsInvalidKey(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "t-spot",
-			"type": "spot",
-			"script": "shared_scripts/check_strategy.py",
-			"args": ["sma_crossover", "BTC/USDT", "1h"],
-			"capital": 1000,
-			"max_drawdown_pct": 60
-		}],
-		"discord": {
-			"enabled": false,
-			"channels": {},
-			"dm_channels": { "hyperliquid-paper-extra": "123456789" }
-		}
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for invalid dm_channels key")
-	}
-	if !strings.Contains(err.Error(), "dm_channels key") {
-		t.Errorf("error = %v, want mention of dm_channels key", err)
-	}
-}
-
-func TestConfigValidationDMChannelsEmptyValue(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "t-spot",
-			"type": "spot",
-			"script": "shared_scripts/check_strategy.py",
-			"args": ["sma_crossover", "BTC/USDT", "1h"],
-			"capital": 1000,
-			"max_drawdown_pct": 60
-		}],
-		"discord": {
-			"enabled": false,
-			"channels": {},
-			"dm_channels": { "hyperliquid-paper": "" }
-		}
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for empty dm_channels value")
-	}
-	if !strings.Contains(err.Error(), "dm_channels[\"hyperliquid-paper\"]") {
-		t.Errorf("error = %v", err)
-	}
-}
-
-func TestConfigValidationDMChannelsValidKeys(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-test",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "BTC", "1h", "--mode=paper"],
-			"capital": 1000,
-			"max_drawdown_pct": 50
-		}],
-		"discord": {
-			"enabled": false,
-			"channels": {},
-			"dm_channels": {
-				"hyperliquid": "111",
-				"hyperliquid-paper": "222",
-				"deribit": "333"
-			}
-		},
-		"telegram": {
-			"enabled": false,
-			"channels": {},
-			"dm_channels": { "okx-paper": "444" }
-		}
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	loaded, err := LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig: %v", err)
-	}
-	if loaded.Discord.DMChannels["hyperliquid"] != "111" || loaded.Discord.DMChannels["hyperliquid-paper"] != "222" {
-		t.Errorf("discord dm_channels mismatch: %#v", loaded.Discord.DMChannels)
-	}
-	if loaded.Telegram.DMChannels["okx-paper"] != "444" {
-		t.Errorf("telegram dm_channels mismatch: %#v", loaded.Telegram.DMChannels)
-	}
-}
-
-func TestConfigValidationDMChannelsOrphanSuffix(t *testing.T) {
-	dir := t.TempDir()
-	cfgJSON := `{
-		"strategies": [{
-			"id": "t-spot",
-			"type": "spot",
-			"script": "shared_scripts/check_strategy.py",
-			"args": ["sma_crossover", "BTC/USDT", "1h"],
-			"capital": 1000,
-			"max_drawdown_pct": 60
-		}],
-		"discord": {
-			"enabled": false,
-			"channels": {},
-			"dm_channels": { "-paper": "123" }
-		}
-	}`
-	path := writeTestConfig(t, dir, cfgJSON)
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("expected validation error for orphan -paper key")
-	}
-	if !strings.Contains(err.Error(), "platform prefix is empty") {
-		t.Errorf("error = %v, want mention of empty platform prefix", err)
 	}
 }
 
@@ -2328,72 +1406,6 @@ func TestConfigValidationManualSymbolSharingAllowed(t *testing.T) {
 				t.Fatalf("expected no error, got: %v", err)
 			}
 		})
-	}
-}
-
-func TestConfigValidationManualPerpsPeerLeverageMismatchRejected(t *testing.T) {
-	cfg := Config{
-		Strategies: []StrategyConfig{
-			{
-				ID:             "hl-manual-eth",
-				Type:           "manual",
-				Platform:       "hyperliquid",
-				Symbol:         "ETH",
-				Timeframe:      "1h",
-				Leverage:       10,
-				Capital:        1000,
-				MaxDrawdownPct: 60,
-			},
-			{
-				ID:             "hl-perps-eth-live",
-				Type:           "perps",
-				Platform:       "hyperliquid",
-				Script:         "shared_scripts/check_hyperliquid.py",
-				Args:           []string{"sma_crossover", "ETH", "1h", "--mode=paper"},
-				Capital:        1000,
-				Leverage:       5,
-				MaxDrawdownPct: 60,
-			},
-		},
-		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
-	}
-	err := validateConfig(&cfg, false)
-	if err == nil || !strings.Contains(err.Error(), "disagree on leverage") {
-		t.Fatalf("expected leverage peer error, got: %v", err)
-	}
-}
-
-func TestConfigValidationManualPerpsPeerMarginModeMismatchRejected(t *testing.T) {
-	cfg := Config{
-		Strategies: []StrategyConfig{
-			{
-				ID:             "hl-manual-eth",
-				Type:           "manual",
-				Platform:       "hyperliquid",
-				Symbol:         "ETH",
-				Timeframe:      "1h",
-				Leverage:       5,
-				MarginMode:     "isolated",
-				Capital:        1000,
-				MaxDrawdownPct: 60,
-			},
-			{
-				ID:             "hl-perps-eth-live",
-				Type:           "perps",
-				Platform:       "hyperliquid",
-				Script:         "shared_scripts/check_hyperliquid.py",
-				Args:           []string{"sma_crossover", "ETH", "1h", "--mode=paper"},
-				Capital:        1000,
-				Leverage:       5,
-				MarginMode:     "cross",
-				MaxDrawdownPct: 60,
-			},
-		},
-		PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
-	}
-	err := validateConfig(&cfg, false)
-	if err == nil || !strings.Contains(err.Error(), "disagree on margin_mode") {
-		t.Fatalf("expected margin_mode peer error, got: %v", err)
 	}
 }
 
@@ -2809,5 +1821,338 @@ func TestStrategyNotifyRatchetTriggersEnabled_TwoLayerResolve(t *testing.T) {
 		if got := c.sc.NotifyRatchetTriggersEnabled(c.cfg); got != c.expected {
 			t.Errorf("%s: got %v, want %v", c.name, got, c.expected)
 		}
+	}
+}
+
+const testSpotStrategyHead = `"id": "test-spot", "type": "spot", "script": "shared_scripts/check_strategy.py", "args": ["sma_crossover", "BTC/USDT", "1h"], "capital": 1000`
+
+const testHLPerpsStrategyHead = `"id": "hl-test-eth", "type": "perps", "platform": "hyperliquid", "script": "shared_scripts/check_hyperliquid.py", "args": ["sma_crossover", "ETH", "1h", "--mode=paper"], "capital": 1000`
+
+func TestLoadConfigPerpsSizingFieldRejections(t *testing.T) {
+	cases := []struct {
+		name    string
+		head    string
+		extra   string
+		wantErr string
+	}{
+		{"leverage on spot", testSpotStrategyHead, `"leverage": 5`, "leverage is only supported for perps"},
+		{"leverage out of range", testHLPerpsStrategyHead, `"leverage": 150`, "leverage must be in"},
+		{"sizing_leverage on spot", testSpotStrategyHead, `"sizing_leverage": 2`, "sizing_leverage is only supported for perps"},
+		{"sizing_leverage out of range", testHLPerpsStrategyHead, `"leverage": 20, "sizing_leverage": 200`, "sizing_leverage must be in"},
+		{"margin_per_trade_usd on spot", testSpotStrategyHead, `"margin_per_trade_usd": 100`, "margin_per_trade_usd is only supported for perps"},
+		{"margin_per_trade_usd zero", testHLPerpsStrategyHead, `"leverage": 20, "margin_per_trade_usd": 0`, "margin_per_trade_usd must be positive"},
+		{"margin_mode invalid value", testHLPerpsStrategyHead, `"margin_mode": "portfolio"`, "margin_mode must be"},
+		{"margin_mode on spot", testSpotStrategyHead, `"margin_mode": "isolated"`, "margin_mode is only supported for HL perps"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTestConfig(t, t.TempDir(), `{"strategies": [{`+tc.head+`, `+tc.extra+`}]}`)
+			_, err := LoadConfig(path)
+			if err == nil {
+				t.Fatalf("expected validation error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadConfigPerpsSizingFieldsAccepted(t *testing.T) {
+	cases := []struct {
+		name  string
+		extra string
+		check func(t *testing.T, sc StrategyConfig)
+	}{
+		{"leverage defaults to 1", ``, func(t *testing.T, sc StrategyConfig) {
+			if sc.Leverage != 1 {
+				t.Errorf("Leverage = %g, want 1 (default)", sc.Leverage)
+			}
+		}},
+		{"explicit leverage also seeds sizing_leverage", `"leverage": 10`, func(t *testing.T, sc StrategyConfig) {
+			if sc.Leverage != 10 {
+				t.Errorf("Leverage = %g, want 10", sc.Leverage)
+			}
+			if sc.SizingLeverage != 10 {
+				t.Errorf("SizingLeverage = %g, want 10 (defaults to leverage)", sc.SizingLeverage)
+			}
+		}},
+		{"explicit sizing_leverage splits exchange and sizing leverage", `"leverage": 20, "sizing_leverage": 2`, func(t *testing.T, sc StrategyConfig) {
+			if got := EffectiveExchangeLeverage(sc); got != 20 {
+				t.Errorf("EffectiveExchangeLeverage = %g, want 20", got)
+			}
+			if got := EffectiveSizingLeverage(sc); got != 2 {
+				t.Errorf("EffectiveSizingLeverage = %g, want 2", got)
+			}
+		}},
+		{"fractional sizing_leverage accepted", `"leverage": 20, "sizing_leverage": 0.5`, func(t *testing.T, sc StrategyConfig) {
+			if sc.SizingLeverage != 0.5 {
+				t.Errorf("SizingLeverage = %g, want 0.5", sc.SizingLeverage)
+			}
+		}},
+		{"margin_mode defaults to isolated", ``, func(t *testing.T, sc StrategyConfig) {
+			if sc.MarginMode != "isolated" {
+				t.Errorf("MarginMode = %q, want %q (default)", sc.MarginMode, "isolated")
+			}
+		}},
+		{"explicit cross margin_mode preserved", `"margin_mode": "cross"`, func(t *testing.T, sc StrategyConfig) {
+			if sc.MarginMode != "cross" {
+				t.Errorf("MarginMode = %q, want %q", sc.MarginMode, "cross")
+			}
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"strategies": [{` + testHLPerpsStrategyHead
+			if tc.extra != "" {
+				body += `, ` + tc.extra
+			}
+			body += `}]}`
+			cfg, err := LoadConfig(writeTestConfig(t, t.TempDir(), body))
+			if err != nil {
+				t.Fatalf("LoadConfig failed: %v", err)
+			}
+			tc.check(t, cfg.Strategies[0])
+		})
+	}
+}
+
+const testHLManualStrategyHead = `"id": "hl-manual-eth-live", "type": "manual", "platform": "hyperliquid", "symbol": "ETH", "timeframe": "1h", "capital": 1000, "leverage": 20, "max_drawdown_pct": 20`
+
+func TestLoadConfigManualStopLossATRMultResolution(t *testing.T) {
+	want := func(v float64) *float64 { return &v }
+	cases := []struct {
+		name     string
+		topLevel string
+		extra    string
+		want     *float64
+	}{
+		{"default_stop_loss_atr_mult=0 is the global opt-out", `"default_stop_loss_atr_mult": 0,`, ``, nil},
+		{"explicit stop_loss_atr_mult preserved", ``, `, "stop_loss_atr_mult": 2.5`, want(2.5)},
+		{"user_defaults.manual override applied", `"user_defaults": {"manual": {"stop_loss_atr_mult": 2.25}},`, ``, want(2.25)},
+		{"user_defaults.manual zero opts manual out", `"user_defaults": {"manual": {"stop_loss_atr_mult": 0}},`, ``, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{` + tc.topLevel + `"strategies": [{` + testHLManualStrategyHead + tc.extra + `}]}`
+			cfg, err := LoadConfig(writeTestConfig(t, t.TempDir(), body))
+			if err != nil {
+				t.Fatalf("LoadConfig failed: %v", err)
+			}
+			got := cfg.Strategies[0].StopLossATRMult
+			switch {
+			case tc.want == nil && got != nil:
+				t.Errorf("StopLossATRMult = %v, want nil", *got)
+			case tc.want != nil && got == nil:
+				t.Fatalf("StopLossATRMult = nil, want %g", *tc.want)
+			case tc.want != nil && *got != *tc.want:
+				t.Errorf("StopLossATRMult = %g, want %g", *got, *tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadConfigHLPerpsPeers(t *testing.T) {
+	peer := func(id, strat, coin, tf string, capital int, extra string) string {
+		return `{"id": "` + id + `", "type": "perps", "platform": "hyperliquid", "script": "shared_scripts/check_hyperliquid.py", "args": ["` + strat + `", "` + coin + `", "` + tf + `", "--mode=paper"], "capital": ` + itoa(capital) + extra + `}`
+	}
+	trend := func(extra string) string { return peer("hl-eth-trend", "sma_crossover", "ETH", "1h", 1000, extra) }
+	breakout := func(extra string) string {
+		return peer("hl-eth-breakout", "donchian_breakout", "ETH", "4h", 500, extra)
+	}
+	stopPcts := func(t *testing.T, cfg *Config) map[string]float64 {
+		got := map[string]float64{}
+		for _, sc := range cfg.Strategies {
+			got[sc.ID] = EffectiveStopLossPct(sc)
+		}
+		return got
+	}
+	cases := []struct {
+		name     string
+		peers    []string
+		wantErrs []string
+		check    func(t *testing.T, cfg *Config)
+	}{
+		{
+			name:  "omitted stop_loss_* on both same-coin peers does not conflict",
+			peers: []string{trend(`, "leverage": 5, "margin_mode": "isolated"`), breakout(`, "leverage": 5, "margin_mode": "isolated"`)},
+			check: func(t *testing.T, cfg *Config) {
+				if len(cfg.Strategies) != 2 {
+					t.Fatalf("expected 2 strategies, got %d", len(cfg.Strategies))
+				}
+				for id, got := range stopPcts(t, cfg) {
+					if got != 0 {
+						t.Errorf("%s EffectiveStopLossPct = %g, want 0 for omitted same-coin peer", id, got)
+					}
+				}
+			},
+		},
+		{
+			name:     "mismatched margin_mode rejected naming the coin",
+			peers:    []string{trend(`, "leverage": 5, "margin_mode": "isolated"`), breakout(`, "leverage": 5, "margin_mode": "cross"`)},
+			wantErrs: []string{"disagree on margin_mode", "ETH"},
+		},
+		{
+			name:     "mismatched leverage rejected",
+			peers:    []string{trend(`, "leverage": 5, "margin_mode": "isolated"`), breakout(`, "leverage": 10, "margin_mode": "isolated"`)},
+			wantErrs: []string{"disagree on leverage"},
+		},
+		{
+			name:  "multiple stop_loss_pct owners allowed",
+			peers: []string{trend(`, "leverage": 5, "margin_mode": "isolated", "stop_loss_pct": 3.0`), breakout(`, "leverage": 5, "margin_mode": "isolated", "stop_loss_pct": 5.0`)},
+		},
+		{
+			name:  "single stop_loss_pct owner keeps its stop; omitted peer stays 0",
+			peers: []string{trend(`, "leverage": 5, "margin_mode": "isolated", "stop_loss_pct": 3.0`), breakout(`, "leverage": 5, "margin_mode": "isolated"`)},
+			check: func(t *testing.T, cfg *Config) {
+				got := stopPcts(t, cfg)
+				if got["hl-eth-trend"] != 3 {
+					t.Errorf("explicit owner EffectiveStopLossPct = %g, want 3", got["hl-eth-trend"])
+				}
+				if got["hl-eth-breakout"] != 0 {
+					t.Errorf("omitted peer EffectiveStopLossPct = %g, want 0", got["hl-eth-breakout"])
+				}
+			},
+		},
+		{
+			name:  "different coins are independent",
+			peers: []string{trend(`, "leverage": 5, "margin_mode": "isolated"`), peer("hl-btc-trend", "sma_crossover", "BTC", "1h", 1000, `, "leverage": 10, "margin_mode": "cross"`)},
+		},
+		{
+			name:  "stop_loss_pct 0 on both peers allowed",
+			peers: []string{trend(`, "leverage": 5, "margin_mode": "isolated", "stop_loss_pct": 0`), breakout(`, "leverage": 5, "margin_mode": "isolated", "stop_loss_pct": 0`)},
+		},
+		{
+			name:  "defaulted margin_mode matches explicit isolated peer",
+			peers: []string{trend(`, "leverage": 5`), breakout(`, "leverage": 5, "margin_mode": "isolated"`)},
+			check: func(t *testing.T, cfg *Config) {
+				for _, sc := range cfg.Strategies {
+					if sc.MarginMode != "isolated" {
+						t.Errorf("strategy %s margin_mode = %q, want %q", sc.ID, sc.MarginMode, "isolated")
+					}
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTestConfig(t, t.TempDir(), `{"strategies": [`+strings.Join(tc.peers, ",")+`]}`)
+			cfg, err := LoadConfig(path)
+			if len(tc.wantErrs) > 0 {
+				if err == nil {
+					t.Fatalf("expected validation error for %s", tc.name)
+				}
+				for _, w := range tc.wantErrs {
+					if !strings.Contains(err.Error(), w) {
+						t.Errorf("error = %v, want %q", err, w)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadConfig failed: %v", err)
+			}
+			if tc.check != nil {
+				tc.check(t, cfg)
+			}
+		})
+	}
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }
+
+func TestConfigValidationDMChannels(t *testing.T) {
+	spotStrategies := `"strategies": [{"id": "t-spot", "type": "spot", "script": "shared_scripts/check_strategy.py", "args": ["sma_crossover", "BTC/USDT", "1h"], "capital": 1000, "max_drawdown_pct": 60}]`
+	cases := []struct {
+		name    string
+		body    string
+		wantErr string
+		check   func(t *testing.T, cfg *Config)
+	}{
+		{
+			name:    "invalid key rejected",
+			body:    `{` + spotStrategies + `, "discord": {"enabled": false, "channels": {}, "dm_channels": {"hyperliquid-paper-extra": "123456789"}}}`,
+			wantErr: "dm_channels key",
+		},
+		{
+			name:    "empty value rejected",
+			body:    `{` + spotStrategies + `, "discord": {"enabled": false, "channels": {}, "dm_channels": {"hyperliquid-paper": ""}}}`,
+			wantErr: `dm_channels["hyperliquid-paper"]`,
+		},
+		{
+			name:    "orphan -paper suffix rejected",
+			body:    `{` + spotStrategies + `, "discord": {"enabled": false, "channels": {}, "dm_channels": {"-paper": "123"}}}`,
+			wantErr: "platform prefix is empty",
+		},
+		{
+			name: "valid keys load on discord and telegram",
+			body: `{
+				"strategies": [{"id": "hl-test", "type": "perps", "platform": "hyperliquid", "script": "shared_scripts/check_hyperliquid.py", "args": ["sma_crossover", "BTC", "1h", "--mode=paper"], "capital": 1000, "max_drawdown_pct": 50}],
+				"discord": {"enabled": false, "channels": {}, "dm_channels": {"hyperliquid": "111", "hyperliquid-paper": "222", "deribit": "333"}},
+				"telegram": {"enabled": false, "channels": {}, "dm_channels": {"okx-paper": "444"}}
+			}`,
+			check: func(t *testing.T, cfg *Config) {
+				if cfg.Discord.DMChannels["hyperliquid"] != "111" || cfg.Discord.DMChannels["hyperliquid-paper"] != "222" {
+					t.Errorf("discord dm_channels mismatch: %#v", cfg.Discord.DMChannels)
+				}
+				if cfg.Telegram.DMChannels["okx-paper"] != "444" {
+					t.Errorf("telegram dm_channels mismatch: %#v", cfg.Telegram.DMChannels)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := LoadConfig(writeTestConfig(t, t.TempDir(), tc.body))
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected validation error for %s", tc.name)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error = %v, want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			tc.check(t, cfg)
+		})
+	}
+}
+
+func TestConfigValidationManualPerpsPeerMismatchRejected(t *testing.T) {
+	cases := []struct {
+		name       string
+		manualLev  float64
+		manualMode string
+		perpsLev   float64
+		perpsMode  string
+		wantErr    string
+	}{
+		{"leverage mismatch", 10, "", 5, "", "disagree on leverage"},
+		{"margin_mode mismatch", 5, "isolated", 5, "cross", "disagree on margin_mode"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{
+				Strategies: []StrategyConfig{
+					{
+						ID: "hl-manual-eth", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Timeframe: "1h",
+						Leverage: tc.manualLev, MarginMode: tc.manualMode, Capital: 1000, MaxDrawdownPct: 60,
+					},
+					{
+						ID: "hl-perps-eth-live", Type: "perps", Platform: "hyperliquid",
+						Script: "shared_scripts/check_hyperliquid.py", Args: []string{"sma_crossover", "ETH", "1h", "--mode=paper"},
+						Capital: 1000, Leverage: tc.perpsLev, MarginMode: tc.perpsMode, MaxDrawdownPct: 60,
+					},
+				},
+				PortfolioRisk: &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80},
+			}
+			err := validateConfig(&cfg, false)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected %q peer error, got: %v", tc.wantErr, err)
+			}
+		})
 	}
 }

--- a/scheduler/config_unknown_keys_test.go
+++ b/scheduler/config_unknown_keys_test.go
@@ -20,37 +20,12 @@ func TestKnownStrategyConfigKeysCoversCoreFields(t *testing.T) {
 		"stop_loss_pct", "stop_loss_margin_pct",
 		"trailing_stop_pct", "trailing_stop_atr_mult", "stop_loss_atr_mult",
 		"trailing_stop_min_move_pct", "margin_mode",
-		"theta_harvest", "futures",
+		"theta_harvest", "futures", "circuit_breaker",
 	}
 	for _, k := range mustHave {
 		if !known[k] {
 			t.Errorf("knownStrategyConfigKeys missing %q — did a StrategyConfig json tag get renamed?", k)
 		}
-	}
-}
-
-func TestValidateStrategyJSONKeysFlagsInventedTPField(t *testing.T) {
-	raw := []byte(`{
-		"strategies": [
-			{
-				"id": "hl-momentum-btc",
-				"type": "perps",
-				"platform": "hyperliquid",
-				"script": "shared_scripts/check_hyperliquid.py",
-				"args": ["momentum", "BTC", "1h"],
-				"take_profit_atr_mult": 2.0
-			}
-		]
-	}`)
-	errs := validateStrategyJSONKeys(raw)
-	if len(errs) != 1 {
-		t.Fatalf("want 1 error for invented field, got %d: %v", len(errs), errs)
-	}
-	if !strings.Contains(errs[0], `strategy[hl-momentum-btc]: unknown field "take_profit_atr_mult"`) {
-		t.Errorf("error missing strategy id + field name: %q", errs[0])
-	}
-	if !strings.Contains(errs[0], "close_strategy") {
-		t.Errorf("error missing TP-field hint pointing operator to close_strategy: %q", errs[0])
 	}
 }
 
@@ -63,30 +38,6 @@ func TestValidateStrategyJSONKeysAcceptsBothCloseSpellings(t *testing.T) {
 	}`)
 	if errs := validateStrategyJSONKeys(raw); len(errs) != 0 {
 		t.Fatalf("want no unknown-field errors for either close spelling, got %v", errs)
-	}
-}
-
-func TestValidateStrategyJSONKeysHintsLegacyParams(t *testing.T) {
-	raw := []byte(`{
-		"strategies": [
-			{"id": "s1", "type": "spot", "script": "x.py", "args": [], "params": {"foo": 1}}
-		]
-	}`)
-	errs := validateStrategyJSONKeys(raw)
-	if len(errs) != 1 || !strings.Contains(errs[0], "open_strategy: {name, params}") {
-		t.Fatalf("want legacy params hint, got %v", errs)
-	}
-}
-
-func TestValidateStrategyJSONKeysHintsStopLossTypos(t *testing.T) {
-	raw := []byte(`{
-		"strategies": [
-			{"id": "s1", "type": "perps", "script": "x.py", "args": [], "stop_loss_atr_multiple": 1.5}
-		]
-	}`)
-	errs := validateStrategyJSONKeys(raw)
-	if len(errs) != 1 || !strings.Contains(errs[0], "valid SL fields") {
-		t.Fatalf("want SL hint for misspelled stop_loss_atr_multiple, got %v", errs)
 	}
 }
 
@@ -118,12 +69,6 @@ func TestValidateStrategyJSONKeysAcceptsAllKnownFields(t *testing.T) {
 	}
 }
 
-func TestKnownStrategyConfigKeysIncludesCircuitBreaker(t *testing.T) {
-	if !knownStrategyConfigKeys()["circuit_breaker"] {
-		t.Fatal("circuit_breaker should be a known strategy config key")
-	}
-}
-
 func TestValidateStrategyJSONKeysIgnoresTopLevelKeys(t *testing.T) {
 	raw := []byte(`{
 		"some_top_level_unknown": true,
@@ -131,38 +76,6 @@ func TestValidateStrategyJSONKeysIgnoresTopLevelKeys(t *testing.T) {
 	}`)
 	if errs := validateStrategyJSONKeys(raw); len(errs) != 0 {
 		t.Fatalf("unknown top-level keys should not be flagged here (only strategy fields), got: %v", errs)
-	}
-}
-
-func TestValidateUserDefaultsJSONKeysFlagsUnknownSibling(t *testing.T) {
-	raw := []byte(`{
-		"user_defaults": {
-			"manaul": {"stop_loss_atr_mult": 2.25}
-		},
-		"strategies": [{"id": "s1", "type": "spot", "script": "x.py", "args": []}]
-	}`)
-	errs := validateUserDefaultsJSONKeys(raw)
-	if len(errs) != 1 {
-		t.Fatalf("want 1 error for typo'd user_defaults sibling, got %d: %v", len(errs), errs)
-	}
-	if !strings.Contains(errs[0], `user_defaults: unknown field "manaul"`) {
-		t.Fatalf("unexpected error: %v", errs)
-	}
-}
-
-func TestValidateUserDefaultsJSONKeysFlagsUnknownManualLeaf(t *testing.T) {
-	raw := []byte(`{
-		"user_defaults": {
-			"manual": {"margin": 125}
-		},
-		"strategies": [{"id": "s1", "type": "spot", "script": "x.py", "args": []}]
-	}`)
-	errs := validateUserDefaultsJSONKeys(raw)
-	if len(errs) != 1 {
-		t.Fatalf("want 1 error for typo'd manual leaf, got %d: %v", len(errs), errs)
-	}
-	if !strings.Contains(errs[0], `user_defaults.manual: unknown field "margin"`) {
-		t.Fatalf("unexpected error: %v", errs)
 	}
 }
 
@@ -250,70 +163,6 @@ func TestLoadConfigRejectsUnknownStrategyKey(t *testing.T) {
 	}
 }
 
-func TestLoadConfigRejectsUnknownUserDefaultsManualLeaf(t *testing.T) {
-	tmp := t.TempDir()
-	path := filepath.Join(tmp, "config.json")
-	body := `{
-		"config_version": 16,
-		"db_file": "` + filepath.Join(tmp, "state.db") + `",
-		"user_defaults": {"manual": {"stop_loss_atr_mlt": 2.25}},
-		"strategies": [
-			{
-				"id": "hl-manual-eth-live",
-				"type": "manual",
-				"platform": "hyperliquid",
-				"symbol": "ETH",
-				"timeframe": "1h",
-				"capital": 1000,
-				"max_drawdown_pct": 20,
-				"leverage": 20
-			}
-		]
-	}`
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("LoadConfig accepted unknown user_defaults.manual field")
-	}
-	if !strings.Contains(err.Error(), `user_defaults.manual: unknown field "stop_loss_atr_mlt"`) {
-		t.Errorf("error %q does not name the unknown user_defaults manual field", err)
-	}
-}
-
-func TestLoadConfigRejectsUnknownUserDefaultsSibling(t *testing.T) {
-	tmp := t.TempDir()
-	path := filepath.Join(tmp, "config.json")
-	body := `{
-		"config_version": 16,
-		"db_file": "` + filepath.Join(tmp, "state.db") + `",
-		"user_defaults": {"manaul": {"stop_loss_atr_mult": 2.25}},
-		"strategies": [
-			{
-				"id": "hl-manual-eth-live",
-				"type": "manual",
-				"platform": "hyperliquid",
-				"symbol": "ETH",
-				"timeframe": "1h",
-				"capital": 1000,
-				"max_drawdown_pct": 20,
-				"leverage": 20
-			}
-		]
-	}`
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	_, err := LoadConfig(path)
-	if err == nil {
-		t.Fatal("LoadConfig accepted unknown user_defaults sibling")
-	}
-	if !strings.Contains(err.Error(), `user_defaults: unknown field "manaul"`) {
-		t.Errorf("error %q does not name the unknown user_defaults sibling", err)
-	}
-}
-
 func TestLoadConfigMigratesLegacyManualDefaultsBeforeUnknownKeyValidation(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "config.json")
@@ -344,5 +193,98 @@ func TestLoadConfigMigratesLegacyManualDefaultsBeforeUnknownKeyValidation(t *tes
 	sc := cfg.Strategies[0]
 	if sc.StopLossATRMult == nil || *sc.StopLossATRMult != 2.25 {
 		t.Fatalf("StopLossATRMult = %v, want migrated legacy alias value 2.25", sc.StopLossATRMult)
+	}
+}
+
+func TestValidateStrategyJSONKeysUnknownFieldHints(t *testing.T) {
+	cases := []struct {
+		name     string
+		strategy string
+		wantSubs []string
+	}{
+		{
+			name:     "invented TP field names strategy id, field, and close_strategy hint",
+			strategy: `{"id": "hl-momentum-btc", "type": "perps", "platform": "hyperliquid", "script": "shared_scripts/check_hyperliquid.py", "args": ["momentum", "BTC", "1h"], "take_profit_atr_mult": 2.0}`,
+			wantSubs: []string{`strategy[hl-momentum-btc]: unknown field "take_profit_atr_mult"`, "close_strategy"},
+		},
+		{
+			name:     "legacy params hints open_strategy shape",
+			strategy: `{"id": "s1", "type": "spot", "script": "x.py", "args": [], "params": {"foo": 1}}`,
+			wantSubs: []string{"open_strategy: {name, params}"},
+		},
+		{
+			name:     "misspelled stop_loss_atr_multiple hints valid SL fields",
+			strategy: `{"id": "s1", "type": "perps", "script": "x.py", "args": [], "stop_loss_atr_multiple": 1.5}`,
+			wantSubs: []string{"valid SL fields"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateStrategyJSONKeys([]byte(`{"strategies": [` + tc.strategy + `]}`))
+			if len(errs) != 1 {
+				t.Fatalf("want 1 error, got %d: %v", len(errs), errs)
+			}
+			for _, w := range tc.wantSubs {
+				if !strings.Contains(errs[0], w) {
+					t.Errorf("error %q missing %q", errs[0], w)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateUserDefaultsJSONKeysFlagsUnknownKeys(t *testing.T) {
+	cases := []struct {
+		name         string
+		userDefaults string
+		wantErr      string
+	}{
+		{"typo'd sibling", `{"manaul": {"stop_loss_atr_mult": 2.25}}`, `user_defaults: unknown field "manaul"`},
+		{"typo'd manual leaf", `{"manual": {"margin": 125}}`, `user_defaults.manual: unknown field "margin"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := []byte(`{"user_defaults": ` + tc.userDefaults + `, "strategies": [{"id": "s1", "type": "spot", "script": "x.py", "args": []}]}`)
+			errs := validateUserDefaultsJSONKeys(raw)
+			if len(errs) != 1 {
+				t.Fatalf("want 1 error, got %d: %v", len(errs), errs)
+			}
+			if !strings.Contains(errs[0], tc.wantErr) {
+				t.Fatalf("unexpected error: %v", errs)
+			}
+		})
+	}
+}
+
+func TestLoadConfigRejectsUnknownUserDefaultsKeys(t *testing.T) {
+	cases := []struct {
+		name         string
+		userDefaults string
+		wantErr      string
+	}{
+		{"manual leaf", `{"manual": {"stop_loss_atr_mlt": 2.25}}`, `user_defaults.manual: unknown field "stop_loss_atr_mlt"`},
+		{"sibling", `{"manaul": {"stop_loss_atr_mult": 2.25}}`, `user_defaults: unknown field "manaul"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			path := filepath.Join(tmp, "config.json")
+			body := `{
+				"config_version": 16,
+				"db_file": "` + filepath.Join(tmp, "state.db") + `",
+				"user_defaults": ` + tc.userDefaults + `,
+				"strategies": [{"id": "hl-manual-eth-live", "type": "manual", "platform": "hyperliquid", "symbol": "ETH", "timeframe": "1h", "capital": 1000, "max_drawdown_pct": 20, "leverage": 20}]
+			}`
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := LoadConfig(path)
+			if err == nil {
+				t.Fatalf("LoadConfig accepted unknown user_defaults %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not name the unknown user_defaults %s", err, tc.name)
+			}
+		})
 	}
 }

--- a/scheduler/daily_loss_test.go
+++ b/scheduler/daily_loss_test.go
@@ -16,168 +16,146 @@ func dlState(id string, initialCapital, dailyPnL float64, date string) *Strategy
 
 func dlToday() string { return time.Now().UTC().Format("2006-01-02") }
 
-func TestEvaluateDailyLossLimitUnconfigured(t *testing.T) {
-	states := map[string]*StrategyState{
-		"a": dlState("a", 1000, -900, dlToday()),
-	}
-	st := evaluateDailyLossLimit(&PortfolioRiskConfig{MaxDrawdownPct: 25}, states, nil, time.Now().UTC())
-	if st.Configured || st.Tripped {
-		t.Fatalf("unconfigured limit must never trip: %+v", st)
-	}
-	if st.LossUSD != 900 {
-		t.Fatalf("LossUSD = %g, want 900", st.LossUSD)
-	}
-	st = evaluateDailyLossLimit(nil, states, nil, time.Now().UTC())
-	if st.Configured || st.Tripped {
-		t.Fatalf("nil portfolio risk must never trip: %+v", st)
-	}
-}
+func dlBool(v bool) *bool { return &v }
 
-func TestEvaluateDailyLossLimitUSDThreshold(t *testing.T) {
-	pr := &PortfolioRiskConfig{DailyMaxLossUSD: 500}
+func TestEvaluateDailyLossLimit(t *testing.T) {
 	now := time.Now().UTC()
-
-	below := map[string]*StrategyState{"a": dlState("a", 0, -499.99, dlToday())}
-	if st := evaluateDailyLossLimit(pr, below, nil, now); st.Tripped {
-		t.Fatalf("loss below threshold must not trip: %+v", st)
+	today := dlToday()
+	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
+	cases := []struct {
+		name         string
+		pr           *PortfolioRiskConfig
+		states       map[string]*StrategyState
+		strategies   []StrategyConfig
+		tripped      bool
+		configured   *bool
+		lossUSD      *float64
+		thresholdUSD *float64
+		capitalBasis *float64
+		pctBasisMiss *bool
+	}{
+		{name: "unconfigured/max_drawdown_only_never_trips",
+			pr:         &PortfolioRiskConfig{MaxDrawdownPct: 25},
+			states:     map[string]*StrategyState{"a": dlState("a", 1000, -900, today)},
+			configured: dlBool(false), lossUSD: fp(900)},
+		{name: "unconfigured/nil_portfolio_risk_never_trips",
+			pr:         nil,
+			states:     map[string]*StrategyState{"a": dlState("a", 1000, -900, today)},
+			configured: dlBool(false)},
+		{name: "usd/below_threshold_not_tripped",
+			pr:     &PortfolioRiskConfig{DailyMaxLossUSD: 500},
+			states: map[string]*StrategyState{"a": dlState("a", 0, -499.99, today)}},
+		{name: "usd/at_threshold_trips",
+			pr:      &PortfolioRiskConfig{DailyMaxLossUSD: 500},
+			states:  map[string]*StrategyState{"a": dlState("a", 0, -500, today)},
+			tripped: true},
+		{name: "usd/multi_strategy_aggregate",
+			pr: &PortfolioRiskConfig{DailyMaxLossUSD: 500},
+			states: map[string]*StrategyState{
+				"a": dlState("a", 0, -300, today),
+				"b": dlState("b", 0, -250, today),
+			},
+			tripped: true, lossUSD: fp(550), thresholdUSD: fp(500)},
+		{name: "pct/basis_sums_initial_capital",
+			pr: &PortfolioRiskConfig{DailyMaxLossPct: 5},
+			states: map[string]*StrategyState{
+				"a": dlState("a", 2000, -100, today),
+				"b": dlState("b", 3000, -160, today),
+			},
+			tripped: true, capitalBasis: fp(5000), thresholdUSD: fp(250)},
+		{name: "pct/under_threshold_not_tripped",
+			pr: &PortfolioRiskConfig{DailyMaxLossPct: 5},
+			states: map[string]*StrategyState{
+				"a": dlState("a", 2000, -100, today),
+				"b": dlState("b", 3000, -140, today),
+			}},
+		{name: "pct_basis/excludes_shared_wallet_pool",
+			pr: &PortfolioRiskConfig{DailyMaxLossPct: 5},
+			states: map[string]*StrategyState{
+				"pool-a":    dlState("pool-a", 1000, -100, today),
+				"allocated": dlState("allocated", 2000, -20, today),
+			},
+			strategies: []StrategyConfig{{ID: "pool-a", sharedWalletPoolBudget: true}, {ID: "allocated"}},
+			tripped:    true, capitalBasis: fp(2000), thresholdUSD: fp(100)},
+		{name: "pct_basis/all_pool_surfaces_basis_miss",
+			pr:           &PortfolioRiskConfig{DailyMaxLossPct: 5},
+			states:       map[string]*StrategyState{"pool-a": dlState("pool-a", 1000, -100, today)},
+			strategies:   []StrategyConfig{{ID: "pool-a", sharedWalletPoolBudget: true}},
+			capitalBasis: fp(0), pctBasisMiss: dlBool(true)},
+		{name: "both_arms/usd_lower_wins",
+			pr:      &PortfolioRiskConfig{DailyMaxLossUSD: 400, DailyMaxLossPct: 5},
+			states:  map[string]*StrategyState{"a": dlState("a", 20000, -450, today)},
+			tripped: true, thresholdUSD: fp(400)},
+		{name: "both_arms/pct_lower_wins",
+			pr:           &PortfolioRiskConfig{DailyMaxLossUSD: 2000, DailyMaxLossPct: 5},
+			states:       map[string]*StrategyState{"a": dlState("a", 20000, -450, today)},
+			thresholdUSD: fp(1000)},
+		{name: "stale_day_counts_zero",
+			pr: &PortfolioRiskConfig{DailyMaxLossUSD: 100},
+			states: map[string]*StrategyState{
+				"stale": dlState("stale", 0, -5000, yesterday),
+				"fresh": dlState("fresh", 0, -50, today),
+			},
+			lossUSD: fp(50)},
+		{name: "wins_offset_losses",
+			pr: &PortfolioRiskConfig{DailyMaxLossUSD: 100},
+			states: map[string]*StrategyState{
+				"win":  dlState("win", 0, 400, today),
+				"loss": dlState("loss", 0, -450, today),
+			},
+			lossUSD: fp(50)},
+		{name: "net_positive_day_loss_zero",
+			pr: &PortfolioRiskConfig{DailyMaxLossUSD: 100},
+			states: map[string]*StrategyState{
+				"win":  dlState("win", 0, 400, today),
+				"loss": dlState("loss", 0, -100, today),
+			},
+			lossUSD: fp(0)},
+		{name: "manual_strategy_pnl_counts",
+			pr: &PortfolioRiskConfig{DailyMaxLossUSD: 300},
+			states: map[string]*StrategyState{
+				"hl-perps": {ID: "hl-perps", Type: "perps", RiskState: RiskState{DailyPnL: -200, DailyPnLDate: today}},
+				"manual":   {ID: "manual", Type: "manual", RiskState: RiskState{DailyPnL: -150, DailyPnLDate: today}},
+			},
+			tripped: true, lossUSD: fp(350)},
+		{name: "pct_basis_miss/pct_only_arm_inert",
+			pr:           &PortfolioRiskConfig{DailyMaxLossPct: 5},
+			states:       map[string]*StrategyState{"a": dlState("a", 0, -10000, today)},
+			pctBasisMiss: dlBool(true)},
+		{name: "pct_basis_miss/usd_arm_still_enforces",
+			pr:      &PortfolioRiskConfig{DailyMaxLossUSD: 500, DailyMaxLossPct: 5},
+			states:  map[string]*StrategyState{"a": dlState("a", 0, -10000, today)},
+			tripped: true, thresholdUSD: fp(500)},
+		{name: "nil_state_entry_skipped",
+			pr: &PortfolioRiskConfig{DailyMaxLossUSD: 100},
+			states: map[string]*StrategyState{
+				"nil": nil,
+				"a":   dlState("a", 0, -150, today),
+			},
+			tripped: true, lossUSD: fp(150)},
 	}
-	atLimit := map[string]*StrategyState{"a": dlState("a", 0, -500, dlToday())}
-	if st := evaluateDailyLossLimit(pr, atLimit, nil, now); !st.Tripped {
-		t.Fatalf("loss at threshold must trip: %+v", st)
-	}
-	beyond := map[string]*StrategyState{
-		"a": dlState("a", 0, -300, dlToday()),
-		"b": dlState("b", 0, -250, dlToday()),
-	}
-	st := evaluateDailyLossLimit(pr, beyond, nil, now)
-	if !st.Tripped || st.LossUSD != 550 || st.ThresholdUSD != 500 {
-		t.Fatalf("multi-strategy aggregate: %+v, want tripped loss=550 threshold=500", st)
-	}
-}
-
-func TestEvaluateDailyLossLimitPctThreshold(t *testing.T) {
-	pr := &PortfolioRiskConfig{DailyMaxLossPct: 5}
-	now := time.Now().UTC()
-	states := map[string]*StrategyState{
-		"a": dlState("a", 2000, -100, dlToday()),
-		"b": dlState("b", 3000, -160, dlToday()),
-	}
-	st := evaluateDailyLossLimit(pr, states, nil, now)
-	if !st.Tripped || st.CapitalBasis != 5000 || st.ThresholdUSD != 250 {
-		t.Fatalf("pct arm: %+v, want tripped basis=5000 threshold=250", st)
-	}
-	states["b"].RiskState.DailyPnL = -140
-	if st := evaluateDailyLossLimit(pr, states, nil, now); st.Tripped {
-		t.Fatalf("loss under pct threshold must not trip: %+v", st)
-	}
-}
-
-func TestEvaluateDailyLossLimitPctBasisExcludesSharedWalletPool(t *testing.T) {
-	pr := &PortfolioRiskConfig{DailyMaxLossPct: 5}
-	now := time.Now().UTC()
-	states := map[string]*StrategyState{
-		"pool-a":    dlState("pool-a", 1000, -100, dlToday()),
-		"allocated": dlState("allocated", 2000, -20, dlToday()),
-	}
-	strategies := []StrategyConfig{
-		{ID: "pool-a", sharedWalletPoolBudget: true},
-		{ID: "allocated"},
-	}
-	st := evaluateDailyLossLimit(pr, states, strategies, now)
-	if st.CapitalBasis != 2000 || st.ThresholdUSD != 100 {
-		t.Fatalf("mixed pool basis=%v threshold=%v, want allocated-only 2000/100", st.CapitalBasis, st.ThresholdUSD)
-	}
-	if !st.Tripped {
-		t.Fatalf("loss $120 must trip allocated-only $100 threshold: %+v", st)
-	}
-
-	delete(states, "allocated")
-	strategies = strategies[:1]
-	st = evaluateDailyLossLimit(pr, states, strategies, now)
-	if st.CapitalBasis != 0 || !st.PctBasisMiss || st.Tripped {
-		t.Fatalf("all-pool pct arm must surface a basis miss: %+v", st)
-	}
-}
-
-func TestEvaluateDailyLossLimitBothArmsLowerWins(t *testing.T) {
-	pr := &PortfolioRiskConfig{DailyMaxLossUSD: 400, DailyMaxLossPct: 5}
-	states := map[string]*StrategyState{"a": dlState("a", 20000, -450, dlToday())}
-	st := evaluateDailyLossLimit(pr, states, nil, time.Now().UTC())
-	if !st.Tripped || st.ThresholdUSD != 400 {
-		t.Fatalf("lower arm must win: %+v, want tripped threshold=400", st)
-	}
-	pr = &PortfolioRiskConfig{DailyMaxLossUSD: 2000, DailyMaxLossPct: 5}
-	st = evaluateDailyLossLimit(pr, states, nil, time.Now().UTC())
-	if st.Tripped || st.ThresholdUSD != 1000 {
-		t.Fatalf("pct arm lower: %+v, want not tripped threshold=1000", st)
-	}
-}
-
-func TestEvaluateDailyLossLimitStaleDayExcluded(t *testing.T) {
-	yesterday := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
-	pr := &PortfolioRiskConfig{DailyMaxLossUSD: 100}
-	states := map[string]*StrategyState{
-		"stale": dlState("stale", 0, -5000, yesterday),
-		"fresh": dlState("fresh", 0, -50, dlToday()),
-	}
-	st := evaluateDailyLossLimit(pr, states, nil, time.Now().UTC())
-	if st.Tripped || st.LossUSD != 50 {
-		t.Fatalf("stale day must count 0: %+v, want loss=50 not tripped", st)
-	}
-}
-
-func TestEvaluateDailyLossLimitWinsOffsetLosses(t *testing.T) {
-	pr := &PortfolioRiskConfig{DailyMaxLossUSD: 100}
-	states := map[string]*StrategyState{
-		"win":  dlState("win", 0, 400, dlToday()),
-		"loss": dlState("loss", 0, -450, dlToday()),
-	}
-	st := evaluateDailyLossLimit(pr, states, nil, time.Now().UTC())
-	if st.Tripped || st.LossUSD != 50 {
-		t.Fatalf("net aggregate: %+v, want loss=50 not tripped", st)
-	}
-	states["loss"].RiskState.DailyPnL = -100
-	st = evaluateDailyLossLimit(pr, states, nil, time.Now().UTC())
-	if st.Tripped || st.LossUSD != 0 {
-		t.Fatalf("net-positive day: %+v, want loss=0 not tripped", st)
-	}
-}
-
-func TestEvaluateDailyLossLimitManualStrategyIncluded(t *testing.T) {
-	pr := &PortfolioRiskConfig{DailyMaxLossUSD: 300}
-	states := map[string]*StrategyState{
-		"hl-perps": {ID: "hl-perps", Type: "perps", RiskState: RiskState{DailyPnL: -200, DailyPnLDate: dlToday()}},
-		"manual":   {ID: "manual", Type: "manual", RiskState: RiskState{DailyPnL: -150, DailyPnLDate: dlToday()}},
-	}
-	st := evaluateDailyLossLimit(pr, states, nil, time.Now().UTC())
-	if !st.Tripped || st.LossUSD != 350 {
-		t.Fatalf("manual PnL must count: %+v, want tripped loss=350", st)
-	}
-}
-
-func TestEvaluateDailyLossLimitPctBasisMiss(t *testing.T) {
-	pr := &PortfolioRiskConfig{DailyMaxLossPct: 5}
-	states := map[string]*StrategyState{"a": dlState("a", 0, -10000, dlToday())}
-	st := evaluateDailyLossLimit(pr, states, nil, time.Now().UTC())
-	if st.Tripped || !st.PctBasisMiss {
-		t.Fatalf("basis-less pct arm: %+v, want not tripped with PctBasisMiss", st)
-	}
-	pr.DailyMaxLossUSD = 500
-	st = evaluateDailyLossLimit(pr, states, nil, time.Now().UTC())
-	if !st.Tripped || st.ThresholdUSD != 500 {
-		t.Fatalf("usd arm with basis miss: %+v, want tripped threshold=500", st)
-	}
-}
-
-func TestEvaluateDailyLossLimitNilStateSkipped(t *testing.T) {
-	pr := &PortfolioRiskConfig{DailyMaxLossUSD: 100}
-	states := map[string]*StrategyState{
-		"nil": nil,
-		"a":   dlState("a", 0, -150, dlToday()),
-	}
-	st := evaluateDailyLossLimit(pr, states, nil, time.Now().UTC())
-	if !st.Tripped || st.LossUSD != 150 {
-		t.Fatalf("nil entries must be skipped: %+v", st)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := evaluateDailyLossLimit(tc.pr, tc.states, tc.strategies, now)
+			if st.Tripped != tc.tripped {
+				t.Fatalf("Tripped = %v, want %v: %+v", st.Tripped, tc.tripped, st)
+			}
+			if tc.configured != nil && st.Configured != *tc.configured {
+				t.Fatalf("Configured = %v, want %v: %+v", st.Configured, *tc.configured, st)
+			}
+			if tc.lossUSD != nil && st.LossUSD != *tc.lossUSD {
+				t.Fatalf("LossUSD = %g, want %g: %+v", st.LossUSD, *tc.lossUSD, st)
+			}
+			if tc.thresholdUSD != nil && st.ThresholdUSD != *tc.thresholdUSD {
+				t.Fatalf("ThresholdUSD = %g, want %g: %+v", st.ThresholdUSD, *tc.thresholdUSD, st)
+			}
+			if tc.capitalBasis != nil && st.CapitalBasis != *tc.capitalBasis {
+				t.Fatalf("CapitalBasis = %g, want %g: %+v", st.CapitalBasis, *tc.capitalBasis, st)
+			}
+			if tc.pctBasisMiss != nil && st.PctBasisMiss != *tc.pctBasisMiss {
+				t.Fatalf("PctBasisMiss = %v, want %v: %+v", st.PctBasisMiss, *tc.pctBasisMiss, st)
+			}
+		})
 	}
 }
 
@@ -308,47 +286,42 @@ func TestManualStateViewDailyLossHold(t *testing.T) {
 	}
 }
 
-func TestManualOpenCoreRefusesDailyLossHold(t *testing.T) {
+func TestManualCoreRefusesDailyLossHold(t *testing.T) {
 	sc := StrategyConfig{ID: "m", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 3}
-	deps := manualCoreDeps{
-		cfg: &Config{},
-		loadState: func(strategyID, symbol string) (manualStateView, error) {
-			return manualStateView{HasStrategy: true, DailyLossHold: true,
-				DailyLossNote: "daily loss limit tripped: today's realized loss $600.00 >= threshold $500.00 (pre-fee; basis=$0.00 initial capital)"}, nil
-		},
-		execute: func(string, string, string, float64, float64, int64, float64, string, float64, bool, hlExecuteSnapshot, ...int64) (*HyperliquidExecuteResult, string, error) {
-			t.Error("execute must not be called while the daily loss limit is tripped")
-			return nil, "", nil
-		},
-		fetchMids: func([]string) (map[string]float64, error) {
-			return map[string]float64{"ETH": 2000}, nil
-		},
+	const note = "daily loss limit tripped: today's realized loss $600.00 >= threshold $500.00 (pre-fee; basis=$0.00 initial capital)"
+	cases := []struct {
+		name string
+		pos  *Position
+		run  func(deps manualCoreDeps) error
+	}{
+		{"manual-open", nil, func(deps manualCoreDeps) error {
+			_, err := manualOpenCore(deps, sc, manualOpenInputs{StrategyID: "m", Margin: 50})
+			return err
+		}},
+		{"manual-add", &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: "long"}, func(deps manualCoreDeps) error {
+			_, err := manualAddCore(deps, sc, manualAddInputs{StrategyID: "m", Margin: 50})
+			return err
+		}},
 	}
-	_, err := manualOpenCore(deps, sc, manualOpenInputs{StrategyID: "m", Margin: 50})
-	if err == nil || !strings.Contains(err.Error(), "daily loss limit tripped") {
-		t.Fatalf("manual-open err = %v, want daily-loss refusal", err)
-	}
-}
-
-func TestManualAddCoreRefusesDailyLossHold(t *testing.T) {
-	sc := StrategyConfig{ID: "m", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 3}
-	pos := &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: "long"}
-	deps := manualCoreDeps{
-		cfg: &Config{},
-		loadState: func(strategyID, symbol string) (manualStateView, error) {
-			return manualStateView{HasStrategy: true, Pos: pos, DailyLossHold: true,
-				DailyLossNote: "daily loss limit tripped: today's realized loss $600.00 >= threshold $500.00 (pre-fee; basis=$0.00 initial capital)"}, nil
-		},
-		execute: func(string, string, string, float64, float64, int64, float64, string, float64, bool, hlExecuteSnapshot, ...int64) (*HyperliquidExecuteResult, string, error) {
-			t.Error("execute must not be called while the daily loss limit is tripped")
-			return nil, "", nil
-		},
-		fetchMids: func([]string) (map[string]float64, error) {
-			return map[string]float64{"ETH": 2000}, nil
-		},
-	}
-	_, err := manualAddCore(deps, sc, manualAddInputs{StrategyID: "m", Margin: 50})
-	if err == nil || !strings.Contains(err.Error(), "daily loss limit tripped") {
-		t.Fatalf("manual-add err = %v, want daily-loss refusal", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := manualCoreDeps{
+				cfg: &Config{},
+				loadState: func(strategyID, symbol string) (manualStateView, error) {
+					return manualStateView{HasStrategy: true, Pos: tc.pos, DailyLossHold: true, DailyLossNote: note}, nil
+				},
+				execute: func(string, string, string, float64, float64, int64, float64, string, float64, bool, hlExecuteSnapshot, ...int64) (*HyperliquidExecuteResult, string, error) {
+					t.Error("execute must not be called while the daily loss limit is tripped")
+					return nil, "", nil
+				},
+				fetchMids: func([]string) (map[string]float64, error) {
+					return map[string]float64{"ETH": 2000}, nil
+				},
+			}
+			err := tc.run(deps)
+			if err == nil || !strings.Contains(err.Error(), "daily loss limit tripped") {
+				t.Fatalf("%s err = %v, want daily-loss refusal", tc.name, err)
+			}
+		})
 	}
 }

--- a/scheduler/db_test.go
+++ b/scheduler/db_test.go
@@ -369,7 +369,7 @@ func TestSaveState_AppendsTradesOnly(t *testing.T) {
 	}
 }
 
-func TestSaveState_KillSwitchEventsCapped(t *testing.T) {
+func TestSaveState_KillSwitchEventsStoredAsIs(t *testing.T) {
 	db := openTestDB(t)
 	now := time.Now().UTC()
 
@@ -428,75 +428,64 @@ func TestLoadState_NilMapsInitialized(t *testing.T) {
 	}
 }
 
-func TestQueryTradeHistory_NoFilter(t *testing.T) {
-	db := openTestDB(t)
-	state := makeTestState()
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState: %v", err)
+func TestQueryTradeHistory_Filters(t *testing.T) {
+	cases := []struct {
+		name      string
+		strategy  string
+		symbol    string
+		limit     int
+		wantTotal int
+		wantLen   int
+		check     func(t *testing.T, trades []Trade)
+	}{
+		{
+			name: "no filter newest first", limit: 50, wantTotal: 2, wantLen: 2,
+			check: func(t *testing.T, trades []Trade) {
+				if trades[0].Side != "sell" {
+					t.Errorf("first trade should be most recent (sell), got %q", trades[0].Side)
+				}
+			},
+		},
+		{
+			name: "by strategy", strategy: "hl-momentum-btc", limit: 50, wantTotal: 2, wantLen: 2,
+			check: func(t *testing.T, trades []Trade) {
+				for _, tr := range trades {
+					if tr.StrategyID != "hl-momentum-btc" {
+						t.Errorf("trade strategy = %q, want %q", tr.StrategyID, "hl-momentum-btc")
+					}
+				}
+			},
+		},
+		{name: "by nonexistent strategy", strategy: "nonexistent", limit: 50, wantTotal: 0, wantLen: 0},
+		{
+			name: "by symbol", symbol: "BTC", limit: 50, wantTotal: 2, wantLen: 2,
+			check: func(t *testing.T, trades []Trade) {
+				for _, tr := range trades {
+					if tr.Symbol != "BTC" {
+						t.Errorf("trade symbol = %q, want %q", tr.Symbol, "BTC")
+					}
+				}
+			},
+		},
+		{name: "limit clamped", limit: 9999, wantTotal: 2, wantLen: 2},
 	}
-
-	trades, total, err := db.QueryTradeHistory("", "", time.Time{}, time.Time{}, 50, 0)
-	if err != nil {
-		t.Fatalf("QueryTradeHistory: %v", err)
-	}
-	if total != 2 {
-		t.Errorf("total = %d, want 2", total)
-	}
-	if len(trades) != 2 {
-		t.Errorf("trades len = %d, want 2", len(trades))
-	}
-	if len(trades) >= 2 && trades[0].Side != "sell" {
-		t.Errorf("first trade should be most recent (sell), got %q", trades[0].Side)
-	}
-}
-
-func TestQueryTradeHistory_ByStrategy(t *testing.T) {
-	db := openTestDB(t)
-	state := makeTestState()
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState: %v", err)
-	}
-
-	trades, total, err := db.QueryTradeHistory("hl-momentum-btc", "", time.Time{}, time.Time{}, 50, 0)
-	if err != nil {
-		t.Fatalf("QueryTradeHistory: %v", err)
-	}
-	if total != 2 {
-		t.Errorf("total = %d, want 2", total)
-	}
-	for _, tr := range trades {
-		if tr.StrategyID != "hl-momentum-btc" {
-			t.Errorf("trade strategy = %q, want %q", tr.StrategyID, "hl-momentum-btc")
-		}
-	}
-
-	trades, total, err = db.QueryTradeHistory("nonexistent", "", time.Time{}, time.Time{}, 50, 0)
-	if err != nil {
-		t.Fatalf("QueryTradeHistory: %v", err)
-	}
-	if total != 0 || len(trades) != 0 {
-		t.Errorf("expected empty result, got total=%d len=%d", total, len(trades))
-	}
-}
-
-func TestQueryTradeHistory_BySymbol(t *testing.T) {
-	db := openTestDB(t)
-	state := makeTestState()
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState: %v", err)
-	}
-
-	trades, total, err := db.QueryTradeHistory("", "BTC", time.Time{}, time.Time{}, 50, 0)
-	if err != nil {
-		t.Fatalf("QueryTradeHistory: %v", err)
-	}
-	if total != 2 {
-		t.Errorf("total = %d, want 2", total)
-	}
-	for _, tr := range trades {
-		if tr.Symbol != "BTC" {
-			t.Errorf("trade symbol = %q, want %q", tr.Symbol, "BTC")
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTestDB(t)
+			if err := db.SaveState(makeTestState()); err != nil {
+				t.Fatalf("SaveState: %v", err)
+			}
+			trades, total, err := db.QueryTradeHistory(tc.strategy, tc.symbol, time.Time{}, time.Time{}, tc.limit, 0)
+			if err != nil {
+				t.Fatalf("QueryTradeHistory: %v", err)
+			}
+			if total != tc.wantTotal || len(trades) != tc.wantLen {
+				t.Fatalf("total=%d len=%d, want %d/%d", total, len(trades), tc.wantTotal, tc.wantLen)
+			}
+			if tc.check != nil {
+				tc.check(t, trades)
+			}
+		})
 	}
 }
 
@@ -575,22 +564,6 @@ func TestQueryTradeHistory_TimeBounds(t *testing.T) {
 	}
 	if total != 2 {
 		t.Errorf("total = %d, want 2", total)
-	}
-	if len(trades) != 2 {
-		t.Errorf("trades len = %d, want 2", len(trades))
-	}
-}
-
-func TestQueryTradeHistory_LimitClamped(t *testing.T) {
-	db := openTestDB(t)
-	state := makeTestState()
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState: %v", err)
-	}
-
-	trades, _, err := db.QueryTradeHistory("", "", time.Time{}, time.Time{}, 9999, 0)
-	if err != nil {
-		t.Fatalf("QueryTradeHistory: %v", err)
 	}
 	if len(trades) != 2 {
 		t.Errorf("trades len = %d, want 2", len(trades))
@@ -691,138 +664,93 @@ func TestSaveState_EmptyStrategies(t *testing.T) {
 }
 
 func TestTradeExchangeFieldsRoundTrip(t *testing.T) {
-	db := openTestDB(t)
 	now := time.Now().UTC().Truncate(time.Nanosecond)
-
-	state := &AppState{
-		CycleCount: 1,
-		Strategies: map[string]*StrategyState{
-			"hl-test": {
-				ID: "hl-test", Type: "perps", Platform: "hyperliquid",
-				Cash: 1000, InitialCapital: 1000,
-				Positions: make(map[string]*Position), OptionPositions: make(map[string]*OptionPosition),
-				TradeHistory: []Trade{
-					{
-						Timestamp: now.Add(-1 * time.Hour), StrategyID: "hl-test", Symbol: "BTC",
-						Side: "buy", Quantity: 0.1, Price: 50000, Value: 5000, TradeType: "perps",
-						Details: "live buy", ExchangeOrderID: "1234567890", ExchangeFee: 1.75,
+	type want struct {
+		orderID string
+		fee     float64
+	}
+	cases := []struct {
+		name     string
+		typ      string
+		platform string
+		trades   []Trade
+		want     []want
+	}{
+		{
+			name: "live perps two trades", typ: "perps", platform: "hyperliquid",
+			trades: []Trade{
+				{Timestamp: now.Add(-1 * time.Hour), Symbol: "BTC", Side: "buy", Quantity: 0.1, Price: 50000, Value: 5000, TradeType: "perps", Details: "live buy", ExchangeOrderID: "1234567890", ExchangeFee: 1.75},
+				{Timestamp: now, Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps", Details: "live sell", ExchangeOrderID: "1234567891", ExchangeFee: 1.79},
+			},
+			want: []want{{"1234567890", 1.75}, {"1234567891", 1.79}},
+		},
+		{
+			name: "live perps single trade", typ: "perps", platform: "hyperliquid",
+			trades: []Trade{
+				{Timestamp: now, Symbol: "BTC", Side: "buy", Quantity: 0.1, Price: 50000, Value: 5000, TradeType: "perps", Details: "live", ExchangeOrderID: "9876543210", ExchangeFee: 2.50},
+			},
+			want: []want{{"9876543210", 2.50}},
+		},
+		{
+			name: "paper spot empty by default", typ: "spot", platform: "binanceus",
+			trades: []Trade{
+				{Timestamp: now, Symbol: "BTC/USDT", Side: "buy", Quantity: 0.01, Price: 50000, Value: 500, TradeType: "spot", Details: "paper trade"},
+			},
+			want: []want{{"", 0}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTestDB(t)
+			const id = "trade-exchange-fields"
+			trades := make([]Trade, len(tc.trades))
+			for i, tr := range tc.trades {
+				tr.StrategyID = id
+				trades[i] = tr
+			}
+			state := &AppState{
+				CycleCount: 1,
+				Strategies: map[string]*StrategyState{
+					id: {
+						ID: id, Type: tc.typ, Platform: tc.platform,
+						Cash: 1000, InitialCapital: 1000,
+						Positions: make(map[string]*Position), OptionPositions: make(map[string]*OptionPosition),
+						TradeHistory: trades,
 					},
-					{
-						Timestamp: now, StrategyID: "hl-test", Symbol: "BTC",
-						Side: "sell", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps",
-						Details: "live sell", ExchangeOrderID: "1234567891", ExchangeFee: 1.79,
-					},
 				},
-			},
-		},
-	}
+			}
+			if err := db.SaveState(state); err != nil {
+				t.Fatalf("SaveState: %v", err)
+			}
 
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState: %v", err)
-	}
+			loaded, err := db.LoadState()
+			if err != nil {
+				t.Fatalf("LoadState: %v", err)
+			}
+			hist := loaded.Strategies[id].TradeHistory
+			if len(hist) != len(tc.want) {
+				t.Fatalf("LoadState trade count = %d, want %d", len(hist), len(tc.want))
+			}
+			for i, w := range tc.want {
+				if hist[i].ExchangeOrderID != w.orderID || hist[i].ExchangeFee != w.fee {
+					t.Errorf("LoadState trade[%d] = (%q, %g), want (%q, %g)", i, hist[i].ExchangeOrderID, hist[i].ExchangeFee, w.orderID, w.fee)
+				}
+			}
 
-	loaded, err := db.LoadState()
-	if err != nil {
-		t.Fatalf("LoadState: %v", err)
-	}
-
-	hlStrat := loaded.Strategies["hl-test"]
-	if hlStrat == nil {
-		t.Fatal("missing strategy hl-test")
-	}
-	if len(hlStrat.TradeHistory) != 2 {
-		t.Fatalf("trade count = %d, want 2", len(hlStrat.TradeHistory))
-	}
-
-	t1 := hlStrat.TradeHistory[0]
-	if t1.ExchangeOrderID != "1234567890" {
-		t.Errorf("trade[0].ExchangeOrderID = %q, want %q", t1.ExchangeOrderID, "1234567890")
-	}
-	if t1.ExchangeFee != 1.75 {
-		t.Errorf("trade[0].ExchangeFee = %g, want 1.75", t1.ExchangeFee)
-	}
-
-	t2 := hlStrat.TradeHistory[1]
-	if t2.ExchangeOrderID != "1234567891" {
-		t.Errorf("trade[1].ExchangeOrderID = %q, want %q", t2.ExchangeOrderID, "1234567891")
-	}
-	if t2.ExchangeFee != 1.79 {
-		t.Errorf("trade[1].ExchangeFee = %g, want 1.79", t2.ExchangeFee)
-	}
-}
-
-func TestTradeExchangeFields_EmptyByDefault(t *testing.T) {
-	db := openTestDB(t)
-	now := time.Now().UTC().Truncate(time.Nanosecond)
-
-	state := &AppState{
-		CycleCount: 1,
-		Strategies: map[string]*StrategyState{
-			"spot-test": {
-				ID: "spot-test", Type: "spot", Platform: "binanceus",
-				Cash: 1000, InitialCapital: 1000,
-				Positions: make(map[string]*Position), OptionPositions: make(map[string]*OptionPosition),
-				TradeHistory: []Trade{
-					{Timestamp: now, StrategyID: "spot-test", Symbol: "BTC/USDT", Side: "buy",
-						Quantity: 0.01, Price: 50000, Value: 500, TradeType: "spot", Details: "paper trade"},
-				},
-			},
-		},
-	}
-
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState: %v", err)
-	}
-	loaded, err := db.LoadState()
-	if err != nil {
-		t.Fatalf("LoadState: %v", err)
-	}
-
-	tr := loaded.Strategies["spot-test"].TradeHistory[0]
-	if tr.ExchangeOrderID != "" {
-		t.Errorf("ExchangeOrderID should be empty for paper trade, got %q", tr.ExchangeOrderID)
-	}
-	if tr.ExchangeFee != 0 {
-		t.Errorf("ExchangeFee should be 0 for paper trade, got %g", tr.ExchangeFee)
-	}
-}
-
-func TestQueryTradeHistory_ExchangeFields(t *testing.T) {
-	db := openTestDB(t)
-	now := time.Now().UTC().Truncate(time.Nanosecond)
-
-	state := &AppState{
-		CycleCount: 1,
-		Strategies: map[string]*StrategyState{
-			"hl-test": {
-				ID: "hl-test", Type: "perps", Platform: "hyperliquid",
-				Cash: 1000, InitialCapital: 1000,
-				Positions: make(map[string]*Position), OptionPositions: make(map[string]*OptionPosition),
-				TradeHistory: []Trade{
-					{Timestamp: now, StrategyID: "hl-test", Symbol: "BTC", Side: "buy",
-						Quantity: 0.1, Price: 50000, Value: 5000, TradeType: "perps",
-						Details: "live", ExchangeOrderID: "9876543210", ExchangeFee: 2.50},
-				},
-			},
-		},
-	}
-
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState: %v", err)
-	}
-
-	trades, total, err := db.QueryTradeHistory("hl-test", "", time.Time{}, time.Time{}, 50, 0)
-	if err != nil {
-		t.Fatalf("QueryTradeHistory: %v", err)
-	}
-	if total != 1 {
-		t.Fatalf("total = %d, want 1", total)
-	}
-	if trades[0].ExchangeOrderID != "9876543210" {
-		t.Errorf("ExchangeOrderID = %q, want %q", trades[0].ExchangeOrderID, "9876543210")
-	}
-	if trades[0].ExchangeFee != 2.50 {
-		t.Errorf("ExchangeFee = %g, want 2.50", trades[0].ExchangeFee)
+			queried, total, err := db.QueryTradeHistory(id, "", time.Time{}, time.Time{}, 50, 0)
+			if err != nil {
+				t.Fatalf("QueryTradeHistory: %v", err)
+			}
+			if total != len(tc.want) || len(queried) != len(tc.want) {
+				t.Fatalf("QueryTradeHistory total=%d len=%d, want %d", total, len(queried), len(tc.want))
+			}
+			for i, w := range tc.want {
+				q := queried[len(queried)-1-i]
+				if q.ExchangeOrderID != w.orderID || q.ExchangeFee != w.fee {
+					t.Errorf("QueryTradeHistory trade[%d] = (%q, %g), want (%q, %g)", i, q.ExchangeOrderID, q.ExchangeFee, w.orderID, w.fee)
+				}
+			}
+		})
 	}
 }
 
@@ -1584,299 +1512,190 @@ func TestMigrateSchema_AddsOpenedAt(t *testing.T) {
 	}
 }
 
-func TestSaveLoadState_LeaderboardSummaries(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "state.db")
-	sdb, err := OpenStateDB(path)
-	if err != nil {
-		t.Fatalf("open db: %v", err)
-	}
-	defer sdb.Close()
-
+func TestSaveLoadState_TimestampMaps(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
-	state := NewAppState()
-	state.LastLeaderboardSummaries = map[string]time.Time{
-		"hyperliquid:*:123":   now.Add(-1 * time.Hour),
-		"hyperliquid:eth:456": now.Add(-2 * time.Hour),
+	cases := []struct {
+		name  string
+		set   func(*AppState, map[string]time.Time)
+		get   func(*AppState) map[string]time.Time
+		value map[string]time.Time
+	}{
+		{
+			name:  "last leaderboard summaries",
+			set:   func(s *AppState, m map[string]time.Time) { s.LastLeaderboardSummaries = m },
+			get:   func(s *AppState) map[string]time.Time { return s.LastLeaderboardSummaries },
+			value: map[string]time.Time{"hyperliquid:*:123": now.Add(-1 * time.Hour), "hyperliquid:eth:456": now.Add(-2 * time.Hour)},
+		},
+		{
+			name:  "last summary post",
+			set:   func(s *AppState, m map[string]time.Time) { s.LastSummaryPost = m },
+			get:   func(s *AppState) map[string]time.Time { return s.LastSummaryPost },
+			value: map[string]time.Time{"spot": now.Add(-5 * time.Minute), "hyperliquid": now.Add(-30 * time.Minute)},
+		},
 	}
-	if err := sdb.SaveState(state); err != nil {
-		t.Fatalf("save: %v", err)
-	}
-
-	loaded, err := sdb.LoadState()
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	if len(loaded.LastLeaderboardSummaries) != 2 {
-		t.Fatalf("expected 2 entries, got %d", len(loaded.LastLeaderboardSummaries))
-	}
-	for k, want := range state.LastLeaderboardSummaries {
-		got, ok := loaded.LastLeaderboardSummaries[k]
-		if !ok {
-			t.Errorf("key %q missing after reload", k)
-			continue
-		}
-		if !got.Equal(want) {
-			t.Errorf("key %q: got %v, want %v", k, got, want)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sdb := openTestDB(t)
+			state := NewAppState()
+			tc.set(state, tc.value)
+			if err := sdb.SaveState(state); err != nil {
+				t.Fatalf("save: %v", err)
+			}
+			loaded, err := sdb.LoadState()
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			got := tc.get(loaded)
+			if len(got) != len(tc.value) {
+				t.Fatalf("expected %d entries, got %d", len(tc.value), len(got))
+			}
+			for k, want := range tc.value {
+				g, ok := got[k]
+				if !ok {
+					t.Errorf("key %q missing after reload", k)
+					continue
+				}
+				if !g.Equal(want) {
+					t.Errorf("key %q: got %v, want %v", k, g, want)
+				}
+			}
+		})
 	}
 }
 
-func TestSaveLoadState_LastSummaryPost(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "state.db")
-	sdb, err := OpenStateDB(path)
-	if err != nil {
-		t.Fatalf("open db: %v", err)
-	}
-	defer sdb.Close()
-
-	now := time.Now().UTC().Truncate(time.Second)
-	state := NewAppState()
-	state.LastSummaryPost = map[string]time.Time{
-		"spot":        now.Add(-5 * time.Minute),
-		"hyperliquid": now.Add(-30 * time.Minute),
-	}
-	if err := sdb.SaveState(state); err != nil {
-		t.Fatalf("save: %v", err)
-	}
-
-	loaded, err := sdb.LoadState()
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	if len(loaded.LastSummaryPost) != 2 {
-		t.Fatalf("expected 2 entries, got %d", len(loaded.LastSummaryPost))
-	}
-	for k, want := range state.LastSummaryPost {
-		got, ok := loaded.LastSummaryPost[k]
-		if !ok {
-			t.Errorf("key %q missing after reload", k)
-			continue
-		}
-		if !got.Equal(want) {
-			t.Errorf("key %q: got %v, want %v", k, got, want)
+func TestSaveState_InitialCapitalGuard(t *testing.T) {
+	strat := func(id string, cash, initial float64) *StrategyState {
+		return &StrategyState{
+			ID: id, Type: "spot", Cash: cash, InitialCapital: initial,
+			Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
 		}
 	}
-}
-
-func TestSaveState_PreservesInitialCapital(t *testing.T) {
-	db := openTestDB(t)
-
-	initial := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-tema-eth": {
-				ID:              "hl-tema-eth",
-				Type:            "perps",
-				Platform:        "hyperliquid",
-				Cash:            505,
-				InitialCapital:  505,
-				Positions:       map[string]*Position{},
-				OptionPositions: map[string]*OptionPosition{},
+	type book struct{ initial, cash float64 }
+	cases := []struct {
+		name         string
+		seed         map[string]*StrategyState
+		save         map[string]*StrategyState
+		wantInMemory map[string]book
+		wantDB       map[string]book
+	}{
+		{
+			name:         "existing baseline is preserved and restored in memory",
+			seed:         map[string]*StrategyState{"hl-tema-eth": strat("hl-tema-eth", 505, 505)},
+			save:         map[string]*StrategyState{"hl-tema-eth": strat("hl-tema-eth", 632, 632)},
+			wantInMemory: map[string]book{"hl-tema-eth": {505, 632}},
+			wantDB:       map[string]book{"hl-tema-eth": {505, 632}},
+		},
+		{
+			name:         "first write lands",
+			save:         map[string]*StrategyState{"new-strat": strat("new-strat", 1000, 1000)},
+			wantInMemory: map[string]book{"new-strat": {1000, 1000}},
+			wantDB:       map[string]book{"new-strat": {1000, 1000}},
+		},
+		{
+			name: "new strategy alongside existing one",
+			seed: map[string]*StrategyState{"old": strat("old", 1000, 1000)},
+			save: map[string]*StrategyState{
+				"old":       strat("old", 1000, 1000),
+				"brand-new": strat("brand-new", 2000, 2000),
 			},
+			wantInMemory: map[string]book{"old": {1000, 1000}, "brand-new": {2000, 2000}},
+			wantDB:       map[string]book{"old": {1000, 1000}, "brand-new": {2000, 2000}},
+		},
+		{
+			name:         "prev zero allows baseline establishment",
+			seed:         map[string]*StrategyState{"legacy": strat("legacy", 0, 0)},
+			save:         map[string]*StrategyState{"legacy": strat("legacy", 1000, 1000)},
+			wantInMemory: map[string]book{"legacy": {1000, 1000}},
+			wantDB:       map[string]book{"legacy": {1000, 1000}},
 		},
 	}
-	if err := db.SaveState(initial); err != nil {
-		t.Fatalf("first SaveState: %v", err)
-	}
-
-	mutated := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-tema-eth": {
-				ID:              "hl-tema-eth",
-				Type:            "perps",
-				Platform:        "hyperliquid",
-				Cash:            632,
-				InitialCapital:  632,
-				Positions:       map[string]*Position{},
-				OptionPositions: map[string]*OptionPosition{},
-			},
-		},
-	}
-	if err := db.SaveState(mutated); err != nil {
-		t.Fatalf("second SaveState: %v", err)
-	}
-
-	if got := mutated.Strategies["hl-tema-eth"].InitialCapital; got != 505 {
-		t.Errorf("in-memory InitialCapital = %g, want 505 (guard should have restored it)", got)
-	}
-
-	if got := mutated.Strategies["hl-tema-eth"].Cash; got != 632 {
-		t.Errorf("Cash = %g, want 632 (guard must only protect initial_capital)", got)
-	}
-
-	loaded, err := db.LoadState()
-	if err != nil {
-		t.Fatalf("LoadState: %v", err)
-	}
-	if got := loaded.Strategies["hl-tema-eth"].InitialCapital; got != 505 {
-		t.Errorf("persisted initial_capital = %g, want 505", got)
-	}
-	if got := loaded.Strategies["hl-tema-eth"].Cash; got != 632 {
-		t.Errorf("persisted cash = %g, want 632", got)
-	}
-}
-
-func TestSaveState_AllowsFirstInitialCapitalWrite(t *testing.T) {
-	db := openTestDB(t)
-
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"new-strat": {
-				ID: "new-strat", Type: "spot", Cash: 1000, InitialCapital: 1000,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
-			},
-		},
-	}
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState: %v", err)
-	}
-
-	loaded, err := db.LoadState()
-	if err != nil {
-		t.Fatalf("LoadState: %v", err)
-	}
-	if got := loaded.Strategies["new-strat"].InitialCapital; got != 1000 {
-		t.Errorf("initial_capital = %g, want 1000 (first write must land)", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTestDB(t)
+			if tc.seed != nil {
+				if err := db.SaveState(&AppState{Strategies: tc.seed}); err != nil {
+					t.Fatalf("seed SaveState: %v", err)
+				}
+			}
+			state := &AppState{Strategies: tc.save}
+			if err := db.SaveState(state); err != nil {
+				t.Fatalf("SaveState: %v", err)
+			}
+			for id, w := range tc.wantInMemory {
+				s := state.Strategies[id]
+				if s.InitialCapital != w.initial || s.Cash != w.cash {
+					t.Errorf("in-memory %s = (initial %g, cash %g), want (%g, %g)", id, s.InitialCapital, s.Cash, w.initial, w.cash)
+				}
+			}
+			loaded, err := db.LoadState()
+			if err != nil {
+				t.Fatalf("LoadState: %v", err)
+			}
+			for id, w := range tc.wantDB {
+				s := loaded.Strategies[id]
+				if s == nil {
+					t.Fatalf("persisted strategy %s missing", id)
+				}
+				if s.InitialCapital != w.initial || s.Cash != w.cash {
+					t.Errorf("persisted %s = (initial %g, cash %g), want (%g, %g)", id, s.InitialCapital, s.Cash, w.initial, w.cash)
+				}
+			}
+		})
 	}
 }
 
-func TestSaveState_AllowsNewStrategies(t *testing.T) {
-	db := openTestDB(t)
-
-	first := &AppState{
-		Strategies: map[string]*StrategyState{
-			"old": {
-				ID: "old", Type: "spot", Cash: 1000, InitialCapital: 1000,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+func TestSetInitialCapital(t *testing.T) {
+	seed := func(t *testing.T, cash float64) *StateDB {
+		db := openTestDB(t)
+		state := &AppState{
+			Strategies: map[string]*StrategyState{
+				"s": {
+					ID: "s", Type: "spot", Cash: cash, InitialCapital: cash,
+					Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+				},
 			},
-		},
+		}
+		if err := db.SaveState(state); err != nil {
+			t.Fatalf("SaveState: %v", err)
+		}
+		return db
 	}
-	if err := db.SaveState(first); err != nil {
-		t.Fatalf("first SaveState: %v", err)
-	}
-
-	second := &AppState{
-		Strategies: map[string]*StrategyState{
-			"old": {
-				ID: "old", Type: "spot", Cash: 1000, InitialCapital: 1000,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+	t.Run("explicit override sticks across a stale save", func(t *testing.T) {
+		db := seed(t, 505)
+		if err := db.SetInitialCapital("s", 750); err != nil {
+			t.Fatalf("SetInitialCapital: %v", err)
+		}
+		state := &AppState{
+			Strategies: map[string]*StrategyState{
+				"s": {
+					ID: "s", Type: "spot", Cash: 505, InitialCapital: 505,
+					Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+				},
 			},
-			"brand-new": {
-				ID: "brand-new", Type: "spot", Cash: 2000, InitialCapital: 2000,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
-			},
-		},
-	}
-	if err := db.SaveState(second); err != nil {
-		t.Fatalf("second SaveState: %v", err)
-	}
-
-	loaded, err := db.LoadState()
-	if err != nil {
-		t.Fatalf("LoadState: %v", err)
-	}
-	if got := loaded.Strategies["brand-new"].InitialCapital; got != 2000 {
-		t.Errorf("new strategy initial_capital = %g, want 2000", got)
-	}
-	if got := loaded.Strategies["old"].InitialCapital; got != 1000 {
-		t.Errorf("old strategy initial_capital = %g, want 1000", got)
-	}
-}
-
-func TestSaveState_AllowsBaselineWhenPrevZero(t *testing.T) {
-	db := openTestDB(t)
-
-	zeroState := &AppState{
-		Strategies: map[string]*StrategyState{
-			"legacy": {
-				ID: "legacy", Type: "spot", Cash: 0, InitialCapital: 0,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
-			},
-		},
-	}
-	if err := db.SaveState(zeroState); err != nil {
-		t.Fatalf("seed SaveState: %v", err)
-	}
-
-	bumped := &AppState{
-		Strategies: map[string]*StrategyState{
-			"legacy": {
-				ID: "legacy", Type: "spot", Cash: 1000, InitialCapital: 1000,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
-			},
-		},
-	}
-	if err := db.SaveState(bumped); err != nil {
-		t.Fatalf("bumped SaveState: %v", err)
-	}
-
-	loaded, err := db.LoadState()
-	if err != nil {
-		t.Fatalf("LoadState: %v", err)
-	}
-	if got := loaded.Strategies["legacy"].InitialCapital; got != 1000 {
-		t.Errorf("initial_capital = %g, want 1000 (prev==0 must allow baseline establishment)", got)
-	}
-}
-
-func TestSetInitialCapital_ExplicitOverride(t *testing.T) {
-	db := openTestDB(t)
-
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"s": {
-				ID: "s", Type: "spot", Cash: 505, InitialCapital: 505,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
-			},
-		},
-	}
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState: %v", err)
-	}
-
-	if err := db.SetInitialCapital("s", 750); err != nil {
-		t.Fatalf("SetInitialCapital: %v", err)
-	}
-
-	state.Strategies["s"].InitialCapital = 505
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState after override: %v", err)
-	}
-
-	loaded, err := db.LoadState()
-	if err != nil {
-		t.Fatalf("LoadState: %v", err)
-	}
-	if got := loaded.Strategies["s"].InitialCapital; got != 750 {
-		t.Errorf("initial_capital = %g, want 750 (override must stick)", got)
-	}
-}
-
-func TestSetInitialCapital_RejectsInvalid(t *testing.T) {
-	db := openTestDB(t)
-
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"s": {
-				ID: "s", Type: "spot", Cash: 1000, InitialCapital: 1000,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
-			},
-		},
-	}
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState: %v", err)
-	}
-
-	if err := db.SetInitialCapital("s", 0); err == nil {
-		t.Error("expected error for zero initial_capital")
-	}
-	if err := db.SetInitialCapital("s", -100); err == nil {
-		t.Error("expected error for negative initial_capital")
-	}
-	if err := db.SetInitialCapital("unknown-id", 1000); err == nil {
-		t.Error("expected error for unknown strategy id")
-	}
+		}
+		if err := db.SaveState(state); err != nil {
+			t.Fatalf("SaveState after override: %v", err)
+		}
+		loaded, err := db.LoadState()
+		if err != nil {
+			t.Fatalf("LoadState: %v", err)
+		}
+		if got := loaded.Strategies["s"].InitialCapital; got != 750 {
+			t.Errorf("initial_capital = %g, want 750 (override must stick)", got)
+		}
+	})
+	t.Run("rejects zero, negative, and unknown strategy", func(t *testing.T) {
+		db := seed(t, 1000)
+		if err := db.SetInitialCapital("s", 0); err == nil {
+			t.Error("expected error for zero initial_capital")
+		}
+		if err := db.SetInitialCapital("s", -100); err == nil {
+			t.Error("expected error for negative initial_capital")
+		}
+		if err := db.SetInitialCapital("unknown-id", 1000); err == nil {
+			t.Error("expected error for unknown strategy id")
+		}
+	})
 }
 
 func TestPersistSharedWalletPoolStateTransitionRoundTrip(t *testing.T) {
@@ -1996,81 +1815,54 @@ func TestSaveState_GuardWarnIsOneShot(t *testing.T) {
 	}
 }
 
-func TestSaveAndLoadDB_PendingCircuitCloseRoundTrip(t *testing.T) {
-	db := openTestDB(t)
-	now := time.Now().UTC().Truncate(time.Second)
-	state := &AppState{
-		CycleCount: 1,
-		LastCycle:  now,
-		Strategies: map[string]*StrategyState{
-			"hl-a": {
-				ID: "hl-a", Type: "perps", Platform: "hyperliquid", Cash: 100, InitialCapital: 100,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
-				RiskState: RiskState{
-					PeakValue: 100, MaxDrawdownPct: 25,
-					PendingCircuitCloses: map[string]*PendingCircuitClose{
-						PlatformPendingCloseHyperliquid: {
-							Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.2585}},
-						},
-					},
+func TestSaveAndLoadDB_PendingCircuitClose(t *testing.T) {
+	seed := func(t *testing.T, pending map[string]*PendingCircuitClose) *StateDB {
+		db := openTestDB(t)
+		state := &AppState{
+			CycleCount: 1,
+			LastCycle:  time.Now().UTC().Truncate(time.Second),
+			Strategies: map[string]*StrategyState{
+				"hl-a": {
+					ID: "hl-a", Type: "perps", Platform: "hyperliquid", Cash: 100, InitialCapital: 100,
+					Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+					RiskState: RiskState{PeakValue: 100, MaxDrawdownPct: 25, PendingCircuitCloses: pending},
 				},
 			},
-		},
+		}
+		if err := db.SaveState(state); err != nil {
+			t.Fatalf("SaveState: %v", err)
+		}
+		return db
 	}
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState: %v", err)
+	assertPending := func(t *testing.T, db *StateDB, label string) {
+		loaded, err := db.LoadState()
+		if err != nil {
+			t.Fatalf("LoadState: %v", err)
+		}
+		p := loaded.Strategies["hl-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
+		if p == nil || len(p.Symbols) != 1 {
+			t.Fatalf("%s pending missing: %+v", label, p)
+		}
+		if p.Symbols[0].Symbol != "ETH" || p.Symbols[0].Size != 0.2585 {
+			t.Errorf("%s pending symbol=%q size=%g want ETH 0.2585", label, p.Symbols[0].Symbol, p.Symbols[0].Size)
+		}
 	}
-	loaded, err := db.LoadState()
-	if err != nil {
-		t.Fatalf("LoadState: %v", err)
-	}
-	p := loaded.Strategies["hl-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
-	if p == nil || len(p.Symbols) != 1 {
-		t.Fatalf("pending missing: %+v", p)
-	}
-	if p.Symbols[0].Symbol != "ETH" || p.Symbols[0].Size != 0.2585 {
-		t.Errorf("pending symbol=%q size=%g want ETH 0.2585", p.Symbols[0].Symbol, p.Symbols[0].Size)
-	}
-}
-
-func TestSaveAndLoadDB_LegacyPendingHLJSON_MigratesOnLoad(t *testing.T) {
-	db := openTestDB(t)
-	now := time.Now().UTC().Truncate(time.Second)
-
-	state := &AppState{
-		CycleCount: 1,
-		LastCycle:  now,
-		Strategies: map[string]*StrategyState{
-			"hl-a": {
-				ID: "hl-a", Type: "perps", Platform: "hyperliquid", Cash: 100, InitialCapital: 100,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
-				RiskState: RiskState{PeakValue: 100, MaxDrawdownPct: 25},
-			},
-		},
-	}
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("seed SaveState: %v", err)
-	}
-
-	legacyJSON := `{"coins":[{"coin":"ETH","sz":0.2585}]}`
-	if _, err := db.db.Exec(
-		"UPDATE strategies SET risk_pending_circuit_closes_json = ? WHERE id = ?",
-		legacyJSON, "hl-a",
-	); err != nil {
-		t.Fatalf("inject legacy JSON: %v", err)
-	}
-
-	loaded, err := db.LoadState()
-	if err != nil {
-		t.Fatalf("LoadState: %v", err)
-	}
-	p := loaded.Strategies["hl-a"].RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
-	if p == nil || len(p.Symbols) != 1 {
-		t.Fatalf("legacy JSON did not migrate on load: %+v", p)
-	}
-	if p.Symbols[0].Symbol != "ETH" || p.Symbols[0].Size != 0.2585 {
-		t.Errorf("legacy-migrated pending symbol=%q size=%g want ETH 0.2585", p.Symbols[0].Symbol, p.Symbols[0].Size)
-	}
+	t.Run("round trip", func(t *testing.T) {
+		db := seed(t, map[string]*PendingCircuitClose{
+			PlatformPendingCloseHyperliquid: {Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.2585}}},
+		})
+		assertPending(t, db, "round-trip")
+	})
+	t.Run("legacy pending hl json migrates on load", func(t *testing.T) {
+		db := seed(t, nil)
+		if _, err := db.db.Exec(
+			"UPDATE strategies SET risk_pending_circuit_closes_json = ? WHERE id = ?",
+			`{"coins":[{"coin":"ETH","sz":0.2585}]}`, "hl-a",
+		); err != nil {
+			t.Fatalf("inject legacy JSON: %v", err)
+		}
+		assertPending(t, db, "legacy-migrated")
+	})
 }
 
 func TestMigrateSchema_PendingCircuitClosesColumn_Idempotent(t *testing.T) {
@@ -2251,69 +2043,98 @@ CREATE TABLE trades (
 	}
 }
 
-func TestLifetimeTradeStatsAll_FreshInsert(t *testing.T) {
-	sdb := openTestDB(t)
+func TestLifetimeTradeStatsAll(t *testing.T) {
 	now := time.Now().UTC()
-	trades := []Trade{
-		{StrategyID: "s1", Timestamp: now, Symbol: "BTC", Side: "buy", Quantity: 0.1, Price: 50000, Value: 5000, TradeType: "perps", Details: "Open long"},
-		{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps", Details: "Close long, PnL: $100.00", IsClose: true, RealizedPnL: 100},
-		{StrategyID: "s1", Timestamp: now.Add(2 * time.Second), Symbol: "BTC", Side: "buy", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps", Details: "Open long"},
-		{StrategyID: "s1", Timestamp: now.Add(3 * time.Second), Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 50500, Value: 5050, TradeType: "perps", Details: "Close long, PnL: $-50.00", IsClose: true, RealizedPnL: -50},
-		{StrategyID: "s2", Timestamp: now, Symbol: "ETH", Side: "buy", Quantity: 0.5, Price: 2000, Value: 1000, TradeType: "perps", Details: "Open long"},
-		{StrategyID: "s2", Timestamp: now.Add(time.Second), Symbol: "ETH", Side: "sell", Quantity: 0.5, Price: 2100, Value: 1050, TradeType: "perps", Details: "Close long, PnL: $50.00", IsClose: true, RealizedPnL: 50},
+	cases := []struct {
+		name       string
+		trades     []Trade
+		want       map[string]LifetimeTradeStats
+		wantAbsent []string
+	}{
+		{
+			name: "fresh insert counts opens wins and losses per strategy",
+			trades: []Trade{
+				{StrategyID: "s1", Timestamp: now, Symbol: "BTC", Side: "buy", Quantity: 0.1, Price: 50000, Value: 5000, TradeType: "perps", Details: "Open long"},
+				{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps", Details: "Close long, PnL: $100.00", IsClose: true, RealizedPnL: 100},
+				{StrategyID: "s1", Timestamp: now.Add(2 * time.Second), Symbol: "BTC", Side: "buy", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps", Details: "Open long"},
+				{StrategyID: "s1", Timestamp: now.Add(3 * time.Second), Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 50500, Value: 5050, TradeType: "perps", Details: "Close long, PnL: $-50.00", IsClose: true, RealizedPnL: -50},
+				{StrategyID: "s2", Timestamp: now, Symbol: "ETH", Side: "buy", Quantity: 0.5, Price: 2000, Value: 1000, TradeType: "perps", Details: "Open long"},
+				{StrategyID: "s2", Timestamp: now.Add(time.Second), Symbol: "ETH", Side: "sell", Quantity: 0.5, Price: 2100, Value: 1050, TradeType: "perps", Details: "Close long, PnL: $50.00", IsClose: true, RealizedPnL: 50},
+			},
+			want:       map[string]LifetimeTradeStats{"s1": {PositionsOpened: 2, Wins: 1, Losses: 1}, "s2": {PositionsOpened: 1, Wins: 1, Losses: 0}},
+			wantAbsent: []string{"s3"},
+		},
+		{
+			name: "partial closes net by position id",
+			trades: []Trade{
+				{StrategyID: "s1", Timestamp: now, Symbol: "BTC", PositionID: "s1-BTC-open-1", Side: "buy", Quantity: 0.5, Price: 50000, Value: 25000, TradeType: "perps", Details: "Open long"},
+				{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", PositionID: "s1-BTC-open-1", Side: "sell", Quantity: 0.25, Price: 50100, Value: 12525, TradeType: "perps", Details: "Close long, PnL: $10.00", IsClose: true, RealizedPnL: 10},
+				{StrategyID: "s1", Timestamp: now.Add(2 * time.Second), Symbol: "BTC", PositionID: "s1-BTC-open-1", Side: "sell", Quantity: 0.25, Price: 49900, Value: 12475, TradeType: "perps", Details: "Close long, PnL: $-3.00", IsClose: true, RealizedPnL: -3},
+			},
+			want: map[string]LifetimeTradeStats{"s1": {PositionsOpened: 1, Wins: 1, Losses: 0}},
+		},
+		{
+			name: "position id scoped by strategy",
+			trades: []Trade{
+				{StrategyID: "s1", Timestamp: now, Symbol: "BTC", PositionID: "shared-position", Side: "sell", Quantity: 1, Price: 101, Value: 101, TradeType: "spot", Details: "Close long, PnL: $1", IsClose: true, RealizedPnL: 1},
+				{StrategyID: "s2", Timestamp: now, Symbol: "BTC", PositionID: "shared-position", Side: "sell", Quantity: 1, Price: 99, Value: 99, TradeType: "spot", Details: "Close long, PnL: $-1", IsClose: true, RealizedPnL: -1},
+			},
+			want: map[string]LifetimeTradeStats{"s1": {PositionsOpened: 0, Wins: 1, Losses: 0}, "s2": {PositionsOpened: 0, Wins: 0, Losses: 1}},
+		},
+		{
+			name: "breakeven position is neither win nor loss",
+			trades: []Trade{
+				{StrategyID: "s1", Timestamp: now, Symbol: "BTC", PositionID: "p1", Side: "sell", Quantity: 0.25, Price: 50100, Value: 12525, TradeType: "perps", Details: "Close long, PnL: $10", IsClose: true, RealizedPnL: 10},
+				{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", PositionID: "p1", Side: "sell", Quantity: 0.25, Price: 49900, Value: 12475, TradeType: "perps", Details: "Close long, PnL: $-10", IsClose: true, RealizedPnL: -10},
+			},
+			want: map[string]LifetimeTradeStats{"s1": {PositionsOpened: 0, Wins: 0, Losses: 0}},
+		},
+		{
+			name: "survives risk state reset because stats derive from trades",
+			trades: []Trade{
+				{StrategyID: "s1", Timestamp: now, Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps", Details: "Close long, PnL: $100", IsClose: true, RealizedPnL: 100},
+				{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 50500, Value: 5050, TradeType: "perps", Details: "Close long, PnL: $-25", IsClose: true, RealizedPnL: -25},
+			},
+			want: map[string]LifetimeTradeStats{"s1": {PositionsOpened: 0, Wins: 1, Losses: 1}},
+		},
 	}
-	for _, tr := range trades {
-		if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
-			t.Fatalf("InsertTrade: %v", err)
-		}
-	}
-
-	stats, err := sdb.LifetimeTradeStatsAll()
-	if err != nil {
-		t.Fatalf("LifetimeTradeStatsAll: %v", err)
-	}
-	if got := stats["s1"]; got.PositionsOpened != 2 || got.Wins != 1 || got.Losses != 1 {
-		t.Errorf("s1 stats = %+v, want PositionsOpened=2 Wins=1 Losses=1", got)
-	}
-	if got := stats["s2"]; got.PositionsOpened != 1 || got.Wins != 1 || got.Losses != 0 {
-		t.Errorf("s2 stats = %+v, want PositionsOpened=1 Wins=1 Losses=0", got)
-	}
-	if _, ok := stats["s3"]; ok {
-		t.Errorf("unexpected entry for s3 with no trades: %+v", stats["s3"])
-	}
-	if got, err := sdb.LifetimeTradeStatsForStrategy("s1"); err != nil {
-		t.Fatalf("LifetimeTradeStatsForStrategy: %v", err)
-	} else if got.PositionsOpened != 2 || got.Wins != 1 || got.Losses != 1 {
-		t.Errorf("single-strategy stats = %+v, want PositionsOpened=2 Wins=1 Losses=1", got)
-	}
-	if got, err := sdb.LifetimeTradeStatsForStrategy("s3"); err != nil {
-		t.Fatalf("LifetimeTradeStatsForStrategy empty: %v", err)
-	} else if got.PositionsOpened != 0 || got.Wins != 0 || got.Losses != 0 {
-		t.Errorf("single-strategy empty stats = %+v, want zero", got)
-	}
-}
-
-func TestLifetimeTradeStatsAll_PartialClosesNetByPositionID(t *testing.T) {
-	sdb := openTestDB(t)
-	now := time.Now().UTC()
-	positionID := "s1-BTC-open-1"
-	trades := []Trade{
-		{StrategyID: "s1", Timestamp: now, Symbol: "BTC", PositionID: positionID, Side: "buy", Quantity: 0.5, Price: 50000, Value: 25000, TradeType: "perps", Details: "Open long"},
-		{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", PositionID: positionID, Side: "sell", Quantity: 0.25, Price: 50100, Value: 12525, TradeType: "perps", Details: "Close long, PnL: $10.00", IsClose: true, RealizedPnL: 10},
-		{StrategyID: "s1", Timestamp: now.Add(2 * time.Second), Symbol: "BTC", PositionID: positionID, Side: "sell", Quantity: 0.25, Price: 49900, Value: 12475, TradeType: "perps", Details: "Close long, PnL: $-3.00", IsClose: true, RealizedPnL: -3},
-	}
-	for _, tr := range trades {
-		if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
-			t.Fatalf("InsertTrade: %v", err)
-		}
-	}
-
-	stats, err := sdb.LifetimeTradeStatsAll()
-	if err != nil {
-		t.Fatalf("LifetimeTradeStatsAll: %v", err)
-	}
-	if got := stats["s1"]; got.PositionsOpened != 1 || got.Wins != 1 || got.Losses != 0 {
-		t.Errorf("stats = %+v, want PositionsOpened=1 Wins=1 Losses=0", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sdb := openTestDB(t)
+			for _, tr := range tc.trades {
+				if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
+					t.Fatalf("InsertTrade: %v", err)
+				}
+			}
+			stats, err := sdb.LifetimeTradeStatsAll()
+			if err != nil {
+				t.Fatalf("LifetimeTradeStatsAll: %v", err)
+			}
+			for id, want := range tc.want {
+				if got := stats[id]; got != want {
+					t.Errorf("%s stats = %+v, want %+v", id, got, want)
+				}
+				got, err := sdb.LifetimeTradeStatsForStrategy(id)
+				if err != nil {
+					t.Fatalf("LifetimeTradeStatsForStrategy(%s): %v", id, err)
+				}
+				if got != want {
+					t.Errorf("%s single-strategy stats = %+v, want %+v", id, got, want)
+				}
+			}
+			for _, id := range tc.wantAbsent {
+				if got, ok := stats[id]; ok {
+					t.Errorf("unexpected entry for %s with no trades: %+v", id, got)
+				}
+				got, err := sdb.LifetimeTradeStatsForStrategy(id)
+				if err != nil {
+					t.Fatalf("LifetimeTradeStatsForStrategy(%s) empty: %v", id, err)
+				}
+				if got != (LifetimeTradeStats{}) {
+					t.Errorf("%s single-strategy empty stats = %+v, want zero", id, got)
+				}
+			}
+		})
 	}
 }
 
@@ -2343,51 +2164,6 @@ func TestLifetimeTradeStatsAll_LegacyNullAndEmptyPositionIDStayPerLeg(t *testing
 	}
 	if got := stats["s1"]; got.PositionsOpened != 0 || got.Wins != 1 || got.Losses != 1 {
 		t.Errorf("legacy stats = %+v, want PositionsOpened=0 Wins=1 Losses=1 (only close legs seeded)", got)
-	}
-}
-
-func TestLifetimeTradeStatsAll_PositionIDScopedByStrategy(t *testing.T) {
-	sdb := openTestDB(t)
-	now := time.Now().UTC()
-	for _, tr := range []Trade{
-		{StrategyID: "s1", Timestamp: now, Symbol: "BTC", PositionID: "shared-position", Side: "sell", Quantity: 1, Price: 101, Value: 101, TradeType: "spot", Details: "Close long, PnL: $1", IsClose: true, RealizedPnL: 1},
-		{StrategyID: "s2", Timestamp: now, Symbol: "BTC", PositionID: "shared-position", Side: "sell", Quantity: 1, Price: 99, Value: 99, TradeType: "spot", Details: "Close long, PnL: $-1", IsClose: true, RealizedPnL: -1},
-	} {
-		if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
-			t.Fatalf("InsertTrade: %v", err)
-		}
-	}
-
-	stats, err := sdb.LifetimeTradeStatsAll()
-	if err != nil {
-		t.Fatalf("LifetimeTradeStatsAll: %v", err)
-	}
-	if got := stats["s1"]; got.PositionsOpened != 0 || got.Wins != 1 || got.Losses != 0 {
-		t.Errorf("s1 stats = %+v, want PositionsOpened=0 Wins=1 Losses=0 (only close legs seeded)", got)
-	}
-	if got := stats["s2"]; got.PositionsOpened != 0 || got.Wins != 0 || got.Losses != 1 {
-		t.Errorf("s2 stats = %+v, want PositionsOpened=0 Wins=0 Losses=1 (only close legs seeded)", got)
-	}
-}
-
-func TestLifetimeTradeStatsAll_BreakevenPositionNeitherWinNorLoss(t *testing.T) {
-	sdb := openTestDB(t)
-	now := time.Now().UTC()
-	for _, tr := range []Trade{
-		{StrategyID: "s1", Timestamp: now, Symbol: "BTC", PositionID: "p1", Side: "sell", Quantity: 0.25, Price: 50100, Value: 12525, TradeType: "perps", Details: "Close long, PnL: $10", IsClose: true, RealizedPnL: 10},
-		{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", PositionID: "p1", Side: "sell", Quantity: 0.25, Price: 49900, Value: 12475, TradeType: "perps", Details: "Close long, PnL: $-10", IsClose: true, RealizedPnL: -10},
-	} {
-		if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
-			t.Fatalf("InsertTrade: %v", err)
-		}
-	}
-
-	stats, err := sdb.LifetimeTradeStatsAll()
-	if err != nil {
-		t.Fatalf("LifetimeTradeStatsAll: %v", err)
-	}
-	if got := stats["s1"]; got.PositionsOpened != 0 || got.Wins != 0 || got.Losses != 0 {
-		t.Errorf("breakeven stats = %+v, want PositionsOpened=0 Wins=0 Losses=0 (only close legs seeded)", got)
 	}
 }
 
@@ -2466,30 +2242,5 @@ func TestLifetimeTradeStatsAll_OptionsSameContractReopenUsesDistinctPositionIDs(
 	}
 	if got := stats[s.ID]; got.PositionsOpened != 2 || got.Wins != 2 || got.Losses != 0 {
 		t.Errorf("option stats = %+v, want PositionsOpened=2 Wins=2 Losses=0", got)
-	}
-}
-
-func TestLifetimeTradeStats_SurvivesRiskStateReset(t *testing.T) {
-	sdb := openTestDB(t)
-	now := time.Now().UTC()
-	closes := []Trade{
-		{StrategyID: "s1", Timestamp: now, Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 51000, Value: 5100, TradeType: "perps", Details: "Close long, PnL: $100", IsClose: true, RealizedPnL: 100},
-		{StrategyID: "s1", Timestamp: now.Add(time.Second), Symbol: "BTC", Side: "sell", Quantity: 0.1, Price: 50500, Value: 5050, TradeType: "perps", Details: "Close long, PnL: $-25", IsClose: true, RealizedPnL: -25},
-	}
-	for _, tr := range closes {
-		if err := sdb.InsertTrade(tr.StrategyID, tr); err != nil {
-			t.Fatalf("InsertTrade: %v", err)
-		}
-	}
-
-	_ = RiskState{}
-
-	stats, err := sdb.LifetimeTradeStatsAll()
-	if err != nil {
-		t.Fatalf("LifetimeTradeStatsAll: %v", err)
-	}
-	got := stats["s1"]
-	if got.PositionsOpened != 0 || got.Wins != 1 || got.Losses != 1 {
-		t.Errorf("post-reset stats = %+v, want PositionsOpened=0 Wins=1 Losses=1 (only close legs seeded)", got)
 	}
 }

--- a/scheduler/exposure_cap_test.go
+++ b/scheduler/exposure_cap_test.go
@@ -48,213 +48,168 @@ func exposureTestPrices() map[string]float64 {
 	return map[string]float64{"BTC": 50000, "ETH": 3000, "SOL": 150}
 }
 
-func TestEvaluateExposureCap_AllLongBookBlocksLongsOnly(t *testing.T) {
-	pr := &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxSameDirectionNotionalUSD: 15000}
-	st := evaluateExposureCap(pr, exposureTestStates(), exposureTestConfigs(), exposureTestPrices(), 20000)
-
-	if !st.Configured {
-		t.Fatal("expected Configured=true")
-	}
-	if st.LongUSD != 19000 {
-		t.Errorf("LongUSD = %f, want 19000", st.LongUSD)
-	}
-	if st.ShortUSD != 0 {
-		t.Errorf("ShortUSD = %f, want 0", st.ShortUSD)
-	}
-	if !st.LongBlocked {
-		t.Error("expected LongBlocked=true (19000 > 15000)")
-	}
-	if st.ShortBlocked {
-		t.Error("expected ShortBlocked=false")
-	}
-
-	blocked, why := exposureCapBlocksSignal(st, "BTC", 1, 0, 0, "", true, true)
-	if !blocked {
-		t.Fatal("expected fresh long open blocked")
-	}
-	if !strings.Contains(why, "new long opens blocked") || !strings.Contains(why, "$19000.00") || !strings.Contains(why, "$15000.00") {
-		t.Errorf("unexpected reason: %q", why)
-	}
-	if blocked, _ := exposureCapBlocksSignal(st, "BTC", -1, 0, 0, "", true, true); blocked {
-		t.Error("short entry must not be blocked when only the long bucket is capped")
+func perpsPosState(id, coin string, qty float64, side string, avgCost float64) *StrategyState {
+	return &StrategyState{
+		ID: id, Type: "perps",
+		Positions:       map[string]*Position{coin: {Symbol: coin, Quantity: qty, Side: side, AvgCost: avgCost}},
+		OptionPositions: make(map[string]*OptionPosition),
 	}
 }
 
-func TestEvaluateExposureCap_NettingPerAsset(t *testing.T) {
-	states := map[string]*StrategyState{
-		"hl-a-btc": {
-			ID: "hl-a-btc", Type: "perps",
-			Positions: map[string]*Position{
-				"BTC": {Symbol: "BTC", Quantity: 0.2, Side: "long", AvgCost: 48000},
-			},
-			OptionPositions: make(map[string]*OptionPosition),
-		},
-		"hl-b-eth": {
-			ID: "hl-b-eth", Type: "perps",
-			Positions: map[string]*Position{
-				"ETH": {Symbol: "ETH", Quantity: 2, Side: "short", AvgCost: 2900},
-			},
-			OptionPositions: make(map[string]*OptionPosition),
-		},
-	}
-	cfgs := []StrategyConfig{
-		{ID: "hl-a-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}},
-		{ID: "hl-b-eth", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "ETH", "1h"}},
-	}
-	prices := map[string]float64{"BTC": 50000, "ETH": 5000}
-	pr := &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxSameDirectionNotionalUSD: 15000}
+func perpsCfg(id, strategy, coin string) StrategyConfig {
+	return StrategyConfig{ID: id, Type: "perps", Platform: "hyperliquid", Args: []string{strategy, coin, "1h"}}
+}
 
-	st := evaluateExposureCap(pr, states, cfgs, prices, 20000)
-	if st.LongUSD != 10000 {
-		t.Errorf("LongUSD = %f, want 10000", st.LongUSD)
+func TestEvaluateExposureCap_Buckets(t *testing.T) {
+	bucketCap := &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxSameDirectionNotionalUSD: 15000}
+	cases := []struct {
+		name               string
+		pr                 *PortfolioRiskConfig
+		states             map[string]*StrategyState
+		cfgs               []StrategyConfig
+		prices             map[string]float64
+		pv                 float64
+		wantConfigured     bool
+		wantLong           float64
+		wantShort          float64
+		wantLongBlocked    bool
+		wantShortBlocked   bool
+		wantSkipped        []string
+		wantSkippedWarning string
+	}{
+		{name: "all_long_book_blocks_longs_only",
+			pr: bucketCap, states: exposureTestStates(), cfgs: exposureTestConfigs(), prices: exposureTestPrices(), pv: 20000,
+			wantConfigured: true, wantLong: 19000, wantShort: 0, wantLongBlocked: true},
+		{name: "netting_per_asset",
+			pr: bucketCap,
+			states: map[string]*StrategyState{
+				"hl-a-btc": perpsPosState("hl-a-btc", "BTC", 0.2, "long", 48000),
+				"hl-b-eth": perpsPosState("hl-b-eth", "ETH", 2, "short", 2900),
+			},
+			cfgs:   []StrategyConfig{perpsCfg("hl-a-btc", "momentum", "BTC"), perpsCfg("hl-b-eth", "momentum", "ETH")},
+			prices: map[string]float64{"BTC": 50000, "ETH": 5000}, pv: 20000,
+			wantConfigured: true, wantLong: 10000, wantShort: 10000},
+		{name: "same_asset_nets_before_bucketing",
+			pr: bucketCap,
+			states: map[string]*StrategyState{
+				"hl-a-btc": perpsPosState("hl-a-btc", "BTC", 0.3, "long", 48000),
+				"hl-b-btc": perpsPosState("hl-b-btc", "BTC", 0.1, "short", 48000),
+			},
+			cfgs:   []StrategyConfig{perpsCfg("hl-a-btc", "momentum", "BTC"), perpsCfg("hl-b-btc", "triple_ema", "BTC")},
+			prices: map[string]float64{"BTC": 50000}, pv: 20000,
+			wantConfigured: true, wantLong: 10000, wantShort: 0},
+		{name: "disabled_by_default_zero_thresholds",
+			pr: &PortfolioRiskConfig{MaxDrawdownPct: 25}, states: exposureTestStates(), cfgs: exposureTestConfigs(), prices: exposureTestPrices(), pv: 20000,
+			wantConfigured: false},
+		{name: "disabled_nil_config",
+			pr: nil, states: exposureTestStates(), cfgs: exposureTestConfigs(), prices: exposureTestPrices(), pv: 20000,
+			wantConfigured: false},
+		{name: "fail_safe_exclusions_do_not_inflate_sum",
+			pr: bucketCap,
+			states: map[string]*StrategyState{
+				"hl-a-btc": perpsPosState("hl-a-btc", "BTC", 0.2, "long", 48000),
+				"hl-b-xyz": perpsPosState("hl-b-xyz", "XYZ", 5, "long", 0),
+				"hl-c-eth": perpsPosState("hl-c-eth", "ETH", -1, "long", 3000),
+			},
+			cfgs:   []StrategyConfig{perpsCfg("hl-a-btc", "momentum", "BTC"), perpsCfg("hl-b-xyz", "momentum", "XYZ"), perpsCfg("hl-c-eth", "momentum", "ETH")},
+			prices: map[string]float64{"BTC": 50000, "ETH": 3000}, pv: 20000,
+			wantConfigured: true, wantLong: 10000, wantShort: 0,
+			wantSkipped:        []string{"hl-b-xyz/XYZ: no usable price", "hl-c-eth/ETH: non-positive quantity"},
+			wantSkippedWarning: "2 position(s) excluded"},
+		{name: "avg_cost_fallback_without_prices",
+			pr: bucketCap, states: exposureTestStates(), cfgs: exposureTestConfigs(), prices: nil, pv: 0,
+			wantConfigured: true, wantLong: 18200, wantShort: 0, wantLongBlocked: true},
+		{name: "manual_positions_counted",
+			pr:     &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxSameDirectionNotionalUSD: 10000},
+			states: map[string]*StrategyState{"hl-manual": {ID: "hl-manual", Type: "manual", Positions: map[string]*Position{"ETH": {Symbol: "ETH", Quantity: 4, Side: "long", AvgCost: 2900}}, OptionPositions: make(map[string]*OptionPosition)}},
+			cfgs:   []StrategyConfig{{ID: "hl-manual", Type: "manual", Platform: "hyperliquid", Args: []string{"hold", "ETH"}}},
+			prices: map[string]float64{"ETH": 3000}, pv: 20000,
+			wantConfigured: true, wantLong: 12000, wantShort: 0, wantLongBlocked: true},
 	}
-	if st.ShortUSD != 10000 {
-		t.Errorf("ShortUSD = %f, want 10000", st.ShortUSD)
-	}
-	if st.LongBlocked || st.ShortBlocked {
-		t.Error("neither bucket may block under a 15000 cap")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := evaluateExposureCap(tc.pr, tc.states, tc.cfgs, tc.prices, tc.pv)
+			if st.Configured != tc.wantConfigured {
+				t.Fatalf("Configured = %v, want %v", st.Configured, tc.wantConfigured)
+			}
+			if !tc.wantConfigured {
+				if st.LongBlocked || st.ShortBlocked {
+					t.Fatalf("disabled cap must not mark buckets blocked: %+v", st)
+				}
+				return
+			}
+			if st.LongUSD != tc.wantLong {
+				t.Errorf("LongUSD = %f, want %f", st.LongUSD, tc.wantLong)
+			}
+			if st.ShortUSD != tc.wantShort {
+				t.Errorf("ShortUSD = %f, want %f", st.ShortUSD, tc.wantShort)
+			}
+			if st.LongBlocked != tc.wantLongBlocked {
+				t.Errorf("LongBlocked = %v, want %v", st.LongBlocked, tc.wantLongBlocked)
+			}
+			if st.ShortBlocked != tc.wantShortBlocked {
+				t.Errorf("ShortBlocked = %v, want %v", st.ShortBlocked, tc.wantShortBlocked)
+			}
+			if len(st.SkippedPositions) != len(tc.wantSkipped) {
+				t.Fatalf("SkippedPositions = %v, want %d entries %v", st.SkippedPositions, len(tc.wantSkipped), tc.wantSkipped)
+			}
+			joined := strings.Join(st.SkippedPositions, "; ")
+			for _, want := range tc.wantSkipped {
+				if !strings.Contains(joined, want) {
+					t.Errorf("missing skip entry %q in %v", want, st.SkippedPositions)
+				}
+			}
+			if tc.wantSkippedWarning != "" {
+				if msg := exposureCapSkippedWarning(st); !strings.Contains(msg, tc.wantSkippedWarning) {
+					t.Errorf("unexpected skipped warning: %q", msg)
+				}
+			}
+		})
 	}
 }
 
-func TestEvaluateExposureCap_SameAssetNetsBeforeBucketing(t *testing.T) {
-	states := map[string]*StrategyState{
-		"hl-a-btc": {
-			ID: "hl-a-btc", Type: "perps",
-			Positions: map[string]*Position{
-				"BTC": {Symbol: "BTC", Quantity: 0.3, Side: "long", AvgCost: 48000},
-			},
-			OptionPositions: make(map[string]*OptionPosition),
-		},
-		"hl-b-btc": {
-			ID: "hl-b-btc", Type: "perps",
-			Positions: map[string]*Position{
-				"BTC": {Symbol: "BTC", Quantity: 0.1, Side: "short", AvgCost: 48000},
-			},
-			OptionPositions: make(map[string]*OptionPosition),
-		},
+func TestExposureCapBlocksSignal(t *testing.T) {
+	bothCapped := ExposureCapStatus{Configured: true, CapUSD: 100, LongUSD: 500, ShortUSD: 500, LongBlocked: true, ShortBlocked: true}
+	longCapped := ExposureCapStatus{Configured: true, CapUSD: 100, LongUSD: 500, LongBlocked: true}
+	shortCapped := ExposureCapStatus{Configured: true, CapUSD: 100, ShortUSD: 500, ShortBlocked: true}
+	longBook := ExposureCapStatus{Configured: true, CapUSD: 15000, LongUSD: 19000, LongBlocked: true}
+	cases := []struct {
+		name          string
+		st            ExposureCapStatus
+		signal        int
+		closeFraction float64
+		posQty        float64
+		posSide       string
+		allowsLong    bool
+		allowsShort   bool
+		wantBlocked   bool
+		wantReason    []string
+	}{
+		{"manage_only_signal0_passes", bothCapped, 0, 0, 1, "long", true, true, false, nil},
+		{"close_action_passes", bothCapped, -1, 1.0, 1, "long", true, true, false, nil},
+		{"pure_close_sell_on_long_passes", bothCapped, -1, 0, 1, "long", true, false, false, nil},
+		{"pure_close_buy_on_short_passes", bothCapped, 1, 0, 1, "short", false, true, false, nil},
+		{"scale_in_add_on_long_blocked_while_longs_capped", longCapped, 1, 0, 1, "long", true, true, true, nil},
+		{"long_to_short_flip_passes_while_only_longs_capped", longCapped, -1, 0, 1, "long", true, true, false, nil},
+		{"long_to_short_flip_held_while_shorts_capped", shortCapped, -1, 0, 1, "long", true, true, true, nil},
+		{"fresh_short_open_blocked_while_shorts_capped", shortCapped, -1, 0, 0, "", true, true, true, nil},
+		{"fresh_short_open_passes_while_only_longs_capped", longCapped, -1, 0, 0, "", true, true, false, nil},
+		{"fresh_long_open_blocked_with_amounts_in_reason", longBook, 1, 0, 0, "", true, true, true, []string{"new long opens blocked", "$19000.00", "$15000.00"}},
+		{"fresh_short_open_passes_on_long_capped_book", longBook, -1, 0, 0, "", true, true, false, nil},
+		{"disabled_cap_never_blocks", ExposureCapStatus{}, 1, 0, 0, "", true, true, false, nil},
 	}
-	cfgs := []StrategyConfig{
-		{ID: "hl-a-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}},
-		{ID: "hl-b-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"triple_ema", "BTC", "1h"}},
-	}
-	prices := map[string]float64{"BTC": 50000}
-	pr := &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxSameDirectionNotionalUSD: 15000}
-
-	st := evaluateExposureCap(pr, states, cfgs, prices, 20000)
-	if st.LongUSD != 10000 {
-		t.Errorf("LongUSD = %f, want 10000", st.LongUSD)
-	}
-	if st.ShortUSD != 0 {
-		t.Errorf("ShortUSD = %f, want 0 (same-asset short nets against the long)", st.ShortUSD)
-	}
-}
-
-func TestEvaluateExposureCap_DisabledByDefault(t *testing.T) {
-	pr := &PortfolioRiskConfig{MaxDrawdownPct: 25}
-	st := evaluateExposureCap(pr, exposureTestStates(), exposureTestConfigs(), exposureTestPrices(), 20000)
-	if st.Configured {
-		t.Error("expected Configured=false with zero thresholds")
-	}
-	if blocked, _ := exposureCapBlocksSignal(st, "BTC", 1, 0, 0, "", true, true); blocked {
-		t.Error("disabled cap must not block")
-	}
-	if st.LongBlocked || st.ShortBlocked {
-		t.Error("disabled cap must not mark buckets blocked")
-	}
-	st = evaluateExposureCap(nil, exposureTestStates(), exposureTestConfigs(), exposureTestPrices(), 20000)
-	if st.Configured {
-		t.Error("expected Configured=false with nil config")
-	}
-}
-
-func TestEvaluateExposureCap_FailSafeExclusions(t *testing.T) {
-	states := map[string]*StrategyState{
-		"hl-a-btc": {
-			ID: "hl-a-btc", Type: "perps",
-			Positions: map[string]*Position{
-				"BTC": {Symbol: "BTC", Quantity: 0.2, Side: "long", AvgCost: 48000},
-			},
-			OptionPositions: make(map[string]*OptionPosition),
-		},
-		"hl-b-xyz": {
-			ID: "hl-b-xyz", Type: "perps",
-			Positions: map[string]*Position{
-				"XYZ": {Symbol: "XYZ", Quantity: 5, Side: "long", AvgCost: 0},
-			},
-			OptionPositions: make(map[string]*OptionPosition),
-		},
-		"hl-c-eth": {
-			ID: "hl-c-eth", Type: "perps",
-			Positions: map[string]*Position{
-				"ETH": {Symbol: "ETH", Quantity: -1, Side: "long", AvgCost: 3000},
-			},
-			OptionPositions: make(map[string]*OptionPosition),
-		},
-	}
-	cfgs := []StrategyConfig{
-		{ID: "hl-a-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}},
-		{ID: "hl-b-xyz", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "XYZ", "1h"}},
-		{ID: "hl-c-eth", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "ETH", "1h"}},
-	}
-	prices := map[string]float64{"BTC": 50000, "ETH": 3000}
-	pr := &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxSameDirectionNotionalUSD: 15000}
-
-	st := evaluateExposureCap(pr, states, cfgs, prices, 20000)
-	if st.LongUSD != 10000 {
-		t.Errorf("LongUSD = %f, want 10000 (only the priceable BTC leg counts)", st.LongUSD)
-	}
-	if st.LongBlocked {
-		t.Error("expected LongBlocked=false — exclusions must not inflate the sum")
-	}
-	if len(st.SkippedPositions) != 2 {
-		t.Fatalf("expected 2 skipped positions, got %v", st.SkippedPositions)
-	}
-	joined := strings.Join(st.SkippedPositions, "; ")
-	if !strings.Contains(joined, "hl-b-xyz/XYZ: no usable price") {
-		t.Errorf("missing unpriceable skip entry: %v", st.SkippedPositions)
-	}
-	if !strings.Contains(joined, "hl-c-eth/ETH: non-positive quantity") {
-		t.Errorf("missing corrupt-quantity skip entry: %v", st.SkippedPositions)
-	}
-	if msg := exposureCapSkippedWarning(st); !strings.Contains(msg, "2 position(s) excluded") {
-		t.Errorf("unexpected skipped warning: %q", msg)
-	}
-}
-
-func TestEvaluateExposureCap_AvgCostFallback(t *testing.T) {
-	pr := &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxSameDirectionNotionalUSD: 15000}
-	st := evaluateExposureCap(pr, exposureTestStates(), exposureTestConfigs(), nil, 0)
-	if st.LongUSD != 18200 {
-		t.Errorf("LongUSD = %f, want 18200 (AvgCost valuation)", st.LongUSD)
-	}
-	if !st.LongBlocked {
-		t.Error("expected LongBlocked=true at AvgCost valuation")
-	}
-	if len(st.SkippedPositions) != 0 {
-		t.Errorf("expected no skips with positive AvgCosts, got %v", st.SkippedPositions)
-	}
-}
-
-func TestEvaluateExposureCap_ManualPositionsCounted(t *testing.T) {
-	states := map[string]*StrategyState{
-		"hl-manual": {
-			ID: "hl-manual", Type: "manual",
-			Positions: map[string]*Position{
-				"ETH": {Symbol: "ETH", Quantity: 4, Side: "long", AvgCost: 2900},
-			},
-			OptionPositions: make(map[string]*OptionPosition),
-		},
-	}
-	cfgs := []StrategyConfig{
-		{ID: "hl-manual", Type: "manual", Platform: "hyperliquid", Args: []string{"hold", "ETH"}},
-	}
-	pr := &PortfolioRiskConfig{MaxDrawdownPct: 25, MaxSameDirectionNotionalUSD: 10000}
-	st := evaluateExposureCap(pr, states, cfgs, map[string]float64{"ETH": 3000}, 20000)
-	if st.LongUSD != 12000 {
-		t.Errorf("LongUSD = %f, want 12000 (manual positions count)", st.LongUSD)
-	}
-	if !st.LongBlocked {
-		t.Error("expected LongBlocked=true")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blocked, why := exposureCapBlocksSignal(tc.st, "BTC", tc.signal, tc.closeFraction, tc.posQty, tc.posSide, tc.allowsLong, tc.allowsShort)
+			if blocked != tc.wantBlocked {
+				t.Fatalf("blocked = %v, want %v (why=%q)", blocked, tc.wantBlocked, why)
+			}
+			for _, want := range tc.wantReason {
+				if !strings.Contains(why, want) {
+					t.Errorf("reason %q missing %q", why, want)
+				}
+			}
+		})
 	}
 }
 
@@ -300,46 +255,6 @@ func TestEvaluateExposureCap_PVBasisMiss(t *testing.T) {
 	}
 	if blocked, _ := exposureCapBlocksSignal(st, "BTC", 1, 0, 0, "", true, true); blocked {
 		t.Error("a non-evaluable concentration arm must not block (fail-safe, surfaced loudly instead)")
-	}
-}
-
-func TestExposureCapBlocksSignal_ManageAndReducePassThrough(t *testing.T) {
-	st := ExposureCapStatus{
-		Configured: true, CapUSD: 100, LongUSD: 500, ShortUSD: 500,
-		LongBlocked: true, ShortBlocked: true,
-	}
-	if blocked, _ := exposureCapBlocksSignal(st, "BTC", 0, 0, 1, "long", true, true); blocked {
-		t.Error("signal==0 must pass (manage-only path keeps running)")
-	}
-	if blocked, _ := exposureCapBlocksSignal(st, "BTC", -1, 1.0, 1, "long", true, true); blocked {
-		t.Error("close action must pass")
-	}
-	if blocked, _ := exposureCapBlocksSignal(st, "BTC", -1, 0, 1, "long", true, false); blocked {
-		t.Error("pure-close sell on a long must pass")
-	}
-	if blocked, _ := exposureCapBlocksSignal(st, "BTC", 1, 0, 1, "short", false, true); blocked {
-		t.Error("pure-close buy on a short must pass")
-	}
-}
-
-func TestExposureCapBlocksSignal_DirectionalIncreases(t *testing.T) {
-	longCapped := ExposureCapStatus{Configured: true, CapUSD: 100, LongUSD: 500, LongBlocked: true}
-	shortCapped := ExposureCapStatus{Configured: true, CapUSD: 100, ShortUSD: 500, ShortBlocked: true}
-
-	if blocked, _ := exposureCapBlocksSignal(longCapped, "BTC", 1, 0, 1, "long", true, true); !blocked {
-		t.Error("scale-in add on a long must be blocked while longs are capped")
-	}
-	if blocked, _ := exposureCapBlocksSignal(longCapped, "BTC", -1, 0, 1, "long", true, true); blocked {
-		t.Error("long→short flip must pass while only the long bucket is capped")
-	}
-	if blocked, _ := exposureCapBlocksSignal(shortCapped, "BTC", -1, 0, 1, "long", true, true); !blocked {
-		t.Error("long→short flip must be held while the short bucket is capped")
-	}
-	if blocked, _ := exposureCapBlocksSignal(shortCapped, "BTC", -1, 0, 0, "", true, true); !blocked {
-		t.Error("fresh short open must be blocked while shorts are capped")
-	}
-	if blocked, _ := exposureCapBlocksSignal(longCapped, "BTC", -1, 0, 0, "", true, true); blocked {
-		t.Error("fresh short open must pass while only longs are capped")
 	}
 }
 
@@ -635,55 +550,53 @@ func exposureCapE2EDeps(t *testing.T, view manualStateView, executed *bool) manu
 
 var errSentinelStopAfterGuards = errors.New("sentinel: guards passed, stop before state update")
 
-func TestManualOpenCoreRefusesExposureCap(t *testing.T) {
-	sc := StrategyConfig{ID: "m", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 3, Direction: "both"}
-	view := manualStateView{HasStrategy: true, ExposureCapAsset: "ETH",
+func TestManualCoreRefusesExposureCap(t *testing.T) {
+	bucketView := manualStateView{HasStrategy: true, ExposureCapAsset: "ETH",
 		ExposureCap: ExposureCapStatus{Configured: true, CapUSD: 15000, LongUSD: 19000, LongBlocked: true}}
-
-	executed := false
-	deps := exposureCapE2EDeps(t, view, &executed)
-	_, err := manualOpenCore(deps, sc, manualOpenInputs{StrategyID: "m", Side: "long", Margin: 50})
-	if err == nil || !strings.Contains(err.Error(), "manual-open (long) blocked") {
-		t.Fatalf("manual-open err = %v, want exposure-cap refusal", err)
-	}
-	if executed {
-		t.Fatal("execute must not be called while the long bucket is capped")
-	}
-
-	executed = false
-	deps = exposureCapE2EDeps(t, view, &executed)
-	_, err = manualOpenCore(deps, sc, manualOpenInputs{StrategyID: "m", Side: "short", Margin: 50})
-	if !executed {
-		t.Fatalf("short entry must reach execute while only the long bucket is capped (err = %v)", err)
-	}
-}
-
-func TestManualAddCoreRefusesConcentrationOnly(t *testing.T) {
-	sc := StrategyConfig{ID: "m", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 3}
 	concStatus := ExposureCapStatus{Configured: true, ConcentrationPct: 40, PortfolioValue: 18200,
 		OverConcentrated: map[string]ExposureCapAssetStat{
 			"ETH": {Direction: "long", Pct: 52.7, NetUSD: 9600},
 		}}
-	longPos := &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: "long"}
-	view := manualStateView{HasStrategy: true, Pos: longPos,
-		ExposureCap: concStatus, ExposureCapAsset: "ETH"}
-
-	executed := false
-	deps := exposureCapE2EDeps(t, view, &executed)
-	_, err := manualAddCore(deps, sc, manualAddInputs{StrategyID: "m", Margin: 50})
-	if err == nil || !strings.Contains(err.Error(), "manual-add (long) blocked") {
-		t.Fatalf("manual-add err = %v, want concentration refusal", err)
+	concView := func(side string) manualStateView {
+		return manualStateView{HasStrategy: true, ExposureCap: concStatus, ExposureCapAsset: "ETH",
+			Pos: &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: side}}
 	}
-	if executed {
-		t.Fatal("execute must not be called on an over-concentrated add")
+	openSC := StrategyConfig{ID: "m", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 3, Direction: "both"}
+	addSC := StrategyConfig{ID: "m", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 3}
+	cases := []struct {
+		name         string
+		view         manualStateView
+		run          func(deps manualCoreDeps) error
+		wantErr      string
+		wantExecuted bool
+	}{
+		{"open_long_refused_by_bucket_arm", bucketView, func(deps manualCoreDeps) error {
+			_, err := manualOpenCore(deps, openSC, manualOpenInputs{StrategyID: "m", Side: "long", Margin: 50})
+			return err
+		}, "manual-open (long) blocked", false},
+		{"open_short_reaches_execute_while_only_longs_capped", bucketView, func(deps manualCoreDeps) error {
+			_, err := manualOpenCore(deps, openSC, manualOpenInputs{StrategyID: "m", Side: "short", Margin: 50})
+			return err
+		}, "", true},
+		{"add_long_refused_by_concentration_only", concView("long"), func(deps manualCoreDeps) error {
+			_, err := manualAddCore(deps, addSC, manualAddInputs{StrategyID: "m", Margin: 50})
+			return err
+		}, "manual-add (long) blocked", false},
+		{"add_short_reaches_execute_when_long_over_concentrated", concView("short"), func(deps manualCoreDeps) error {
+			_, err := manualAddCore(deps, addSC, manualAddInputs{StrategyID: "m", Margin: 50})
+			return err
+		}, "", true},
 	}
-
-	shortPos := &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: "short"}
-	view.Pos = shortPos
-	executed = false
-	deps = exposureCapE2EDeps(t, view, &executed)
-	_, err = manualAddCore(deps, sc, manualAddInputs{StrategyID: "m", Margin: 50})
-	if !executed {
-		t.Fatalf("short add must reach execute when ETH is long-over-concentrated (err = %v)", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			executed := false
+			err := tc.run(exposureCapE2EDeps(t, tc.view, &executed))
+			if tc.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("err = %v, want refusal containing %q", err, tc.wantErr)
+			}
+			if executed != tc.wantExecuted {
+				t.Fatalf("executed = %v, want %v (err = %v)", executed, tc.wantExecuted, err)
+			}
+		})
 	}
 }

--- a/scheduler/hyperliquid_fills_test.go
+++ b/scheduler/hyperliquid_fills_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -27,138 +28,6 @@ func withFastFillRetries(t *testing.T) {
 		hlFillLookupRetries = origRetries
 		hlFillLookupRetryDelay = origDelay
 	})
-}
-
-func TestLookupHyperliquidFillByOID_AggregatesPartialFills(t *testing.T) {
-	withFastFillRetries(t)
-	srv := newHLUserFillsServer(t, []map[string]any{
-		{"coin": "BTC", "oid": 12345, "fee": "0.50", "closedPnl": "100.00", "sz": "0.1"},
-		{"coin": "BTC", "oid": 12345, "fee": "0.30", "closedPnl": "50.00", "sz": "0.05"},
-		{"coin": "BTC", "oid": 99999, "fee": "1.00", "closedPnl": "200.00", "sz": "0.2"},
-	})
-	defer srv.Close()
-	origURL := hlMainnetURL
-	hlMainnetURL = srv.URL
-	defer func() { hlMainnetURL = origURL }()
-
-	got, ok := lookupHyperliquidFillByOID("0xtest", 12345, 0)
-	if !ok {
-		t.Fatal("expected ok=true")
-	}
-	if got.Count != 2 {
-		t.Errorf("Count = %d, want 2", got.Count)
-	}
-	if got.Fee < 0.799 || got.Fee > 0.801 {
-		t.Errorf("Fee = %g, want ~0.80", got.Fee)
-	}
-	if got.ClosedPnLGross < 149.99 || got.ClosedPnLGross > 150.01 {
-		t.Errorf("ClosedPnLGross = %g, want ~150.00", got.ClosedPnLGross)
-	}
-}
-
-func TestLookupHyperliquidFillByOID_NoMatchReturnsFalse(t *testing.T) {
-	withFastFillRetries(t)
-	srv := newHLUserFillsServer(t, []map[string]any{
-		{"coin": "BTC", "oid": 99999, "fee": "1.00", "sz": "0.2"},
-	})
-	defer srv.Close()
-	origURL := hlMainnetURL
-	hlMainnetURL = srv.URL
-	defer func() { hlMainnetURL = origURL }()
-
-	if _, ok := lookupHyperliquidFillByOID("0xtest", 12345, 0); ok {
-		t.Error("expected ok=false for missing OID")
-	}
-}
-
-func TestLookupHyperliquidFillByOID_EmptyAddressShortCircuits(t *testing.T) {
-	withFastFillRetries(t)
-	if _, ok := lookupHyperliquidFillByOID("", 12345, 0); ok {
-		t.Error("expected ok=false for empty address")
-	}
-}
-
-func TestLookupHyperliquidFillByCoinSize_MatchesByCoinAndSize(t *testing.T) {
-	withFastFillRetries(t)
-	srv := newHLUserFillsServer(t, []map[string]any{
-		{"coin": "BTC", "oid": 1, "fee": "0.40", "closedPnl": "75.00", "sz": "0.123456"},
-		{"coin": "ETH", "oid": 2, "fee": "0.10", "closedPnl": "5.00", "sz": "0.123456"},
-		{"coin": "BTC", "oid": 3, "fee": "0.20", "closedPnl": "10.00", "sz": "0.5"},
-	})
-	defer srv.Close()
-	origURL := hlMainnetURL
-	hlMainnetURL = srv.URL
-	defer func() { hlMainnetURL = origURL }()
-
-	got, ok := lookupHyperliquidFillByCoinSize("0xtest", "BTC", 0.123456, 1e-4, 0)
-	if !ok {
-		t.Fatal("expected ok=true")
-	}
-	if got.Count != 1 {
-		t.Errorf("Count = %d, want 1", got.Count)
-	}
-	if got.Fee < 0.399 || got.Fee > 0.401 {
-		t.Errorf("Fee = %g, want ~0.40", got.Fee)
-	}
-}
-
-func TestLookupHyperliquidFillByCoinSize_PicksNewestGroupNotSumOfWindow(t *testing.T) {
-	withFastFillRetries(t)
-	srv := newHLUserFillsServer(t, []map[string]any{
-		{"coin": "BTC", "oid": 100, "fee": "0.40", "closedPnl": "75.00", "sz": "0.1", "time": 1_000_000_000},
-		{"coin": "BTC", "oid": 200, "fee": "0.50", "closedPnl": "90.00", "sz": "0.1", "time": 2_000_000_000},
-	})
-	defer srv.Close()
-	origURL := hlMainnetURL
-	hlMainnetURL = srv.URL
-	defer func() { hlMainnetURL = origURL }()
-
-	got, ok := lookupHyperliquidFillByCoinSize("0xtest", "BTC", 0.1, 1e-4, 0)
-	if !ok {
-		t.Fatal("expected ok=true")
-	}
-	if got.Count != 1 {
-		t.Errorf("Count = %d, want 1 (only newest OID's group)", got.Count)
-	}
-	if got.OID != 200 {
-		t.Errorf("OID = %d, want 200 (newest fill)", got.OID)
-	}
-	if got.Fee < 0.499 || got.Fee > 0.501 {
-		t.Errorf("Fee = %g, want ~0.50 (newest only, not 0.40+0.50)", got.Fee)
-	}
-	if got.ClosedPnLGross < 89.99 || got.ClosedPnLGross > 90.01 {
-		t.Errorf("ClosedPnLGross = %g, want ~90.00 (newest only)", got.ClosedPnLGross)
-	}
-}
-
-func TestLookupHyperliquidFillByCoinSize_AggregatesPartialFillsByAnchorOID(t *testing.T) {
-	withFastFillRetries(t)
-	srv := newHLUserFillsServer(t, []map[string]any{
-		{"coin": "BTC", "oid": 555, "fee": "0.20", "closedPnl": "30.00", "sz": "0.04", "time": 1_500_000_000},
-		{"coin": "BTC", "oid": 555, "fee": "0.30", "closedPnl": "40.00", "sz": "0.10", "time": 2_000_000_000},
-		{"coin": "BTC", "oid": 999, "fee": "0.99", "closedPnl": "99.00", "sz": "0.10", "time": 1_000_000_000},
-	})
-	defer srv.Close()
-	origURL := hlMainnetURL
-	hlMainnetURL = srv.URL
-	defer func() { hlMainnetURL = origURL }()
-
-	got, ok := lookupHyperliquidFillByCoinSize("0xtest", "BTC", 0.10, 1e-4, 0)
-	if !ok {
-		t.Fatal("expected ok=true")
-	}
-	if got.OID != 555 {
-		t.Errorf("OID = %d, want 555 (newest matching anchor)", got.OID)
-	}
-	if got.Count != 2 {
-		t.Errorf("Count = %d, want 2 (both fills sharing OID 555)", got.Count)
-	}
-	if got.Fee < 0.499 || got.Fee > 0.501 {
-		t.Errorf("Fee = %g, want ~0.50 (0.20+0.30, not including OID 999)", got.Fee)
-	}
-	if got.ClosedPnLGross < 69.99 || got.ClosedPnLGross > 70.01 {
-		t.Errorf("ClosedPnLGross = %g, want ~70.00 (30+40, not including OID 999)", got.ClosedPnLGross)
-	}
 }
 
 func TestLookupHyperliquidReconcileFillFee_OIDFirstFallsBackToCoinSize(t *testing.T) {
@@ -312,68 +181,159 @@ func TestReconcileFillLookupSinceMs_BoundsTo24h(t *testing.T) {
 	}
 }
 
-func TestLookupHyperliquidFillByOID_AccumulatesFilledQty(t *testing.T) {
+func withHLFillsServer(t *testing.T, fills []map[string]any) {
+	t.Helper()
 	withFastFillRetries(t)
-	srv := newHLUserFillsServer(t, []map[string]any{
-		{"coin": "ETH", "oid": 55555, "fee": "0.10", "closedPnl": "5.00", "sz": "0.211"},
-		{"coin": "ETH", "oid": 55555, "fee": "0.05", "closedPnl": "2.50", "sz": "0.100"},
-		{"coin": "ETH", "oid": 99999, "fee": "1.00", "closedPnl": "50.00", "sz": "0.422"},
-	})
-	defer srv.Close()
+	srv := newHLUserFillsServer(t, fills)
 	origURL := hlMainnetURL
 	hlMainnetURL = srv.URL
-	defer func() { hlMainnetURL = origURL }()
+	t.Cleanup(func() {
+		hlMainnetURL = origURL
+		srv.Close()
+	})
+}
 
-	got, ok := lookupHyperliquidFillByOID("0xtest", 55555, 0)
-	if !ok {
-		t.Fatal("expected ok=true")
-	}
-	if got.Count != 2 {
-		t.Errorf("Count = %d, want 2", got.Count)
-	}
-	wantQty := 0.311
-	if got.FilledQty < wantQty-1e-9 || got.FilledQty > wantQty+1e-9 {
-		t.Errorf("FilledQty = %g, want %g", got.FilledQty, wantQty)
+func assertFillField(t *testing.T, name string, got, want, tol float64) {
+	t.Helper()
+	if math.Abs(got-want) > tol {
+		t.Errorf("%s = %g, want ~%g", name, got, want)
 	}
 }
 
-func TestLookupHyperliquidFillByCoinSize_SetsFilledQtyNoOIDCase(t *testing.T) {
-	withFastFillRetries(t)
-	srv := newHLUserFillsServer(t, []map[string]any{
-		{"coin": "ETH", "oid": nil, "fee": "0.08", "closedPnl": "4.00", "sz": "0.211", "time": 1000},
-	})
-	defer srv.Close()
-	origURL := hlMainnetURL
-	hlMainnetURL = srv.URL
-	defer func() { hlMainnetURL = origURL }()
-
-	got, ok := lookupHyperliquidFillByCoinSize("0xtest", "ETH", 0.211, 1e-4, 0)
-	if !ok {
-		t.Fatal("expected ok=true")
-	}
-	if got.FilledQty < 0.211-1e-9 || got.FilledQty > 0.211+1e-9 {
-		t.Errorf("FilledQty = %g, want 0.211", got.FilledQty)
+func TestLookupHyperliquidFillByOID(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		fills     []map[string]any
+		addr      string
+		oid       int64
+		wantOK    bool
+		wantCount int
+		wantFee   float64
+		wantPnL   float64
+		wantQty   float64
+	}{
+		{
+			name: "aggregates partial fills sharing the OID",
+			fills: []map[string]any{
+				{"coin": "BTC", "oid": 12345, "fee": "0.50", "closedPnl": "100.00", "sz": "0.1"},
+				{"coin": "BTC", "oid": 12345, "fee": "0.30", "closedPnl": "50.00", "sz": "0.05"},
+				{"coin": "BTC", "oid": 99999, "fee": "1.00", "closedPnl": "200.00", "sz": "0.2"},
+			},
+			addr: "0xtest", oid: 12345, wantOK: true, wantCount: 2, wantFee: 0.80, wantPnL: 150.00, wantQty: 0.15,
+		},
+		{
+			name: "accumulates filled qty across partial fills",
+			fills: []map[string]any{
+				{"coin": "ETH", "oid": 55555, "fee": "0.10", "closedPnl": "5.00", "sz": "0.211"},
+				{"coin": "ETH", "oid": 55555, "fee": "0.05", "closedPnl": "2.50", "sz": "0.100"},
+				{"coin": "ETH", "oid": 99999, "fee": "1.00", "closedPnl": "50.00", "sz": "0.422"},
+			},
+			addr: "0xtest", oid: 55555, wantOK: true, wantCount: 2, wantFee: 0.15, wantPnL: 7.50, wantQty: 0.311,
+		},
+		{
+			name: "no match returns false",
+			fills: []map[string]any{
+				{"coin": "BTC", "oid": 99999, "fee": "1.00", "sz": "0.2"},
+			},
+			addr: "0xtest", oid: 12345, wantOK: false,
+		},
+		{
+			name: "empty address short-circuits",
+			fills: []map[string]any{
+				{"coin": "BTC", "oid": 12345, "fee": "1.00", "sz": "0.2"},
+			},
+			addr: "", oid: 12345, wantOK: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withHLFillsServer(t, tc.fills)
+			got, ok := lookupHyperliquidFillByOID(tc.addr, tc.oid, 0)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got.Count != tc.wantCount {
+				t.Errorf("Count = %d, want %d", got.Count, tc.wantCount)
+			}
+			assertFillField(t, "Fee", got.Fee, tc.wantFee, 1e-3)
+			assertFillField(t, "ClosedPnLGross", got.ClosedPnLGross, tc.wantPnL, 1e-2)
+			assertFillField(t, "FilledQty", got.FilledQty, tc.wantQty, 1e-9)
+		})
 	}
 }
 
-func TestLookupHyperliquidFillByCoinSize_AccumulatesFilledQtyWithOID(t *testing.T) {
-	withFastFillRetries(t)
-	srv := newHLUserFillsServer(t, []map[string]any{
-		{"coin": "ETH", "oid": 77777, "fee": "0.05", "closedPnl": "2.00", "sz": "0.100", "time": 2000},
-		{"coin": "ETH", "oid": 77777, "fee": "0.06", "closedPnl": "3.00", "sz": "0.111", "time": 1900},
-		{"coin": "ETH", "oid": 88888, "fee": "0.50", "closedPnl": "10.00", "sz": "0.422", "time": 1000},
-	})
-	defer srv.Close()
-	origURL := hlMainnetURL
-	hlMainnetURL = srv.URL
-	defer func() { hlMainnetURL = origURL }()
-
-	got, ok := lookupHyperliquidFillByCoinSize("0xtest", "ETH", 0.100, 1e-4, 0)
-	if !ok {
-		t.Fatal("expected ok=true")
-	}
-	wantQty := 0.211
-	if got.FilledQty < wantQty-1e-9 || got.FilledQty > wantQty+1e-9 {
-		t.Errorf("FilledQty = %g, want %g (sum across OID group)", got.FilledQty, wantQty)
+func TestLookupHyperliquidFillByCoinSize(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		fills     []map[string]any
+		coin      string
+		size      float64
+		wantOID   int64
+		wantCount int
+		wantFee   float64
+		wantPnL   float64
+		wantQty   float64
+	}{
+		{
+			name: "matches by coin and size",
+			fills: []map[string]any{
+				{"coin": "BTC", "oid": 1, "fee": "0.40", "closedPnl": "75.00", "sz": "0.123456"},
+				{"coin": "ETH", "oid": 2, "fee": "0.10", "closedPnl": "5.00", "sz": "0.123456"},
+				{"coin": "BTC", "oid": 3, "fee": "0.20", "closedPnl": "10.00", "sz": "0.5"},
+			},
+			coin: "BTC", size: 0.123456, wantOID: 1, wantCount: 1, wantFee: 0.40, wantPnL: 75.00, wantQty: 0.123456,
+		},
+		{
+			name: "picks the newest group and never the sum of the window",
+			fills: []map[string]any{
+				{"coin": "BTC", "oid": 100, "fee": "0.40", "closedPnl": "75.00", "sz": "0.1", "time": 1_000_000_000},
+				{"coin": "BTC", "oid": 200, "fee": "0.50", "closedPnl": "90.00", "sz": "0.1", "time": 2_000_000_000},
+			},
+			coin: "BTC", size: 0.1, wantOID: 200, wantCount: 1, wantFee: 0.50, wantPnL: 90.00, wantQty: 0.1,
+		},
+		{
+			name: "aggregates partial fills by the newest anchor OID",
+			fills: []map[string]any{
+				{"coin": "BTC", "oid": 555, "fee": "0.20", "closedPnl": "30.00", "sz": "0.04", "time": 1_500_000_000},
+				{"coin": "BTC", "oid": 555, "fee": "0.30", "closedPnl": "40.00", "sz": "0.10", "time": 2_000_000_000},
+				{"coin": "BTC", "oid": 999, "fee": "0.99", "closedPnl": "99.00", "sz": "0.10", "time": 1_000_000_000},
+			},
+			coin: "BTC", size: 0.10, wantOID: 555, wantCount: 2, wantFee: 0.50, wantPnL: 70.00, wantQty: 0.14,
+		},
+		{
+			name: "sets filled qty when the fill carries no OID",
+			fills: []map[string]any{
+				{"coin": "ETH", "oid": nil, "fee": "0.08", "closedPnl": "4.00", "sz": "0.211", "time": 1000},
+			},
+			coin: "ETH", size: 0.211, wantOID: 0, wantCount: 1, wantFee: 0.08, wantPnL: 4.00, wantQty: 0.211,
+		},
+		{
+			name: "accumulates filled qty across the OID group",
+			fills: []map[string]any{
+				{"coin": "ETH", "oid": 77777, "fee": "0.05", "closedPnl": "2.00", "sz": "0.100", "time": 2000},
+				{"coin": "ETH", "oid": 77777, "fee": "0.06", "closedPnl": "3.00", "sz": "0.111", "time": 1900},
+				{"coin": "ETH", "oid": 88888, "fee": "0.50", "closedPnl": "10.00", "sz": "0.422", "time": 1000},
+			},
+			coin: "ETH", size: 0.100, wantOID: 77777, wantCount: 2, wantFee: 0.11, wantPnL: 5.00, wantQty: 0.211,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withHLFillsServer(t, tc.fills)
+			got, ok := lookupHyperliquidFillByCoinSize("0xtest", tc.coin, tc.size, 1e-4, 0)
+			if !ok {
+				t.Fatal("expected ok=true")
+			}
+			if got.OID != tc.wantOID {
+				t.Errorf("OID = %d, want %d", got.OID, tc.wantOID)
+			}
+			if got.Count != tc.wantCount {
+				t.Errorf("Count = %d, want %d", got.Count, tc.wantCount)
+			}
+			assertFillField(t, "Fee", got.Fee, tc.wantFee, 1e-3)
+			assertFillField(t, "ClosedPnLGross", got.ClosedPnLGross, tc.wantPnL, 1e-2)
+			assertFillField(t, "FilledQty", got.FilledQty, tc.wantQty, 1e-9)
+		})
 	}
 }

--- a/scheduler/hyperliquid_liquidation_guard_test.go
+++ b/scheduler/hyperliquid_liquidation_guard_test.go
@@ -1268,7 +1268,7 @@ func TestRunHyperliquidLiquidationAuditNoOpCases(t *testing.T) {
 			return append(strategies, scB)
 		}, liqAuditLiqETH(), hlNetSideByCoinAllLong(), liqAuditOnChainOne(), true, 4242, 2325, false},
 		{"no on-chain position for the coin", true, 3.125, nil, liqAuditLiqETH(), hlNetSideByCoinAllLong(), map[string]float64{}, true, 4242, 2325, false},
-		{"failed snapshot fetch with no stop armed raises no phantom alert", true, 3.0, zeroStop, map[string]float64{}, nil, map[string]float64{}, false, 0, 0, true},
+		{"failed snapshot fetch with no stop armed raises no phantom alert", true, 3.0, zeroStop, liqAuditLiqETH(), hlNetSideByCoinAllLong(), liqAuditOnChainOne(), false, 0, 0, true},
 		{"stale net side leaves a healthy resting stop untouched", true, 3.125, nil, liqAuditLiqETH(), map[string]string{"ETH": "short"}, liqAuditOnChainOne(), true, 4242, 2325, true},
 		{"stale net side skips the sole-owner re-arm", true, 3.125, zeroStop, liqAuditLiqETH(), map[string]string{"ETH": "short"}, liqAuditOnChainOne(), true, 0, 0, true},
 	} {

--- a/scheduler/hyperliquid_liquidation_guard_test.go
+++ b/scheduler/hyperliquid_liquidation_guard_test.go
@@ -256,58 +256,6 @@ func TestClearHLPerpsPositionAlertThrottlesClearsBoth(t *testing.T) {
 	hlLiquidationAlerts.Delete(hlLiquidationAlertKey("spot-eth", "ETH"))
 }
 
-func TestPlanHyperliquidLiquidationAuditClassification(t *testing.T) {
-	cands := []hlLiquidationAuditCandidate{
-		{StrategyID: "b-scalar", Symbol: "ETH", Side: "long", Qty: 1, StopLossOID: 11, StopLossTriggerPx: 2325, LiquidationPx: 2340.5, StaticScalarOwner: true, BookConsistent: true},
-		{StrategyID: "a-trailing", Symbol: "ETH", Side: "long", Qty: 1, StopLossOID: 12, StopLossTriggerPx: 2325, LiquidationPx: 2340.5, StaticScalarOwner: false, BookConsistent: true},
-		{StrategyID: "c-ok", Symbol: "ETH", Side: "long", Qty: 1, StopLossOID: 13, StopLossTriggerPx: 2360, LiquidationPx: 2340.5, StaticScalarOwner: true, BookConsistent: true},
-		{StrategyID: "d-unknown", Symbol: "BTC", Side: "long", Qty: 1, StopLossOID: 14, StopLossTriggerPx: 100, LiquidationPx: 0, StaticScalarOwner: true, BookConsistent: true},
-		{StrategyID: "e-nostop", Symbol: "BTC", Side: "long", Qty: 1, Unprotected: true, RearmTriggerPx: 39000, LiquidationPx: 40000, StaticScalarOwner: false, BookConsistent: true},
-		{StrategyID: "f-noqty", Symbol: "BTC", Side: "long", Qty: 0, StopLossOID: 15, StopLossTriggerPx: 39000, LiquidationPx: 40000, StaticScalarOwner: true, BookConsistent: true},
-	}
-	actions := planHyperliquidLiquidationAudit(cands)
-	if len(actions) != 2 {
-		t.Fatalf("actions = %d, want 2 (only the two past-liquidation candidates)", len(actions))
-	}
-	if actions[0].Candidate.StrategyID != "a-trailing" || actions[1].Candidate.StrategyID != "b-scalar" {
-		t.Fatalf("actions not sorted deterministically: %s, %s", actions[0].Candidate.StrategyID, actions[1].Candidate.StrategyID)
-	}
-	for _, a := range actions {
-		if a.Kind != hlAuditTighten {
-			t.Errorf("%s: kind = %v, want a tighten job — the audit heals every owner", a.Candidate.StrategyID, a.Kind)
-		}
-	}
-	want := 2340.5 * (1 + hlLiquidationStopBufferPct/100.0)
-	if !approxEqLiq(actions[1].ClampedTriggerPx, want) {
-		t.Errorf("clamped trigger = %g, want %g", actions[1].ClampedTriggerPx, want)
-	}
-}
-
-func TestPlanHyperliquidLiquidationAuditRearmsUnprotectedScalarOwner(t *testing.T) {
-	cands := []hlLiquidationAuditCandidate{
-		{StrategyID: "hl-eth", Symbol: "ETH", Side: "long", Qty: 1, Unprotected: true, RearmTriggerPx: 2325, LiquidationPx: 2300, StaticScalarOwner: true, BookConsistent: true},
-	}
-	actions := planHyperliquidLiquidationAudit(cands)
-	if len(actions) != 1 || actions[0].Kind != hlAuditRearm {
-		t.Fatalf("actions = %+v, want one re-arm job", actions)
-	}
-	if !approxEqLiq(actions[0].ClampedTriggerPx, 2325) {
-		t.Errorf("re-arm trigger = %g, want 2325", actions[0].ClampedTriggerPx)
-	}
-}
-
-func TestPlanHyperliquidLiquidationAuditRefusesUnreconciledCoin(t *testing.T) {
-	cands := []hlLiquidationAuditCandidate{
-		{StrategyID: "hl-eth", Symbol: "ETH", Side: "long", Qty: 1, StopLossOID: 11, StopLossTriggerPx: 2325, LiquidationPx: 2340.5, StaticScalarOwner: true, BookConsistent: false},
-		{StrategyID: "hl-eth2", Symbol: "ETH", Side: "long", Qty: 1, Unprotected: true, RearmTriggerPx: 2325, LiquidationPx: 2340.5, StaticScalarOwner: true, BookConsistent: false},
-	}
-	for _, a := range planHyperliquidLiquidationAudit(cands) {
-		if a.Kind != hlAuditRefuse {
-			t.Errorf("%s: kind = %v, want a refusal on an unreconciled coin", a.Candidate.StrategyID, a.Kind)
-		}
-	}
-}
-
 func TestHLLiquidationCoinBookConsistent(t *testing.T) {
 	got := hlLiquidationCoinBookConsistent(
 		map[string]float64{"ETH": 2.0, "BTC": 1.0, "SOL": 0.5, "AVAX": 3.0, "DOGE": 5.0, "MIX": -0.6, "PHANTOM": 1.1},
@@ -387,54 +335,6 @@ func TestCollectHLLiquidationAuditCandidatesHealsSoleOwnerDrift(t *testing.T) {
 	}
 }
 
-func TestRunHyperliquidLiquidationAuditSkipsWithoutSnapshot(t *testing.T) {
-	strategies, state := liqAuditFixture(t, true, 3.0)
-	state.Strategies["hl-eth"].Positions["ETH"].StopLossOID = 0
-	state.Strategies["hl-eth"].Positions["ETH"].StopLossTriggerPx = 0
-	calls := 0
-	orig := runHyperliquidUpdateStopLossFunc
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, qty, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		calls++
-		return &HyperliquidStopLossUpdateResult{StopLossOID: 7, StopLossTriggerPx: triggerPx}, "", nil
-	}
-	defer func() { runHyperliquidUpdateStopLossFunc = orig }()
-	hlLiquidationAlerts.Delete(hlLiquidationAlertKey("hl-eth", "ETH"))
-
-	res := runHyperliquidLiquidationAudit(strategies, state, map[string]float64{}, nil, map[string]float64{}, false, &sync.RWMutex{}, nil, time.Now().UTC())
-	if res.ImmediateFills != 0 || len(res.CloseDetails) != 0 {
-		t.Errorf("result = %+v, want an empty result with no snapshot", res)
-	}
-	if calls != 0 {
-		t.Errorf("placement calls = %d, want 0 with no snapshot", calls)
-	}
-	if _, alerted := hlLiquidationAlerts.Load(hlLiquidationAlertKey("hl-eth", "ETH")); alerted {
-		t.Error("a failed fetch must not raise a phantom-position alert")
-	}
-}
-
-func TestHLLiquidationAlertMessageOmitsUnknownGeometry(t *testing.T) {
-	headline, detail, unprotected := hlLiquidationAlertMessage(0, 0, 0, hlLiquidationActionUnreconciled, "")
-	if strings.Contains(detail, "$0.0000") {
-		t.Errorf("detail = %q, want no fabricated $0.0000 prices", detail)
-	}
-	if !strings.Contains(detail, "NO exchange-side stop") {
-		t.Errorf("detail = %q, want it to say the position has no stop", detail)
-	}
-	if headline != "**HL POSITION UNPROTECTED**" {
-		t.Errorf("headline = %q, want the unprotected headline", headline)
-	}
-	if !unprotected {
-		t.Error("a refused candidate with no stop is unprotected — must log CRITICAL")
-	}
-	_, armedDetail, armedUnprotected := hlLiquidationAlertMessage(2325, 2352, 2340.5, hlLiquidationActionUnreconciled, "")
-	if !strings.Contains(armedDetail, "$2325.0000") || !strings.Contains(armedDetail, "$2340.5000") {
-		t.Errorf("detail = %q, want the real trigger and liquidation prices", armedDetail)
-	}
-	if armedUnprotected {
-		t.Error("a refused TIGHTEN still has the old order resting — not unprotected")
-	}
-}
-
 func liqAuditFixture(t *testing.T, live bool, stopPct float64) ([]StrategyConfig, *AppState) {
 	t.Helper()
 	mode := "--mode=live"
@@ -457,45 +357,6 @@ func liqAuditFixture(t *testing.T, live bool, stopPct float64) ([]StrategyConfig
 		}},
 	}}
 	return []StrategyConfig{sc}, state
-}
-
-func TestRunHyperliquidLiquidationAuditReplacesScalarStop(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	var mu sync.RWMutex
-
-	var gotTrigger float64
-	var gotCancelOID int64
-	var gotSize float64
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		gotTrigger, gotCancelOID, gotSize = triggerPx, cancelStopLossOID, size
-		return &HyperliquidStopLossUpdateResult{StopLossOID: 9001, StopLossTriggerPx: triggerPx}, "", nil
-	}
-
-	res := runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if res.ImmediateFills != 0 {
-		t.Fatalf("immediate fills = %d, want 0 (a resting replacement)", res.ImmediateFills)
-	}
-	if gotCancelOID != 4242 {
-		t.Errorf("cancel OID = %d, want the resting 4242", gotCancelOID)
-	}
-	if !approxEqLiq(gotSize, 1.0) {
-		t.Errorf("replace size = %g, want 1.0", gotSize)
-	}
-	wantTrigger := 2340.5 * (1 + hlLiquidationStopBufferPct/100.0)
-	if !approxEqLiq(gotTrigger, wantTrigger) {
-		t.Errorf("replace trigger = %g, want %g (just inside liquidation)", gotTrigger, wantTrigger)
-	}
-	pos := state.Strategies["hl-eth"].Positions["ETH"]
-	if pos.StopLossOID != 9001 {
-		t.Errorf("position SL oid = %d, want the replacement 9001", pos.StopLossOID)
-	}
-	if !approxEqLiq(pos.StopLossTriggerPx, wantTrigger) {
-		t.Errorf("position trigger = %g, want %g", pos.StopLossTriggerPx, wantTrigger)
-	}
 }
 
 func TestRunHyperliquidLiquidationAuditKeepsOriginalStopOnFailure(t *testing.T) {
@@ -579,109 +440,6 @@ func TestRunHyperliquidLiquidationAuditCancelledThenRejectedRearms(t *testing.T)
 	}
 }
 
-func TestRunHyperliquidLiquidationAuditCancelThenPlaceIsANormalClamp(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	var mu sync.RWMutex
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		return &HyperliquidStopLossUpdateResult{CancelStopLossSucceeded: true, StopLossOID: 5150, StopLossTriggerPx: triggerPx}, "", nil
-	}
-	runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if got := state.Strategies["hl-eth"].Positions["ETH"].StopLossOID; got != 5150 {
-		t.Fatalf("position SL oid = %d, want the replacement 5150", got)
-	}
-	st, _ := hlLiquidationAlerts.Load(hlLiquidationAlertKey("hl-eth", "ETH"))
-	if s, ok := st.(hlLiquidationAlertState); !ok || s.LastAction != hlLiquidationActionClamped {
-		t.Errorf("last action = %+v, want a landed clamp — no false protection-lost alert", st)
-	}
-	clearHLLiquidationAlert("hl-eth", "ETH")
-}
-
-func TestRunHyperliquidLiquidationAuditFillAtSubmitReportsExited(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-	defer clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	var mu sync.RWMutex
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		return &HyperliquidStopLossUpdateResult{
-			CancelStopLossSucceeded:   true,
-			StopLossFilledImmediately: true,
-			StopLossTriggerPx:         triggerPx,
-		}, "", nil
-	}
-	res := runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if res.ImmediateFills != 1 || len(res.CloseDetails) != 1 {
-		t.Fatalf("immediate fills = %d, close details = %d, want 1/1", res.ImmediateFills, len(res.CloseDetails))
-	}
-	st, _ := hlLiquidationAlerts.Load(hlLiquidationAlertKey("hl-eth", "ETH"))
-	if s2, ok := st.(hlLiquidationAlertState); !ok || s2.LastAction != hlLiquidationActionExited {
-		t.Errorf("last action = %+v, want %q — the position is FLAT", st, hlLiquidationActionExited)
-	}
-}
-
-func TestRunHyperliquidLiquidationAuditImmediateCloseReasonsTheAudit(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-	defer clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	var mu sync.RWMutex
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		return &HyperliquidStopLossUpdateResult{
-			CancelStopLossSucceeded:   true,
-			StopLossFilledImmediately: true,
-			StopLossTriggerPx:         triggerPx,
-		}, "", nil
-	}
-	res := runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if res.ImmediateFills != 1 || len(res.CloseDetails) != 1 {
-		t.Fatalf("immediate fills = %d, close details = %d, want 1/1", res.ImmediateFills, len(res.CloseDetails))
-	}
-	ss := state.Strategies["hl-eth"]
-	if len(ss.ClosedPositions) == 0 {
-		t.Fatal("no closed position recorded for the immediate close")
-	}
-	cp := ss.ClosedPositions[len(ss.ClosedPositions)-1]
-	if cp.CloseReason != "liquidation_clamp_sl_immediate" {
-		t.Errorf("persisted CloseReason = %q, want liquidation_clamp_sl_immediate (not the trailing walker)", cp.CloseReason)
-	}
-	if len(ss.TradeHistory) == 0 {
-		t.Fatal("no trade recorded for the immediate close")
-	}
-	tr := ss.TradeHistory[len(ss.TradeHistory)-1]
-	if !strings.Contains(tr.Details, "Liquidation-clamp SL") {
-		t.Errorf("trade details %q must match the LIQUIDATION-CLAMP operator wording", tr.Details)
-	}
-}
-
-func TestRunHyperliquidLiquidationAuditFilledExternallyReportsFilled(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-	defer clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	var mu sync.RWMutex
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		return &HyperliquidStopLossUpdateResult{StopLossFilledExternally: true}, "", nil
-	}
-	res := runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if res.ImmediateFills != 0 {
-		t.Fatalf("the reconciler owns this close, audit booked %d", res.ImmediateFills)
-	}
-	st, _ := hlLiquidationAlerts.Load(hlLiquidationAlertKey("hl-eth", "ETH"))
-	if s2, ok := st.(hlLiquidationAlertState); !ok || s2.LastAction != hlLiquidationActionFilledOnChain {
-		t.Errorf("last action = %+v, want %q", st, hlLiquidationActionFilledOnChain)
-	}
-}
-
 func TestStaticScalarOwnerCannotScaleIn(t *testing.T) {
 	sc := StrategyConfig{
 		ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Script: "x.py",
@@ -697,27 +455,6 @@ func TestStaticScalarOwnerCannotScaleIn(t *testing.T) {
 	err := validateConfig(cfg, true)
 	if err == nil || !strings.Contains(err.Error(), "allow_scale_in on live perps requires") {
 		t.Fatalf("allow_scale_in on a static scalar owner must be rejected at load, got %v", err)
-	}
-}
-
-func TestRunHyperliquidLiquidationAuditSkipsPaper(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, false, 3.125)
-	var mu sync.RWMutex
-	called := false
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		called = true
-		return &HyperliquidStopLossUpdateResult{StopLossOID: 1}, "", nil
-	}
-	runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if called {
-		t.Fatal("a paper strategy must never be clamped against a live liquidation price")
-	}
-	if state.Strategies["hl-eth"].Positions["ETH"].StopLossOID != 4242 {
-		t.Error("paper position state must be untouched")
 	}
 }
 
@@ -754,134 +491,6 @@ func TestRunHyperliquidLiquidationAuditHealsTrailingOwner(t *testing.T) {
 	runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
 	if calls != 0 {
 		t.Errorf("a reachable resting trigger must produce no further order churn, got %d placements", calls)
-	}
-}
-
-func TestRunHyperliquidLiquidationAuditIsIndependentOfSignalResults(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 0)
-	strategies[0].StopLossPct = nil
-	strategies[0].TrailingStopATRMult = floatPtr(2.5)
-	strategies[0].Args = []string{"x.py", "ETH", "4h", "--mode=live"}
-	var mu sync.RWMutex
-	placed := false
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		placed = true
-		return &HyperliquidStopLossUpdateResult{StopLossOID: 9200, StopLossTriggerPx: triggerPx}, "", nil
-	}
-	runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if !placed {
-		t.Fatal("a non-due 4h trailing owner must still be healed by the per-cycle audit")
-	}
-}
-
-func TestRunHyperliquidLiquidationAuditRefusesPhantomOnSharedCoin(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-	clearHLLiquidationAlert("hl-eth-b", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	scB := strategies[0]
-	scB.ID = "hl-eth-b"
-	strategies = append(strategies, scB)
-	state.Strategies["hl-eth-b"] = &StrategyState{ID: "hl-eth-b", Platform: "hyperliquid", Type: "perps", Positions: map[string]*Position{
-		"ETH": {Symbol: "ETH", Side: "long", Quantity: 1.0, AvgCost: 2400, RiskAnchorPrice: 2400, EntryATR: 30, StopLossOID: 4343, StopLossTriggerPx: 2325},
-	}}
-	var mu sync.RWMutex
-	called := false
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		called = true
-		return &HyperliquidStopLossUpdateResult{StopLossOID: 1}, "", nil
-	}
-	runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if called {
-		t.Fatal("the audit must not move a reduce-only trigger on a coin whose book exceeds the on-chain snapshot")
-	}
-	if state.Strategies["hl-eth"].Positions["ETH"].StopLossOID != 4242 {
-		t.Error("a refused candidate's state must be untouched")
-	}
-}
-
-func TestRunHyperliquidLiquidationAuditHealsConsistentNonDuePosition(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	strategies[0].Args = []string{"x.py", "ETH", "1d", "--mode=live"}
-	var mu sync.RWMutex
-	called := false
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		called = true
-		return &HyperliquidStopLossUpdateResult{StopLossOID: 9300, StopLossTriggerPx: triggerPx}, "", nil
-	}
-	runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if !called {
-		t.Fatal("a consistent book must still be healed regardless of due-ness")
-	}
-}
-
-func TestRunHyperliquidLiquidationAuditNoOpsWithoutOnChainPosition(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	var mu sync.RWMutex
-	called := false
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		called = true
-		return &HyperliquidStopLossUpdateResult{StopLossOID: 1}, "", nil
-	}
-	runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{}, true, &mu, nil, time.Now().UTC())
-	if called {
-		t.Fatal("no on-chain position for the coin must be a no-op")
-	}
-}
-
-func TestRunHyperliquidLiquidationAuditReportsBookedCloses(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	var mu sync.RWMutex
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		return &HyperliquidStopLossUpdateResult{StopLossFilledImmediately: true, StopLossTriggerPx: triggerPx}, "", nil
-	}
-	res := runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if res.ImmediateFills != 1 {
-		t.Fatalf("immediate fills = %d, want 1", res.ImmediateFills)
-	}
-	if len(res.CloseDetails) != 1 {
-		t.Fatalf("close details = %d, want 1 — a booked close must reach the trade notifier", len(res.CloseDetails))
-	}
-	cd := res.CloseDetails[0]
-	if cd.SC.ID != "hl-eth" || cd.Symbol != "ETH" || cd.Detail == "" {
-		t.Errorf("close detail = %+v, want a populated per-strategy line", cd)
-	}
-	if _, still := state.Strategies["hl-eth"].Positions["ETH"]; still {
-		t.Error("an immediate fill must book the close and drop the position")
-	}
-}
-
-func TestRunHyperliquidLiquidationAuditRestingClampEmitsNoClose(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	var mu sync.RWMutex
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		return &HyperliquidStopLossUpdateResult{StopLossOID: 9400, StopLossTriggerPx: triggerPx}, "", nil
-	}
-	res := runHyperliquidLiquidationAudit(strategies, state, map[string]float64{"ETH": 2340.5}, hlNetSideByCoinAllLong(), map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if len(res.CloseDetails) != 0 || res.ImmediateFills != 0 {
-		t.Fatalf("a resting clamp must produce no close notification, got %+v", res)
 	}
 }
 
@@ -1083,38 +692,6 @@ func TestCollectHLLiquidationAuditCandidatesSideMismatchSkipsOppositeLeg(t *test
 	}
 }
 
-func TestRunHyperliquidLiquidationAuditStaleSideSoleOwnerDoesNothing(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	var mu sync.RWMutex
-	calls := 0
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		calls++
-		return &HyperliquidStopLossUpdateResult{StopLossOID: 9001, StopLossTriggerPx: triggerPx}, "", nil
-	}
-
-	res := runHyperliquidLiquidationAudit(strategies, state,
-		map[string]float64{"ETH": 2340.5},
-		map[string]string{"ETH": "short"},
-		map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if calls != 0 {
-		t.Errorf("placement calls = %d, want 0 — a side mismatch must never touch the resting order", calls)
-	}
-	if res.ImmediateFills != 0 || len(res.CloseDetails) != 0 {
-		t.Errorf("result = %+v, want empty", res)
-	}
-	pos := state.Strategies["hl-eth"].Positions["ETH"]
-	if pos.StopLossOID != 4242 || pos.StopLossTriggerPx != 2325 {
-		t.Errorf("state changed: oid=%d trigger=%g — the healthy stop must be untouched", pos.StopLossOID, pos.StopLossTriggerPx)
-	}
-	if _, alerted := hlLiquidationAlerts.Load(hlLiquidationAlertKey("hl-eth", "ETH")); alerted {
-		t.Error("a side mismatch must not raise a past-liquidation alert")
-	}
-}
-
 func TestProtectionSyncSideMismatchNeverForcesPastLiquidationReplace(t *testing.T) {
 	mult := 2.0
 	sc := StrategyConfig{
@@ -1192,56 +769,6 @@ func TestHLStopBankruptcyBoundSkipsInertPctFieldsUnderUnifiedClose(t *testing.T)
 	}
 }
 
-func TestAuditRearmSkipsStaleSideSoleOwner(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	state.Strategies["hl-eth"].Positions["ETH"].StopLossOID = 0
-	state.Strategies["hl-eth"].Positions["ETH"].StopLossTriggerPx = 0
-	var mu sync.RWMutex
-	calls := 0
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		calls++
-		return &HyperliquidStopLossUpdateResult{StopLossOID: 9001, StopLossTriggerPx: triggerPx}, "", nil
-	}
-	runHyperliquidLiquidationAudit(strategies, state,
-		map[string]float64{"ETH": 2340.5},
-		map[string]string{"ETH": "short"},
-		map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if calls != 0 {
-		t.Errorf("re-arm placements = %d, want 0 against an unconfirmed side", calls)
-	}
-	if _, alerted := hlLiquidationAlerts.Load(hlLiquidationAlertKey("hl-eth", "ETH")); alerted {
-		t.Error("a skipped stale-side re-arm must not raise the unthrottled CRITICAL")
-	}
-}
-
-func TestAuditRearmProceedsWithMatchingSideAndUnknownGeometry(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	state.Strategies["hl-eth"].Positions["ETH"].StopLossOID = 0
-	state.Strategies["hl-eth"].Positions["ETH"].StopLossTriggerPx = 0
-	var mu sync.RWMutex
-	var gotTrigger float64
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		gotTrigger = triggerPx
-		return &HyperliquidStopLossUpdateResult{StopLossOID: 9001, StopLossTriggerPx: triggerPx}, "", nil
-	}
-	runHyperliquidLiquidationAudit(strategies, state,
-		map[string]float64{},
-		map[string]string{"ETH": "long"},
-		map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	want := 2400 * (1 - 0.03125)
-	if !approxEqLiq(gotTrigger, want) {
-		t.Errorf("re-arm trigger = %g, want the unclamped configured distance %g", gotTrigger, want)
-	}
-}
-
 func liqTrailingAuditFixture(t *testing.T) ([]StrategyConfig, *AppState) {
 	t.Helper()
 	trail := 3.0
@@ -1260,145 +787,6 @@ func liqTrailingAuditFixture(t *testing.T) ([]StrategyConfig, *AppState) {
 		}},
 	}}
 	return []StrategyConfig{sc}, state
-}
-
-func TestAuditRetriesPlacementItStrippedSameCycle(t *testing.T) {
-	for _, tc := range []struct {
-		name          string
-		retryOK       bool
-		wantCalls     int
-		wantSecondOID int64
-		wantFinalOID  int64
-		wantAction    hlLiquidationAlertAction
-	}{
-		{"retry rests", true, 2, 0, 9002, hlLiquidationActionClamped},
-		{"retry also fails", false, 2, 0, 0, hlLiquidationActionProtectionLost},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			old := runHyperliquidUpdateStopLossFunc
-			defer func() { runHyperliquidUpdateStopLossFunc = old }()
-			clearHLLiquidationAlert("hl-eth", "ETH")
-
-			strategies, state := liqTrailingAuditFixture(t)
-			var mu sync.RWMutex
-			type call struct {
-				cancelOID int64
-				trigger   float64
-			}
-			var calls []call
-			callN := 0
-			runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-				callN++
-				calls = append(calls, call{cancelOID: cancelOID, trigger: triggerPx})
-				if callN == 1 {
-					return &HyperliquidStopLossUpdateResult{
-						CancelStopLossSucceeded: true,
-						StopLossError:           "Order would exceed the open order limit",
-					}, "", nil
-				}
-				if tc.retryOK {
-					return &HyperliquidStopLossUpdateResult{StopLossOID: 9002, StopLossTriggerPx: triggerPx}, "", nil
-				}
-				return &HyperliquidStopLossUpdateResult{
-					CancelStopLossSucceeded: false,
-					StopLossError:           "Order would exceed the open order limit",
-				}, "", nil
-			}
-
-			runHyperliquidLiquidationAudit(strategies, state,
-				map[string]float64{"ETH": 2340.5},
-				hlNetSideByCoinAllLong(),
-				map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-
-			if len(calls) != tc.wantCalls {
-				t.Fatalf("placement calls = %d (%+v), want %d", len(calls), calls, tc.wantCalls)
-			}
-			if tc.wantCalls == 2 && calls[1].cancelOID != tc.wantSecondOID {
-				t.Errorf("retry cancelOID = %d, want %d (nothing left to cancel)", calls[1].cancelOID, tc.wantSecondOID)
-			}
-			pos := state.Strategies["hl-eth"].Positions["ETH"]
-			if pos.StopLossOID != tc.wantFinalOID {
-				t.Errorf("final oid = %d, want %d", pos.StopLossOID, tc.wantFinalOID)
-			}
-			if last := lastLiqAlertAction("hl-eth", "ETH"); last != tc.wantAction {
-				t.Errorf("alert action = %q, want %q", last, tc.wantAction)
-			}
-		})
-	}
-
-	t.Run("first-try rest takes no retry", func(t *testing.T) {
-		old := runHyperliquidUpdateStopLossFunc
-		defer func() { runHyperliquidUpdateStopLossFunc = old }()
-		clearHLLiquidationAlert("hl-eth", "ETH")
-
-		strategies, state := liqTrailingAuditFixture(t)
-		var mu sync.RWMutex
-		calls := 0
-		runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-			calls++
-			return &HyperliquidStopLossUpdateResult{StopLossOID: 9001, StopLossTriggerPx: triggerPx}, "", nil
-		}
-		runHyperliquidLiquidationAudit(strategies, state,
-			map[string]float64{"ETH": 2340.5},
-			hlNetSideByCoinAllLong(),
-			map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-		if calls != 1 {
-			t.Errorf("placement calls = %d, want 1", calls)
-		}
-	})
-}
-
-func TestLiquidationAuditIntervalSeconds(t *testing.T) {
-	mk := func(id string, platform, typ string, live bool) StrategyConfig {
-		args := []string{"--mode", "paper"}
-		if live {
-			args = []string{"--mode", "live"}
-		}
-		return StrategyConfig{ID: id, Platform: platform, Type: typ, Args: args}
-	}
-	strategies := []StrategyConfig{
-		mk("hl-live-a", "hyperliquid", "perps", true),
-		mk("hl-paper-b", "hyperliquid", "perps", false),
-		mk("okx-live-c", "okx", "perps", true),
-		mk("hl-live-spot", "hyperliquid", "spot", true),
-	}
-	intervals := map[string]int{"hl-live-a": 300, "hl-paper-b": 60, "okx-live-c": 120, "hl-live-spot": 30}
-	if got := liquidationAuditIntervalSeconds(strategies, intervals); got != 150 {
-		t.Errorf("interval = %d, want 150 (half of hl-live-a's 300)", got)
-	}
-	if got := liquidationAuditIntervalSeconds(strategies[1:], intervals); got != 0 {
-		t.Errorf("interval without any live HL perps or manual = %d, want 0", got)
-	}
-}
-
-func TestLiquidationAuditIntervalStrictlyShorterAndCoversManual(t *testing.T) {
-	live := func(id, typ string) StrategyConfig {
-		return StrategyConfig{ID: id, Platform: "hyperliquid", Type: typ, Args: []string{"--mode", "live"}}
-	}
-
-	perps4h := []StrategyConfig{live("hl-4h", "perps")}
-	iv4h := map[string]int{"hl-4h": 14400}
-	got := liquidationAuditIntervalSeconds(perps4h, iv4h)
-	if got != 7200 {
-		t.Errorf("4h fleet cadence = %d, want 7200", got)
-	}
-	if got >= 14400 {
-		t.Errorf("cadence %d is not strictly shorter than the 14400s interval it bounds", got)
-	}
-
-	manualOnly := []StrategyConfig{live("hl-manual", "manual")}
-	if got := liquidationAuditIntervalSeconds(manualOnly, map[string]int{"hl-manual": 3600}); got != 1800 {
-		t.Errorf("manual-only cadence = %d, want 1800 (manual is an audit candidate)", got)
-	}
-
-	if got := liquidationAuditIntervalSeconds(perps4h, map[string]int{"hl-4h": 30}); got != liquidationAuditMinIntervalSeconds {
-		t.Errorf("fast-fleet cadence = %d, want floor %d", got, liquidationAuditMinIntervalSeconds)
-	}
-
-	paperManual := []StrategyConfig{{ID: "hl-pm", Platform: "hyperliquid", Type: "manual", Args: []string{"--mode", "paper"}}}
-	if got := liquidationAuditIntervalSeconds(paperManual, map[string]int{"hl-pm": 3600}); got != 0 {
-		t.Errorf("paper manual cadence = %d, want 0", got)
-	}
 }
 
 func TestBuildHLLiquidationMaps(t *testing.T) {
@@ -1607,38 +995,6 @@ func TestApplyAuditStopUpdateCountsStateMutations(t *testing.T) {
 	})
 }
 
-func TestOutcomeUnknownIsNotProtectionLost(t *testing.T) {
-	if hlLiquidationActionUnprotected(hlLiquidationActionOutcomeUnknown) {
-		t.Errorf("outcome-unknown counted as unprotected — the operator is told a fact nobody measured")
-	}
-	if !hlLiquidationActionUnprotected(hlLiquidationActionProtectionLost) {
-		t.Errorf("protection lost must still count as unprotected")
-	}
-
-	headline, detail, unprotected := hlLiquidationAlertMessage(1800, 1900, 1750, hlLiquidationActionOutcomeUnknown, "recovery")
-	if unprotected {
-		t.Errorf("outcome-unknown message flagged unprotected")
-	}
-	if !strings.Contains(headline, "OUTCOME UNKNOWN") {
-		t.Errorf("headline = %q, want an outcome-unknown headline", headline)
-	}
-	for _, want := range []string{"could NOT be read", "may be resting", "KEPT"} {
-		if !strings.Contains(detail, want) {
-			t.Errorf("detail = %q, want it to contain %q", detail, want)
-		}
-	}
-	if strings.Contains(detail, "no exchange-side stop right now") {
-		t.Errorf("detail asserts the position is unprotected: %q", detail)
-	}
-
-	if hlLiquidationMayRetryReplace(&HyperliquidStopLossUpdateResult{StopLossOutcomeUnknown: true}) {
-		t.Errorf("outcome-unknown must not license an in-cycle retry")
-	}
-	if !hlLiquidationMayRetryReplace(&HyperliquidStopLossUpdateResult{}) {
-		t.Errorf("a positively rejected placement must still retry")
-	}
-}
-
 func TestPlaceFreshClassifiesByWhatRests(t *testing.T) {
 	old := runHyperliquidUpdateStopLossFunc
 	defer func() { runHyperliquidUpdateStopLossFunc = old }()
@@ -1684,119 +1040,6 @@ func TestPlaceFreshClassifiesByWhatRests(t *testing.T) {
 	})
 }
 
-func TestAuditRetryAdoptsBookDiffResolvedOID(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqTrailingAuditFixture(t)
-	var mu sync.RWMutex
-	callN := 0
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		callN++
-		if callN == 1 {
-			return &HyperliquidStopLossUpdateResult{
-				CancelStopLossSucceeded: true,
-				StopLossError:           "Order would exceed the open order limit",
-			}, "", nil
-		}
-		return &HyperliquidStopLossUpdateResult{
-			StopLossError:     "place_stop_loss returned no usable status: {...}",
-			StopLossOID:       9002,
-			StopLossTriggerPx: triggerPx,
-		}, "", nil
-	}
-
-	res := runHyperliquidLiquidationAudit(strategies, state,
-		map[string]float64{"ETH": 2340.5},
-		hlNetSideByCoinAllLong(),
-		map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-
-	if callN != 2 {
-		t.Errorf("placement calls = %d, want 2 (clamp + in-cycle retry)", callN)
-	}
-	pos := state.Strategies["hl-eth"].Positions["ETH"]
-	if pos.StopLossOID != 9002 {
-		t.Errorf("final oid = %d, want 9002 (resolved retry adopted)", pos.StopLossOID)
-	}
-	if last := lastLiqAlertAction("hl-eth", "ETH"); last != hlLiquidationActionClamped {
-		t.Errorf("alert action = %q, want %q (no protection-lost report)", last, hlLiquidationActionClamped)
-	}
-	if res.StateMutations < 1 {
-		t.Errorf("state mutations = %d, want >= 1 (oid rewrite must flush)", res.StateMutations)
-	}
-}
-
-func TestAuditRetryOutcomeUnknownKeepsStateAndReportsUnknown(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqTrailingAuditFixture(t)
-	var mu sync.RWMutex
-	callN := 0
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		callN++
-		if callN == 1 {
-			return &HyperliquidStopLossUpdateResult{
-				CancelStopLossSucceeded: true,
-				StopLossError:           "Order would exceed the open order limit",
-			}, "", nil
-		}
-		return &HyperliquidStopLossUpdateResult{
-			StopLossError:          "place_stop_loss failed: boom",
-			StopLossOutcomeUnknown: true,
-			StopLossTriggerPx:      triggerPx,
-		}, "", nil
-	}
-
-	runHyperliquidLiquidationAudit(strategies, state,
-		map[string]float64{"ETH": 2340.5},
-		hlNetSideByCoinAllLong(),
-		map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-
-	pos := state.Strategies["hl-eth"].Positions["ETH"]
-	if pos.StopLossOID != 4242 || pos.StopLossTriggerPx != 2325 {
-		t.Fatalf("state cleared to oid=%d trigger=%.4f, want kept 4242/2325 (never an Unprotected re-arm candidate)", pos.StopLossOID, pos.StopLossTriggerPx)
-	}
-	if last := lastLiqAlertAction("hl-eth", "ETH"); last != hlLiquidationActionOutcomeUnknown {
-		t.Errorf("alert action = %q, want %q", last, hlLiquidationActionOutcomeUnknown)
-	}
-}
-
-func TestAuditRetryCapRejectedStillProtectionLost(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqTrailingAuditFixture(t)
-	var mu sync.RWMutex
-	callN := 0
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		callN++
-		return &HyperliquidStopLossUpdateResult{
-			CancelStopLossSucceeded: callN == 1,
-			StopLossError:           "Order would exceed the open order limit",
-		}, "", nil
-	}
-
-	runHyperliquidLiquidationAudit(strategies, state,
-		map[string]float64{"ETH": 2340.5},
-		hlNetSideByCoinAllLong(),
-		map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-
-	if callN != 2 {
-		t.Errorf("placement calls = %d, want 2", callN)
-	}
-	pos := state.Strategies["hl-eth"].Positions["ETH"]
-	if pos.StopLossOID != 0 || pos.StopLossTriggerPx != 0 {
-		t.Errorf("dead oid not cleared: oid=%d trigger=%.4f, want 0/0", pos.StopLossOID, pos.StopLossTriggerPx)
-	}
-	if last := lastLiqAlertAction("hl-eth", "ETH"); last != hlLiquidationActionProtectionLost {
-		t.Errorf("alert action = %q, want %q", last, hlLiquidationActionProtectionLost)
-	}
-}
-
 func TestFlushOffCycleLiquidationAuditStateForceProbe(t *testing.T) {
 	cfg := &Config{Strategies: []StrategyConfig{{ID: "hl-live", Platform: "hyperliquid", Type: "perps"}}}
 	newState := func() *AppState {
@@ -1829,130 +1072,6 @@ func TestFlushOffCycleLiquidationAuditStateForceProbe(t *testing.T) {
 			t.Errorf("failures = %d, want 4 (probe failure counts like any save failure)", failures)
 		}
 	})
-}
-
-func TestAuditRearmOutcomeUnknownRecordsTriggerAndStops(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	state.Strategies["hl-eth"].Positions["ETH"].StopLossOID = 0
-	state.Strategies["hl-eth"].Positions["ETH"].StopLossTriggerPx = 0
-	var mu sync.RWMutex
-	calls := 0
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		calls++
-		if cancelOID != 0 {
-			t.Errorf("re-arm must place fresh, got cancelOID=%d", cancelOID)
-		}
-		return &HyperliquidStopLossUpdateResult{
-			StopLossError:          "place_stop_loss returned no usable status: {...}",
-			StopLossOutcomeUnknown: true,
-			StopLossTriggerPx:      triggerPx,
-		}, "", nil
-	}
-
-	runHyperliquidLiquidationAudit(strategies, state,
-		map[string]float64{"ETH": 2340.5},
-		hlNetSideByCoinAllLong(),
-		map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if calls != 1 {
-		t.Fatalf("first-pass placement calls = %d, want 1", calls)
-	}
-	pos := state.Strategies["hl-eth"].Positions["ETH"]
-	wantTrigger := 2340.5 * 1.005
-	if pos.StopLossTriggerPx != wantTrigger || pos.StopLossOID != 0 {
-		t.Fatalf("state = oid=%d trigger=%.4f, want oid=0 trigger=%.4f (requested trigger recorded)", pos.StopLossOID, pos.StopLossTriggerPx, wantTrigger)
-	}
-	if last := lastLiqAlertAction("hl-eth", "ETH"); last != hlLiquidationActionPlacementUnknown {
-		t.Fatalf("alert action = %q, want %q (fresh re-arm cancelled nothing)", last, hlLiquidationActionPlacementUnknown)
-	}
-
-	runHyperliquidLiquidationAudit(strategies, state,
-		map[string]float64{"ETH": 2340.5},
-		hlNetSideByCoinAllLong(),
-		map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	if calls != 1 {
-		t.Errorf("second-pass placement calls = %d total, want still 1 (no duplicate)", calls)
-	}
-	if last := lastLiqAlertAction("hl-eth", "ETH"); last != hlLiquidationActionPlacementUnknown {
-		t.Errorf("second-cycle alert action = %q, want %q (unresolved stays surfaced)", last, hlLiquidationActionPlacementUnknown)
-	}
-}
-
-func TestAuditRearmCapRejectedStillRetriedNextCycle(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	state.Strategies["hl-eth"].Positions["ETH"].StopLossOID = 0
-	state.Strategies["hl-eth"].Positions["ETH"].StopLossTriggerPx = 0
-	var mu sync.RWMutex
-	calls := 0
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		calls++
-		return &HyperliquidStopLossUpdateResult{
-			StopLossError: "Order would exceed the open order limit",
-		}, "", nil
-	}
-	for i := 0; i < 2; i++ {
-		runHyperliquidLiquidationAudit(strategies, state,
-			map[string]float64{"ETH": 2340.5},
-			hlNetSideByCoinAllLong(),
-			map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	}
-	if calls != 2 {
-		t.Errorf("placement calls across two passes = %d, want 2 (genuine rejection keeps retrying)", calls)
-	}
-	if last := lastLiqAlertAction("hl-eth", "ETH"); last != hlLiquidationActionRearmFailed {
-		t.Errorf("alert action = %q, want %q", last, hlLiquidationActionRearmFailed)
-	}
-}
-
-func TestAuditRearmAdoptsBookDiffResolvedOID(t *testing.T) {
-	old := runHyperliquidUpdateStopLossFunc
-	defer func() { runHyperliquidUpdateStopLossFunc = old }()
-	clearHLLiquidationAlert("hl-eth", "ETH")
-
-	strategies, state := liqAuditFixture(t, true, 3.125)
-	state.Strategies["hl-eth"].Positions["ETH"].StopLossOID = 0
-	state.Strategies["hl-eth"].Positions["ETH"].StopLossTriggerPx = 0
-	var mu sync.RWMutex
-	runHyperliquidUpdateStopLossFunc = func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
-		return &HyperliquidStopLossUpdateResult{
-			StopLossError:     "place_stop_loss returned no usable status: {...}",
-			StopLossOID:       9002,
-			StopLossTriggerPx: triggerPx,
-		}, "", nil
-	}
-	runHyperliquidLiquidationAudit(strategies, state,
-		map[string]float64{"ETH": 2340.5},
-		hlNetSideByCoinAllLong(),
-		map[string]float64{"ETH": 1.0}, true, &mu, nil, time.Now().UTC())
-	pos := state.Strategies["hl-eth"].Positions["ETH"]
-	if pos.StopLossOID != 9002 {
-		t.Errorf("oid = %d, want 9002 (resolved re-arm adopted)", pos.StopLossOID)
-	}
-	if last := lastLiqAlertAction("hl-eth", "ETH"); last != hlLiquidationActionRearmed {
-		t.Errorf("alert action = %q, want %q", last, hlLiquidationActionRearmed)
-	}
-}
-
-func TestHLLiquidationArmClampActionOutcomeUnknown(t *testing.T) {
-	if got := hlLiquidationArmClampAction(&HyperliquidStopLossUpdateResult{
-		StopLossError:          "boom",
-		StopLossOutcomeUnknown: true,
-		StopLossTriggerPx:      2300,
-	}, true); got != hlLiquidationActionPlacementUnknown {
-		t.Errorf("action = %q, want %q", got, hlLiquidationActionPlacementUnknown)
-	}
-	if got := hlLiquidationArmClampAction(&HyperliquidStopLossUpdateResult{
-		StopLossError: "Order would exceed the open order limit",
-	}, true); got != hlLiquidationActionRearmFailed {
-		t.Errorf("positive rejection = %q, want re-arm failed", got)
-	}
 }
 
 func TestAuditTightenOutcomeUnknownRecordsTriggerAndStops(t *testing.T) {
@@ -2054,19 +1173,500 @@ func TestApplyAuditStopUpdateBooksPartialFillQty(t *testing.T) {
 	}
 }
 
-func TestLiquidationAlertPlacementUnknownWording(t *testing.T) {
-	_, detailTighten, unprotectedTighten := hlLiquidationAlertMessage(2325, 2352.2025, 2340.5, hlLiquidationActionOutcomeUnknown, "rec")
-	if !strings.Contains(detailTighten, "CANCELLED") {
-		t.Errorf("tighten detail lost the cancel claim: %q", detailTighten)
+func liqAuditOnChainOne() map[string]float64 { return map[string]float64{"ETH": 1.0} }
+
+func liqAuditLiqETH() map[string]float64 { return map[string]float64{"ETH": 2340.5} }
+
+func liqAuditClampedTrigger() float64 { return 2340.5 * (1 + hlLiquidationStopBufferPct/100.0) }
+
+func stubLiqAuditStopLoss(t *testing.T, fn func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error)) {
+	t.Helper()
+	old := runHyperliquidUpdateStopLossFunc
+	runHyperliquidUpdateStopLossFunc = fn
+	t.Cleanup(func() { runHyperliquidUpdateStopLossFunc = old })
+}
+
+func TestPlanHyperliquidLiquidationAudit(t *testing.T) {
+	t.Run("classification sorts deterministically and tightens every past-liquidation owner", func(t *testing.T) {
+		cands := []hlLiquidationAuditCandidate{
+			{StrategyID: "b-scalar", Symbol: "ETH", Side: "long", Qty: 1, StopLossOID: 11, StopLossTriggerPx: 2325, LiquidationPx: 2340.5, StaticScalarOwner: true, BookConsistent: true},
+			{StrategyID: "a-trailing", Symbol: "ETH", Side: "long", Qty: 1, StopLossOID: 12, StopLossTriggerPx: 2325, LiquidationPx: 2340.5, StaticScalarOwner: false, BookConsistent: true},
+			{StrategyID: "c-ok", Symbol: "ETH", Side: "long", Qty: 1, StopLossOID: 13, StopLossTriggerPx: 2360, LiquidationPx: 2340.5, StaticScalarOwner: true, BookConsistent: true},
+			{StrategyID: "d-unknown", Symbol: "BTC", Side: "long", Qty: 1, StopLossOID: 14, StopLossTriggerPx: 100, LiquidationPx: 0, StaticScalarOwner: true, BookConsistent: true},
+			{StrategyID: "e-nostop", Symbol: "BTC", Side: "long", Qty: 1, Unprotected: true, RearmTriggerPx: 39000, LiquidationPx: 40000, StaticScalarOwner: false, BookConsistent: true},
+			{StrategyID: "f-noqty", Symbol: "BTC", Side: "long", Qty: 0, StopLossOID: 15, StopLossTriggerPx: 39000, LiquidationPx: 40000, StaticScalarOwner: true, BookConsistent: true},
+		}
+		actions := planHyperliquidLiquidationAudit(cands)
+		if len(actions) != 2 {
+			t.Fatalf("actions = %d, want 2 (only the two past-liquidation candidates)", len(actions))
+		}
+		if actions[0].Candidate.StrategyID != "a-trailing" || actions[1].Candidate.StrategyID != "b-scalar" {
+			t.Fatalf("actions not sorted deterministically: %s, %s", actions[0].Candidate.StrategyID, actions[1].Candidate.StrategyID)
+		}
+		for _, a := range actions {
+			if a.Kind != hlAuditTighten {
+				t.Errorf("%s: kind = %v, want a tighten job — the audit heals every owner", a.Candidate.StrategyID, a.Kind)
+			}
+		}
+		if !approxEqLiq(actions[1].ClampedTriggerPx, liqAuditClampedTrigger()) {
+			t.Errorf("clamped trigger = %g, want %g", actions[1].ClampedTriggerPx, liqAuditClampedTrigger())
+		}
+	})
+
+	t.Run("unprotected static-scalar owner is re-armed at the configured distance", func(t *testing.T) {
+		cands := []hlLiquidationAuditCandidate{
+			{StrategyID: "hl-eth", Symbol: "ETH", Side: "long", Qty: 1, Unprotected: true, RearmTriggerPx: 2325, LiquidationPx: 2300, StaticScalarOwner: true, BookConsistent: true},
+		}
+		actions := planHyperliquidLiquidationAudit(cands)
+		if len(actions) != 1 || actions[0].Kind != hlAuditRearm {
+			t.Fatalf("actions = %+v, want one re-arm job", actions)
+		}
+		if !approxEqLiq(actions[0].ClampedTriggerPx, 2325) {
+			t.Errorf("re-arm trigger = %g, want 2325", actions[0].ClampedTriggerPx)
+		}
+	})
+
+	t.Run("unreconciled coin refuses both tighten and re-arm", func(t *testing.T) {
+		cands := []hlLiquidationAuditCandidate{
+			{StrategyID: "hl-eth", Symbol: "ETH", Side: "long", Qty: 1, StopLossOID: 11, StopLossTriggerPx: 2325, LiquidationPx: 2340.5, StaticScalarOwner: true, BookConsistent: false},
+			{StrategyID: "hl-eth2", Symbol: "ETH", Side: "long", Qty: 1, Unprotected: true, RearmTriggerPx: 2325, LiquidationPx: 2340.5, StaticScalarOwner: true, BookConsistent: false},
+		}
+		for _, a := range planHyperliquidLiquidationAudit(cands) {
+			if a.Kind != hlAuditRefuse {
+				t.Errorf("%s: kind = %v, want a refusal on an unreconciled coin", a.Candidate.StrategyID, a.Kind)
+			}
+		}
+	})
+}
+
+func TestRunHyperliquidLiquidationAuditNoOpCases(t *testing.T) {
+	zeroStop := func(strategies []StrategyConfig, state *AppState) []StrategyConfig {
+		state.Strategies["hl-eth"].Positions["ETH"].StopLossOID = 0
+		state.Strategies["hl-eth"].Positions["ETH"].StopLossTriggerPx = 0
+		return strategies
 	}
-	if unprotectedTighten {
-		t.Error("outcome unknown must not classify as unprotected")
+	for _, tc := range []struct {
+		name        string
+		live        bool
+		stopPct     float64
+		mutate      func([]StrategyConfig, *AppState) []StrategyConfig
+		liq         map[string]float64
+		net         map[string]string
+		onChain     map[string]float64
+		snapshot    bool
+		wantOID     int64
+		wantTrigger float64
+		wantNoAlert bool
+	}{
+		{"paper strategy is never clamped against a live liquidation price", false, 3.125, nil, liqAuditLiqETH(), hlNetSideByCoinAllLong(), liqAuditOnChainOne(), true, 4242, 2325, true},
+		{"shared coin whose book exceeds the on-chain snapshot refuses", true, 3.125, func(strategies []StrategyConfig, state *AppState) []StrategyConfig {
+			scB := strategies[0]
+			scB.ID = "hl-eth-b"
+			state.Strategies["hl-eth-b"] = &StrategyState{ID: "hl-eth-b", Platform: "hyperliquid", Type: "perps", Positions: map[string]*Position{
+				"ETH": {Symbol: "ETH", Side: "long", Quantity: 1.0, AvgCost: 2400, RiskAnchorPrice: 2400, EntryATR: 30, StopLossOID: 4343, StopLossTriggerPx: 2325},
+			}}
+			return append(strategies, scB)
+		}, liqAuditLiqETH(), hlNetSideByCoinAllLong(), liqAuditOnChainOne(), true, 4242, 2325, false},
+		{"no on-chain position for the coin", true, 3.125, nil, liqAuditLiqETH(), hlNetSideByCoinAllLong(), map[string]float64{}, true, 4242, 2325, false},
+		{"failed snapshot fetch with no stop armed raises no phantom alert", true, 3.0, zeroStop, map[string]float64{}, nil, map[string]float64{}, false, 0, 0, true},
+		{"stale net side leaves a healthy resting stop untouched", true, 3.125, nil, liqAuditLiqETH(), map[string]string{"ETH": "short"}, liqAuditOnChainOne(), true, 4242, 2325, true},
+		{"stale net side skips the sole-owner re-arm", true, 3.125, zeroStop, liqAuditLiqETH(), map[string]string{"ETH": "short"}, liqAuditOnChainOne(), true, 0, 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearHLLiquidationAlert("hl-eth", "ETH")
+			clearHLLiquidationAlert("hl-eth-b", "ETH")
+			t.Cleanup(func() {
+				clearHLLiquidationAlert("hl-eth", "ETH")
+				clearHLLiquidationAlert("hl-eth-b", "ETH")
+			})
+			strategies, state := liqAuditFixture(t, tc.live, tc.stopPct)
+			if tc.mutate != nil {
+				strategies = tc.mutate(strategies, state)
+			}
+			calls := 0
+			stubLiqAuditStopLoss(t, func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+				calls++
+				return &HyperliquidStopLossUpdateResult{StopLossOID: 9001, StopLossTriggerPx: triggerPx}, "", nil
+			})
+			res := runHyperliquidLiquidationAudit(strategies, state, tc.liq, tc.net, tc.onChain, tc.snapshot, &sync.RWMutex{}, nil, time.Now().UTC())
+			if calls != 0 {
+				t.Errorf("placement calls = %d, want 0 — the audit must not touch the resting order", calls)
+			}
+			if res.ImmediateFills != 0 || len(res.CloseDetails) != 0 {
+				t.Errorf("result = %+v, want empty", res)
+			}
+			pos := state.Strategies["hl-eth"].Positions["ETH"]
+			if pos.StopLossOID != tc.wantOID || !approxEqLiq(pos.StopLossTriggerPx, tc.wantTrigger) {
+				t.Errorf("state = oid=%d trigger=%g, want untouched oid=%d trigger=%g", pos.StopLossOID, pos.StopLossTriggerPx, tc.wantOID, tc.wantTrigger)
+			}
+			if _, alerted := hlLiquidationAlerts.Load(hlLiquidationAlertKey("hl-eth", "ETH")); tc.wantNoAlert && alerted {
+				t.Error("a no-op pass must not raise a liquidation alert")
+			}
+		})
 	}
-	_, detailFresh, unprotectedFresh := hlLiquidationAlertMessage(0, 2352.2025, 2340.5, hlLiquidationActionPlacementUnknown, "rec")
-	if strings.Contains(detailFresh, "old trigger was CANCELLED") || !strings.Contains(detailFresh, "Nothing was cancelled") {
-		t.Errorf("fresh-placement detail asserts a cancel that never happened: %q", detailFresh)
+}
+
+func TestRunHyperliquidLiquidationAuditHealsRegardlessOfDueness(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(sc *StrategyConfig)
+	}{
+		{"non-due 4h trailing owner", func(sc *StrategyConfig) {
+			sc.StopLossPct = nil
+			sc.TrailingStopATRMult = floatPtr(2.5)
+			sc.Args = []string{"x.py", "ETH", "4h", "--mode=live"}
+		}},
+		{"non-due 1d static scalar owner", func(sc *StrategyConfig) {
+			sc.Args = []string{"x.py", "ETH", "1d", "--mode=live"}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearHLLiquidationAlert("hl-eth", "ETH")
+			t.Cleanup(func() { clearHLLiquidationAlert("hl-eth", "ETH") })
+			strategies, state := liqAuditFixture(t, true, 3.125)
+			tc.mutate(&strategies[0])
+			placed := false
+			stubLiqAuditStopLoss(t, func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+				placed = true
+				return &HyperliquidStopLossUpdateResult{StopLossOID: 9200, StopLossTriggerPx: triggerPx}, "", nil
+			})
+			runHyperliquidLiquidationAudit(strategies, state, liqAuditLiqETH(), hlNetSideByCoinAllLong(), liqAuditOnChainOne(), true, &sync.RWMutex{}, nil, time.Now().UTC())
+			if !placed {
+				t.Fatal("a consistent book must still be healed by the per-cycle audit regardless of due-ness")
+			}
+		})
 	}
-	if unprotectedFresh {
-		t.Error("placement unknown must not classify as unprotected")
+}
+
+func TestRunHyperliquidLiquidationAuditTightenOutcomes(t *testing.T) {
+	wantTrigger := liqAuditClampedTrigger()
+	for _, tc := range []struct {
+		name           string
+		result         HyperliquidStopLossUpdateResult
+		wantOID        int64
+		wantPosTrigger float64
+		wantAction     hlLiquidationAlertAction
+	}{
+		{"resting replacement lands", HyperliquidStopLossUpdateResult{StopLossOID: 9001}, 9001, wantTrigger, hlLiquidationActionClamped},
+		{"cancel then place is a normal clamp", HyperliquidStopLossUpdateResult{CancelStopLossSucceeded: true, StopLossOID: 5150}, 5150, wantTrigger, hlLiquidationActionClamped},
+		{"filled externally is the reconciler's close", HyperliquidStopLossUpdateResult{StopLossFilledExternally: true}, 4242, 2325, hlLiquidationActionFilledOnChain},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearHLLiquidationAlert("hl-eth", "ETH")
+			t.Cleanup(func() { clearHLLiquidationAlert("hl-eth", "ETH") })
+			strategies, state := liqAuditFixture(t, true, 3.125)
+			var gotTrigger, gotSize float64
+			var gotCancelOID int64
+			stubLiqAuditStopLoss(t, func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+				gotTrigger, gotCancelOID, gotSize = triggerPx, cancelOID, size
+				r := tc.result
+				if r.StopLossOID > 0 {
+					r.StopLossTriggerPx = triggerPx
+				}
+				return &r, "", nil
+			})
+			res := runHyperliquidLiquidationAudit(strategies, state, liqAuditLiqETH(), hlNetSideByCoinAllLong(), liqAuditOnChainOne(), true, &sync.RWMutex{}, nil, time.Now().UTC())
+			if res.ImmediateFills != 0 || len(res.CloseDetails) != 0 {
+				t.Fatalf("result = %+v, want no booked close on a resting or external outcome", res)
+			}
+			if gotCancelOID != 4242 {
+				t.Errorf("cancel OID = %d, want the resting 4242", gotCancelOID)
+			}
+			if !approxEqLiq(gotSize, 1.0) {
+				t.Errorf("replace size = %g, want 1.0", gotSize)
+			}
+			if !approxEqLiq(gotTrigger, wantTrigger) {
+				t.Errorf("replace trigger = %g, want %g (just inside liquidation)", gotTrigger, wantTrigger)
+			}
+			pos := state.Strategies["hl-eth"].Positions["ETH"]
+			if pos.StopLossOID != tc.wantOID || !approxEqLiq(pos.StopLossTriggerPx, tc.wantPosTrigger) {
+				t.Errorf("position = oid=%d trigger=%g, want oid=%d trigger=%g", pos.StopLossOID, pos.StopLossTriggerPx, tc.wantOID, tc.wantPosTrigger)
+			}
+			if last := lastLiqAlertAction("hl-eth", "ETH"); last != tc.wantAction {
+				t.Errorf("alert action = %q, want %q", last, tc.wantAction)
+			}
+		})
+	}
+}
+
+func TestRunHyperliquidLiquidationAuditImmediateFillBooksClose(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result HyperliquidStopLossUpdateResult
+	}{
+		{"cancel then immediate fill at submit", HyperliquidStopLossUpdateResult{CancelStopLossSucceeded: true, StopLossFilledImmediately: true}},
+		{"immediate fill without a cancel flag", HyperliquidStopLossUpdateResult{StopLossFilledImmediately: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearHLLiquidationAlert("hl-eth", "ETH")
+			t.Cleanup(func() { clearHLLiquidationAlert("hl-eth", "ETH") })
+			strategies, state := liqAuditFixture(t, true, 3.125)
+			stubLiqAuditStopLoss(t, func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+				r := tc.result
+				r.StopLossTriggerPx = triggerPx
+				return &r, "", nil
+			})
+			res := runHyperliquidLiquidationAudit(strategies, state, liqAuditLiqETH(), hlNetSideByCoinAllLong(), liqAuditOnChainOne(), true, &sync.RWMutex{}, nil, time.Now().UTC())
+			if res.ImmediateFills != 1 || len(res.CloseDetails) != 1 {
+				t.Fatalf("immediate fills = %d, close details = %d, want 1/1 — a booked close must reach the trade notifier", res.ImmediateFills, len(res.CloseDetails))
+			}
+			cd := res.CloseDetails[0]
+			if cd.SC.ID != "hl-eth" || cd.Symbol != "ETH" || cd.Detail == "" {
+				t.Errorf("close detail = %+v, want a populated per-strategy line", cd)
+			}
+			ss := state.Strategies["hl-eth"]
+			if _, still := ss.Positions["ETH"]; still {
+				t.Error("an immediate fill must book the close and drop the position")
+			}
+			if len(ss.ClosedPositions) == 0 {
+				t.Fatal("no closed position recorded for the immediate close")
+			}
+			if cp := ss.ClosedPositions[len(ss.ClosedPositions)-1]; cp.CloseReason != "liquidation_clamp_sl_immediate" {
+				t.Errorf("persisted CloseReason = %q, want liquidation_clamp_sl_immediate (not the trailing walker)", cp.CloseReason)
+			}
+			if len(ss.TradeHistory) == 0 {
+				t.Fatal("no trade recorded for the immediate close")
+			}
+			if tr := ss.TradeHistory[len(ss.TradeHistory)-1]; !strings.Contains(tr.Details, "Liquidation-clamp SL") {
+				t.Errorf("trade details %q must match the LIQUIDATION-CLAMP operator wording", tr.Details)
+			}
+			if last := lastLiqAlertAction("hl-eth", "ETH"); last != hlLiquidationActionExited {
+				t.Errorf("alert action = %q, want %q — the position is FLAT", last, hlLiquidationActionExited)
+			}
+		})
+	}
+}
+
+func TestAuditRetriesPlacementItStrippedSameCycle(t *testing.T) {
+	capRejected := "Order would exceed the open order limit"
+	for _, tc := range []struct {
+		name             string
+		second           HyperliquidStopLossUpdateResult
+		wantFinalOID     int64
+		wantFinalTrigger float64
+		wantAction       hlLiquidationAlertAction
+		wantMinMutations int
+	}{
+		{"retry rests", HyperliquidStopLossUpdateResult{StopLossOID: 9002}, 9002, -1, hlLiquidationActionClamped, 0},
+		{"retry resolves a resting oid by book diff despite the error text", HyperliquidStopLossUpdateResult{StopLossError: "place_stop_loss returned no usable status: {...}", StopLossOID: 9002}, 9002, -1, hlLiquidationActionClamped, 1},
+		{"retry outcome unknown keeps the recorded state and reports unknown", HyperliquidStopLossUpdateResult{StopLossError: "place_stop_loss failed: boom", StopLossOutcomeUnknown: true}, 4242, 2325, hlLiquidationActionOutcomeUnknown, 0},
+		{"retry also cap-rejected is protection lost", HyperliquidStopLossUpdateResult{StopLossError: capRejected}, 0, 0, hlLiquidationActionProtectionLost, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearHLLiquidationAlert("hl-eth", "ETH")
+			t.Cleanup(func() { clearHLLiquidationAlert("hl-eth", "ETH") })
+			strategies, state := liqTrailingAuditFixture(t)
+			type call struct {
+				cancelOID int64
+				trigger   float64
+			}
+			var calls []call
+			stubLiqAuditStopLoss(t, func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+				calls = append(calls, call{cancelOID: cancelOID, trigger: triggerPx})
+				if len(calls) == 1 {
+					return &HyperliquidStopLossUpdateResult{CancelStopLossSucceeded: true, StopLossError: capRejected}, "", nil
+				}
+				r := tc.second
+				if r.StopLossOID > 0 || r.StopLossOutcomeUnknown {
+					r.StopLossTriggerPx = triggerPx
+				}
+				return &r, "", nil
+			})
+			res := runHyperliquidLiquidationAudit(strategies, state, liqAuditLiqETH(), hlNetSideByCoinAllLong(), liqAuditOnChainOne(), true, &sync.RWMutex{}, nil, time.Now().UTC())
+			if len(calls) != 2 {
+				t.Fatalf("placement calls = %d (%+v), want 2 (clamp + in-cycle retry)", len(calls), calls)
+			}
+			if calls[1].cancelOID != 0 {
+				t.Errorf("retry cancelOID = %d, want 0 (nothing left to cancel)", calls[1].cancelOID)
+			}
+			pos := state.Strategies["hl-eth"].Positions["ETH"]
+			if pos.StopLossOID != tc.wantFinalOID {
+				t.Errorf("final oid = %d, want %d", pos.StopLossOID, tc.wantFinalOID)
+			}
+			if tc.wantFinalTrigger >= 0 && !approxEqLiq(pos.StopLossTriggerPx, tc.wantFinalTrigger) {
+				t.Errorf("final trigger = %.4f, want %.4f", pos.StopLossTriggerPx, tc.wantFinalTrigger)
+			}
+			if last := lastLiqAlertAction("hl-eth", "ETH"); last != tc.wantAction {
+				t.Errorf("alert action = %q, want %q", last, tc.wantAction)
+			}
+			if res.StateMutations < tc.wantMinMutations {
+				t.Errorf("state mutations = %d, want >= %d (oid rewrite must flush)", res.StateMutations, tc.wantMinMutations)
+			}
+		})
+	}
+
+	t.Run("first-try rest takes no retry", func(t *testing.T) {
+		clearHLLiquidationAlert("hl-eth", "ETH")
+		t.Cleanup(func() { clearHLLiquidationAlert("hl-eth", "ETH") })
+		strategies, state := liqTrailingAuditFixture(t)
+		calls := 0
+		stubLiqAuditStopLoss(t, func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+			calls++
+			return &HyperliquidStopLossUpdateResult{StopLossOID: 9001, StopLossTriggerPx: triggerPx}, "", nil
+		})
+		runHyperliquidLiquidationAudit(strategies, state, liqAuditLiqETH(), hlNetSideByCoinAllLong(), liqAuditOnChainOne(), true, &sync.RWMutex{}, nil, time.Now().UTC())
+		if calls != 1 {
+			t.Errorf("placement calls = %d, want 1", calls)
+		}
+	})
+}
+
+func TestAuditRearmOutcomes(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		liq         map[string]float64
+		result      HyperliquidStopLossUpdateResult
+		passes      int
+		wantCalls   int
+		wantOID     int64
+		wantTrigger float64
+		wantAction  hlLiquidationAlertAction
+	}{
+		{"outcome unknown records the requested trigger and stops re-placing", liqAuditLiqETH(), HyperliquidStopLossUpdateResult{StopLossError: "place_stop_loss returned no usable status: {...}", StopLossOutcomeUnknown: true}, 2, 1, 0, 2340.5 * 1.005, hlLiquidationActionPlacementUnknown},
+		{"genuine cap rejection keeps retrying next cycle", liqAuditLiqETH(), HyperliquidStopLossUpdateResult{StopLossError: "Order would exceed the open order limit"}, 2, 2, 0, -1, hlLiquidationActionRearmFailed},
+		{"book-diff resolved oid is adopted despite the error text", liqAuditLiqETH(), HyperliquidStopLossUpdateResult{StopLossError: "place_stop_loss returned no usable status: {...}", StopLossOID: 9002}, 1, 1, 9002, -1, hlLiquidationActionRearmed},
+		{"matching side with unknown geometry places the unclamped configured distance", map[string]float64{}, HyperliquidStopLossUpdateResult{StopLossOID: 9001}, 1, 1, 9001, 2400 * (1 - 0.03125), ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearHLLiquidationAlert("hl-eth", "ETH")
+			t.Cleanup(func() { clearHLLiquidationAlert("hl-eth", "ETH") })
+			strategies, state := liqAuditFixture(t, true, 3.125)
+			state.Strategies["hl-eth"].Positions["ETH"].StopLossOID = 0
+			state.Strategies["hl-eth"].Positions["ETH"].StopLossTriggerPx = 0
+			calls := 0
+			var gotTrigger float64
+			stubLiqAuditStopLoss(t, func(script, symbol, side string, size, triggerPx float64, cancelOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
+				calls++
+				gotTrigger = triggerPx
+				if cancelOID != 0 {
+					t.Errorf("re-arm must place fresh, got cancelOID=%d", cancelOID)
+				}
+				r := tc.result
+				if r.StopLossOID > 0 || r.StopLossOutcomeUnknown {
+					r.StopLossTriggerPx = triggerPx
+				}
+				return &r, "", nil
+			})
+			for i := 0; i < tc.passes; i++ {
+				runHyperliquidLiquidationAudit(strategies, state, tc.liq, hlNetSideByCoinAllLong(), liqAuditOnChainOne(), true, &sync.RWMutex{}, nil, time.Now().UTC())
+				if tc.wantAction != "" {
+					if last := lastLiqAlertAction("hl-eth", "ETH"); last != tc.wantAction {
+						t.Errorf("pass %d alert action = %q, want %q", i+1, last, tc.wantAction)
+					}
+				}
+			}
+			if calls != tc.wantCalls {
+				t.Errorf("placement calls across %d pass(es) = %d, want %d", tc.passes, calls, tc.wantCalls)
+			}
+			pos := state.Strategies["hl-eth"].Positions["ETH"]
+			if pos.StopLossOID != tc.wantOID {
+				t.Errorf("oid = %d, want %d", pos.StopLossOID, tc.wantOID)
+			}
+			if tc.wantTrigger >= 0 {
+				if !approxEqLiq(gotTrigger, tc.wantTrigger) {
+					t.Errorf("re-arm trigger = %.4f, want %.4f", gotTrigger, tc.wantTrigger)
+				}
+				if !approxEqLiq(pos.StopLossTriggerPx, tc.wantTrigger) {
+					t.Errorf("recorded trigger = %.4f, want %.4f", pos.StopLossTriggerPx, tc.wantTrigger)
+				}
+			}
+		})
+	}
+}
+
+func TestLiquidationAuditIntervalSeconds(t *testing.T) {
+	mk := func(id, platform, typ string, live bool) StrategyConfig {
+		args := []string{"--mode", "paper"}
+		if live {
+			args = []string{"--mode", "live"}
+		}
+		return StrategyConfig{ID: id, Platform: platform, Type: typ, Args: args}
+	}
+	fleet := []StrategyConfig{
+		mk("hl-live-a", "hyperliquid", "perps", true),
+		mk("hl-paper-b", "hyperliquid", "perps", false),
+		mk("okx-live-c", "okx", "perps", true),
+		mk("hl-live-spot", "hyperliquid", "spot", true),
+	}
+	fleetIntervals := map[string]int{"hl-live-a": 300, "hl-paper-b": 60, "okx-live-c": 120, "hl-live-spot": 30}
+	for _, tc := range []struct {
+		name       string
+		strategies []StrategyConfig
+		intervals  map[string]int
+		want       int
+	}{
+		{"half of the sole live HL perps interval", fleet, fleetIntervals, 150},
+		{"no live HL perps or manual", fleet[1:], fleetIntervals, 0},
+		{"4h fleet cadence is strictly shorter than the interval it bounds", []StrategyConfig{mk("hl-4h", "hyperliquid", "perps", true)}, map[string]int{"hl-4h": 14400}, 7200},
+		{"manual-only fleet is an audit candidate", []StrategyConfig{mk("hl-manual", "hyperliquid", "manual", true)}, map[string]int{"hl-manual": 3600}, 1800},
+		{"fast fleet clamps to the floor", []StrategyConfig{mk("hl-4h", "hyperliquid", "perps", true)}, map[string]int{"hl-4h": 30}, liquidationAuditMinIntervalSeconds},
+		{"paper manual is not a candidate", []StrategyConfig{mk("hl-pm", "hyperliquid", "manual", false)}, map[string]int{"hl-pm": 3600}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := liquidationAuditIntervalSeconds(tc.strategies, tc.intervals); got != tc.want {
+				t.Errorf("interval = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHLLiquidationAlertMessage(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		trigger         float64
+		clamped         float64
+		liq             float64
+		action          hlLiquidationAlertAction
+		wantHeadline    string
+		wantContains    []string
+		wantNotContains []string
+		wantUnprotected bool
+	}{
+		{"refused with no stop omits fabricated geometry and is unprotected", 0, 0, 0, hlLiquidationActionUnreconciled, "**HL POSITION UNPROTECTED**", []string{"NO exchange-side stop"}, []string{"$0.0000"}, true},
+		{"refused tighten keeps the old order and names the real prices", 2325, 2352, 2340.5, hlLiquidationActionUnreconciled, "", []string{"$2325.0000", "$2340.5000"}, nil, false},
+		{"outcome unknown never claims the position is naked", 1800, 1900, 1750, hlLiquidationActionOutcomeUnknown, "OUTCOME UNKNOWN", []string{"could NOT be read", "may be resting", "KEPT"}, []string{"no exchange-side stop right now"}, false},
+		{"outcome unknown after a tighten keeps the cancel claim", 2325, 2352.2025, 2340.5, hlLiquidationActionOutcomeUnknown, "", []string{"CANCELLED"}, nil, false},
+		{"placement unknown after a fresh re-arm asserts no cancel", 0, 2352.2025, 2340.5, hlLiquidationActionPlacementUnknown, "", []string{"Nothing was cancelled"}, []string{"old trigger was CANCELLED"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			headline, detail, unprotected := hlLiquidationAlertMessage(tc.trigger, tc.clamped, tc.liq, tc.action, "rec")
+			if tc.wantHeadline != "" && !strings.Contains(headline, tc.wantHeadline) {
+				t.Errorf("headline = %q, want it to contain %q", headline, tc.wantHeadline)
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(detail, want) {
+					t.Errorf("detail = %q, want it to contain %q", detail, want)
+				}
+			}
+			for _, bad := range tc.wantNotContains {
+				if strings.Contains(detail, bad) {
+					t.Errorf("detail = %q, must not contain %q", detail, bad)
+				}
+			}
+			if unprotected != tc.wantUnprotected {
+				t.Errorf("unprotected = %v, want %v", unprotected, tc.wantUnprotected)
+			}
+		})
+	}
+}
+
+func TestOutcomeUnknownIsNotProtectionLost(t *testing.T) {
+	if hlLiquidationActionUnprotected(hlLiquidationActionOutcomeUnknown) {
+		t.Errorf("outcome-unknown counted as unprotected — the operator is told a fact nobody measured")
+	}
+	if !hlLiquidationActionUnprotected(hlLiquidationActionProtectionLost) {
+		t.Errorf("protection lost must still count as unprotected")
+	}
+	if hlLiquidationMayRetryReplace(&HyperliquidStopLossUpdateResult{StopLossOutcomeUnknown: true}) {
+		t.Errorf("outcome-unknown must not license an in-cycle retry")
+	}
+	if !hlLiquidationMayRetryReplace(&HyperliquidStopLossUpdateResult{}) {
+		t.Errorf("a positively rejected placement must still retry")
+	}
+	if got := hlLiquidationArmClampAction(&HyperliquidStopLossUpdateResult{StopLossError: "boom", StopLossOutcomeUnknown: true, StopLossTriggerPx: 2300}, true); got != hlLiquidationActionPlacementUnknown {
+		t.Errorf("arm-clamp action = %q, want %q", got, hlLiquidationActionPlacementUnknown)
+	}
+	if got := hlLiquidationArmClampAction(&HyperliquidStopLossUpdateResult{StopLossError: "Order would exceed the open order limit"}, true); got != hlLiquidationActionRearmFailed {
+		t.Errorf("positive rejection = %q, want re-arm failed", got)
 	}
 }

--- a/scheduler/kill_switch_close_test.go
+++ b/scheduler/kill_switch_close_test.go
@@ -659,68 +659,6 @@ func TestHyperliquidKillSwitchClose_SharedCoinSplitsFillByVirtualQuantity(t *tes
 		{ID: "hl-b", Platform: "hyperliquid", Type: "perps", Leverage: 5, CapitalPct: 0.75,
 			Args: []string{"ema", "ETH", "1h", "--mode=live"}},
 	}
-	plan := KillSwitchClosePlan{
-		OnChainConfirmedFlat: true,
-		CloseReport: HyperliquidLiveCloseReport{
-			Fills: map[string]HyperliquidCloseFill{
-				"ETH": {TotalSz: 2.0, AvgPx: 3000, Fee: 4.0},
-			},
-		},
-	}
-	s := &StrategyState{
-		ID:       "hl-a",
-		Type:     "perps",
-		Platform: "hyperliquid",
-		Cash:     1000,
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 1.5, AvgCost: 3100, Side: "long", Multiplier: 1, Leverage: 5},
-		},
-	}
-	peerState := &StrategyState{
-		ID:       "hl-b",
-		Type:     "perps",
-		Platform: "hyperliquid",
-		Cash:     3000,
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3100, Side: "long", Multiplier: 1, Leverage: 5},
-		},
-	}
-	hlVirtualQty := snapshotHyperliquidVirtualQuantities(map[string]*StrategyState{
-		"hl-a": s,
-		"hl-b": peerState,
-	}, hlLive)
-
-	forceCloseKillSwitchPositions(s, hlLive[0], map[string]float64{"ETH": 2800}, plan.CloseReport.Fills, hlLive, hlVirtualQty, nil)
-
-	if len(s.TradeHistory) != 1 {
-		t.Fatalf("expected 1 trade, got %d", len(s.TradeHistory))
-	}
-	trade := s.TradeHistory[0]
-	if math.Abs(trade.Quantity-1.5) > 1e-9 {
-		t.Errorf("Trade.Quantity = %.6f; want 1.5 virtual-quantity share of 2.0 fill", trade.Quantity)
-	}
-	if trade.Price != 3000 {
-		t.Errorf("Trade.Price = %.2f; want real fill AvgPx 3000", trade.Price)
-	}
-	if trade.ExchangeFee != 3.0 {
-		t.Errorf("Trade.ExchangeFee = %.4f; want virtual-quantity fill Fee 3.0", trade.ExchangeFee)
-	}
-	if len(s.ClosedPositions) != 1 {
-		t.Fatalf("expected 1 closed position, got %d", len(s.ClosedPositions))
-	}
-	wantPnL := -153.0
-	if math.Abs(s.ClosedPositions[0].RealizedPnL-wantPnL) > 1e-9 {
-		t.Errorf("RealizedPnL = %.4f; want %.4f", s.ClosedPositions[0].RealizedPnL, wantPnL)
-	}
-}
-
-func TestHyperliquidKillSwitchClose_SharedCoinPeersSumToReport(t *testing.T) {
-	hlLive := []StrategyConfig{
-		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", Leverage: 5, CapitalPct: 0.25,
-			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
-		{ID: "hl-b", Platform: "hyperliquid", Type: "perps", Leverage: 5, CapitalPct: 0.75,
-			Args: []string{"ema", "ETH", "1h", "--mode=live"}},
-	}
 	const totalSz, totalFee, avgPx = 2.0, 4.0, 3000.0
 	fills := map[string]HyperliquidCloseFill{
 		"ETH": {TotalSz: totalSz, AvgPx: avgPx, Fee: totalFee},
@@ -762,6 +700,15 @@ func TestHyperliquidKillSwitchClose_SharedCoinPeersSumToReport(t *testing.T) {
 	}
 	if tA.Price != avgPx || tB.Price != avgPx {
 		t.Errorf("peer fill prices = %.2f / %.2f; want %.2f for both", tA.Price, tB.Price, avgPx)
+	}
+	if math.Abs(tA.ExchangeFee-3.0) > 1e-9 || math.Abs(tB.ExchangeFee-1.0) > 1e-9 {
+		t.Errorf("peer fees = %.4f / %.4f; want 3.0 / 1.0 (virtual-quantity share of %.1f)", tA.ExchangeFee, tB.ExchangeFee, totalFee)
+	}
+	if len(stateA.ClosedPositions) != 1 {
+		t.Fatalf("expected 1 closed position for A, got %d", len(stateA.ClosedPositions))
+	}
+	if wantPnL := -153.0; math.Abs(stateA.ClosedPositions[0].RealizedPnL-wantPnL) > 1e-9 {
+		t.Errorf("A RealizedPnL = %.4f; want %.4f (1.5 * (3000-3100) - 3.0 fee)", stateA.ClosedPositions[0].RealizedPnL, wantPnL)
 	}
 }
 
@@ -956,292 +903,12 @@ func TestPlanKillSwitchClose_NoHLConfigured(t *testing.T) {
 	}
 }
 
-func TestPlanKillSwitchClose_DeterministicErrorOrder(t *testing.T) {
-	hlLive := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps",
-			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
-			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
-		{ID: "hl-sol", Platform: "hyperliquid", Type: "perps",
-			Args: []string{"sma", "SOL", "1h", "--mode=live"}},
-		{ID: "hl-doge", Platform: "hyperliquid", Type: "perps",
-			Args: []string{"sma", "DOGE", "1h", "--mode=live"}},
-	}
-	positions := []HLPosition{
-		{Coin: "BTC", Size: 0.01}, {Coin: "ETH", Size: 0.1},
-		{Coin: "SOL", Size: 1.0}, {Coin: "DOGE", Size: 100},
-	}
-	errs := map[string]error{
-		"BTC": fmt.Errorf("err"), "ETH": fmt.Errorf("err"),
-		"SOL": fmt.Errorf("err"), "DOGE": fmt.Errorf("err"),
-	}
-	var prev string
-	for i := 0; i < 10; i++ {
-		closer, _ := stubHLLiveCloser(errs)
-		fetcher, _ := stubHLStateFetcher(positions, nil)
-		plan := planKillSwitchClose(defaultHLInputs("0xaddr", true, positions, hlLive,
-			"reason", time.Second, closer, fetcher))
-		if prev != "" && plan.DiscordMessage != prev {
-			t.Fatalf("message should be deterministic across calls\niter %d: %s\nprev: %s", i, plan.DiscordMessage, prev)
-		}
-		prev = plan.DiscordMessage
-	}
-	btcPos := strings.Index(prev, "BTC:")
-	dogePos := strings.Index(prev, "DOGE:")
-	ethPos := strings.Index(prev, "ETH:")
-	solPos := strings.Index(prev, "SOL:")
-	if !(btcPos < dogePos && dogePos < ethPos && ethPos < solPos) {
-		t.Errorf("expected alphabetical ordering BTC < DOGE < ETH < SOL, got positions btc=%d doge=%d eth=%d sol=%d in: %s",
-			btcPos, dogePos, ethPos, solPos, prev)
-	}
-}
-
 func TestPlanKillSwitchClose_ZeroInputsAreSafe(t *testing.T) {
 	closer, _ := stubHLLiveCloser(nil)
 	fetcher, _ := stubHLStateFetcher(nil, nil)
 	plan := planKillSwitchClose(defaultHLInputs("", false, nil, nil, "", time.Second, closer, fetcher))
 	if !plan.OnChainConfirmedFlat {
 		t.Errorf("zero inputs should yield ConfirmedFlat=true, got %+v", plan)
-	}
-}
-
-func TestPlanKillSwitchClose_OKXHappyPath(t *testing.T) {
-	okxLive := []StrategyConfig{
-		{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
-			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
-	}
-	positions := []OKXPosition{{Coin: "BTC", Size: 0.01, EntryPrice: 42000, Side: "long"}}
-	closer, calls := stubOKXLiveCloser(nil)
-	fetcher, fetchCalls := stubOKXPositionsFetcher(positions, nil)
-
-	in := KillSwitchCloseInputs{
-		OKXLiveAllPerps: okxLive,
-		OKXCloser:       closer,
-		OKXFetcher:      fetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	}
-	plan := planKillSwitchClose(in)
-
-	if !plan.OnChainConfirmedFlat {
-		t.Fatalf("expected ConfirmedFlat, got plan=%+v", plan)
-	}
-	if *fetchCalls != 1 {
-		t.Errorf("OKX fetcher should be called exactly once, got %d", *fetchCalls)
-	}
-	if len(*calls) != 1 || (*calls)[0] != "BTC" {
-		t.Errorf("closer calls = %v, want [BTC]", *calls)
-	}
-	if !strings.Contains(plan.DiscordMessage, "OKX closes: [BTC]") {
-		t.Errorf("expected OKX closes in message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_OKXCloseError(t *testing.T) {
-	okxLive := []StrategyConfig{
-		{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
-			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
-	}
-	positions := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
-	closer, _ := stubOKXLiveCloser(map[string]error{"BTC": fmt.Errorf("okx rate limited")})
-	fetcher, _ := stubOKXPositionsFetcher(positions, nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		OKXLiveAllPerps: okxLive,
-		OKXCloser:       closer,
-		OKXFetcher:      fetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat on OKX close error — would clear virtual state while on-chain is live")
-	}
-	if got, ok := plan.OKXCloseReport.Errors["BTC"]; !ok || got == nil {
-		t.Errorf("expected BTC error in OKX report, got %v", plan.OKXCloseReport.Errors)
-	}
-	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
-		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
-	}
-	if !strings.Contains(plan.DiscordMessage, "okx rate limited") {
-		t.Errorf("expected OKX error detail in message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_OKXFetchFailure(t *testing.T) {
-	okxLive := []StrategyConfig{
-		{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
-			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
-	}
-	closer, calls := stubOKXLiveCloser(nil)
-	fetcher, _ := stubOKXPositionsFetcher(nil, fmt.Errorf("okx auth failed"))
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		OKXLiveAllPerps: okxLive,
-		OKXCloser:       closer,
-		OKXFetcher:      fetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat on OKX fetch failure")
-	}
-	if len(*calls) != 0 {
-		t.Errorf("closer must not be invoked when fetch failed, got %v", *calls)
-	}
-	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
-		t.Errorf("expected LATCHED message on fetch failure, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_OKXSpotSurfacesGap(t *testing.T) {
-	okxSpot := []StrategyConfig{
-		{ID: "okx-sma-btc-spot", Platform: "okx", Type: "spot",
-			Args: []string{"sma", "BTC", "1h", "--mode=live", "--inst-type=spot"}},
-	}
-	closer, _ := stubOKXLiveCloser(nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		OKXLiveAllSpot:  okxSpot,
-		OKXCloser:       closer,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if !plan.OnChainConfirmedFlat {
-		t.Errorf("spot-only presence must not block ConfirmedFlat, got plan=%+v", plan)
-	}
-	if !plan.OKXSpotPresent {
-		t.Error("expected OKXSpotPresent=true")
-	}
-	if plan.CanAutoResetWithoutOwner() {
-		t.Error("OKX spot operator-required gap must suppress no-owner auto-reset")
-	}
-	if !strings.Contains(plan.DiscordMessage, "OKX spot") {
-		t.Errorf("expected spot gap note in message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_HLAndOKXHappyPath(t *testing.T) {
-	hlLive := []StrategyConfig{
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
-			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
-	}
-	okxLive := []StrategyConfig{
-		{ID: "okx-btc", Platform: "okx", Type: "perps",
-			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
-	}
-	hlPos := []HLPosition{{Coin: "ETH", Size: 0.5}}
-	okxPos := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
-	hlCloser, hlCalls := stubHLLiveCloser(nil)
-	hlFetcher, _ := stubHLStateFetcher(nil, nil)
-	okxCloser, okxCalls := stubOKXLiveCloser(nil)
-	okxFetcher, _ := stubOKXPositionsFetcher(okxPos, nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		HLAddr:          "0xaddr",
-		HLStateFetched:  true,
-		HLPositions:     hlPos,
-		HLLiveAll:       hlLive,
-		HLCloser:        hlCloser,
-		HLFetcher:       hlFetcher,
-		OKXLiveAllPerps: okxLive,
-		OKXCloser:       okxCloser,
-		OKXFetcher:      okxFetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if !plan.OnChainConfirmedFlat {
-		t.Fatalf("expected ConfirmedFlat when both platforms succeed, got plan=%+v", plan)
-	}
-	if len(*hlCalls) != 1 || (*hlCalls)[0] != "ETH" {
-		t.Errorf("HL closer calls = %v, want [ETH]", *hlCalls)
-	}
-	if len(*okxCalls) != 1 || (*okxCalls)[0] != "BTC" {
-		t.Errorf("OKX closer calls = %v, want [BTC]", *okxCalls)
-	}
-	if !strings.Contains(plan.DiscordMessage, "HL closes: [ETH]") {
-		t.Errorf("expected HL closes in message, got: %s", plan.DiscordMessage)
-	}
-	if !strings.Contains(plan.DiscordMessage, "OKX closes: [BTC]") {
-		t.Errorf("expected OKX closes in message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_HLSuccessOKXFailureStillLatches(t *testing.T) {
-	hlLive := []StrategyConfig{
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
-			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
-	}
-	okxLive := []StrategyConfig{
-		{ID: "okx-btc", Platform: "okx", Type: "perps",
-			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
-	}
-	hlPos := []HLPosition{{Coin: "ETH", Size: 0.5}}
-	okxPos := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
-	hlCloser, _ := stubHLLiveCloser(nil)
-	hlFetcher, _ := stubHLStateFetcher(nil, nil)
-	okxCloser, _ := stubOKXLiveCloser(map[string]error{"BTC": fmt.Errorf("okx err")})
-	okxFetcher, _ := stubOKXPositionsFetcher(okxPos, nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		HLAddr:          "0xaddr",
-		HLStateFetched:  true,
-		HLPositions:     hlPos,
-		HLLiveAll:       hlLive,
-		HLCloser:        hlCloser,
-		HLFetcher:       hlFetcher,
-		OKXLiveAllPerps: okxLive,
-		OKXCloser:       okxCloser,
-		OKXFetcher:      okxFetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("OKX failure must latch the switch even when HL succeeded")
-	}
-	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
-		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
-	}
-	if !strings.Contains(plan.DiscordMessage, "okx err") {
-		t.Errorf("OKX error missing from message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_OKXUnconfiguredBlocksReset(t *testing.T) {
-	okxLive := []StrategyConfig{
-		{ID: "okx-btc", Platform: "okx", Type: "perps",
-			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
-	}
-	positions := []OKXPosition{
-		{Coin: "BTC", Size: 0.01, Side: "long"},
-		{Coin: "SOL", Size: 100, Side: "long"},
-	}
-	closer, calls := stubOKXLiveCloser(nil)
-	fetcher, _ := stubOKXPositionsFetcher(positions, nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		OKXLiveAllPerps: okxLive,
-		OKXCloser:       closer,
-		OKXFetcher:      fetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat — unconfigured SOL position is still on-chain")
-	}
-	if len(plan.OKXUnconfigured) != 1 || plan.OKXUnconfigured[0].Coin != "SOL" {
-		t.Errorf("expected OKXUnconfigured=[SOL], got %v", plan.OKXUnconfigured)
-	}
-	if len(*calls) != 1 || (*calls)[0] != "BTC" {
-		t.Errorf("closer calls = %v, want [BTC]", *calls)
-	}
-	if !strings.Contains(plan.DiscordMessage, "manual intervention required") {
-		t.Errorf("expected manual intervention note, got: %s", plan.DiscordMessage)
 	}
 }
 
@@ -1272,157 +939,6 @@ func stubRHPositionsFetcher(positions []RobinhoodPosition, err error) (Robinhood
 	return fetcher, &calls
 }
 
-func TestPlanKillSwitchClose_RobinhoodHappyPath(t *testing.T) {
-	rhLive := []StrategyConfig{
-		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
-			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
-	}
-	positions := []RobinhoodPosition{{Coin: "BTC", Size: 0.01, AvgPrice: 42000}}
-	closer, calls := stubRHLiveCloser(nil)
-	fetcher, fetchCalls := stubRHPositionsFetcher(positions, nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		RHLiveCrypto:    rhLive,
-		RHCloser:        closer,
-		RHFetcher:       fetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if !plan.OnChainConfirmedFlat {
-		t.Fatalf("expected ConfirmedFlat, got plan=%+v", plan)
-	}
-	if *fetchCalls != 1 {
-		t.Errorf("Robinhood fetcher should be called exactly once, got %d", *fetchCalls)
-	}
-	if len(*calls) != 1 || (*calls)[0] != "BTC" {
-		t.Errorf("closer calls = %v, want [BTC]", *calls)
-	}
-	if !strings.Contains(plan.DiscordMessage, "Robinhood closes: [BTC]") {
-		t.Errorf("expected Robinhood closes in message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_RobinhoodCloseError(t *testing.T) {
-	rhLive := []StrategyConfig{
-		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
-			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
-	}
-	positions := []RobinhoodPosition{{Coin: "BTC", Size: 0.01}}
-	closer, _ := stubRHLiveCloser(map[string]error{"BTC": fmt.Errorf("rh rate limited")})
-	fetcher, _ := stubRHPositionsFetcher(positions, nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		RHLiveCrypto:    rhLive,
-		RHCloser:        closer,
-		RHFetcher:       fetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat on Robinhood close error — would clear virtual state while live is still active")
-	}
-	if got, ok := plan.RHCloseReport.Errors["BTC"]; !ok || got == nil {
-		t.Errorf("expected BTC error in Robinhood report, got %v", plan.RHCloseReport.Errors)
-	}
-	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
-		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
-	}
-	if !strings.Contains(plan.DiscordMessage, "rh rate limited") {
-		t.Errorf("expected Robinhood error detail in message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_RobinhoodFetchFailure(t *testing.T) {
-	rhLive := []StrategyConfig{
-		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
-			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
-	}
-	closer, calls := stubRHLiveCloser(nil)
-	fetcher, _ := stubRHPositionsFetcher(nil, fmt.Errorf("rh auth failed"))
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		RHLiveCrypto:    rhLive,
-		RHCloser:        closer,
-		RHFetcher:       fetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat on Robinhood fetch failure")
-	}
-	if len(*calls) != 0 {
-		t.Errorf("closer must not be invoked when fetch failed, got %v", *calls)
-	}
-	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
-		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_RobinhoodOptionsSurfacesGap(t *testing.T) {
-	rhOptions := []StrategyConfig{
-		{ID: "rh-ccall-spy", Platform: "robinhood", Type: "options",
-			Args: []string{"covered_call", "SPY", "1d", "--mode=live"}},
-	}
-	closer, _ := stubRHLiveCloser(nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		RHLiveOptions:   rhOptions,
-		RHCloser:        closer,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if !plan.OnChainConfirmedFlat {
-		t.Errorf("options-only presence must not block ConfirmedFlat, got plan=%+v", plan)
-	}
-	if !plan.RHOptionsPresent {
-		t.Error("expected RHOptionsPresent=true")
-	}
-	if plan.CanAutoResetWithoutOwner() {
-		t.Error("Robinhood options operator-required gap must suppress no-owner auto-reset")
-	}
-	if !strings.Contains(plan.DiscordMessage, "Robinhood options") {
-		t.Errorf("expected options gap note in message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_RobinhoodUnconfiguredBlocksReset(t *testing.T) {
-	rhLive := []StrategyConfig{
-		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
-			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
-	}
-	positions := []RobinhoodPosition{
-		{Coin: "BTC", Size: 0.01},
-		{Coin: "DOGE", Size: 100},
-	}
-	closer, calls := stubRHLiveCloser(nil)
-	fetcher, _ := stubRHPositionsFetcher(positions, nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		RHLiveCrypto:    rhLive,
-		RHCloser:        closer,
-		RHFetcher:       fetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat — unconfigured DOGE balance is still live")
-	}
-	if len(plan.RHUnconfigured) != 1 || plan.RHUnconfigured[0].Coin != "DOGE" {
-		t.Errorf("expected RHUnconfigured=[DOGE], got %v", plan.RHUnconfigured)
-	}
-	if len(*calls) != 1 || (*calls)[0] != "BTC" {
-		t.Errorf("closer calls = %v, want [BTC]", *calls)
-	}
-	if !strings.Contains(plan.DiscordMessage, "manual intervention required") {
-		t.Errorf("expected manual intervention note, got: %s", plan.DiscordMessage)
-	}
-}
-
 func TestPlanKillSwitchClose_HLAndOKXAndRobinhoodHappyPath(t *testing.T) {
 	hlLive := []StrategyConfig{
 		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
@@ -1440,9 +956,9 @@ func TestPlanKillSwitchClose_HLAndOKXAndRobinhoodHappyPath(t *testing.T) {
 	okxPos := []OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}
 	rhPos := []RobinhoodPosition{{Coin: "SOL", Size: 2.5}}
 
-	hlCloser, _ := stubHLLiveCloser(nil)
+	hlCloser, hlCalls := stubHLLiveCloser(nil)
 	hlFetcher, _ := stubHLStateFetcher(nil, nil)
-	okxCloser, _ := stubOKXLiveCloser(nil)
+	okxCloser, okxCalls := stubOKXLiveCloser(nil)
 	okxFetcher, _ := stubOKXPositionsFetcher(okxPos, nil)
 	rhCloser, rhCalls := stubRHLiveCloser(nil)
 	rhFetcher, _ := stubRHPositionsFetcher(rhPos, nil)
@@ -1465,7 +981,13 @@ func TestPlanKillSwitchClose_HLAndOKXAndRobinhoodHappyPath(t *testing.T) {
 	})
 
 	if !plan.OnChainConfirmedFlat {
-		t.Fatalf("expected ConfirmedFlat, got plan=%+v", plan)
+		t.Fatalf("expected ConfirmedFlat when every platform succeeds, got plan=%+v", plan)
+	}
+	if len(*hlCalls) != 1 || (*hlCalls)[0] != "ETH" {
+		t.Errorf("HL closer calls = %v, want [ETH]", *hlCalls)
+	}
+	if len(*okxCalls) != 1 || (*okxCalls)[0] != "BTC" {
+		t.Errorf("OKX closer calls = %v, want [BTC]", *okxCalls)
 	}
 	if len(*rhCalls) != 1 || (*rhCalls)[0] != "SOL" {
 		t.Errorf("Robinhood closer calls = %v, want [SOL]", *rhCalls)
@@ -1478,119 +1000,6 @@ func TestPlanKillSwitchClose_HLAndOKXAndRobinhoodHappyPath(t *testing.T) {
 	}
 	if !strings.Contains(plan.DiscordMessage, "Robinhood closes: [SOL]") {
 		t.Errorf("expected Robinhood closes in message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_RobinhoodFailureStillLatchesAcrossPlatforms(t *testing.T) {
-	hlLive := []StrategyConfig{
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
-			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
-	}
-	rhLive := []StrategyConfig{
-		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
-			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
-	}
-	hlPos := []HLPosition{{Coin: "ETH", Size: 0.5}}
-	rhPos := []RobinhoodPosition{{Coin: "BTC", Size: 0.01}}
-
-	hlCloser, _ := stubHLLiveCloser(nil)
-	hlFetcher, _ := stubHLStateFetcher(nil, nil)
-	rhCloser, _ := stubRHLiveCloser(map[string]error{"BTC": fmt.Errorf("rh err")})
-	rhFetcher, _ := stubRHPositionsFetcher(rhPos, nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		HLAddr:          "0xaddr",
-		HLStateFetched:  true,
-		HLPositions:     hlPos,
-		HLLiveAll:       hlLive,
-		HLCloser:        hlCloser,
-		HLFetcher:       hlFetcher,
-		RHLiveCrypto:    rhLive,
-		RHCloser:        rhCloser,
-		RHFetcher:       rhFetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("Robinhood failure must latch the switch even when HL succeeded")
-	}
-	if !strings.Contains(plan.DiscordMessage, "rh err") {
-		t.Errorf("Robinhood error missing from message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_RobinhoodDeterministicErrorOrder(t *testing.T) {
-	rhLive := []StrategyConfig{
-		{ID: "rh-btc", Platform: "robinhood", Type: "spot", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
-		{ID: "rh-eth", Platform: "robinhood", Type: "spot", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
-		{ID: "rh-doge", Platform: "robinhood", Type: "spot", Args: []string{"sma", "DOGE", "1h", "--mode=live"}},
-	}
-	positions := []RobinhoodPosition{
-		{Coin: "BTC", Size: 0.01}, {Coin: "ETH", Size: 0.1}, {Coin: "DOGE", Size: 100},
-	}
-	errs := map[string]error{
-		"BTC": fmt.Errorf("err"), "ETH": fmt.Errorf("err"), "DOGE": fmt.Errorf("err"),
-	}
-	var prev string
-	for i := 0; i < 10; i++ {
-		closer, _ := stubRHLiveCloser(errs)
-		fetcher, _ := stubRHPositionsFetcher(positions, nil)
-		plan := planKillSwitchClose(KillSwitchCloseInputs{
-			RHLiveCrypto:    rhLive,
-			RHCloser:        closer,
-			RHFetcher:       fetcher,
-			PortfolioReason: "reason",
-			CloseTimeout:    time.Second,
-		})
-		if prev != "" && plan.DiscordMessage != prev {
-			t.Fatalf("message should be deterministic, iter %d:\n%s\nprev:\n%s", i, plan.DiscordMessage, prev)
-		}
-		prev = plan.DiscordMessage
-	}
-	btcPos := strings.Index(prev, "BTC:")
-	dogePos := strings.Index(prev, "DOGE:")
-	ethPos := strings.Index(prev, "ETH:")
-	if !(btcPos < dogePos && dogePos < ethPos) {
-		t.Errorf("expected alphabetical BTC < DOGE < ETH in: %s", prev)
-	}
-}
-
-func TestPlanKillSwitchClose_OKXDeterministicErrorOrder(t *testing.T) {
-	okxLive := []StrategyConfig{
-		{ID: "okx-btc", Platform: "okx", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
-		{ID: "okx-eth", Platform: "okx", Type: "perps", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
-		{ID: "okx-sol", Platform: "okx", Type: "perps", Args: []string{"sma", "SOL", "1h", "--mode=live"}},
-	}
-	positions := []OKXPosition{
-		{Coin: "BTC", Size: 0.01, Side: "long"},
-		{Coin: "ETH", Size: 0.1, Side: "long"},
-		{Coin: "SOL", Size: 1.0, Side: "long"},
-	}
-	errs := map[string]error{
-		"BTC": fmt.Errorf("err"), "ETH": fmt.Errorf("err"), "SOL": fmt.Errorf("err"),
-	}
-	var prev string
-	for i := 0; i < 10; i++ {
-		closer, _ := stubOKXLiveCloser(errs)
-		fetcher, _ := stubOKXPositionsFetcher(positions, nil)
-		plan := planKillSwitchClose(KillSwitchCloseInputs{
-			OKXLiveAllPerps: okxLive,
-			OKXCloser:       closer,
-			OKXFetcher:      fetcher,
-			PortfolioReason: "reason",
-			CloseTimeout:    time.Second,
-		})
-		if prev != "" && plan.DiscordMessage != prev {
-			t.Fatalf("message should be deterministic, iter %d:\n%s\nprev:\n%s", i, plan.DiscordMessage, prev)
-		}
-		prev = plan.DiscordMessage
-	}
-	btcPos := strings.Index(prev, "BTC:")
-	ethPos := strings.Index(prev, "ETH:")
-	solPos := strings.Index(prev, "SOL:")
-	if !(btcPos < ethPos && ethPos < solPos) {
-		t.Errorf("expected alphabetical BTC < ETH < SOL in: %s", prev)
 	}
 }
 
@@ -1621,163 +1030,390 @@ func stubTSPositionsFetcher(positions []TopStepPosition, err error) (TopStepPosi
 	return fetcher, &calls
 }
 
-func TestPlanKillSwitchClose_TopStepHappyPath(t *testing.T) {
-	tsLive := []StrategyConfig{
-		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
-			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
-	}
-	positions := []TopStepPosition{{Coin: "ES", Size: 2, AvgPrice: 5000, Side: "long"}}
-	closer, calls := stubTSLiveCloser(nil)
-	fetcher, fetchCalls := stubTSPositionsFetcher(positions, nil)
+type killSwitchPlatformHarness struct {
+	name         string
+	label        string
+	coin         string
+	extraCoin    string
+	build        func(coins []string, closeErrs map[string]error, fetchErr error) (KillSwitchCloseInputs, *[]string, *int)
+	errs         func(plan KillSwitchClosePlan) map[string]error
+	unconfigured func(plan KillSwitchClosePlan) []string
+}
 
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		TSLiveAll:       tsLive,
-		TSCloser:        closer,
-		TSFetcher:       fetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if !plan.OnChainConfirmedFlat {
-		t.Fatalf("expected ConfirmedFlat, got plan=%+v", plan)
-	}
-	if *fetchCalls != 1 {
-		t.Errorf("TopStep fetcher should be called exactly once, got %d", *fetchCalls)
-	}
-	if len(*calls) != 1 || (*calls)[0] != "ES" {
-		t.Errorf("closer calls = %v, want [ES]", *calls)
-	}
-	if !strings.Contains(plan.DiscordMessage, "TopStep closes: [ES]") {
-		t.Errorf("expected TopStep closes in message, got: %s", plan.DiscordMessage)
+func killSwitchPlatformHarnesses() []killSwitchPlatformHarness {
+	return []killSwitchPlatformHarness{
+		{
+			name: "OKX", label: "OKX", coin: "BTC", extraCoin: "SOL",
+			build: func(coins []string, closeErrs map[string]error, fetchErr error) (KillSwitchCloseInputs, *[]string, *int) {
+				var positions []OKXPosition
+				for _, c := range coins {
+					positions = append(positions, OKXPosition{Coin: c, Size: 0.01, EntryPrice: 42000, Side: "long"})
+				}
+				closer, calls := stubOKXLiveCloser(closeErrs)
+				fetcher, fetchCalls := stubOKXPositionsFetcher(positions, fetchErr)
+				return KillSwitchCloseInputs{
+					OKXLiveAllPerps: []StrategyConfig{{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
+						Args: []string{"sma", "BTC", "1h", "--mode=live"}}},
+					OKXCloser:       closer,
+					OKXFetcher:      fetcher,
+					PortfolioReason: "drawdown reason",
+					CloseTimeout:    time.Second,
+				}, calls, fetchCalls
+			},
+			errs: func(plan KillSwitchClosePlan) map[string]error { return plan.OKXCloseReport.Errors },
+			unconfigured: func(plan KillSwitchClosePlan) []string {
+				var out []string
+				for _, p := range plan.OKXUnconfigured {
+					out = append(out, p.Coin)
+				}
+				return out
+			},
+		},
+		{
+			name: "Robinhood", label: "Robinhood", coin: "BTC", extraCoin: "DOGE",
+			build: func(coins []string, closeErrs map[string]error, fetchErr error) (KillSwitchCloseInputs, *[]string, *int) {
+				var positions []RobinhoodPosition
+				for _, c := range coins {
+					positions = append(positions, RobinhoodPosition{Coin: c, Size: 0.01, AvgPrice: 42000})
+				}
+				closer, calls := stubRHLiveCloser(closeErrs)
+				fetcher, fetchCalls := stubRHPositionsFetcher(positions, fetchErr)
+				return KillSwitchCloseInputs{
+					RHLiveCrypto: []StrategyConfig{{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+						Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}}},
+					RHCloser:        closer,
+					RHFetcher:       fetcher,
+					PortfolioReason: "drawdown reason",
+					CloseTimeout:    time.Second,
+				}, calls, fetchCalls
+			},
+			errs: func(plan KillSwitchClosePlan) map[string]error { return plan.RHCloseReport.Errors },
+			unconfigured: func(plan KillSwitchClosePlan) []string {
+				var out []string
+				for _, p := range plan.RHUnconfigured {
+					out = append(out, p.Coin)
+				}
+				return out
+			},
+		},
+		{
+			name: "TopStep", label: "TopStep", coin: "ES", extraCoin: "NQ",
+			build: func(coins []string, closeErrs map[string]error, fetchErr error) (KillSwitchCloseInputs, *[]string, *int) {
+				var positions []TopStepPosition
+				for _, c := range coins {
+					positions = append(positions, TopStepPosition{Coin: c, Size: 2, AvgPrice: 5000, Side: "long"})
+				}
+				closer, calls := stubTSLiveCloser(closeErrs)
+				fetcher, fetchCalls := stubTSPositionsFetcher(positions, fetchErr)
+				return KillSwitchCloseInputs{
+					TSLiveAll: []StrategyConfig{{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+						Args: []string{"momentum", "ES", "1h", "--mode=live"}}},
+					TSCloser:        closer,
+					TSFetcher:       fetcher,
+					PortfolioReason: "drawdown reason",
+					CloseTimeout:    time.Second,
+				}, calls, fetchCalls
+			},
+			errs: func(plan KillSwitchClosePlan) map[string]error { return plan.TSCloseReport.Errors },
+			unconfigured: func(plan KillSwitchClosePlan) []string {
+				var out []string
+				for _, p := range plan.TSUnconfigured {
+					out = append(out, p.Coin)
+				}
+				return out
+			},
+		},
 	}
 }
 
-func TestPlanKillSwitchClose_TopStepCloseError(t *testing.T) {
-	tsLive := []StrategyConfig{
-		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
-			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
-	}
-	positions := []TopStepPosition{{Coin: "ES", Size: 2}}
-	closer, _ := stubTSLiveCloser(map[string]error{"ES": fmt.Errorf("market closed")})
-	fetcher, _ := stubTSPositionsFetcher(positions, nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		TSLiveAll:       tsLive,
-		TSCloser:        closer,
-		TSFetcher:       fetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat on TopStep close error — would clear virtual state while CME is still active")
-	}
-	if got, ok := plan.TSCloseReport.Errors["ES"]; !ok || got == nil {
-		t.Errorf("expected ES error in TopStep report, got %v", plan.TSCloseReport.Errors)
-	}
-	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
-		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
-	}
-	if !strings.Contains(plan.DiscordMessage, "market closed") {
-		t.Errorf("expected TopStep error detail in message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_TopStepFetchFailure(t *testing.T) {
-	tsLive := []StrategyConfig{
-		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
-			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
-	}
-	closer, calls := stubTSLiveCloser(nil)
-	fetcher, _ := stubTSPositionsFetcher(nil, fmt.Errorf("topstepx 401"))
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		TSLiveAll:       tsLive,
-		TSCloser:        closer,
-		TSFetcher:       fetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat on TopStep fetch failure")
-	}
-	if len(*calls) != 0 {
-		t.Errorf("closer must not be invoked when fetch failed, got %v", *calls)
-	}
-	if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
-		t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
-	}
-}
-
-func TestPlanKillSwitchClose_TopStepUnconfiguredBlocksReset(t *testing.T) {
-	tsLive := []StrategyConfig{
-		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
-			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
-	}
-	positions := []TopStepPosition{
-		{Coin: "ES", Size: 2},
-		{Coin: "NQ", Size: 1},
-	}
-	closer, calls := stubTSLiveCloser(nil)
-	fetcher, _ := stubTSPositionsFetcher(positions, nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		TSLiveAll:       tsLive,
-		TSCloser:        closer,
-		TSFetcher:       fetcher,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat — unconfigured NQ position is still live")
-	}
-	if len(plan.TSUnconfigured) != 1 || plan.TSUnconfigured[0].Coin != "NQ" {
-		t.Errorf("expected TSUnconfigured=[NQ], got %v", plan.TSUnconfigured)
-	}
-	if len(*calls) != 1 || (*calls)[0] != "ES" {
-		t.Errorf("closer calls = %v, want [ES]", *calls)
-	}
-	if !strings.Contains(plan.DiscordMessage, "manual intervention required") {
-		t.Errorf("expected manual intervention note, got: %s", plan.DiscordMessage)
+func TestPlanKillSwitchClose_PlatformLifecycle(t *testing.T) {
+	for _, h := range killSwitchPlatformHarnesses() {
+		t.Run(h.name+"/HappyPath", func(t *testing.T) {
+			in, calls, fetchCalls := h.build([]string{h.coin}, nil, nil)
+			plan := planKillSwitchClose(in)
+			if !plan.OnChainConfirmedFlat {
+				t.Fatalf("expected ConfirmedFlat, got plan=%+v", plan)
+			}
+			if *fetchCalls != 1 {
+				t.Errorf("%s fetcher should be called exactly once, got %d", h.name, *fetchCalls)
+			}
+			if len(*calls) != 1 || (*calls)[0] != h.coin {
+				t.Errorf("closer calls = %v, want [%s]", *calls, h.coin)
+			}
+			if want := h.label + " closes: [" + h.coin + "]"; !strings.Contains(plan.DiscordMessage, want) {
+				t.Errorf("expected %q in message, got: %s", want, plan.DiscordMessage)
+			}
+		})
+		t.Run(h.name+"/CloseError", func(t *testing.T) {
+			in, _, _ := h.build([]string{h.coin}, map[string]error{h.coin: fmt.Errorf("%s venue rate limited", h.name)}, nil)
+			plan := planKillSwitchClose(in)
+			if plan.OnChainConfirmedFlat {
+				t.Fatalf("expected NOT ConfirmedFlat on %s close error — would clear virtual state while the venue is still live", h.name)
+			}
+			if got, ok := h.errs(plan)[h.coin]; !ok || got == nil {
+				t.Errorf("expected %s error in %s report, got %v", h.coin, h.name, h.errs(plan))
+			}
+			if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
+				t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
+			}
+			if !strings.Contains(plan.DiscordMessage, h.name+" venue rate limited") {
+				t.Errorf("expected %s error detail in message, got: %s", h.name, plan.DiscordMessage)
+			}
+		})
+		t.Run(h.name+"/FetchFailure", func(t *testing.T) {
+			in, calls, _ := h.build(nil, nil, fmt.Errorf("%s auth failed", h.name))
+			plan := planKillSwitchClose(in)
+			if plan.OnChainConfirmedFlat {
+				t.Fatalf("expected NOT ConfirmedFlat on %s fetch failure", h.name)
+			}
+			if len(*calls) != 0 {
+				t.Errorf("closer must not be invoked when fetch failed, got %v", *calls)
+			}
+			if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
+				t.Errorf("expected LATCHED message on fetch failure, got: %s", plan.DiscordMessage)
+			}
+		})
+		t.Run(h.name+"/UnconfiguredBlocksReset", func(t *testing.T) {
+			in, calls, _ := h.build([]string{h.coin, h.extraCoin}, nil, nil)
+			plan := planKillSwitchClose(in)
+			if plan.OnChainConfirmedFlat {
+				t.Fatalf("expected NOT ConfirmedFlat — unconfigured %s position is still live", h.extraCoin)
+			}
+			if got := h.unconfigured(plan); len(got) != 1 || got[0] != h.extraCoin {
+				t.Errorf("expected unconfigured=[%s], got %v", h.extraCoin, got)
+			}
+			if len(*calls) != 1 || (*calls)[0] != h.coin {
+				t.Errorf("closer calls = %v, want [%s]", *calls, h.coin)
+			}
+			if !strings.Contains(plan.DiscordMessage, "manual intervention required") {
+				t.Errorf("expected manual intervention note, got: %s", plan.DiscordMessage)
+			}
+		})
 	}
 }
 
-func TestPlanKillSwitchClose_TopStepFailureStillLatchesAcrossPlatforms(t *testing.T) {
+func TestPlanKillSwitchClose_PeerPlatformFailureStillLatches(t *testing.T) {
 	hlLive := []StrategyConfig{
-		{ID: "hl-mom-btc", Platform: "hyperliquid", Type: "perps",
-			Args: []string{"momentum", "BTC", "1h", "--mode=live"}},
+		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"sma", "ETH", "1h", "--mode=live"}},
 	}
-	hlPositions := []HLPosition{{Coin: "BTC", Size: 0.5}}
-	hlCloser, _ := stubHLLiveCloser(nil)
-
-	tsLive := []StrategyConfig{
-		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
-			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
+	hlPos := []HLPosition{{Coin: "ETH", Size: 0.5}}
+	cases := []struct {
+		name string
+		wire func(in *KillSwitchCloseInputs)
+		want string
+	}{
+		{
+			name: "OKX", want: "okx err",
+			wire: func(in *KillSwitchCloseInputs) {
+				in.OKXLiveAllPerps = []StrategyConfig{{ID: "okx-btc", Platform: "okx", Type: "perps",
+					Args: []string{"sma", "BTC", "1h", "--mode=live"}}}
+				in.OKXCloser, _ = stubOKXLiveCloser(map[string]error{"BTC": fmt.Errorf("okx err")})
+				in.OKXFetcher, _ = stubOKXPositionsFetcher([]OKXPosition{{Coin: "BTC", Size: 0.01, Side: "long"}}, nil)
+			},
+		},
+		{
+			name: "Robinhood", want: "rh err",
+			wire: func(in *KillSwitchCloseInputs) {
+				in.RHLiveCrypto = []StrategyConfig{{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+					Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}}}
+				in.RHCloser, _ = stubRHLiveCloser(map[string]error{"BTC": fmt.Errorf("rh err")})
+				in.RHFetcher, _ = stubRHPositionsFetcher([]RobinhoodPosition{{Coin: "BTC", Size: 0.01}}, nil)
+			},
+		},
+		{
+			name: "TopStep", want: "venue down",
+			wire: func(in *KillSwitchCloseInputs) {
+				in.TSLiveAll = []StrategyConfig{{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+					Args: []string{"momentum", "ES", "1h", "--mode=live"}}}
+				in.TSCloser, _ = stubTSLiveCloser(map[string]error{"ES": fmt.Errorf("venue down")})
+				in.TSFetcher, _ = stubTSPositionsFetcher([]TopStepPosition{{Coin: "ES", Size: 2}}, nil)
+			},
+		},
 	}
-	tsPositions := []TopStepPosition{{Coin: "ES", Size: 2}}
-	tsCloser, _ := stubTSLiveCloser(map[string]error{"ES": fmt.Errorf("venue down")})
-	tsFetcher, _ := stubTSPositionsFetcher(tsPositions, nil)
-
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		HLAddr:          "0xabc",
-		HLStateFetched:  true,
-		HLPositions:     hlPositions,
-		HLLiveAll:       hlLive,
-		HLCloser:        hlCloser,
-		TSLiveAll:       tsLive,
-		TSCloser:        tsCloser,
-		TSFetcher:       tsFetcher,
-		PortfolioReason: "reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat when TopStep fails even though HL succeeded")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hlCloser, _ := stubHLLiveCloser(nil)
+			hlFetcher, _ := stubHLStateFetcher(nil, nil)
+			in := defaultHLInputs("0xaddr", true, hlPos, hlLive, "drawdown reason", time.Second, hlCloser, hlFetcher)
+			tc.wire(&in)
+			plan := planKillSwitchClose(in)
+			if plan.OnChainConfirmedFlat {
+				t.Fatalf("%s failure must latch the switch even when HL succeeded", tc.name)
+			}
+			if len(plan.CloseReport.ClosedCoins) != 1 || plan.CloseReport.ClosedCoins[0] != "ETH" {
+				t.Errorf("HL close should still run: got %v", plan.CloseReport.ClosedCoins)
+			}
+			if !strings.Contains(plan.DiscordMessage, "LATCHED, RETRYING") {
+				t.Errorf("expected LATCHED message, got: %s", plan.DiscordMessage)
+			}
+			if !strings.Contains(plan.DiscordMessage, tc.want) {
+				t.Errorf("%s error missing from message, got: %s", tc.name, plan.DiscordMessage)
+			}
+		})
 	}
-	if len(plan.CloseReport.ClosedCoins) != 1 || plan.CloseReport.ClosedCoins[0] != "BTC" {
-		t.Errorf("HL close should still run: got %v", plan.CloseReport.ClosedCoins)
+}
+
+func TestPlanKillSwitchClose_OperatorRequiredGapSuppressesAutoReset(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      KillSwitchCloseInputs
+		present func(plan KillSwitchClosePlan) bool
+		want    string
+	}{
+		{
+			name: "OKX spot", want: "OKX spot",
+			in: KillSwitchCloseInputs{OKXLiveAllSpot: []StrategyConfig{{ID: "okx-sma-btc-spot", Platform: "okx", Type: "spot",
+				Args: []string{"sma", "BTC", "1h", "--mode=live", "--inst-type=spot"}}}},
+			present: func(plan KillSwitchClosePlan) bool { return plan.OKXSpotPresent },
+		},
+		{
+			name: "Robinhood options", want: "Robinhood options",
+			in: KillSwitchCloseInputs{RHLiveOptions: []StrategyConfig{{ID: "rh-ccall-spy", Platform: "robinhood", Type: "options",
+				Args: []string{"covered_call", "SPY", "1d", "--mode=live"}}}},
+			present: func(plan KillSwitchClosePlan) bool { return plan.RHOptionsPresent },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.in.OKXCloser, _ = stubOKXLiveCloser(nil)
+			tc.in.RHCloser, _ = stubRHLiveCloser(nil)
+			tc.in.PortfolioReason = "drawdown reason"
+			tc.in.CloseTimeout = time.Second
+			plan := planKillSwitchClose(tc.in)
+			if !plan.OnChainConfirmedFlat {
+				t.Errorf("%s-only presence must not block ConfirmedFlat, got plan=%+v", tc.name, plan)
+			}
+			if !tc.present(plan) {
+				t.Errorf("expected %s present flag on the plan", tc.name)
+			}
+			if plan.CanAutoResetWithoutOwner() {
+				t.Errorf("%s operator-required gap must suppress no-owner auto-reset", tc.name)
+			}
+			if !strings.Contains(plan.DiscordMessage, tc.want) {
+				t.Errorf("expected %q gap note in message, got: %s", tc.want, plan.DiscordMessage)
+			}
+		})
+	}
+}
+
+func TestPlanKillSwitchClose_DeterministicErrorOrder(t *testing.T) {
+	errFor := func(coins ...string) map[string]error {
+		out := map[string]error{}
+		for _, c := range coins {
+			out[c] = fmt.Errorf("err")
+		}
+		return out
+	}
+	cases := []struct {
+		name  string
+		order []string
+		build func() KillSwitchCloseInputs
+	}{
+		{
+			name: "HL", order: []string{"BTC", "DOGE", "ETH", "SOL"},
+			build: func() KillSwitchCloseInputs {
+				hlLive := []StrategyConfig{
+					{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+					{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+					{ID: "hl-sol", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "SOL", "1h", "--mode=live"}},
+					{ID: "hl-doge", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "DOGE", "1h", "--mode=live"}},
+				}
+				positions := []HLPosition{
+					{Coin: "BTC", Size: 0.01}, {Coin: "ETH", Size: 0.1},
+					{Coin: "SOL", Size: 1.0}, {Coin: "DOGE", Size: 100},
+				}
+				closer, _ := stubHLLiveCloser(errFor("BTC", "ETH", "SOL", "DOGE"))
+				fetcher, _ := stubHLStateFetcher(positions, nil)
+				return defaultHLInputs("0xaddr", true, positions, hlLive, "reason", time.Second, closer, fetcher)
+			},
+		},
+		{
+			name: "Robinhood", order: []string{"BTC", "DOGE", "ETH"},
+			build: func() KillSwitchCloseInputs {
+				closer, _ := stubRHLiveCloser(errFor("BTC", "ETH", "DOGE"))
+				fetcher, _ := stubRHPositionsFetcher([]RobinhoodPosition{
+					{Coin: "BTC", Size: 0.01}, {Coin: "ETH", Size: 0.1}, {Coin: "DOGE", Size: 100},
+				}, nil)
+				return KillSwitchCloseInputs{
+					RHLiveCrypto: []StrategyConfig{
+						{ID: "rh-btc", Platform: "robinhood", Type: "spot", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+						{ID: "rh-eth", Platform: "robinhood", Type: "spot", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+						{ID: "rh-doge", Platform: "robinhood", Type: "spot", Args: []string{"sma", "DOGE", "1h", "--mode=live"}},
+					},
+					RHCloser: closer, RHFetcher: fetcher, PortfolioReason: "reason", CloseTimeout: time.Second,
+				}
+			},
+		},
+		{
+			name: "OKX", order: []string{"BTC", "ETH", "SOL"},
+			build: func() KillSwitchCloseInputs {
+				closer, _ := stubOKXLiveCloser(errFor("BTC", "ETH", "SOL"))
+				fetcher, _ := stubOKXPositionsFetcher([]OKXPosition{
+					{Coin: "BTC", Size: 0.01, Side: "long"}, {Coin: "ETH", Size: 0.1, Side: "long"}, {Coin: "SOL", Size: 1.0, Side: "long"},
+				}, nil)
+				return KillSwitchCloseInputs{
+					OKXLiveAllPerps: []StrategyConfig{
+						{ID: "okx-btc", Platform: "okx", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+						{ID: "okx-eth", Platform: "okx", Type: "perps", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+						{ID: "okx-sol", Platform: "okx", Type: "perps", Args: []string{"sma", "SOL", "1h", "--mode=live"}},
+					},
+					OKXCloser: closer, OKXFetcher: fetcher, PortfolioReason: "reason", CloseTimeout: time.Second,
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var prev string
+			for i := 0; i < 10; i++ {
+				plan := planKillSwitchClose(tc.build())
+				if prev != "" && plan.DiscordMessage != prev {
+					t.Fatalf("message should be deterministic across calls\niter %d: %s\nprev: %s", i, plan.DiscordMessage, prev)
+				}
+				prev = plan.DiscordMessage
+			}
+			last := -1
+			for _, coin := range tc.order {
+				idx := strings.Index(prev, coin+":")
+				if idx < 0 || idx <= last {
+					t.Fatalf("expected alphabetical ordering %v in: %s", tc.order, prev)
+				}
+				last = idx
+			}
+		})
+	}
+}
+
+func TestPlanKillSwitchClose_FetcherUnwiredLatches(t *testing.T) {
+	cases := []struct {
+		name string
+		in   KillSwitchCloseInputs
+		want string
+	}{
+		{name: "HL", want: "HLFetcher unwired", in: KillSwitchCloseInputs{HLAddr: "0xabc", HLStateFetched: false, HLFetcher: nil}},
+		{name: "OKX", want: "OKXFetcher unwired", in: KillSwitchCloseInputs{OKXFetcher: nil,
+			OKXLiveAllPerps: []StrategyConfig{{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
+				Args: []string{"sma", "BTC", "1h", "--mode=live"}}}}},
+		{name: "RH", want: "RHFetcher unwired", in: KillSwitchCloseInputs{RHFetcher: nil,
+			RHLiveCrypto: []StrategyConfig{{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
+				Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}}}}},
+		{name: "TS", want: "TSFetcher unwired", in: KillSwitchCloseInputs{TSFetcher: nil,
+			TSLiveAll: []StrategyConfig{{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
+				Args: []string{"momentum", "ES", "1h", "--mode=live"}}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.in.PortfolioReason = "drawdown reason"
+			tc.in.CloseTimeout = time.Second
+			plan := planKillSwitchClose(tc.in)
+			if plan.OnChainConfirmedFlat {
+				t.Fatalf("expected NOT ConfirmedFlat when %s is unwired with the platform configured", tc.want)
+			}
+			if !strings.Contains(strings.Join(plan.LogLines, "\n"), tc.want) {
+				t.Errorf("expected log line mentioning %q, got: %v", tc.want, plan.LogLines)
+			}
+		})
 	}
 }
 
@@ -1803,186 +1439,66 @@ func TestPlanKillSwitchClose_PlatformBudgetOverrides(t *testing.T) {
 	}
 }
 
-func TestPlanKillSwitchClose_HLFetcherUnwiredLatches(t *testing.T) {
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		HLAddr:          "0xabc",
-		HLStateFetched:  false,
-		HLFetcher:       nil,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat when HLFetcher unwired with HLAddr set")
-	}
-	found := false
-	for _, line := range plan.LogLines {
-		if strings.Contains(line, "HLFetcher unwired") {
-			found = true
-			break
+func TestKillSwitchInstanceLabel(t *testing.T) {
+	for _, tc := range []struct{ path, want string }{
+		{"/var/lib/go-trader/live/config.json", "live"},
+		{"/var/lib/go-trader/paper-hl-eth/config.json", "paper-hl-eth"},
+	} {
+		if got := killSwitchInstanceLabel(tc.path); got != tc.want {
+			t.Errorf("killSwitchInstanceLabel(%q) = %q, want %q", tc.path, got, tc.want)
 		}
 	}
-	if !found {
-		t.Errorf("expected log line mentioning HLFetcher unwired, got: %v", plan.LogLines)
+	if got := killSwitchInstanceLabel("config.json"); got == "." || got == "" {
+		t.Errorf("killSwitchInstanceLabel(%q) = %q, want a real non-empty fallback", "config.json", got)
 	}
 }
 
-func TestPlanKillSwitchClose_OKXFetcherUnwiredLatches(t *testing.T) {
-	okxLive := []StrategyConfig{
-		{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
-			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+func TestFormatKillSwitchResetPrompt(t *testing.T) {
+	cases := []struct {
+		name     string
+		instance string
+		addr     string
+		plan     KillSwitchClosePlan
+		want     []string
+		reject   []string
+	}{
+		{
+			name: "confirmed flat includes context and identity", instance: "live", addr: "0xabc123",
+			plan: KillSwitchClosePlan{OnChainConfirmedFlat: true,
+				DiscordMessage: "**PORTFOLIO KILL SWITCH**\nportfolio drawdown 25.0% exceeds limit 20.0%\nHL closes: [ETH]. Virtual state cleared. Manual reset required."},
+			want:   []string{"live", "0xabc123", "portfolio drawdown 25.0%", "HL closes: [ETH]", "does not itself close or protect any position"},
+			reject: []string{"still retrying"},
+		},
+		{
+			name: "latched retrying warns protection may be gone", instance: "live", addr: "0xabc123",
+			plan: KillSwitchClosePlan{OnChainConfirmedFlat: false,
+				DiscordMessage: "**PORTFOLIO KILL SWITCH (LATCHED, RETRYING)**\nportfolio drawdown 25.0% exceeds limit 20.0%\nHL live close errors — ETH: timeout. Virtual state preserved. Next cycle will retry."},
+			want: []string{"still retrying", "stop-losses may already be cancelled"},
+		},
+		{
+			name: "omits address when HL not configured", instance: "paper-hl-eth", addr: "",
+			plan: KillSwitchClosePlan{OnChainConfirmedFlat: true,
+				DiscordMessage: "**PORTFOLIO KILL SWITCH**\nreason\nHL not configured. Virtual state cleared. Manual reset required."},
+			want: []string{"paper-hl-eth"},
+		},
 	}
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		OKXLiveAllPerps: okxLive,
-		OKXFetcher:      nil,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat when OKXFetcher unwired with strategies configured")
-	}
-	found := false
-	for _, line := range plan.LogLines {
-		if strings.Contains(line, "OKXFetcher unwired") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected log line mentioning OKXFetcher unwired, got: %v", plan.LogLines)
-	}
-}
-
-func TestPlanKillSwitchClose_RHFetcherUnwiredLatches(t *testing.T) {
-	rhLive := []StrategyConfig{
-		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
-			Args: []string{"sma_crossover", "BTC", "1h", "--mode=live"}},
-	}
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		RHLiveCrypto:    rhLive,
-		RHFetcher:       nil,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat when RHFetcher unwired with strategies configured")
-	}
-	found := false
-	for _, line := range plan.LogLines {
-		if strings.Contains(line, "RHFetcher unwired") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected log line mentioning RHFetcher unwired, got: %v", plan.LogLines)
-	}
-}
-
-func TestPlanKillSwitchClose_TSFetcherUnwiredLatches(t *testing.T) {
-	tsLive := []StrategyConfig{
-		{ID: "ts-momentum-es", Platform: "topstep", Type: "futures",
-			Args: []string{"momentum", "ES", "1h", "--mode=live"}},
-	}
-	plan := planKillSwitchClose(KillSwitchCloseInputs{
-		TSLiveAll:       tsLive,
-		TSFetcher:       nil,
-		PortfolioReason: "drawdown reason",
-		CloseTimeout:    time.Second,
-	})
-
-	if plan.OnChainConfirmedFlat {
-		t.Fatal("expected NOT ConfirmedFlat when TSFetcher unwired with strategies configured")
-	}
-	found := false
-	for _, line := range plan.LogLines {
-		if strings.Contains(line, "TSFetcher unwired") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected log line mentioning TSFetcher unwired, got: %v", plan.LogLines)
-	}
-}
-
-func TestKillSwitchInstanceLabel_UsesConfigDirBasename(t *testing.T) {
-	got := killSwitchInstanceLabel("/var/lib/go-trader/live/config.json")
-	if got != "live" {
-		t.Errorf("killSwitchInstanceLabel(.../live/config.json) = %q, want %q", got, "live")
-	}
-	got = killSwitchInstanceLabel("/var/lib/go-trader/paper-hl-eth/config.json")
-	if got != "paper-hl-eth" {
-		t.Errorf("killSwitchInstanceLabel(.../paper-hl-eth/config.json) = %q, want %q", got, "paper-hl-eth")
-	}
-}
-
-func TestKillSwitchInstanceLabel_FallsBackWhenPathGivesNothingUseful(t *testing.T) {
-	got := killSwitchInstanceLabel("config.json")
-	if got == "." {
-		t.Errorf("killSwitchInstanceLabel(%q) = %q, want a real fallback, not \".\"", "config.json", got)
-	}
-	if got == "" {
-		t.Error("killSwitchInstanceLabel must never return an empty label")
-	}
-}
-
-func TestFormatKillSwitchResetPrompt_ConfirmedFlatIncludesContextAndIdentity(t *testing.T) {
-	plan := KillSwitchClosePlan{
-		OnChainConfirmedFlat: true,
-		DiscordMessage:       "**PORTFOLIO KILL SWITCH**\nportfolio drawdown 25.0% exceeds limit 20.0%\nHL closes: [ETH]. Virtual state cleared. Manual reset required.",
-	}
-
-	got := formatKillSwitchResetPrompt("live", "0xabc123", plan)
-
-	if !strings.Contains(got, "live") || !strings.Contains(got, "0xabc123") {
-		t.Errorf("expected instance label and HL address in prompt, got: %s", got)
-	}
-	if !strings.Contains(got, "portfolio drawdown 25.0%") {
-		t.Errorf("expected reused drawdown reason in prompt, got: %s", got)
-	}
-	if !strings.Contains(got, "HL closes: [ETH]") {
-		t.Errorf("expected reused close report in prompt, got: %s", got)
-	}
-	if !strings.Contains(got, "does not itself close or protect any position") {
-		t.Errorf("expected explicit reset semantics in prompt, got: %s", got)
-	}
-	if strings.Contains(got, "still retrying") {
-		t.Errorf("confirmed-flat prompt must not claim the close is still retrying, got: %s", got)
-	}
-}
-
-func TestFormatKillSwitchResetPrompt_LatchedRetryingWarnsProtectionMayBeGone(t *testing.T) {
-	plan := KillSwitchClosePlan{
-		OnChainConfirmedFlat: false,
-		DiscordMessage:       "**PORTFOLIO KILL SWITCH (LATCHED, RETRYING)**\nportfolio drawdown 25.0% exceeds limit 20.0%\nHL live close errors — ETH: timeout. Virtual state preserved. Next cycle will retry.",
-	}
-
-	got := formatKillSwitchResetPrompt("live", "0xabc123", plan)
-
-	if !strings.Contains(got, "still retrying") {
-		t.Errorf("expected a not-yet-confirmed-flat warning in prompt, got: %s", got)
-	}
-	if !strings.Contains(got, "stop-losses may already be cancelled") {
-		t.Errorf("expected the naked-stop-loss risk to be called out while retrying, got: %s", got)
-	}
-}
-
-func TestFormatKillSwitchResetPrompt_OmitsAddressWhenHLNotConfigured(t *testing.T) {
-	plan := KillSwitchClosePlan{
-		OnChainConfirmedFlat: true,
-		DiscordMessage:       "**PORTFOLIO KILL SWITCH**\nreason\nHL not configured. Virtual state cleared. Manual reset required.",
-	}
-
-	got := formatKillSwitchResetPrompt("paper-hl-eth", "", plan)
-
-	if strings.Contains(got, "Hyperliquid ") && strings.Contains(got, "()") {
-		t.Errorf("expected no dangling empty-address parenthetical, got: %s", got)
-	}
-	if !strings.Contains(got, "paper-hl-eth") {
-		t.Errorf("expected instance label present regardless of HL address, got: %s", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatKillSwitchResetPrompt(tc.instance, tc.addr, tc.plan)
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("prompt missing %q, got: %s", w, got)
+				}
+			}
+			for _, r := range tc.reject {
+				if strings.Contains(got, r) {
+					t.Errorf("prompt must not contain %q, got: %s", r, got)
+				}
+			}
+			if tc.addr == "" && strings.Contains(got, "Hyperliquid ") && strings.Contains(got, "()") {
+				t.Errorf("expected no dangling empty-address parenthetical, got: %s", got)
+			}
+		})
 	}
 }
 

--- a/scheduler/kill_switch_limit_orders_test.go
+++ b/scheduler/kill_switch_limit_orders_test.go
@@ -311,6 +311,12 @@ func TestPlanKillSwitchClose_UnadoptedLimitFillKeepsRowAndBlocksFlat(t *testing.
 	if !strings.Contains(plan.DiscordMessage, "unadopted fill") {
 		t.Errorf("message must name the unadopted fill, got: %s", plan.DiscordMessage)
 	}
+	if !strings.Contains(plan.DiscordMessage, "queue row kept so the scheduler books the fill") {
+		t.Errorf("an eligible row must still defer to the reconciler, got: %s", plan.DiscordMessage)
+	}
+	if strings.Contains(plan.DiscordMessage, "NO automatic path can book") {
+		t.Errorf("an eligible row must not escalate, got: %s", plan.DiscordMessage)
+	}
 }
 
 func TestPlanKillSwitchClose_LimitRowDeleteFailureBlocksFlat(t *testing.T) {
@@ -395,56 +401,36 @@ func TestPlanKillSwitchClose_OrphanedLimitRowCancelledViaFallbackScript(t *testi
 	}
 }
 
-func TestPlanKillSwitchClose_OrphanedLimitRowWithFillEscalates(t *testing.T) {
-	peer := StrategyConfig{ID: "hl-ema-eth", Platform: "hyperliquid", Type: "perps",
-		Script: "shared_scripts/check_hyperliquid.py", Args: []string{"ema_crossover", "ETH", "1h", "--mode=live"}}
-	db := newLimitTestStateDB(t)
-	seedKillSwitchLimitRow(t, db, "hl-manual-eth-deleted")
-
-	stubs := &killSwitchLimitStubs{}
-	deps := stubs.deps(okCancel, offBookStatus(0.2), db.DeletePendingLimitOrder)
-
-	plan := planKillSwitchClose(killSwitchLimitInputs(db, []StrategyConfig{peer}, deps))
-
-	if plan.OnChainConfirmedFlat || plan.CanAutoResetWithoutOwner() {
-		t.Fatal("an unbookable fill must block confirmed-flat and auto-reset")
-	}
-	if len(stubs.deleted) != 0 {
-		t.Fatalf("a row carrying an unadopted fill must never be auto-deleted, deleted = %v", stubs.deleted)
-	}
-	for _, want := range []string{"NO automatic path can book", "absent from this config", "manual intervention required"} {
-		if !strings.Contains(plan.DiscordMessage, want) {
-			t.Errorf("message missing %q, got: %s", want, plan.DiscordMessage)
-		}
-	}
-	if strings.Contains(plan.DiscordMessage, "queue row kept so the scheduler books the fill") {
-		t.Errorf("message must not promise a booking that cannot happen, got: %s", plan.DiscordMessage)
-	}
-}
-
 func TestPlanKillSwitchClose_AdoptionIneligibleLimitFillNamesTheBlock(t *testing.T) {
 	cases := []struct {
-		name string
-		sc   StrategyConfig
-		want string
+		name  string
+		rowID string
+		sc    StrategyConfig
+		want  []string
 	}{
 		{
-			name: "strategy flipped to paper",
+			name: "strategy flipped to paper", rowID: "hl-manual-eth-live",
 			sc: StrategyConfig{ID: "hl-manual-eth-live", Platform: "hyperliquid", Type: "manual",
 				Script: "shared_scripts/check_hyperliquid.py", Args: []string{"hold", "ETH", "30m"}},
-			want: "not Hyperliquid-live",
+			want: []string{"not Hyperliquid-live"},
 		},
 		{
-			name: "strategy type changed away from manual",
+			name: "strategy type changed away from manual", rowID: "hl-manual-eth-live",
 			sc: StrategyConfig{ID: "hl-manual-eth-live", Platform: "hyperliquid", Type: "perps",
 				Script: "shared_scripts/check_hyperliquid.py", Args: []string{"ema_crossover", "ETH", "1h", "--mode=live"}},
-			want: `type is "perps"`,
+			want: []string{`type is "perps"`},
+		},
+		{
+			name: "orphaned row whose strategy is absent from config", rowID: "hl-manual-eth-deleted",
+			sc: StrategyConfig{ID: "hl-ema-eth", Platform: "hyperliquid", Type: "perps",
+				Script: "shared_scripts/check_hyperliquid.py", Args: []string{"ema_crossover", "ETH", "1h", "--mode=live"}},
+			want: []string{"absent from this config", "manual intervention required"},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			db := newLimitTestStateDB(t)
-			seedKillSwitchLimitRow(t, db, "hl-manual-eth-live")
+			seedKillSwitchLimitRow(t, db, tc.rowID)
 			stubs := &killSwitchLimitStubs{}
 			deps := stubs.deps(okCancel, offBookStatus(0.2), db.DeletePendingLimitOrder)
 
@@ -456,32 +442,15 @@ func TestPlanKillSwitchClose_AdoptionIneligibleLimitFillNamesTheBlock(t *testing
 			if len(stubs.deleted) != 0 {
 				t.Fatalf("a row carrying an unadopted fill must never be auto-deleted, deleted = %v", stubs.deleted)
 			}
-			if !strings.Contains(plan.DiscordMessage, tc.want) ||
-				!strings.Contains(plan.DiscordMessage, "NO automatic path can book") {
-				t.Errorf("message must name why nothing can book the fill, got: %s", plan.DiscordMessage)
+			for _, want := range append(tc.want, "NO automatic path can book") {
+				if !strings.Contains(plan.DiscordMessage, want) {
+					t.Errorf("message must name why nothing can book the fill, missing %q, got: %s", want, plan.DiscordMessage)
+				}
+			}
+			if strings.Contains(plan.DiscordMessage, "queue row kept so the scheduler books the fill") {
+				t.Errorf("message must not promise a booking that cannot happen, got: %s", plan.DiscordMessage)
 			}
 		})
-	}
-}
-
-func TestPlanKillSwitchClose_AdoptionEligibleLimitFillStillDefersToReconciler(t *testing.T) {
-	sc := killSwitchLimitTestStrategy()
-	db := newLimitTestStateDB(t)
-	seedKillSwitchLimitRow(t, db, sc.ID)
-
-	stubs := &killSwitchLimitStubs{}
-	deps := stubs.deps(okCancel, offBookStatus(0.2), db.DeletePendingLimitOrder)
-
-	plan := planKillSwitchClose(killSwitchLimitInputs(db, []StrategyConfig{sc}, deps))
-
-	if plan.OnChainConfirmedFlat || plan.CanAutoResetWithoutOwner() {
-		t.Fatal("an unadopted fill must block confirmed-flat and auto-reset")
-	}
-	if !strings.Contains(plan.DiscordMessage, "queue row kept so the scheduler books the fill") {
-		t.Errorf("an eligible row must still defer to the reconciler, got: %s", plan.DiscordMessage)
-	}
-	if strings.Contains(plan.DiscordMessage, "NO automatic path can book") {
-		t.Errorf("an eligible row must not escalate, got: %s", plan.DiscordMessage)
 	}
 }
 

--- a/scheduler/kill_switch_manual_test.go
+++ b/scheduler/kill_switch_manual_test.go
@@ -169,43 +169,48 @@ func TestHyperliquidKillSwitchShareSplit_PerpsAndManualPeers(t *testing.T) {
 	}
 }
 
-func TestCollectHLKillSwitchStopOIDs_IncludesManualTriggers(t *testing.T) {
-	strategies := map[string]*StrategyState{
-		"hl-manual-eth-live": {Positions: map[string]*Position{
-			"ETH": {StopLossOID: 111, TPOIDs: []int64{222}},
-		}},
-		"hl-perps-btc-live": {Positions: map[string]*Position{
-			"BTC": {StopLossOID: 333},
-		}},
+func TestCollectHLKillSwitchStopOIDs(t *testing.T) {
+	cases := []struct {
+		name       string
+		strategies map[string]*StrategyState
+		roster     []StrategyConfig
+		want       map[string][]int64
+	}{
+		{
+			name: "includes manual triggers",
+			strategies: map[string]*StrategyState{
+				"hl-manual-eth-live": {Positions: map[string]*Position{"ETH": {StopLossOID: 111, TPOIDs: []int64{222}}}},
+				"hl-perps-btc-live":  {Positions: map[string]*Position{"BTC": {StopLossOID: 333}}},
+			},
+			roster: []StrategyConfig{
+				{ID: "hl-perps-btc-live", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+				{ID: "hl-manual-eth-live", Platform: "hyperliquid", Type: "manual", Symbol: "ETH", Args: []string{"hold", "ETH", "1h", "--mode=live"}},
+			},
+			want: map[string][]int64{"BTC": {333}, "ETH": {111, 222}},
+		},
+		{
+			name: "lower-case manual symbol falls back to raw key",
+			strategies: map[string]*StrategyState{
+				"hl-manual-sol-live": {Positions: map[string]*Position{"sol": {StopLossOID: 444}}},
+			},
+			roster: []StrategyConfig{
+				{ID: "hl-manual-sol-live", Platform: "hyperliquid", Type: "manual", Symbol: "sol", Args: []string{"hold", "sol", "1h", "--mode=live"}},
+			},
+			want: map[string][]int64{"sol": {444}},
+		},
 	}
-	roster := []StrategyConfig{
-		{ID: "hl-perps-btc-live", Platform: "hyperliquid", Type: "perps",
-			Args: []string{"sma", "BTC", "1h", "--mode=live"}},
-		{ID: "hl-manual-eth-live", Platform: "hyperliquid", Type: "manual", Symbol: "ETH",
-			Args: []string{"hold", "ETH", "1h", "--mode=live"}},
-	}
-	out := collectHLKillSwitchStopOIDs(strategies, roster)
-	if !reflect.DeepEqual(out["BTC"], []int64{333}) {
-		t.Errorf("BTC OIDs = %v; want [333]", out["BTC"])
-	}
-	if !reflect.DeepEqual(out["ETH"], []int64{111, 222}) {
-		t.Errorf("ETH OIDs = %v; want [111 222] — a manual coin's resting triggers must be cancelled before the flatten", out["ETH"])
-	}
-}
-
-func TestCollectHLKillSwitchStopOIDs_LowerCaseManualSymbolFallsBackToRawKey(t *testing.T) {
-	strategies := map[string]*StrategyState{
-		"hl-manual-sol-live": {Positions: map[string]*Position{
-			"sol": {StopLossOID: 444},
-		}},
-	}
-	roster := []StrategyConfig{
-		{ID: "hl-manual-sol-live", Platform: "hyperliquid", Type: "manual", Symbol: "sol",
-			Args: []string{"hold", "sol", "1h", "--mode=live"}},
-	}
-	out := collectHLKillSwitchStopOIDs(strategies, roster)
-	if !reflect.DeepEqual(out["sol"], []int64{444}) {
-		t.Errorf("sol OIDs = %v; want [444] under the raw configured symbol", out["sol"])
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := collectHLKillSwitchStopOIDs(tc.strategies, tc.roster)
+			for coin, want := range tc.want {
+				if !reflect.DeepEqual(out[coin], want) {
+					t.Errorf("%s OIDs = %v; want %v — a coin's resting triggers must be cancelled before the flatten", coin, out[coin], want)
+				}
+			}
+			if len(out) != len(tc.want) {
+				t.Errorf("collected coins = %v; want exactly %v", out, tc.want)
+			}
+		})
 	}
 }
 

--- a/scheduler/kill_switch_reset_dm_test.go
+++ b/scheduler/kill_switch_reset_dm_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -9,137 +10,97 @@ import (
 	"time"
 )
 
-func TestParseKillSwitchResetDMTimeout_DefaultsToSixHours(t *testing.T) {
-	d, err := ParseKillSwitchResetDMTimeout("")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func writeKillSwitchResetDMConfig(t *testing.T, timeoutField string) string {
+	t.Helper()
+	path := t.TempDir() + "/config.json"
+	cfgJSON := `{
+		` + timeoutField + `
+		"strategies": [{
+			"id": "hl-sole",
+			"type": "perps",
+			"platform": "hyperliquid",
+			"script": "shared_scripts/check_hyperliquid.py",
+			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
+			"capital": 1000,
+			"max_drawdown_pct": 10,
+			"leverage": 5
+		}]
+	}`
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
 	}
-	if d != DefaultKillSwitchResetDMTimeout {
-		t.Fatalf("got %s, want %s", d, DefaultKillSwitchResetDMTimeout)
-	}
-	if DefaultKillSwitchResetDMTimeout == 30*time.Minute {
-		t.Fatal("default must not be the former hard-coded 30m")
-	}
+	return path
+}
+
+func TestParseKillSwitchResetDMTimeout(t *testing.T) {
 	if DefaultKillSwitchResetDMTimeout != 6*time.Hour {
 		t.Fatalf("default = %s, want 6h", DefaultKillSwitchResetDMTimeout)
 	}
+	cases := []struct {
+		raw     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{raw: "", want: DefaultKillSwitchResetDMTimeout},
+		{raw: "30m", want: 30 * time.Minute},
+		{raw: "nonsense", wantErr: true},
+		{raw: "0", wantErr: true},
+		{raw: "-1h", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%q", tc.raw), func(t *testing.T) {
+			d, err := ParseKillSwitchResetDMTimeout(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %s", tc.raw, d)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if d != tc.want {
+				t.Fatalf("got %s, want %s", d, tc.want)
+			}
+		})
+	}
 }
 
-func TestParseKillSwitchResetDMTimeout_ParsesGoDuration(t *testing.T) {
-	d, err := ParseKillSwitchResetDMTimeout("30m")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != 30*time.Minute {
-		t.Fatalf("got %s, want 30m", d)
-	}
-}
+func TestLoadConfig_KillSwitchResetDMTimeout(t *testing.T) {
+	prev := killSwitchResetDMTimeout
+	t.Cleanup(func() { killSwitchResetDMTimeout = prev })
 
-func TestParseKillSwitchResetDMTimeout_RejectsInvalid(t *testing.T) {
-	if _, err := ParseKillSwitchResetDMTimeout("nonsense"); err == nil {
-		t.Fatal("expected error for invalid duration")
-	}
-}
-
-func TestParseKillSwitchResetDMTimeout_RejectsNonPositive(t *testing.T) {
-	for _, raw := range []string{"0", "-1h"} {
-		if _, err := ParseKillSwitchResetDMTimeout(raw); err == nil {
-			t.Fatalf("expected error for %q", raw)
+	t.Run("applies configured value", func(t *testing.T) {
+		cfg, err := LoadConfigForProbe(writeKillSwitchResetDMConfig(t, `"kill_switch_reset_dm_timeout": "45m",`))
+		if err != nil {
+			t.Fatalf("LoadConfigForProbe: %v", err)
 		}
-	}
-}
-
-func TestLoadConfig_AppliesKillSwitchResetDMTimeout(t *testing.T) {
-	prev := killSwitchResetDMTimeout
-	t.Cleanup(func() { killSwitchResetDMTimeout = prev })
-
-	dir := t.TempDir()
-	path := dir + "/config.json"
-	cfgJSON := `{
-		"kill_switch_reset_dm_timeout": "45m",
-		"strategies": [{
-			"id": "hl-sole",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"max_drawdown_pct": 10,
-			"leverage": 5
-		}]
-	}`
-	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	cfg, err := LoadConfigForProbe(path)
-	if err != nil {
-		t.Fatalf("LoadConfigForProbe: %v", err)
-	}
-	if cfg.KillSwitchResetDMTimeout != "45m" {
-		t.Fatalf("KillSwitchResetDMTimeout = %q, want 45m", cfg.KillSwitchResetDMTimeout)
-	}
-	if err := applyKillSwitchResetDMTimeoutFromConfig(cfg); err != nil {
-		t.Fatalf("applyKillSwitchResetDMTimeoutFromConfig: %v", err)
-	}
-	if effectiveKillSwitchResetDMTimeout() != 45*time.Minute {
-		t.Fatalf("runtime timeout = %s, want 45m", effectiveKillSwitchResetDMTimeout())
-	}
-}
-
-func TestLoadConfig_KillSwitchResetDMTimeoutDefaultsToSixHours(t *testing.T) {
-	prev := killSwitchResetDMTimeout
-	t.Cleanup(func() { killSwitchResetDMTimeout = prev })
-
-	dir := t.TempDir()
-	path := dir + "/config.json"
-	cfgJSON := `{
-		"strategies": [{
-			"id": "hl-sole",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"max_drawdown_pct": 10,
-			"leverage": 5
-		}]
-	}`
-	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	if _, err := LoadConfigForProbe(path); err != nil {
-		t.Fatalf("LoadConfigForProbe: %v", err)
-	}
-	if err := applyKillSwitchResetDMTimeoutFromConfig(&Config{}); err != nil {
-		t.Fatalf("applyKillSwitchResetDMTimeoutFromConfig: %v", err)
-	}
-	if effectiveKillSwitchResetDMTimeout() != DefaultKillSwitchResetDMTimeout {
-		t.Fatalf("runtime timeout = %s, want %s", effectiveKillSwitchResetDMTimeout(), DefaultKillSwitchResetDMTimeout)
-	}
-}
-
-func TestLoadConfig_RejectsInvalidKillSwitchResetDMTimeout(t *testing.T) {
-	dir := t.TempDir()
-	path := dir + "/config.json"
-	cfgJSON := `{
-		"kill_switch_reset_dm_timeout": "nonsense",
-		"strategies": [{
-			"id": "hl-sole",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"max_drawdown_pct": 10,
-			"leverage": 5
-		}]
-	}`
-	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	if _, err := LoadConfigForProbe(path); err == nil {
-		t.Fatal("expected LoadConfigForProbe to reject invalid kill_switch_reset_dm_timeout")
-	}
+		if cfg.KillSwitchResetDMTimeout != "45m" {
+			t.Fatalf("KillSwitchResetDMTimeout = %q, want 45m", cfg.KillSwitchResetDMTimeout)
+		}
+		if err := applyKillSwitchResetDMTimeoutFromConfig(cfg); err != nil {
+			t.Fatalf("applyKillSwitchResetDMTimeoutFromConfig: %v", err)
+		}
+		if effectiveKillSwitchResetDMTimeout() != 45*time.Minute {
+			t.Fatalf("runtime timeout = %s, want 45m", effectiveKillSwitchResetDMTimeout())
+		}
+	})
+	t.Run("omitted defaults to six hours", func(t *testing.T) {
+		if _, err := LoadConfigForProbe(writeKillSwitchResetDMConfig(t, "")); err != nil {
+			t.Fatalf("LoadConfigForProbe: %v", err)
+		}
+		if err := applyKillSwitchResetDMTimeoutFromConfig(&Config{}); err != nil {
+			t.Fatalf("applyKillSwitchResetDMTimeoutFromConfig: %v", err)
+		}
+		if effectiveKillSwitchResetDMTimeout() != DefaultKillSwitchResetDMTimeout {
+			t.Fatalf("runtime timeout = %s, want %s", effectiveKillSwitchResetDMTimeout(), DefaultKillSwitchResetDMTimeout)
+		}
+	})
+	t.Run("rejects invalid value", func(t *testing.T) {
+		if _, err := LoadConfigForProbe(writeKillSwitchResetDMConfig(t, `"kill_switch_reset_dm_timeout": "nonsense",`)); err == nil {
+			t.Fatal("expected LoadConfigForProbe to reject invalid kill_switch_reset_dm_timeout")
+		}
+	})
 }
 
 func TestApplyHotReloadConfig_UpdatesKillSwitchResetDMTimeout(t *testing.T) {
@@ -168,24 +129,7 @@ func TestLoadConfigForProbe_DoesNotMutateAdoptedKillSwitchResetDMTimeout(t *test
 	t.Cleanup(func() { killSwitchResetDMTimeout = prev })
 	applyKillSwitchResetDMTimeout(90 * time.Minute)
 
-	dir := t.TempDir()
-	path := dir + "/config.json"
-	cfgJSON := `{
-		"kill_switch_reset_dm_timeout": "15m",
-		"strategies": [{
-			"id": "hl-sole",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"max_drawdown_pct": 10,
-			"leverage": 5
-		}]
-	}`
-	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	path := writeKillSwitchResetDMConfig(t, `"kill_switch_reset_dm_timeout": "15m",`)
 	if _, err := LoadConfigForProbe(path); err != nil {
 		t.Fatalf("LoadConfigForProbe: %v", err)
 	}
@@ -221,24 +165,7 @@ func TestKillSwitchResetDMTimeout_ConcurrentProbeDoesNotRace(t *testing.T) {
 	t.Cleanup(func() { killSwitchResetDMTimeout = prev })
 	applyKillSwitchResetDMTimeout(time.Hour)
 
-	dir := t.TempDir()
-	path := dir + "/config.json"
-	cfgJSON := `{
-		"kill_switch_reset_dm_timeout": "30m",
-		"strategies": [{
-			"id": "hl-sole",
-			"type": "perps",
-			"platform": "hyperliquid",
-			"script": "shared_scripts/check_hyperliquid.py",
-			"args": ["sma_crossover", "ETH", "1h", "--mode=paper"],
-			"capital": 1000,
-			"max_drawdown_pct": 10,
-			"leverage": 5
-		}]
-	}`
-	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	path := writeKillSwitchResetDMConfig(t, `"kill_switch_reset_dm_timeout": "30m",`)
 
 	done := make(chan struct{})
 	go func() {

--- a/scheduler/notional_cap_test.go
+++ b/scheduler/notional_cap_test.go
@@ -90,36 +90,6 @@ func astBlockContainsContinue(body *ast.BlockStmt) bool {
 	return found
 }
 
-func TestNotionalCapHoldPassesReduceAndManage(t *testing.T) {
-	const notionalBlocked = true
-	cases := []struct {
-		name          string
-		signal        int
-		closeFraction float64
-		posQty        float64
-		posSide       string
-		allowsLong    bool
-		allowsShort   bool
-		wantHold      bool
-	}{
-		{"manage_only_signal0", 0, 0, 1, "long", true, true, false},
-		{"long_sell_pure_close", -1, 0, 1, "long", true, false, false},
-		{"long_close_fraction", -1, 0.5, 1, "long", true, true, false},
-		{"flat_buy_fresh_open", 1, 0, 0, "", true, true, true},
-		{"long_buy_scale_in", 1, 0, 1, "long", true, true, true},
-		{"long_sell_flip_both", -1, 0, 1, "long", true, true, true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			held := notionalBlocked && pausedBlocksSignal(tc.signal, tc.closeFraction, tc.posQty, tc.posSide, tc.allowsLong, tc.allowsShort)
-			if held != tc.wantHold {
-				t.Fatalf("hold=%v want %v (signal=%d cf=%.2f qty=%.1f side=%q)",
-					held, tc.wantHold, tc.signal, tc.closeFraction, tc.posQty, tc.posSide)
-			}
-		})
-	}
-}
-
 func TestEvaluateNotionalCapHold(t *testing.T) {
 	states := map[string]*StrategyState{
 		"a": {ID: "a", Positions: map[string]*Position{
@@ -181,47 +151,42 @@ func TestManualStateViewNotionalHold(t *testing.T) {
 	}
 }
 
-func TestManualOpenCoreRefusesNotionalHold(t *testing.T) {
+func TestManualCoreRefusesNotionalHold(t *testing.T) {
 	sc := StrategyConfig{ID: "m", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 3}
-	deps := manualCoreDeps{
-		cfg: &Config{},
-		loadState: func(strategyID, symbol string) (manualStateView, error) {
-			return manualStateView{HasStrategy: true, NotionalHold: true,
-				NotionalNote: "portfolio notional $60000.00 exceeds cap $50000.00 — new opens blocked, exits continue"}, nil
-		},
-		execute: func(string, string, string, float64, float64, int64, float64, string, float64, bool, hlExecuteSnapshot, ...int64) (*HyperliquidExecuteResult, string, error) {
-			t.Error("execute must not be called while the notional cap is breached")
-			return nil, "", nil
-		},
-		fetchMids: func([]string) (map[string]float64, error) {
-			return map[string]float64{"ETH": 2000}, nil
-		},
+	const note = "portfolio notional $60000.00 exceeds cap $50000.00 — new opens blocked, exits continue"
+	cases := []struct {
+		name string
+		pos  *Position
+		run  func(deps manualCoreDeps) error
+	}{
+		{"manual-open", nil, func(deps manualCoreDeps) error {
+			_, err := manualOpenCore(deps, sc, manualOpenInputs{StrategyID: "m", Margin: 50})
+			return err
+		}},
+		{"manual-add", &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: "long"}, func(deps manualCoreDeps) error {
+			_, err := manualAddCore(deps, sc, manualAddInputs{StrategyID: "m", Margin: 50})
+			return err
+		}},
 	}
-	_, err := manualOpenCore(deps, sc, manualOpenInputs{StrategyID: "m", Margin: 50})
-	if err == nil || !strings.Contains(err.Error(), "new opens blocked, exits continue") {
-		t.Fatalf("manual-open err = %v, want notional refusal", err)
-	}
-}
-
-func TestManualAddCoreRefusesNotionalHold(t *testing.T) {
-	sc := StrategyConfig{ID: "m", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 3}
-	pos := &Position{Symbol: "ETH", Quantity: 1, AvgCost: 2000, Side: "long"}
-	deps := manualCoreDeps{
-		cfg: &Config{},
-		loadState: func(strategyID, symbol string) (manualStateView, error) {
-			return manualStateView{HasStrategy: true, Pos: pos, NotionalHold: true,
-				NotionalNote: "portfolio notional $60000.00 exceeds cap $50000.00 — new opens blocked, exits continue"}, nil
-		},
-		execute: func(string, string, string, float64, float64, int64, float64, string, float64, bool, hlExecuteSnapshot, ...int64) (*HyperliquidExecuteResult, string, error) {
-			t.Error("execute must not be called while the notional cap is breached")
-			return nil, "", nil
-		},
-		fetchMids: func([]string) (map[string]float64, error) {
-			return map[string]float64{"ETH": 2000}, nil
-		},
-	}
-	_, err := manualAddCore(deps, sc, manualAddInputs{StrategyID: "m", Margin: 50})
-	if err == nil || !strings.Contains(err.Error(), "new opens blocked, exits continue") {
-		t.Fatalf("manual-add err = %v, want notional refusal", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := manualCoreDeps{
+				cfg: &Config{},
+				loadState: func(strategyID, symbol string) (manualStateView, error) {
+					return manualStateView{HasStrategy: true, Pos: tc.pos, NotionalHold: true, NotionalNote: note}, nil
+				},
+				execute: func(string, string, string, float64, float64, int64, float64, string, float64, bool, hlExecuteSnapshot, ...int64) (*HyperliquidExecuteResult, string, error) {
+					t.Error("execute must not be called while the notional cap is breached")
+					return nil, "", nil
+				},
+				fetchMids: func([]string) (map[string]float64, error) {
+					return map[string]float64{"ETH": 2000}, nil
+				},
+			}
+			err := tc.run(deps)
+			if err == nil || !strings.Contains(err.Error(), "new opens blocked, exits continue") {
+				t.Fatalf("%s err = %v, want notional refusal", tc.name, err)
+			}
+		})
 	}
 }

--- a/scheduler/risk_test.go
+++ b/scheduler/risk_test.go
@@ -25,60 +25,55 @@ func newRiskState(date string, dailyPnL float64) RiskState {
 	}
 }
 
-func TestRolloverDailyPnL_SameDay(t *testing.T) {
-	r := newRiskState(todayUTC(), 123.45)
-	rolloverDailyPnL(&r)
-	if r.DailyPnL != 123.45 {
-		t.Errorf("expected DailyPnL=123.45 unchanged; got %.2f", r.DailyPnL)
+func TestRolloverDailyPnL(t *testing.T) {
+	cases := []struct {
+		name     string
+		date     string
+		dailyPnL float64
+		wantPnL  float64
+	}{
+		{"same day keeps accumulated pnl", todayUTC(), 123.45, 123.45},
+		{"new day resets pnl", yesterday(), 99.99, 0},
+		{"empty date resets pnl", "", 50.0, 0},
 	}
-	if r.DailyPnLDate != todayUTC() {
-		t.Errorf("expected DailyPnLDate=%s; got %s", todayUTC(), r.DailyPnLDate)
-	}
-}
-
-func TestRolloverDailyPnL_NewDay(t *testing.T) {
-	r := newRiskState(yesterday(), 99.99)
-	rolloverDailyPnL(&r)
-	if r.DailyPnL != 0 {
-		t.Errorf("expected DailyPnL reset to 0; got %.2f", r.DailyPnL)
-	}
-	if r.DailyPnLDate != todayUTC() {
-		t.Errorf("expected DailyPnLDate=%s; got %s", todayUTC(), r.DailyPnLDate)
-	}
-}
-
-func TestRolloverDailyPnL_EmptyDate(t *testing.T) {
-	r := newRiskState("", 50.0)
-	rolloverDailyPnL(&r)
-	if r.DailyPnL != 0 {
-		t.Errorf("expected DailyPnL reset to 0 on empty date; got %.2f", r.DailyPnL)
-	}
-	if r.DailyPnLDate != todayUTC() {
-		t.Errorf("expected DailyPnLDate=%s; got %s", todayUTC(), r.DailyPnLDate)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newRiskState(tc.date, tc.dailyPnL)
+			rolloverDailyPnL(&r)
+			if r.DailyPnL != tc.wantPnL {
+				t.Errorf("DailyPnL = %.2f, want %.2f", r.DailyPnL, tc.wantPnL)
+			}
+			if r.DailyPnLDate != todayUTC() {
+				t.Errorf("DailyPnLDate = %s, want %s", r.DailyPnLDate, todayUTC())
+			}
+		})
 	}
 }
 
-func TestRecordTradeResult_MidnightCrossing(t *testing.T) {
-	r := newRiskState(yesterday(), 200.0)
-
-	RecordTradeResult(&r, 50.0)
-
-	if r.DailyPnL != 50.0 {
-		t.Errorf("expected DailyPnL=50 after midnight crossing; got %.2f", r.DailyPnL)
+func TestRecordTradeResult(t *testing.T) {
+	cases := []struct {
+		name    string
+		date    string
+		start   float64
+		pnls    []float64
+		wantPnL float64
+	}{
+		{"midnight crossing resets before booking", yesterday(), 200.0, []float64{50.0}, 50.0},
+		{"same day accumulates", todayUTC(), 100.0, []float64{30.0, -10.0}, 120.0},
 	}
-	if r.DailyPnLDate != todayUTC() {
-		t.Errorf("expected DailyPnLDate=%s; got %s", todayUTC(), r.DailyPnLDate)
-	}
-}
-
-func TestRecordTradeResult_SameDayAccumulation(t *testing.T) {
-	r := newRiskState(todayUTC(), 100.0)
-
-	RecordTradeResult(&r, 30.0)
-	RecordTradeResult(&r, -10.0)
-
-	if r.DailyPnL != 120.0 {
-		t.Errorf("expected DailyPnL=120 after two trades; got %.2f", r.DailyPnL)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newRiskState(tc.date, tc.start)
+			for _, pnl := range tc.pnls {
+				RecordTradeResult(&r, pnl)
+			}
+			if r.DailyPnL != tc.wantPnL {
+				t.Errorf("DailyPnL = %.2f, want %.2f", r.DailyPnL, tc.wantPnL)
+			}
+			if r.DailyPnLDate != todayUTC() {
+				t.Errorf("DailyPnLDate = %s, want %s", r.DailyPnLDate, todayUTC())
+			}
+		})
 	}
 }
 
@@ -252,154 +247,151 @@ func TestCheckPortfolioRisk_PeakTracking(t *testing.T) {
 }
 
 func TestPortfolioNotional(t *testing.T) {
-	strategies := map[string]*StrategyState{
-		"spot-strat": {
-			Positions: map[string]*Position{
-				"BTC": {Symbol: "BTC", Quantity: 0.5, AvgCost: 40000.0, Side: "long"},
-				"ETH": {Symbol: "ETH", Quantity: 10.0, AvgCost: 3000.0, Side: "long"},
-			},
-			OptionPositions: make(map[string]*OptionPosition),
-		},
-		"options-strat": {
-			Positions: make(map[string]*Position),
-			OptionPositions: map[string]*OptionPosition{
-				"BTC-put-40000-sell": {
-					Action:          "sell",
-					Strike:          40000.0,
-					Quantity:        2.0,
-					CurrentValueUSD: -500.0,
+	cases := []struct {
+		name       string
+		strategies map[string]*StrategyState
+		prices     map[string]float64
+		want       float64
+		frozen     float64
+	}{
+		{
+			name: "spot plus options",
+			strategies: map[string]*StrategyState{
+				"spot-strat": {
+					Positions: map[string]*Position{
+						"BTC": {Symbol: "BTC", Quantity: 0.5, AvgCost: 40000.0, Side: "long"},
+						"ETH": {Symbol: "ETH", Quantity: 10.0, AvgCost: 3000.0, Side: "long"},
+					},
+					OptionPositions: make(map[string]*OptionPosition),
 				},
-				"BTC-call-50000-buy": {
-					Action:          "buy",
-					Strike:          50000.0,
-					Quantity:        1.0,
-					CurrentValueUSD: 800.0,
+				"options-strat": {
+					Positions: make(map[string]*Position),
+					OptionPositions: map[string]*OptionPosition{
+						"BTC-put-40000-sell": {Action: "sell", Strike: 40000.0, Quantity: 2.0, CurrentValueUSD: -500.0},
+						"BTC-call-50000-buy": {Action: "buy", Strike: 50000.0, Quantity: 1.0, CurrentValueUSD: 800.0},
+					},
 				},
 			},
+			prices: map[string]float64{"BTC": 50000.0, "ETH": 3500.0},
+			want:   140800.0,
 		},
-	}
-
-	prices := map[string]float64{
-		"BTC": 50000.0,
-		"ETH": 3500.0,
-	}
-
-	notional := PortfolioNotional(strategies, prices)
-
-	expected := 140800.0
-	if notional < expected-0.01 || notional > expected+0.01 {
-		t.Errorf("expected notional=%.2f; got %.2f", expected, notional)
-	}
-}
-
-func TestPortfolioNotional_IncludesPerps(t *testing.T) {
-	strategies := map[string]*StrategyState{
-		"hl-momentum-btc": {
-			Type: "perps",
-			Positions: map[string]*Position{
-				"BTC": {Symbol: "BTC", Quantity: 0.4, AvgCost: 40000.0, Side: "long"},
+		{
+			name: "includes perps at live mark",
+			strategies: map[string]*StrategyState{
+				"hl-momentum-btc": {
+					Type:            "perps",
+					Positions:       map[string]*Position{"BTC": {Symbol: "BTC", Quantity: 0.4, AvgCost: 40000.0, Side: "long"}},
+					OptionPositions: make(map[string]*OptionPosition),
+				},
+				"spot-btc": {
+					Type:            "spot",
+					Positions:       map[string]*Position{"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.1, AvgCost: 45000.0, Side: "long"}},
+					OptionPositions: make(map[string]*OptionPosition),
+				},
 			},
-			OptionPositions: make(map[string]*OptionPosition),
+			prices: map[string]float64{"BTC/USDT": 50000.0, "BTC": 50000.0},
+			want:   25000.0,
 		},
-		"spot-btc": {
-			Type: "spot",
-			Positions: map[string]*Position{
-				"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.1, AvgCost: 45000.0, Side: "long"},
+		{
+			name: "includes futures at live mark with multiplier",
+			strategies: map[string]*StrategyState{
+				"ts-trend-es": {
+					Type:            "futures",
+					Positions:       map[string]*Position{"ES": {Symbol: "ES", Quantity: 2, AvgCost: 5000.0, Side: "long", Multiplier: 50}},
+					OptionPositions: make(map[string]*OptionPosition),
+				},
+				"ts-mr-nq": {
+					Type:            "futures",
+					Positions:       map[string]*Position{"NQ": {Symbol: "NQ", Quantity: 1, AvgCost: 18000.0, Side: "short", Multiplier: 20}},
+					OptionPositions: make(map[string]*OptionPosition),
+				},
 			},
-			OptionPositions: make(map[string]*OptionPosition),
+			prices: map[string]float64{"ES": 5100.0, "NQ": 18500.0},
+			want:   880000.0,
+			frozen: 860000.0,
 		},
-	}
-
-	prices := map[string]float64{
-		"BTC/USDT": 50000.0,
-		"BTC":      50000.0,
-	}
-
-	notional := PortfolioNotional(strategies, prices)
-
-	expected := 25000.0
-	if notional < expected-0.01 || notional > expected+0.01 {
-		t.Errorf("expected notional=%.2f; got %.2f", expected, notional)
-	}
-}
-
-func TestPortfolioNotional_IncludesFutures(t *testing.T) {
-	strategies := map[string]*StrategyState{
-		"ts-trend-es": {
-			Type: "futures",
-			Positions: map[string]*Position{
-				"ES": {Symbol: "ES", Quantity: 2, AvgCost: 5000.0, Side: "long", Multiplier: 50},
+		{
+			name: "futures mark miss falls back to entry",
+			strategies: map[string]*StrategyState{
+				"ts-trend-cl": {
+					Type:            "futures",
+					Positions:       map[string]*Position{"CL": {Symbol: "CL", Quantity: 1, AvgCost: 80.0, Side: "long", Multiplier: 1000}},
+					OptionPositions: make(map[string]*OptionPosition),
+				},
 			},
-			OptionPositions: make(map[string]*OptionPosition),
+			prices: map[string]float64{},
+			want:   80000.0,
 		},
-		"ts-mr-nq": {
-			Type: "futures",
-			Positions: map[string]*Position{
-				"NQ": {Symbol: "NQ", Quantity: 1, AvgCost: 18000.0, Side: "short", Multiplier: 20},
+		{
+			name: "includes perps short at live mark",
+			strategies: map[string]*StrategyState{
+				"hl-mean-rev-eth": {
+					Type:            "perps",
+					Positions:       map[string]*Position{"ETH": {Symbol: "ETH", Quantity: 2.0, AvgCost: 3000.0, Side: "short"}},
+					OptionPositions: make(map[string]*OptionPosition),
+				},
 			},
-			OptionPositions: make(map[string]*OptionPosition),
+			prices: map[string]float64{"ETH/USDT": 3200.0, "ETH": 3200.0},
+			want:   6400.0,
 		},
 	}
-
-	prices := map[string]float64{
-		"ES": 5100.0,
-		"NQ": 18500.0,
-	}
-
-	notional := PortfolioNotional(strategies, prices)
-
-	expected := 880000.0
-	if notional < expected-0.01 || notional > expected+0.01 {
-		t.Errorf("expected futures notional at live mark=%.2f; got %.2f", expected, notional)
-	}
-
-	frozen := 860000.0
-	if notional == frozen {
-		t.Errorf("notional equals frozen-entry value %.2f — mark price was not applied", frozen)
-	}
-}
-
-func TestPortfolioNotional_FuturesMarkMiss(t *testing.T) {
-	strategies := map[string]*StrategyState{
-		"ts-trend-cl": {
-			Type: "futures",
-			Positions: map[string]*Position{
-				"CL": {Symbol: "CL", Quantity: 1, AvgCost: 80.0, Side: "long", Multiplier: 1000},
-			},
-			OptionPositions: make(map[string]*OptionPosition),
-		},
-	}
-	notional := PortfolioNotional(strategies, map[string]float64{})
-
-	expected := 80000.0
-	if notional < expected-0.01 || notional > expected+0.01 {
-		t.Errorf("expected fallback notional=%.2f; got %.2f", expected, notional)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			notional := PortfolioNotional(tc.strategies, tc.prices)
+			if math.Abs(notional-tc.want) > 0.01 {
+				t.Errorf("expected notional=%.2f; got %.2f", tc.want, notional)
+			}
+			if tc.frozen != 0 && notional == tc.frozen {
+				t.Errorf("notional equals frozen-entry value %.2f: mark price was not applied", tc.frozen)
+			}
+		})
 	}
 }
 
 func TestCollectFuturesMarkSymbols(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "ts-trend-es", Type: "futures", Platform: "topstep", Args: []string{"trend", "ES", "1h"}},
-		{ID: "ts-mr-es", Type: "futures", Platform: "topstep", Args: []string{"mean_rev", "ES", "15m"}},
-		{ID: "ts-trend-nq", Type: "futures", Platform: "topstep", Args: []string{"trend", "NQ", "1h"}},
-		{ID: "ts-trend-mes", Type: "futures", Platform: "topstep", Args: []string{"trend", "MES", "1h"}},
-		{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
-		{ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "ETH", "1h"}},
-		{ID: "deribit-vol-btc", Type: "options", Platform: "deribit", Args: []string{"vol", "BTC"}},
-		{ID: "ts-short", Type: "futures", Platform: "topstep", Args: []string{"trend"}},
-		{ID: "ts-empty-sym", Type: "futures", Platform: "topstep", Args: []string{"trend", "", "1h"}},
-		{ID: "ibkr-trend-cl", Type: "futures", Platform: "ibkr", Args: []string{"trend", "CL", "1h"}},
+	cases := []struct {
+		name       string
+		strategies []StrategyConfig
+		want       []string
+	}{
+		{
+			name: "topstep futures only, deduplicated and sorted",
+			strategies: []StrategyConfig{
+				{ID: "ts-trend-es", Type: "futures", Platform: "topstep", Args: []string{"trend", "ES", "1h"}},
+				{ID: "ts-mr-es", Type: "futures", Platform: "topstep", Args: []string{"mean_rev", "ES", "15m"}},
+				{ID: "ts-trend-nq", Type: "futures", Platform: "topstep", Args: []string{"trend", "NQ", "1h"}},
+				{ID: "ts-trend-mes", Type: "futures", Platform: "topstep", Args: []string{"trend", "MES", "1h"}},
+				{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
+				{ID: "hl-eth", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "ETH", "1h"}},
+				{ID: "deribit-vol-btc", Type: "options", Platform: "deribit", Args: []string{"vol", "BTC"}},
+				{ID: "ts-short", Type: "futures", Platform: "topstep", Args: []string{"trend"}},
+				{ID: "ts-empty-sym", Type: "futures", Platform: "topstep", Args: []string{"trend", "", "1h"}},
+				{ID: "ibkr-trend-cl", Type: "futures", Platform: "ibkr", Args: []string{"trend", "CL", "1h"}},
+			},
+			want: []string{"ES", "MES", "NQ"},
+		},
+		{
+			name: "ignores manual strategies",
+			strategies: []StrategyConfig{
+				{ID: "manual-hl-eth", Type: "manual", Platform: "hyperliquid", Symbol: "ETH",
+					Args: []string{"hold", "ETH", "1h", "--mode=live"}},
+				{ID: "ts-trend-es", Type: "futures", Platform: "topstep", Args: []string{"trend", "ES", "1h"}},
+			},
+			want: []string{"ES"},
+		},
 	}
-
-	got := collectFuturesMarkSymbols(strategies)
-	want := []string{"ES", "MES", "NQ"}
-	if len(got) != len(want) {
-		t.Fatalf("got %d symbols %v, want %d %v", len(got), got, len(want), want)
-	}
-	for i, sym := range want {
-		if got[i] != sym {
-			t.Errorf("got[%d]=%q, want %q (full: %v)", i, got[i], sym, got)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectFuturesMarkSymbols(tc.strategies)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d symbols %v, want %d %v", len(got), got, len(tc.want), tc.want)
+			}
+			for i, sym := range tc.want {
+				if got[i] != sym {
+					t.Errorf("got[%d]=%q, want %q (full: %v)", i, got[i], sym, got)
+				}
+			}
+		})
 	}
 }
 
@@ -431,29 +423,6 @@ func TestMergeFuturesMarks(t *testing.T) {
 	}
 	if _, ok := prices["CL"]; ok {
 		t.Errorf("prices[CL] should not be set when mark is negative (got %v)", prices["CL"])
-	}
-}
-
-func TestPortfolioNotional_IncludesPerpsShort(t *testing.T) {
-	strategies := map[string]*StrategyState{
-		"hl-mean-rev-eth": {
-			Type: "perps",
-			Positions: map[string]*Position{
-				"ETH": {Symbol: "ETH", Quantity: 2.0, AvgCost: 3000.0, Side: "short"},
-			},
-			OptionPositions: make(map[string]*OptionPosition),
-		},
-	}
-	prices := map[string]float64{
-		"ETH/USDT": 3200.0,
-		"ETH":      3200.0,
-	}
-
-	notional := PortfolioNotional(strategies, prices)
-
-	expected := 6400.0
-	if notional < expected-0.01 || notional > expected+0.01 {
-		t.Errorf("expected short notional at live mark=%.2f; got %.2f", expected, notional)
 	}
 }
 
@@ -492,52 +461,73 @@ func TestCollectPriceSymbols(t *testing.T) {
 }
 
 func TestCollectPerpsMarkSymbols(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "hl-momentum-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}},
-		{ID: "hl-mr-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"mean_rev", "BTC", "15m"}},
-		{ID: "hl-trend-eth", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "ETH", "1h"}},
-		{ID: "okx-ema-sol-perp", Type: "perps", Platform: "okx", Args: []string{"ema", "SOL", "1h"}},
-		{ID: "okx-ema-btc-perp", Type: "perps", Platform: "okx", Args: []string{"ema", "BTC", "1h"}},
-		{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
-		{ID: "deribit-vol-btc", Type: "options", Platform: "deribit", Args: []string{"vol", "BTC"}},
-		{ID: "ts-trend-es", Type: "futures", Platform: "topstep", Args: []string{"trend", "ES", "1h"}},
-		{ID: "hl-short", Type: "perps", Platform: "hyperliquid", Args: []string{"trend"}},
-		{ID: "hl-empty", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "", "1h"}},
+	cases := []struct {
+		name       string
+		strategies []StrategyConfig
+		wantHL     []string
+		wantOKX    []string
+	}{
+		{
+			name: "perps split by venue, deduplicated and sorted",
+			strategies: []StrategyConfig{
+				{ID: "hl-momentum-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"momentum", "BTC", "1h"}},
+				{ID: "hl-mr-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"mean_rev", "BTC", "15m"}},
+				{ID: "hl-trend-eth", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "ETH", "1h"}},
+				{ID: "okx-ema-sol-perp", Type: "perps", Platform: "okx", Args: []string{"ema", "SOL", "1h"}},
+				{ID: "okx-ema-btc-perp", Type: "perps", Platform: "okx", Args: []string{"ema", "BTC", "1h"}},
+				{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
+				{ID: "deribit-vol-btc", Type: "options", Platform: "deribit", Args: []string{"vol", "BTC"}},
+				{ID: "ts-trend-es", Type: "futures", Platform: "topstep", Args: []string{"trend", "ES", "1h"}},
+				{ID: "hl-short", Type: "perps", Platform: "hyperliquid", Args: []string{"trend"}},
+				{ID: "hl-empty", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "", "1h"}},
+			},
+			wantHL:  []string{"BTC", "ETH"},
+			wantOKX: []string{"BTC", "SOL"},
+		},
+		{
+			name: "no perps yields empty lists",
+			strategies: []StrategyConfig{
+				{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
+			},
+		},
+		{
+			name: "manual hyperliquid keyed on sc.Symbol, okx manual ignored",
+			strategies: []StrategyConfig{
+				{ID: "manual-hl-eth", Type: "manual", Platform: "hyperliquid", Symbol: "ETH",
+					Args: []string{"hold", "WRONGCOIN", "1h", "--mode=live"}},
+				{ID: "manual-hl-hype", Type: "manual", Platform: "hyperliquid", Symbol: "HYPE",
+					Args: []string{"hold", "HYPE", "1h", "--mode=paper"}},
+				{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
+				{ID: "manual-hl-btc", Type: "manual", Platform: "hyperliquid", Symbol: "BTC",
+					Args: []string{"hold", "BTC", "1h", "--mode=live"}},
+				{ID: "manual-okx-sol", Type: "manual", Platform: "okx", Symbol: "SOL",
+					Args: []string{"hold", "SOL", "1h", "--mode=live"}},
+				{ID: "manual-hl-empty", Type: "manual", Platform: "hyperliquid", Symbol: "",
+					Args: []string{"hold", "DOGE", "1h", "--mode=live"}},
+			},
+			wantHL: []string{"BTC", "ETH", "HYPE"},
+		},
 	}
-
-	hlCoins, okxCoins := collectPerpsMarkSymbols(strategies)
-
-	wantHL := []string{"BTC", "ETH"}
-	if len(hlCoins) != len(wantHL) {
-		t.Fatalf("hlCoins = %v, want %v", hlCoins, wantHL)
-	}
-	for i, c := range wantHL {
-		if hlCoins[i] != c {
-			t.Errorf("hlCoins[%d] = %q, want %q", i, hlCoins[i], c)
-		}
-	}
-
-	wantOKX := []string{"BTC", "SOL"}
-	if len(okxCoins) != len(wantOKX) {
-		t.Fatalf("okxCoins = %v, want %v", okxCoins, wantOKX)
-	}
-	for i, c := range wantOKX {
-		if okxCoins[i] != c {
-			t.Errorf("okxCoins[%d] = %q, want %q", i, okxCoins[i], c)
-		}
-	}
-}
-
-func TestCollectPerpsMarkSymbols_Empty(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
-	}
-	hlCoins, okxCoins := collectPerpsMarkSymbols(strategies)
-	if len(hlCoins) != 0 {
-		t.Errorf("hlCoins = %v, want empty", hlCoins)
-	}
-	if len(okxCoins) != 0 {
-		t.Errorf("okxCoins = %v, want empty", okxCoins)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hlCoins, okxCoins := collectPerpsMarkSymbols(tc.strategies)
+			if len(hlCoins) != len(tc.wantHL) {
+				t.Fatalf("hlCoins = %v, want %v", hlCoins, tc.wantHL)
+			}
+			for i, c := range tc.wantHL {
+				if hlCoins[i] != c {
+					t.Errorf("hlCoins[%d] = %q, want %q", i, hlCoins[i], c)
+				}
+			}
+			if len(okxCoins) != len(tc.wantOKX) {
+				t.Fatalf("okxCoins = %v, want %v", okxCoins, tc.wantOKX)
+			}
+			for i, c := range tc.wantOKX {
+				if okxCoins[i] != c {
+					t.Errorf("okxCoins[%d] = %q, want %q", i, okxCoins[i], c)
+				}
+			}
+		})
 	}
 }
 
@@ -1122,51 +1112,51 @@ func TestClearLatchedKillSwitchSharedWallet_FetchFailurePreservesLatch(t *testin
 	}
 }
 
-func TestClearLatchedKillSwitchSharedWallet_NoSharedWalletNoOp(t *testing.T) {
-	resetSchedulerStarted(t)
-	state := latchedSharedWalletState()
-	strategies := []StrategyConfig{
-		{ID: "spot-a", Platform: "binanceus", Capital: 1000},
-		{ID: "spot-b", Platform: "binanceus", Capital: 1000},
-		{ID: "hl-solo", Platform: "hyperliquid", CapitalPct: 0.5, Capital: 1000},
+func TestClearLatchedKillSwitchSharedWallet_NoOp(t *testing.T) {
+	cases := []struct {
+		name       string
+		state      func() *AppState
+		strategies func(t *testing.T) []StrategyConfig
+	}{
+		{
+			name:  "no shared wallet detected",
+			state: latchedSharedWalletState,
+			strategies: func(t *testing.T) []StrategyConfig {
+				return []StrategyConfig{
+					{ID: "spot-a", Platform: "binanceus", Capital: 1000},
+					{ID: "spot-b", Platform: "binanceus", Capital: 1000},
+					{ID: "hl-solo", Platform: "hyperliquid", CapitalPct: 0.5, Capital: 1000},
+				}
+			},
+		},
+		{
+			name: "switch already inactive",
+			state: func() *AppState {
+				return &AppState{PortfolioRisk: PortfolioRiskState{PeakValue: 10000, KillSwitchActive: false}}
+			},
+			strategies: sharedHLStrategies,
+		},
 	}
-
-	calls := 0
-	fetcher := func(platform string) (float64, error) {
-		calls++
-		return 5000, nil
-	}
-
-	cleared := ClearLatchedKillSwitchSharedWallet(state, strategies, fetcher)
-	if cleared {
-		t.Error("expected no clear when no shared wallet detected")
-	}
-	if calls != 0 {
-		t.Errorf("expected fetcher NOT called for non-shared wallets; got %d calls", calls)
-	}
-	if !state.PortfolioRisk.KillSwitchActive {
-		t.Error("expected KillSwitchActive to remain true")
-	}
-}
-
-func TestClearLatchedKillSwitchSharedWallet_InactiveSwitchNoOp(t *testing.T) {
-	resetSchedulerStarted(t)
-	state := &AppState{
-		PortfolioRisk: PortfolioRiskState{PeakValue: 10000, KillSwitchActive: false},
-	}
-	strategies := sharedHLStrategies(t)
-
-	calls := 0
-	fetcher := func(platform string) (float64, error) {
-		calls++
-		return 5000, nil
-	}
-
-	if cleared := ClearLatchedKillSwitchSharedWallet(state, strategies, fetcher); cleared {
-		t.Error("expected no clear when switch already inactive")
-	}
-	if calls != 0 {
-		t.Errorf("expected fetcher NOT called when switch inactive; got %d calls", calls)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetSchedulerStarted(t)
+			state := tc.state()
+			wantActive := state.PortfolioRisk.KillSwitchActive
+			calls := 0
+			fetcher := func(platform string) (float64, error) {
+				calls++
+				return 5000, nil
+			}
+			if cleared := ClearLatchedKillSwitchSharedWallet(state, tc.strategies(t), fetcher); cleared {
+				t.Error("expected no clear")
+			}
+			if calls != 0 {
+				t.Errorf("expected fetcher NOT called; got %d calls", calls)
+			}
+			if state.PortfolioRisk.KillSwitchActive != wantActive {
+				t.Errorf("KillSwitchActive = %v, want unchanged %v", state.PortfolioRisk.KillSwitchActive, wantActive)
+			}
+		})
 	}
 }
 
@@ -1446,199 +1436,260 @@ func TestAutoResetConfirmedFlatKillSwitch_NoRelatchOnNextTick(t *testing.T) {
 	}
 }
 
-func TestPerpsMarginDrawdownInputs_OnlyPerpsCount(t *testing.T) {
-	s := &StrategyState{
-		Positions: map[string]*Position{
-			"ETH":      {Symbol: "ETH", Quantity: 0.2, AvgCost: 2000, Side: "long", Multiplier: 1, Leverage: 20},
-			"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.05, AvgCost: 50000, Side: "long"},
+func TestPerpsMarginDrawdownInputs(t *testing.T) {
+	cases := []struct {
+		name       string
+		positions  map[string]*Position
+		leverage   float64
+		prices     map[string]float64
+		wantLoss   float64
+		wantMargin float64
+	}{
+		{
+			name: "only perps count, gain books no loss",
+			positions: map[string]*Position{
+				"ETH":      {Symbol: "ETH", Quantity: 0.2, AvgCost: 2000, Side: "long", Multiplier: 1, Leverage: 20},
+				"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.05, AvgCost: 50000, Side: "long"},
+			},
+			leverage: 20, prices: map[string]float64{"ETH": 3000, "BTC/USDT": 60000, "ES": 4500},
+			wantLoss: 0, wantMargin: 30,
+		},
+		{
+			name: "only underwater legs add to loss",
+			positions: map[string]*Position{
+				"ETH": {Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 10},
+				"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 1, Leverage: 10},
+			},
+			leverage: 10, prices: map[string]float64{"ETH": 2700, "BTC": 47500},
+			wantLoss: 300, wantMargin: 745,
+		},
+		{
+			name: "missing price falls back to avg cost",
+			positions: map[string]*Position{
+				"HYPE": {Symbol: "HYPE", Quantity: 100, AvgCost: 20, Side: "long", Multiplier: 1, Leverage: 10},
+			},
+			leverage: 10, prices: map[string]float64{},
+			wantLoss: 0, wantMargin: 200,
+		},
+		{
+			name: "zero price falls back to avg cost",
+			positions: map[string]*Position{
+				"HYPE": {Symbol: "HYPE", Quantity: 100, AvgCost: 20, Side: "long", Multiplier: 1, Leverage: 10},
+			},
+			leverage: 10, prices: map[string]float64{"HYPE": 0},
+			wantLoss: 0, wantMargin: 200,
+		},
+		{
+			name:      "no positions",
+			positions: map[string]*Position{},
+			leverage:  10,
+		},
+		{
+			name: "uses config leverage not position leverage",
+			positions: map[string]*Position{
+				"ETH": {Symbol: "ETH", Quantity: 1.0, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 20},
+			},
+			leverage: 2, prices: map[string]float64{"ETH": 2900},
+			wantLoss: 100, wantMargin: 1450,
+		},
+		{
+			name: "zero config leverage returns zero",
+			positions: map[string]*Position{
+				"ETH": {Symbol: "ETH", Quantity: 1.0, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 20},
+			},
+			leverage: 0, prices: map[string]float64{"ETH": 2900},
 		},
 	}
-	prices := map[string]float64{"ETH": 3000, "BTC/USDT": 60000, "ES": 4500}
-
-	loss, margin := perpsMarginDrawdownInputs(s, 20, prices)
-	if margin < 29.999 || margin > 30.001 {
-		t.Errorf("margin = %.4f; want 30.0 (only perps count)", margin)
-	}
-	if loss != 0 {
-		t.Errorf("loss = %.4f; want 0 (ETH has unrealized gain, not loss)", loss)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loss, margin := perpsMarginDrawdownInputs(&StrategyState{Positions: tc.positions}, tc.leverage, tc.prices)
+			if math.Abs(margin-tc.wantMargin) > 1e-6 {
+				t.Errorf("margin = %.4f; want %.4f", margin, tc.wantMargin)
+			}
+			if math.Abs(loss-tc.wantLoss) > 1e-6 {
+				t.Errorf("loss = %.4f; want %.4f", loss, tc.wantLoss)
+			}
+		})
 	}
 }
 
-func TestPerpsMarginDrawdownInputs_UnrealizedLoss(t *testing.T) {
-	s := &StrategyState{
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 10},
-			"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 50000, Side: "short", Multiplier: 1, Leverage: 10},
+func TestAggregatePerpsMarginInputs(t *testing.T) {
+	ethLong := map[string]*Position{
+		"ETH": {Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 20},
+	}
+	cases := []struct {
+		name       string
+		strategies map[string]*StrategyState
+		configs    []StrategyConfig
+		prices     map[string]float64
+		wantLoss   float64
+		wantMargin float64
+	}{
+		{
+			name: "sums perps only across strategies",
+			strategies: map[string]*StrategyState{
+				"hl-btc": {Type: "perps", Positions: map[string]*Position{
+					"BTC": {Symbol: "BTC", Quantity: 1, AvgCost: 40000, Side: "short", Multiplier: 1, Leverage: 10},
+				}},
+				"hl-eth": {Type: "perps", Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 10, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 5},
+				}},
+				"spot-sol": {Type: "spot", Positions: map[string]*Position{
+					"SOL/USDT": {Symbol: "SOL/USDT", Quantity: 100, AvgCost: 150, Side: "long"},
+				}},
+				"ts-es": {Type: "futures", Positions: map[string]*Position{
+					"ES": {Symbol: "ES", Quantity: 1, AvgCost: 5000, Side: "long", Multiplier: 50},
+				}},
+			},
+			configs:  []StrategyConfig{{ID: "hl-btc", Leverage: 10}, {ID: "hl-eth", Leverage: 5}},
+			prices:   map[string]float64{"BTC": 42000, "ETH": 3100, "SOL/USDT": 200, "ES": 5100},
+			wantLoss: 2000, wantMargin: 10400,
+		},
+		{
+			name: "no perps returns zero",
+			strategies: map[string]*StrategyState{
+				"spot-btc": {Type: "spot", Positions: map[string]*Position{
+					"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.5, AvgCost: 40000, Side: "long"},
+				}},
+			},
+			prices: map[string]float64{"BTC/USDT": 50000},
+		},
+		{
+			name:       "uses config leverage not position leverage",
+			strategies: map[string]*StrategyState{"hl-eth": {Type: "perps", Positions: ethLong}},
+			configs:    []StrategyConfig{{ID: "hl-eth", Leverage: 2}},
+			prices:     map[string]float64{"ETH": 2900},
+			wantLoss:   100, wantMargin: 1450,
+		},
+		{
+			name:       "uses exchange leverage not sizing_leverage",
+			strategies: map[string]*StrategyState{"hl-eth": {Type: "perps", Positions: ethLong}},
+			configs:    []StrategyConfig{{ID: "hl-eth", Leverage: 20, SizingLeverage: 2}},
+			prices:     map[string]float64{"ETH": 2900},
+			wantLoss:   100, wantMargin: 145,
+		},
+		{
+			name:       "missing config skips the strategy",
+			strategies: map[string]*StrategyState{"hl-orphan": {Type: "perps", Positions: ethLong}},
+			prices:     map[string]float64{"ETH": 2900},
 		},
 	}
-	prices := map[string]float64{"ETH": 2700, "BTC": 47500}
-	loss, margin := perpsMarginDrawdownInputs(s, 10, prices)
-	if margin < 744.999 || margin > 745.001 {
-		t.Errorf("margin = %.4f; want 745", margin)
-	}
-	if loss < 299.999 || loss > 300.001 {
-		t.Errorf("loss = %.4f; want 300 (only ETH is underwater)", loss)
-	}
-}
-
-func TestPerpsMarginDrawdownInputs_FallbackToAvgCost(t *testing.T) {
-	s := &StrategyState{
-		Positions: map[string]*Position{
-			"HYPE": {Symbol: "HYPE", Quantity: 100, AvgCost: 20, Side: "long", Multiplier: 1, Leverage: 10},
-		},
-	}
-	_, margin := perpsMarginDrawdownInputs(s, 10, map[string]float64{})
-	want := 100.0 * 20.0 / 10.0
-	if margin < want-0.001 || margin > want+0.001 {
-		t.Errorf("margin with missing price = %.4f; want %.4f", margin, want)
-	}
-
-	_, margin = perpsMarginDrawdownInputs(s, 10, map[string]float64{"HYPE": 0})
-	if margin < want-0.001 || margin > want+0.001 {
-		t.Errorf("margin with zero price = %.4f; want %.4f", margin, want)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loss, margin := AggregatePerpsMarginInputs(tc.strategies, tc.configs, tc.prices)
+			if math.Abs(margin-tc.wantMargin) > 1e-6 {
+				t.Errorf("margin = %.4f; want %.4f", margin, tc.wantMargin)
+			}
+			if math.Abs(loss-tc.wantLoss) > 1e-6 {
+				t.Errorf("loss = %.4f; want %.4f", loss, tc.wantLoss)
+			}
+		})
 	}
 }
 
-func TestPerpsMarginDrawdownInputs_NoPositions(t *testing.T) {
-	s := &StrategyState{Positions: map[string]*Position{}}
-	loss, margin := perpsMarginDrawdownInputs(s, 10, nil)
-	if loss != 0 || margin != 0 {
-		t.Errorf("perpsMarginDrawdownInputs with no positions = (%.4f, %.4f); want (0, 0)", loss, margin)
-	}
-}
-
-func TestPerpsMarginDrawdownInputs_UsesConfigLeverageNotPosLeverage(t *testing.T) {
-	s := &StrategyState{
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 1.0, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 20},
-		},
-	}
-	prices := map[string]float64{"ETH": 2900}
-
-	loss, margin := perpsMarginDrawdownInputs(s, 2, prices)
-
-	wantMargin := 1450.0
-	if math.Abs(margin-wantMargin) > 1e-6 {
-		t.Errorf("margin = %.4f; want %.4f (must use configLeverage=2, NOT pos.Leverage=20)", margin, wantMargin)
-	}
-	if math.Abs(loss-100) > 1e-6 {
-		t.Errorf("loss = %.4f; want 100", loss)
-	}
-}
-
-func TestPerpsMarginDrawdownInputs_ZeroConfigLeverageReturnsZero(t *testing.T) {
-	s := &StrategyState{
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 1.0, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 20},
-		},
-	}
-	loss, margin := perpsMarginDrawdownInputs(s, 0, map[string]float64{"ETH": 2900})
-	if loss != 0 || margin != 0 {
-		t.Errorf("zero configLeverage must return (0, 0); got (%.4f, %.4f)", loss, margin)
-	}
-}
-
-func TestAggregatePerpsMarginInputs_UsesConfigLeverage(t *testing.T) {
-	strategies := map[string]*StrategyState{
-		"hl-eth": {
+func TestCheckRisk_DrawdownBasis(t *testing.T) {
+	hlSC := &StrategyConfig{ID: "hl-test", Platform: "hyperliquid", Type: "perps", Leverage: 20}
+	perpsState := func(cash, peak, maxDD float64, positions map[string]*Position) *StrategyState {
+		return &StrategyState{
+			ID:   "hl-test",
 			Type: "perps",
-			Positions: map[string]*Position{
-				"ETH": {Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 20},
+			Cash: cash,
+			RiskState: RiskState{
+				PeakValue:      peak,
+				MaxDrawdownPct: maxDD,
+				DailyPnLDate:   todayUTC(),
 			},
+			Positions:       positions,
+			OptionPositions: make(map[string]*OptionPosition),
+			TradeHistory:    []Trade{},
+		}
+	}
+	cases := []struct {
+		name          string
+		state         *StrategyState
+		sc            *StrategyConfig
+		prices        map[string]float64
+		wantAllowed   bool
+		ddLo, ddHi    float64
+		wantOpenCount int
+	}{
+		{
+			name: "perps margin basis fires early on unrealized loss",
+			state: perpsState(584, 589, 25, map[string]*Position{
+				"ETH": {Symbol: "ETH", Quantity: 0.236, AvgCost: 2357.0, Side: "long", Multiplier: 1, Leverage: 20},
+			}),
+			sc: hlSC, prices: map[string]float64{"ETH": 2307.5},
+			ddLo: 40, ddHi: math.Inf(1),
 		},
-	}
-	configs := []StrategyConfig{
-		{ID: "hl-eth", Leverage: 2},
-	}
-	prices := map[string]float64{"ETH": 2900}
-	loss, margin := AggregatePerpsMarginInputs(strategies, configs, prices)
-
-	if math.Abs(margin-1450) > 1e-6 {
-		t.Errorf("margin = %.4f; want 1450 (config leverage, not pos.Leverage)", margin)
-	}
-	if math.Abs(loss-100) > 1e-6 {
-		t.Errorf("loss = %.4f; want 100", loss)
-	}
-}
-
-func TestAggregatePerpsMarginInputs_UsesExchangeLeverageNotSizingLeverage(t *testing.T) {
-	strategies := map[string]*StrategyState{
-		"hl-eth": {
-			Type: "perps",
-			Positions: map[string]*Position{
-				"ETH": {Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 20},
+		{
+			name: "perps drawdown fires before any closed trades",
+			state: perpsState(500, 500, 10, map[string]*Position{
+				"ETH": {Symbol: "ETH", Quantity: 1, AvgCost: 100, Side: "long", Multiplier: 1, Leverage: 20},
+			}),
+			sc: hlSC, prices: map[string]float64{"ETH": 80},
+			ddLo: 10, ddHi: math.Inf(1),
+		},
+		{
+			name: "perps margin basis below threshold stays allowed",
+			state: perpsState(584, 589, 25, map[string]*Position{
+				"ETH": {Symbol: "ETH", Quantity: 0.236, AvgCost: 2357.0, Side: "long", Multiplier: 1, Leverage: 20},
+			}),
+			sc: hlSC, prices: map[string]float64{"ETH": 2355.0},
+			wantAllowed: true, ddLo: 0, ddHi: 24.999, wantOpenCount: 1,
+		},
+		{
+			name: "prior realized losses do not inflate the perps drawdown",
+			state: perpsState(900, 1000, 25, map[string]*Position{
+				"ETH": {Symbol: "ETH", Quantity: 0.001, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 20},
+			}),
+			sc: hlSC, prices: map[string]float64{"ETH": 3000},
+			wantAllowed: true, ddLo: 0, ddHi: 0.001, wantOpenCount: 1,
+		},
+		{
+			name:  "perps with no open positions falls back to peak basis",
+			state: perpsState(700, 1000, 25, map[string]*Position{}),
+			ddLo:  29, ddHi: 31,
+		},
+		{
+			name: "spot stays on peak basis",
+			state: &StrategyState{
+				Type: "spot",
+				Cash: 500.0,
+				RiskState: RiskState{
+					PeakValue:      1000.0,
+					MaxDrawdownPct: 25.0,
+					DailyPnLDate:   todayUTC(),
+				},
+				Positions: map[string]*Position{
+					"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.01, AvgCost: 50000, Side: "long"},
+				},
+				OptionPositions: make(map[string]*OptionPosition),
 			},
+			prices:      map[string]float64{"BTC/USDT": 30000},
+			wantAllowed: true, ddLo: 19.5, ddHi: 20.5, wantOpenCount: 1,
 		},
 	}
-	configs := []StrategyConfig{
-		{ID: "hl-eth", Leverage: 20, SizingLeverage: 2},
-	}
-	prices := map[string]float64{"ETH": 2900}
-	loss, margin := AggregatePerpsMarginInputs(strategies, configs, prices)
-
-	if math.Abs(margin-145) > 1e-6 {
-		t.Errorf("margin = %.4f; want 145 (exchange leverage 20, not sizing_leverage 2)", margin)
-	}
-	if math.Abs(loss-100) > 1e-6 {
-		t.Errorf("loss = %.4f; want 100", loss)
-	}
-}
-
-func TestAggregatePerpsMarginInputs_MissingConfigSkipsStrategy(t *testing.T) {
-	strategies := map[string]*StrategyState{
-		"hl-orphan": {
-			Type: "perps",
-			Positions: map[string]*Position{
-				"ETH": {Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 20},
-			},
-		},
-	}
-	loss, margin := AggregatePerpsMarginInputs(strategies, nil, map[string]float64{"ETH": 2900})
-	if loss != 0 || margin != 0 {
-		t.Errorf("orphan strategy without config must contribute 0; got (%.4f, %.4f)", loss, margin)
-	}
-}
-
-func TestCheckRisk_PerpsMarginDrawdown_FiresEarly(t *testing.T) {
-	s := &StrategyState{
-		ID:   "hl-test",
-		Type: "perps",
-		Cash: 584.0,
-		RiskState: RiskState{
-			PeakValue:      589.0,
-			MaxDrawdownPct: 25.0,
-			DailyPnLDate:   todayUTC(),
-		},
-		Positions: map[string]*Position{
-			"ETH": {
-				Symbol:     "ETH",
-				Quantity:   0.236,
-				AvgCost:    2357.0,
-				Side:       "long",
-				Multiplier: 1,
-				Leverage:   20,
-			},
-		},
-		OptionPositions: make(map[string]*OptionPosition),
-		TradeHistory:    []Trade{},
-	}
-	prices := map[string]float64{"ETH": 2307.5}
-	pv := PortfolioValue(s, prices)
-
-	sc := &StrategyConfig{ID: "hl-test", Platform: "hyperliquid", Type: "perps", Leverage: 20}
-	allowed, reason := CheckRisk(sc, s, pv, prices, nil, nil)
-
-	if allowed {
-		t.Errorf("expected circuit breaker to fire on margin-based drawdown; reason=%s", reason)
-	}
-	if s.RiskState.CurrentDrawdownPct < 25.0 {
-		t.Errorf("expected CurrentDrawdownPct > 25 on margin basis; got %.2f", s.RiskState.CurrentDrawdownPct)
-	}
-	if s.RiskState.CurrentDrawdownPct < 40 {
-		t.Errorf("expected margin-based drawdown well above threshold; got %.2f", s.RiskState.CurrentDrawdownPct)
-	}
-	if len(s.Positions) != 0 {
-		t.Errorf("expected positions force-closed; got %d", len(s.Positions))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := tc.state
+			pv := PortfolioValue(s, tc.prices)
+			allowed, reason := CheckRisk(tc.sc, s, pv, tc.prices, nil, nil)
+			if allowed != tc.wantAllowed {
+				t.Fatalf("allowed = %v, want %v (reason=%q dd=%.2f)", allowed, tc.wantAllowed, reason, s.RiskState.CurrentDrawdownPct)
+			}
+			if !tc.wantAllowed && !strings.HasPrefix(reason, RiskReasonMaxDrawdownExceeded) {
+				t.Fatalf("reason = %q, want %q prefix", reason, RiskReasonMaxDrawdownExceeded)
+			}
+			if s.RiskState.CircuitBreaker == tc.wantAllowed {
+				t.Errorf("CircuitBreaker = %v, want %v", s.RiskState.CircuitBreaker, !tc.wantAllowed)
+			}
+			if dd := s.RiskState.CurrentDrawdownPct; dd < tc.ddLo || dd > tc.ddHi {
+				t.Errorf("CurrentDrawdownPct = %.2f, want within [%.3f, %.3f]", dd, tc.ddLo, tc.ddHi)
+			}
+			if len(s.Positions) != tc.wantOpenCount {
+				t.Errorf("open positions = %d, want %d", len(s.Positions), tc.wantOpenCount)
+			}
+		})
 	}
 }
 
@@ -1664,380 +1715,155 @@ func TestCheckRisk_SharedWalletPoolUsesMarginWithoutFakePeak(t *testing.T) {
 	}
 }
 
-func TestCheckRisk_PerpsDrawdownFiresBeforeAnyClosedTrades(t *testing.T) {
-	s := &StrategyState{
-		ID:   "hl-first-trade",
-		Type: "perps",
-		Cash: 500,
-		RiskState: RiskState{
-			PeakValue:      500,
-			MaxDrawdownPct: 10,
-			DailyPnLDate:   todayUTC(),
-		},
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 1, AvgCost: 100, Side: "long", Multiplier: 1, Leverage: 20},
-		},
-		OptionPositions: make(map[string]*OptionPosition),
-		TradeHistory:    []Trade{},
-	}
-	prices := map[string]float64{"ETH": 80}
-	pv := PortfolioValue(s, prices)
-	sc := &StrategyConfig{ID: "hl-first-trade", Platform: "hyperliquid", Type: "perps", Leverage: 20}
-
-	allowed, reason := CheckRisk(sc, s, pv, prices, nil, nil)
-
-	if allowed {
-		t.Fatalf("expected first open position to trip drawdown circuit breaker; reason=%s", reason)
-	}
-	if !strings.HasPrefix(reason, RiskReasonMaxDrawdownExceeded) {
-		t.Fatalf("reason = %q, want %q prefix", reason, RiskReasonMaxDrawdownExceeded)
-	}
-	if !s.RiskState.CircuitBreaker {
-		t.Fatal("expected circuit breaker to be active")
-	}
-	if len(s.Positions) != 0 {
-		t.Errorf("expected positions force-closed; got %d", len(s.Positions))
-	}
-}
-
-func TestCheckRisk_LiveHLSharedCoin_PausesWithoutClose(t *testing.T) {
-	sc := StrategyConfig{
-		ID: "hl-tema", Platform: "hyperliquid", Type: "perps",
+func TestCheckRisk_LiveHLCircuitBreaker_SharedCoinVsSoleOwner(t *testing.T) {
+	peer := StrategyConfig{ID: "hl-rmc", Platform: "hyperliquid", Type: "perps",
 		CapitalPct: 0.5, Capital: 500, Leverage: 20,
-		Args: []string{"triple_ema", "ETH", "1h", "--mode=live"},
+		Args: []string{"rsi_macd", "ETH", "1h", "--mode=live"}}
+	cases := []struct {
+		name        string
+		capitalPct  float64
+		withPeer    bool
+		hlPositions []HLPosition
+		wantClose   bool
+	}{
+		{"shared coin pauses without close", 0.5, true, []HLPosition{{Coin: "ETH", Size: 0.517, EntryPrice: 3000}}, false},
+		{"shared coin pauses without close when HL fetch failed", 0.5, true, nil, false},
+		{"sole owner still force-closes", 0, false, []HLPosition{{Coin: "ETH", Size: 0.517, EntryPrice: 3000}}, true},
 	}
-	hlLiveAll := []StrategyConfig{
-		sc,
-		{ID: "hl-rmc", Platform: "hyperliquid", Type: "perps",
-			CapitalPct: 0.5, Capital: 500, Leverage: 20,
-			Args: []string{"rsi_macd", "ETH", "1h", "--mode=live"}},
-	}
-	assist := &PlatformRiskAssist{
-		HLPositions: []HLPosition{{Coin: "ETH", Size: 0.517, EntryPrice: 3000}},
-		HLLiveAll:   hlLiveAll,
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := StrategyConfig{
+				ID: "hl-tema", Platform: "hyperliquid", Type: "perps",
+				CapitalPct: tc.capitalPct, Capital: 500, Leverage: 20,
+				Args: []string{"triple_ema", "ETH", "1h", "--mode=live"},
+			}
+			hlLiveAll := []StrategyConfig{sc}
+			if tc.withPeer {
+				hlLiveAll = append(hlLiveAll, peer)
+			}
+			assist := &PlatformRiskAssist{HLPositions: tc.hlPositions, HLLiveAll: hlLiveAll}
+			s := &StrategyState{
+				ID:       sc.ID,
+				Type:     "perps",
+				Platform: "hyperliquid",
+				Cash:     584.0,
+				RiskState: RiskState{
+					PeakValue:      589.0,
+					MaxDrawdownPct: 25.0,
+					DailyPnLDate:   todayUTC(),
+				},
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.236, AvgCost: 2357.0, Side: "long", Multiplier: 1, Leverage: 20},
+				},
+				OptionPositions: make(map[string]*OptionPosition),
+				TradeHistory:    []Trade{},
+			}
+			prices := map[string]float64{"ETH": 2307.5}
 
-	s := &StrategyState{
-		ID:       sc.ID,
-		Type:     "perps",
-		Platform: "hyperliquid",
-		Cash:     584.0,
-		RiskState: RiskState{
-			PeakValue:      589.0,
-			MaxDrawdownPct: 25.0,
-			DailyPnLDate:   todayUTC(),
-		},
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.236, AvgCost: 2357.0, Side: "long", Multiplier: 1, Leverage: 20},
-		},
-		OptionPositions: make(map[string]*OptionPosition),
-		TradeHistory:    []Trade{},
-	}
-	prices := map[string]float64{"ETH": 2307.5}
-	pv := PortfolioValue(s, prices)
+			allowed, _ := CheckRisk(&sc, s, PortfolioValue(s, prices), prices, nil, assist)
 
-	_, _ = CheckRisk(&sc, s, pv, prices, nil, assist)
-
-	if !s.RiskState.CircuitBreaker {
-		t.Fatal("expected circuit breaker to be active")
-	}
-	if p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid); p != nil {
-		t.Fatalf("expected no Hyperliquid pending close for shared coin; got %+v", p)
-	}
-	if _, ok := s.Positions["ETH"]; !ok {
-		t.Fatal("expected shared-coin virtual position to remain open")
-	}
-	if len(s.TradeHistory) != 0 {
-		t.Fatalf("expected no circuit-breaker close trade for shared coin; got %d", len(s.TradeHistory))
+			if allowed {
+				t.Fatal("expected risk block")
+			}
+			if !s.RiskState.CircuitBreaker {
+				t.Fatal("expected circuit breaker to be active")
+			}
+			p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
+			_, open := s.Positions["ETH"]
+			if tc.wantClose {
+				if p == nil || len(p.Symbols) != 1 || p.Symbols[0].Symbol != "ETH" {
+					t.Fatalf("expected Hyperliquid pending close for sole owner; got %+v", p)
+				}
+				if open {
+					t.Fatal("expected sole-owner virtual position to be force-closed")
+				}
+				if len(s.TradeHistory) != 1 {
+					t.Fatalf("expected one circuit-breaker close trade; got %d", len(s.TradeHistory))
+				}
+				return
+			}
+			if p != nil {
+				t.Fatalf("expected no Hyperliquid pending close for shared coin; got %+v", p)
+			}
+			if !open {
+				t.Fatal("expected shared-coin virtual position to remain open")
+			}
+			if len(s.TradeHistory) != 0 {
+				t.Fatalf("expected no circuit-breaker close trade for shared coin; got %d", len(s.TradeHistory))
+			}
+		})
 	}
 }
 
-func TestCheckRisk_LiveHLSharedCoin_PausesWithoutCloseWhenHLFetchFailed(t *testing.T) {
-	sc := StrategyConfig{
-		ID: "hl-tema", Platform: "hyperliquid", Type: "perps",
-		CapitalPct: 0.5, Capital: 500, Leverage: 20,
-		Args: []string{"triple_ema", "ETH", "1h", "--mode=live"},
+func TestCheckRisk_LiveTopStepCB_PendingFlatten(t *testing.T) {
+	cases := []struct {
+		name        string
+		withPeer    bool
+		tsSize      int
+		posQty      float64
+		wantPending bool
+		wantSize    float64
+	}{
+		{"sole peer sets pending full flatten", false, 3, 3, true, 3},
+		{"multi-peer contract sets no pending", true, 5, 2, false, 0},
 	}
-	assist := &PlatformRiskAssist{
-		HLLiveAll: []StrategyConfig{
-			sc,
-			{ID: "hl-rmc", Platform: "hyperliquid", Type: "perps",
-				CapitalPct: 0.5, Capital: 500, Leverage: 20,
-				Args: []string{"rsi_macd", "ETH", "1h", "--mode=live"}},
-		},
-	}
-	s := &StrategyState{
-		ID:       sc.ID,
-		Type:     "perps",
-		Platform: "hyperliquid",
-		Cash:     584.0,
-		RiskState: RiskState{
-			PeakValue:      589.0,
-			MaxDrawdownPct: 25.0,
-			DailyPnLDate:   todayUTC(),
-		},
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.236, AvgCost: 2357.0, Side: "long", Multiplier: 1, Leverage: 20},
-		},
-		OptionPositions: make(map[string]*OptionPosition),
-		TradeHistory:    []Trade{},
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := StrategyConfig{
+				ID: "ts-a", Platform: "topstep", Type: "futures",
+				Capital: 5000,
+				Args:    []string{"sma", "ES", "15m", "--mode=live"},
+			}
+			tsLiveAll := []StrategyConfig{sc}
+			if tc.withPeer {
+				tsLiveAll = append(tsLiveAll, StrategyConfig{ID: "ts-b", Platform: "topstep", Type: "futures",
+					Capital: 5000,
+					Args:    []string{"rsi", "ES", "15m", "--mode=live"}})
+			}
+			assist := &PlatformRiskAssist{
+				TSPositions: []TopStepPosition{{Coin: "ES", Size: tc.tsSize, Side: "long"}},
+				TSLiveAll:   tsLiveAll,
+			}
+			s := &StrategyState{
+				ID:   sc.ID,
+				Type: "futures",
+				Cash: 3000.0,
+				RiskState: RiskState{
+					PeakValue:      5000.0,
+					MaxDrawdownPct: 25.0,
+					DailyPnLDate:   todayUTC(),
+				},
+				Positions: map[string]*Position{
+					"ES": {Symbol: "ES", Quantity: tc.posQty, AvgCost: 5000, Side: "long", Multiplier: 50},
+				},
+				OptionPositions: make(map[string]*OptionPosition),
+			}
+			prices := map[string]float64{"ES": 4995}
 
-	allowed, _ := CheckRisk(&sc, s, PortfolioValue(s, map[string]float64{"ETH": 2307.5}), map[string]float64{"ETH": 2307.5}, nil, assist)
-
-	if allowed {
-		t.Fatal("expected risk block")
-	}
-	if p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid); p != nil {
-		t.Fatalf("expected no pending close without HL position snapshot for shared coin; got %+v", p)
-	}
-	if _, ok := s.Positions["ETH"]; !ok {
-		t.Fatal("expected virtual position to remain open when HL fetch failed")
-	}
-}
-
-func TestCheckRisk_LiveHLSoleOwner_StillForceCloses(t *testing.T) {
-	sc := StrategyConfig{
-		ID: "hl-tema", Platform: "hyperliquid", Type: "perps",
-		Capital: 500, Leverage: 20,
-		Args: []string{"triple_ema", "ETH", "1h", "--mode=live"},
-	}
-	assist := &PlatformRiskAssist{
-		HLPositions: []HLPosition{{Coin: "ETH", Size: 0.517, EntryPrice: 3000}},
-		HLLiveAll:   []StrategyConfig{sc},
-	}
-	s := &StrategyState{
-		ID:       sc.ID,
-		Type:     "perps",
-		Platform: "hyperliquid",
-		Cash:     584.0,
-		RiskState: RiskState{
-			PeakValue:      589.0,
-			MaxDrawdownPct: 25.0,
-			DailyPnLDate:   todayUTC(),
-		},
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.236, AvgCost: 2357.0, Side: "long", Multiplier: 1, Leverage: 20},
-		},
-		OptionPositions: make(map[string]*OptionPosition),
-		TradeHistory:    []Trade{},
-	}
-	prices := map[string]float64{"ETH": 2307.5}
-
-	allowed, _ := CheckRisk(&sc, s, PortfolioValue(s, prices), prices, nil, assist)
-
-	if allowed {
-		t.Fatal("expected risk block")
-	}
-	if p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseHyperliquid); p == nil || len(p.Symbols) != 1 || p.Symbols[0].Symbol != "ETH" {
-		t.Fatalf("expected Hyperliquid pending close for sole owner; got %+v", p)
-	}
-	if _, ok := s.Positions["ETH"]; ok {
-		t.Fatal("expected sole-owner virtual position to be force-closed")
-	}
-	if len(s.TradeHistory) != 1 {
-		t.Fatalf("expected one circuit-breaker close trade; got %d", len(s.TradeHistory))
-	}
-}
-
-func TestCheckRisk_LiveTopStepCB_SetsPendingFullFlatten(t *testing.T) {
-	sc := StrategyConfig{
-		ID: "ts-es", Platform: "topstep", Type: "futures",
-		Capital: 5000,
-		Args:    []string{"sma", "ES", "15m", "--mode=live"},
-	}
-	tsLiveAll := []StrategyConfig{sc}
-	assist := &PlatformRiskAssist{
-		TSPositions: []TopStepPosition{{Coin: "ES", Size: 3, Side: "long"}},
-		TSLiveAll:   tsLiveAll,
-	}
-
-	s := &StrategyState{
-		ID:   sc.ID,
-		Type: "futures",
-		Cash: 3000.0,
-		RiskState: RiskState{
-			PeakValue:      5000.0,
-			MaxDrawdownPct: 25.0,
-			DailyPnLDate:   todayUTC(),
-		},
-		Positions: map[string]*Position{
-			"ES": {Symbol: "ES", Quantity: 3, AvgCost: 5000, Side: "long", Multiplier: 50},
-		},
-		OptionPositions: make(map[string]*OptionPosition),
-	}
-	prices := map[string]float64{"ES": 4995}
-	pv := PortfolioValue(s, prices)
-
-	allowed, _ := CheckRisk(&sc, s, pv, prices, nil, assist)
-	if allowed {
-		t.Fatal("expected CB fire (drawdown exceeds 25%)")
-	}
-
-	p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep)
-	if p == nil {
-		t.Fatal("expected PendingCircuitCloses[topstep] after CB fire")
-	}
-	if len(p.Symbols) != 1 {
-		t.Fatalf("expected 1 pending symbol, got %d", len(p.Symbols))
-	}
-	c0 := p.Symbols[0]
-	if c0.Symbol != "ES" {
-		t.Errorf("symbol=%q want ES", c0.Symbol)
-	}
-	if c0.Size != 3 {
-		t.Errorf("pending size=%.0f want 3 (full flatten for sole peer)", c0.Size)
-	}
-}
-
-func TestCheckRisk_LiveTopStepCB_MultiPeerNoPending(t *testing.T) {
-	sc := StrategyConfig{
-		ID: "ts-a", Platform: "topstep", Type: "futures",
-		Capital: 5000,
-		Args:    []string{"sma", "ES", "15m", "--mode=live"},
-	}
-	tsLiveAll := []StrategyConfig{
-		sc,
-		{ID: "ts-b", Platform: "topstep", Type: "futures",
-			Capital: 5000,
-			Args:    []string{"rsi", "ES", "15m", "--mode=live"}},
-	}
-	assist := &PlatformRiskAssist{
-		TSPositions: []TopStepPosition{{Coin: "ES", Size: 5, Side: "long"}},
-		TSLiveAll:   tsLiveAll,
-	}
-
-	s := &StrategyState{
-		ID:   sc.ID,
-		Type: "futures",
-		Cash: 3000.0,
-		RiskState: RiskState{
-			PeakValue:      5000.0,
-			MaxDrawdownPct: 25.0,
-			DailyPnLDate:   todayUTC(),
-		},
-		Positions: map[string]*Position{
-			"ES": {Symbol: "ES", Quantity: 2, AvgCost: 5000, Side: "long", Multiplier: 50},
-		},
-		OptionPositions: make(map[string]*OptionPosition),
-	}
-	prices := map[string]float64{"ES": 4995}
-	pv := PortfolioValue(s, prices)
-
-	allowed, _ := CheckRisk(&sc, s, pv, prices, nil, assist)
-	if allowed {
-		t.Fatal("expected CB fire")
-	}
-
-	if s.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep) != nil {
-		t.Error("expected no pending TS entry for multi-peer contract")
-	}
-}
-
-func TestCheckRisk_PerpsMarginDrawdown_BelowThreshold(t *testing.T) {
-	s := &StrategyState{
-		Type: "perps",
-		Cash: 584.0,
-		RiskState: RiskState{
-			PeakValue:      589.0,
-			MaxDrawdownPct: 25.0,
-			DailyPnLDate:   todayUTC(),
-		},
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.236, AvgCost: 2357.0, Side: "long", Multiplier: 1, Leverage: 20},
-		},
-		OptionPositions: make(map[string]*OptionPosition),
-	}
-	prices := map[string]float64{"ETH": 2355.0}
-	pv := PortfolioValue(s, prices)
-	sc := &StrategyConfig{ID: "hl-test", Platform: "hyperliquid", Type: "perps", Leverage: 20}
-	allowed, reason := CheckRisk(sc, s, pv, prices, nil, nil)
-	if !allowed {
-		t.Errorf("expected allowed below margin drawdown threshold; reason=%s dd=%.2f",
-			reason, s.RiskState.CurrentDrawdownPct)
-	}
-	if s.RiskState.CurrentDrawdownPct >= 25 {
-		t.Errorf("expected drawdown < 25%%; got %.2f", s.RiskState.CurrentDrawdownPct)
-	}
-}
-
-func TestCheckRisk_PerpsPriorRealizedLossesDoNotInflateDrawdown(t *testing.T) {
-	s := &StrategyState{
-		Type: "perps",
-		Cash: 900.0,
-		RiskState: RiskState{
-			PeakValue:      1000.0,
-			MaxDrawdownPct: 25.0,
-			DailyPnLDate:   todayUTC(),
-		},
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.001, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 20},
-		},
-		OptionPositions: make(map[string]*OptionPosition),
-	}
-	prices := map[string]float64{"ETH": 3000}
-	pv := PortfolioValue(s, prices)
-	sc := &StrategyConfig{ID: "hl-test", Platform: "hyperliquid", Type: "perps", Leverage: 20}
-	allowed, reason := CheckRisk(sc, s, pv, prices, nil, nil)
-	if !allowed {
-		t.Errorf("expected fresh position with no unrealized PnL to NOT fire; reason=%s dd=%.2f",
-			reason, s.RiskState.CurrentDrawdownPct)
-	}
-	if s.RiskState.CurrentDrawdownPct > 0.001 {
-		t.Errorf("expected drawdown ≈ 0 (no unrealized loss on open position); got %.2f",
-			s.RiskState.CurrentDrawdownPct)
-	}
-	if len(s.Positions) != 1 {
-		t.Errorf("expected position to survive; got %d", len(s.Positions))
-	}
-}
-
-func TestCheckRisk_PerpsNoOpenPositions_FallsBackToPeak(t *testing.T) {
-	s := &StrategyState{
-		Type: "perps",
-		Cash: 700.0,
-		RiskState: RiskState{
-			PeakValue:      1000.0,
-			MaxDrawdownPct: 25.0,
-			DailyPnLDate:   todayUTC(),
-		},
-		Positions:       map[string]*Position{},
-		OptionPositions: make(map[string]*OptionPosition),
-	}
-	pv := PortfolioValue(s, nil)
-	allowed, _ := CheckRisk(nil, s, pv, nil, nil, nil)
-	if allowed {
-		t.Error("expected peak-relative drawdown to fire when no perps margin deployed")
-	}
-	if s.RiskState.CurrentDrawdownPct < 29 || s.RiskState.CurrentDrawdownPct > 31 {
-		t.Errorf("expected peak-relative drawdown ≈ 30%%; got %.2f", s.RiskState.CurrentDrawdownPct)
-	}
-}
-
-func TestCheckRisk_SpotUnchanged(t *testing.T) {
-	s := &StrategyState{
-		Type: "spot",
-		Cash: 500.0,
-		RiskState: RiskState{
-			PeakValue:      1000.0,
-			MaxDrawdownPct: 25.0,
-			DailyPnLDate:   todayUTC(),
-		},
-		Positions: map[string]*Position{
-			"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.01, AvgCost: 50000, Side: "long"},
-		},
-		OptionPositions: make(map[string]*OptionPosition),
-	}
-	prices := map[string]float64{"BTC/USDT": 30000}
-	pv := PortfolioValue(s, prices)
-	allowed, _ := CheckRisk(nil, s, pv, prices, nil, nil)
-	if !allowed {
-		t.Errorf("expected spot strategy to stay within 25%% peak drawdown; dd=%.2f",
-			s.RiskState.CurrentDrawdownPct)
-	}
-	if s.RiskState.CurrentDrawdownPct < 19.5 || s.RiskState.CurrentDrawdownPct > 20.5 {
-		t.Errorf("expected spot drawdown ≈ 20%% (peak-relative); got %.2f",
-			s.RiskState.CurrentDrawdownPct)
+			allowed, _ := CheckRisk(&sc, s, PortfolioValue(s, prices), prices, nil, assist)
+			if allowed {
+				t.Fatal("expected CB fire (drawdown exceeds 25%)")
+			}
+			p := s.RiskState.getPendingCircuitClose(PlatformPendingCloseTopStep)
+			if !tc.wantPending {
+				if p != nil {
+					t.Errorf("expected no pending TS entry for multi-peer contract; got %+v", p)
+				}
+				return
+			}
+			if p == nil {
+				t.Fatal("expected PendingCircuitCloses[topstep] after CB fire")
+			}
+			if len(p.Symbols) != 1 {
+				t.Fatalf("expected 1 pending symbol, got %d", len(p.Symbols))
+			}
+			if p.Symbols[0].Symbol != "ES" {
+				t.Errorf("symbol=%q want ES", p.Symbols[0].Symbol)
+			}
+			if p.Symbols[0].Size != tc.wantSize {
+				t.Errorf("pending size=%.0f want %.0f (full flatten for sole peer)", p.Symbols[0].Size, tc.wantSize)
+			}
+		})
 	}
 }
 
@@ -2211,61 +2037,67 @@ func TestCheckPortfolioRiskMissingPooledEquitySuppressesOnlyEquityArm(t *testing
 	}
 }
 
-func TestCheckPortfolioRisk_MixedAccount_SpotEquityStillHonored(t *testing.T) {
-	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
-	prs := &PortfolioRiskState{PeakValue: 10000}
+func TestCheckPortfolioRisk_LatchSource(t *testing.T) {
+	type pctRange struct{ lo, hi float64 }
+	cases := []struct {
+		name         string
+		peak         float64
+		totalValue   float64
+		perpsLoss    float64
+		perpsMargin  float64
+		wantSource   string
+		reasonMargin bool
+		equityDD     *pctRange
+		marginDD     *pctRange
+		eventDD      *pctRange
+	}{
+		{
+			name: "mixed account: spot equity drawdown still latches",
+			peak: 10000, totalValue: 7000, perpsLoss: 0, perpsMargin: 500,
+			wantSource: "equity",
+		},
+		{
+			name: "mixed account: equity governs when both breach",
+			peak: 10000, totalValue: 7000, perpsLoss: 600, perpsMargin: 1000,
+			wantSource: "equity",
+			equityDD:   &pctRange{29.9, 30.1}, marginDD: &pctRange{59.9, 60.1}, eventDD: &pctRange{29.9, 30.1},
+		},
+		{
+			name: "cold-start peak zero: margin can still fire",
+			peak: 0, totalValue: 0, perpsLoss: 500, perpsMargin: 1000,
+			wantSource: "margin", reasonMargin: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+			prs := &PortfolioRiskState{PeakValue: tc.peak}
 
-	totalValue := 7000.0
-	perpsLoss := 0.0
-	perpsMargin := 500.0
-
-	allowed, _, _, reason := CheckPortfolioRisk(prs, cfg, totalValue, 0, perpsLoss, perpsMargin)
-	if allowed {
-		t.Errorf("expected equity-drawdown kill switch to fire at 30%%; got allowed=true")
-	}
-	if !prs.KillSwitchActive {
-		t.Error("expected KillSwitchActive=true")
-	}
-	if strings.Contains(reason, "margin") {
-		t.Errorf("expected reason to reference equity drawdown, not margin; got %q", reason)
-	}
-	if len(prs.Events) != 1 || prs.Events[0].Source != "equity" {
-		t.Errorf("expected one triggered event with Source=equity; got %+v", prs.Events)
-	}
-}
-
-func TestCheckPortfolioRisk_MixedAccount_EquityGovernsWhenBothBreach(t *testing.T) {
-	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
-	prs := &PortfolioRiskState{PeakValue: 10000}
-
-	totalValue := 7000.0
-	perpsLoss := 600.0
-	perpsMargin := 1000.0
-
-	allowed, _, _, reason := CheckPortfolioRisk(prs, cfg, totalValue, 0, perpsLoss, perpsMargin)
-	if allowed {
-		t.Error("expected kill switch to fire on 30% equity drawdown")
-	}
-	if !prs.KillSwitchActive {
-		t.Error("expected KillSwitchActive=true")
-	}
-	if strings.Contains(reason, "margin") {
-		t.Errorf("expected the equity reason to drive the latch; got %q", reason)
-	}
-	if prs.CurrentDrawdownPct < 29.9 || prs.CurrentDrawdownPct > 30.1 {
-		t.Errorf("expected CurrentDrawdownPct (equity)≈30%%; got %.2f", prs.CurrentDrawdownPct)
-	}
-	if prs.CurrentMarginDrawdownPct < 59.9 || prs.CurrentMarginDrawdownPct > 60.1 {
-		t.Errorf("expected CurrentMarginDrawdownPct≈60%%; got %.2f", prs.CurrentMarginDrawdownPct)
-	}
-	if len(prs.Events) != 1 {
-		t.Fatalf("expected exactly one event; got %+v", prs.Events)
-	}
-	if prs.Events[0].Source != "equity" {
-		t.Errorf("expected triggered event Source=equity; got %q", prs.Events[0].Source)
-	}
-	if prs.Events[0].DrawdownPct < 29.9 || prs.Events[0].DrawdownPct > 30.1 {
-		t.Errorf("expected event DrawdownPct≈30%% (equity signal); got %.2f", prs.Events[0].DrawdownPct)
+			allowed, _, _, reason := CheckPortfolioRisk(prs, cfg, tc.totalValue, 0, tc.perpsLoss, tc.perpsMargin)
+			if allowed {
+				t.Errorf("expected kill switch to fire; got allowed=true reason=%q", reason)
+			}
+			if !prs.KillSwitchActive {
+				t.Error("expected KillSwitchActive=true")
+			}
+			if strings.Contains(reason, "margin") != tc.reasonMargin {
+				t.Errorf("reason mentions margin = %v, want %v; got %q", !tc.reasonMargin, tc.reasonMargin, reason)
+			}
+			if len(prs.Events) != 1 {
+				t.Fatalf("expected exactly one event; got %+v", prs.Events)
+			}
+			if prs.Events[0].Source != tc.wantSource {
+				t.Errorf("triggered event Source = %q, want %q", prs.Events[0].Source, tc.wantSource)
+			}
+			check := func(label string, got float64, want *pctRange) {
+				if want != nil && (got < want.lo || got > want.hi) {
+					t.Errorf("%s = %.2f, want within [%.1f, %.1f]", label, got, want.lo, want.hi)
+				}
+			}
+			check("CurrentDrawdownPct", prs.CurrentDrawdownPct, tc.equityDD)
+			check("CurrentMarginDrawdownPct", prs.CurrentMarginDrawdownPct, tc.marginDD)
+			check("Events[0].DrawdownPct", prs.Events[0].DrawdownPct, tc.eventDD)
+		})
 	}
 }
 
@@ -2311,24 +2143,6 @@ func TestCheckPortfolioRisk_Incident1448_MarginTripAvertedWhenEquityHealthy(t *t
 	}
 	if prs.Events[0].DrawdownPct < 30.9 || prs.Events[0].DrawdownPct > 31.1 {
 		t.Errorf("expected event DrawdownPct≈31%% (equity signal); got %.2f", prs.Events[0].DrawdownPct)
-	}
-}
-
-func TestCheckPortfolioRisk_BothWarnMarginAboveLimit_ReasonNamesEquityGovernance(t *testing.T) {
-	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
-	prs := &PortfolioRiskState{PeakValue: 10000}
-
-	_, _, warning, reason := CheckPortfolioRisk(prs, cfg, 7800, 0, 400, 1000)
-	if !warning || prs.KillSwitchActive {
-		t.Fatalf("expected warning without latch; warning=%v active=%v reason=%q", warning, prs.KillSwitchActive, reason)
-	}
-	for _, want := range []string{"equity=", "margin=", "exceeds limit", "#1448"} {
-		if !strings.Contains(reason, want) {
-			t.Errorf("expected reason to contain %q; got %q", want, reason)
-		}
-	}
-	if strings.Contains(reason, "approaching") {
-		t.Errorf("margin is over the limit, not approaching it; got %q", reason)
 	}
 }
 
@@ -2436,124 +2250,72 @@ func TestCheckPortfolioRisk_NoPerps_EquityBehaviorUnchanged(t *testing.T) {
 	}
 }
 
-func TestCheckPortfolioRisk_MarginWarning(t *testing.T) {
-	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
-	prs := &PortfolioRiskState{PeakValue: 10000}
-
-	_, _, warning, reason := CheckPortfolioRisk(prs, cfg, 10000, 0, 210, 1000)
-	if !warning {
-		t.Errorf("expected warning=true at 21%% margin drawdown; reason=%q", reason)
-	}
-	if !strings.Contains(reason, "margin") {
-		t.Errorf("expected warning reason to reference margin; got %q", reason)
-	}
-	if prs.KillSwitchActive {
-		t.Error("expected kill switch NOT active (warning, not fire)")
-	}
-
-	_, _, warning, reason = CheckPortfolioRisk(prs, cfg, 10000, 0, 210, 1000)
-	if !warning {
-		t.Errorf("expected repeated warning=true while margin drawdown remains above threshold; reason=%q", reason)
-	}
-	if !strings.Contains(reason, "margin") {
-		t.Errorf("expected repeated warning reason to reference margin; got %q", reason)
-	}
-}
-
-func TestAggregatePerpsMarginInputs(t *testing.T) {
-	strategies := map[string]*StrategyState{
-		"hl-btc": {
-			Type: "perps",
-			Positions: map[string]*Position{
-				"BTC": {Symbol: "BTC", Quantity: 1, AvgCost: 40000, Side: "short", Multiplier: 1, Leverage: 10},
-			},
+func TestCheckPortfolioRisk_MarginWarningReasons(t *testing.T) {
+	cases := []struct {
+		name            string
+		totalValue      float64
+		perpsLoss       float64
+		perpsMargin     float64
+		cycles          int
+		wantWarning     bool
+		wantContains    []string
+		wantNotContains []string
+		marginDDLo      float64
+		marginDDHi      float64
+	}{
+		{
+			name:       "margin drawdown in warn band warns on every cycle without latch",
+			totalValue: 10000, perpsLoss: 210, perpsMargin: 1000, cycles: 2,
+			wantWarning: true, wantContains: []string{"margin"},
+			marginDDLo: 20.9, marginDDHi: 21.1,
 		},
-		"hl-eth": {
-			Type: "perps",
-			Positions: map[string]*Position{
-				"ETH": {Symbol: "ETH", Quantity: 10, AvgCost: 3000, Side: "long", Multiplier: 1, Leverage: 5},
-			},
+		{
+			name:       "margin drawdown below warn band populates the field without warning",
+			totalValue: 10000, perpsLoss: 100, perpsMargin: 1000, cycles: 1,
+			marginDDLo: 9.9, marginDDHi: 10.1,
 		},
-		"spot-sol": {
-			Type: "spot",
-			Positions: map[string]*Position{
-				"SOL/USDT": {Symbol: "SOL/USDT", Quantity: 100, AvgCost: 150, Side: "long"},
-			},
+		{
+			name:       "both signals in warn band name both",
+			totalValue: 7800, perpsLoss: 230, perpsMargin: 1000, cycles: 1,
+			wantWarning: true, wantContains: []string{"equity=", "margin="},
+			marginDDLo: 22.9, marginDDHi: 23.1,
 		},
-		"ts-es": {
-			Type: "futures",
-			Positions: map[string]*Position{
-				"ES": {Symbol: "ES", Quantity: 1, AvgCost: 5000, Side: "long", Multiplier: 50},
-			},
+		{
+			name:       "margin above limit while equity warns names equity governance (#1448)",
+			totalValue: 7800, perpsLoss: 400, perpsMargin: 1000, cycles: 1,
+			wantWarning:     true,
+			wantContains:    []string{"equity=", "margin=", "exceeds limit", "#1448"},
+			wantNotContains: []string{"approaching"},
+			marginDDLo:      39.9, marginDDHi: 40.1,
 		},
 	}
-	prices := map[string]float64{
-		"BTC":      42000,
-		"ETH":      3100,
-		"SOL/USDT": 200,
-		"ES":       5100,
-	}
-	configs := []StrategyConfig{
-		{ID: "hl-btc", Leverage: 10},
-		{ID: "hl-eth", Leverage: 5},
-	}
-
-	loss, margin := AggregatePerpsMarginInputs(strategies, configs, prices)
-
-	expectedLoss := 2000.0
-	expectedMargin := 10400.0
-	if loss < expectedLoss-0.01 || loss > expectedLoss+0.01 {
-		t.Errorf("expected loss=%.2f; got %.2f", expectedLoss, loss)
-	}
-	if margin < expectedMargin-0.01 || margin > expectedMargin+0.01 {
-		t.Errorf("expected margin=%.2f; got %.2f", expectedMargin, margin)
-	}
-}
-
-func TestAggregatePerpsMarginInputs_NoPerpsReturnsZero(t *testing.T) {
-	strategies := map[string]*StrategyState{
-		"spot-btc": {
-			Type: "spot",
-			Positions: map[string]*Position{
-				"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.5, AvgCost: 40000, Side: "long"},
-			},
-		},
-	}
-	loss, margin := AggregatePerpsMarginInputs(strategies, nil, map[string]float64{"BTC/USDT": 50000})
-	if loss != 0 || margin != 0 {
-		t.Errorf("expected (0, 0) for no perps; got (%.2f, %.2f)", loss, margin)
-	}
-}
-
-func TestCheckPortfolioRisk_PeakZero_MarginCanStillFire(t *testing.T) {
-	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
-	prs := &PortfolioRiskState{PeakValue: 0}
-
-	allowed, _, _, reason := CheckPortfolioRisk(prs, cfg, 0, 0, 500, 1000)
-	if allowed {
-		t.Errorf("expected cold-start margin drawdown to fire kill switch; got allowed=true, reason=%s", reason)
-	}
-	if !prs.KillSwitchActive {
-		t.Error("expected KillSwitchActive=true on cold-start margin blowup")
-	}
-	if !strings.Contains(reason, "margin") {
-		t.Errorf("expected margin-driven reason; got %q", reason)
-	}
-	if len(prs.Events) != 1 || prs.Events[0].Source != "margin" {
-		t.Errorf("expected one triggered event with Source=margin; got %+v", prs.Events)
-	}
-}
-
-func TestCheckPortfolioRisk_BothSignalsBreachWarn_ReasonIncludesBoth(t *testing.T) {
-	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
-	prs := &PortfolioRiskState{PeakValue: 10000}
-
-	_, _, warning, reason := CheckPortfolioRisk(prs, cfg, 7800, 0, 230, 1000)
-	if !warning {
-		t.Fatalf("expected warning=true; reason=%q", reason)
-	}
-	if !strings.Contains(reason, "equity=") || !strings.Contains(reason, "margin=") {
-		t.Errorf("expected reason to mention both equity= and margin=; got %q", reason)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
+			prs := &PortfolioRiskState{PeakValue: 10000}
+			for i := 0; i < tc.cycles; i++ {
+				allowed, _, warning, reason := CheckPortfolioRisk(prs, cfg, tc.totalValue, 0, tc.perpsLoss, tc.perpsMargin)
+				if !allowed || prs.KillSwitchActive {
+					t.Fatalf("cycle %d: expected no latch; allowed=%v active=%v reason=%q", i, allowed, prs.KillSwitchActive, reason)
+				}
+				if warning != tc.wantWarning {
+					t.Fatalf("cycle %d: warning = %v, want %v; reason=%q", i, warning, tc.wantWarning, reason)
+				}
+				for _, want := range tc.wantContains {
+					if !strings.Contains(reason, want) {
+						t.Errorf("cycle %d: expected reason to contain %q; got %q", i, want, reason)
+					}
+				}
+				for _, unwanted := range tc.wantNotContains {
+					if strings.Contains(reason, unwanted) {
+						t.Errorf("cycle %d: reason must not contain %q; got %q", i, unwanted, reason)
+					}
+				}
+			}
+			if prs.CurrentMarginDrawdownPct < tc.marginDDLo || prs.CurrentMarginDrawdownPct > tc.marginDDHi {
+				t.Errorf("CurrentMarginDrawdownPct = %.2f, want within [%.1f, %.1f]", prs.CurrentMarginDrawdownPct, tc.marginDDLo, tc.marginDDHi)
+			}
+		})
 	}
 }
 
@@ -2698,19 +2460,6 @@ func TestTruncateWarningField_UTF8Safe(t *testing.T) {
 	}
 }
 
-func TestCheckPortfolioRisk_MarginWarning_FieldsPopulated(t *testing.T) {
-	cfg := &PortfolioRiskConfig{MaxDrawdownPct: 25, WarnThresholdPct: 80}
-	prs := &PortfolioRiskState{PeakValue: 10000}
-
-	_, _, warning, _ := CheckPortfolioRisk(prs, cfg, 10000, 0, 100, 1000)
-	if warning {
-		t.Error("expected warning=false at 10%% margin drawdown")
-	}
-	if prs.CurrentMarginDrawdownPct < 9.9 || prs.CurrentMarginDrawdownPct > 10.1 {
-		t.Errorf("expected CurrentMarginDrawdownPct≈10%%; got %.2f", prs.CurrentMarginDrawdownPct)
-	}
-}
-
 func TestRiskState_PendingCircuitClose_Marshal_EmptyReturnsBlank(t *testing.T) {
 	cases := []struct {
 		name string
@@ -2734,64 +2483,107 @@ func TestRiskState_PendingCircuitClose_Marshal_EmptyReturnsBlank(t *testing.T) {
 	}
 }
 
-func TestRiskState_PendingCircuitClose_MarshalUnmarshalRoundTrip(t *testing.T) {
-	src := &RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
-		PlatformPendingCloseHyperliquid: {Symbols: []PendingCircuitCloseSymbol{
-			{Symbol: "ETH", Size: 0.2585},
-			{Symbol: "BTC", Size: 0.01},
+func TestRiskState_PendingCircuitClose_RoundTrip(t *testing.T) {
+	notifiedAt := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name    string
+		pending map[string]*PendingCircuitClose
+	}{
+		{"two symbols on one platform", map[string]*PendingCircuitClose{
+			PlatformPendingCloseHyperliquid: {Symbols: []PendingCircuitCloseSymbol{
+				{Symbol: "ETH", Size: 0.2585},
+				{Symbol: "BTC", Size: 0.01},
+			}},
 		}},
-	}}
-	blob := src.MarshalPendingCircuitClosesJSON()
-	if blob == "" {
-		t.Fatal("non-empty marshal expected")
+		{"multi platform", map[string]*PendingCircuitClose{
+			"hyperliquid": {Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}}},
+			"okx":         {Symbols: []PendingCircuitCloseSymbol{{Symbol: "BTC-USDT-SWAP", Size: 0.01}}},
+		}},
+		{"consecutive failures and last notified", map[string]*PendingCircuitClose{
+			PlatformPendingCloseHyperliquid: {
+				Symbols:             []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.25}},
+				ConsecutiveFailures: 7,
+				LastNotifiedAt:      notifiedAt,
+			},
+		}},
 	}
-
-	var dst RiskState
-	dst.UnmarshalPendingCircuitClosesJSON(blob)
-
-	got := dst.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
-	if got == nil || len(got.Symbols) != 2 {
-		t.Fatalf("round-trip missing entries: %+v", got)
-	}
-	byName := map[string]float64{}
-	for _, s := range got.Symbols {
-		byName[s.Symbol] = s.Size
-	}
-	if byName["ETH"] != 0.2585 || byName["BTC"] != 0.01 {
-		t.Errorf("round-trip sizes wrong: %+v", byName)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &RiskState{PendingCircuitCloses: tc.pending}
+			blob := src.MarshalPendingCircuitClosesJSON()
+			if blob == "" {
+				t.Fatal("non-empty marshal expected")
+			}
+			var dst RiskState
+			dst.UnmarshalPendingCircuitClosesJSON(blob)
+			for platform, want := range tc.pending {
+				got := dst.getPendingCircuitClose(platform)
+				if got == nil || len(got.Symbols) != len(want.Symbols) {
+					t.Fatalf("%s entry lost in round-trip: %+v", platform, got)
+				}
+				byName := map[string]float64{}
+				for _, s := range got.Symbols {
+					byName[s.Symbol] = s.Size
+				}
+				for _, s := range want.Symbols {
+					if byName[s.Symbol] != s.Size {
+						t.Errorf("%s size for %s = %g, want %g", platform, s.Symbol, byName[s.Symbol], s.Size)
+					}
+				}
+				if got.ConsecutiveFailures != want.ConsecutiveFailures {
+					t.Errorf("%s ConsecutiveFailures = %d, want %d", platform, got.ConsecutiveFailures, want.ConsecutiveFailures)
+				}
+				if !got.LastNotifiedAt.Equal(want.LastNotifiedAt) {
+					t.Errorf("%s LastNotifiedAt = %v, want %v", platform, got.LastNotifiedAt, want.LastNotifiedAt)
+				}
+			}
+		})
 	}
 }
 
-func TestRiskState_PendingCircuitClose_UnmarshalLegacyHL(t *testing.T) {
-	var r RiskState
-	r.UnmarshalPendingCircuitClosesJSON(`{"coins":[{"coin":"ETH","sz":0.2585}]}`)
-
-	p := r.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
-	if p == nil || len(p.Symbols) != 1 {
-		t.Fatalf("legacy JSON did not convert: %+v", p)
+func TestRiskState_PendingCircuitClose_Unmarshal(t *testing.T) {
+	seeded := func() RiskState {
+		return RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
+			PlatformPendingCloseHyperliquid: {Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 1}}},
+		}}
 	}
-	if p.Symbols[0].Symbol != "ETH" || p.Symbols[0].Size != 0.2585 {
-		t.Errorf("legacy conversion wrong: got symbol=%q size=%g", p.Symbols[0].Symbol, p.Symbols[0].Size)
+	cases := []struct {
+		name       string
+		start      RiskState
+		blob       string
+		wantNilMap bool
+		wantSymbol string
+		wantSize   float64
+	}{
+		{"legacy hl coins shape converts", RiskState{}, `{"coins":[{"coin":"ETH","sz":0.2585}]}`, false, "ETH", 0.2585},
+		{"legacy row defaults zero consecutive failures", RiskState{}, `{"hyperliquid":{"symbols":[{"symbol":"ETH","size":0.25}]}}`, false, "ETH", 0.25},
+		{"empty blob clears", seeded(), "", true, "", 0},
+		{"malformed blob clears", seeded(), `not-json{`, true, "", 0},
 	}
-}
-
-func TestRiskState_PendingCircuitClose_UnmarshalEmptyClears(t *testing.T) {
-	r := RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
-		PlatformPendingCloseHyperliquid: {Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 1}}},
-	}}
-	r.UnmarshalPendingCircuitClosesJSON("")
-	if r.PendingCircuitCloses != nil {
-		t.Errorf("expected nil map after empty unmarshal; got %+v", r.PendingCircuitCloses)
-	}
-}
-
-func TestRiskState_PendingCircuitClose_UnmarshalMalformedClears(t *testing.T) {
-	r := RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
-		PlatformPendingCloseHyperliquid: {Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 1}}},
-	}}
-	r.UnmarshalPendingCircuitClosesJSON(`not-json{`)
-	if r.PendingCircuitCloses != nil {
-		t.Errorf("expected nil map after malformed unmarshal; got %+v", r.PendingCircuitCloses)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.start
+			r.UnmarshalPendingCircuitClosesJSON(tc.blob)
+			if tc.wantNilMap {
+				if r.PendingCircuitCloses != nil {
+					t.Errorf("expected nil map after unmarshal; got %+v", r.PendingCircuitCloses)
+				}
+				return
+			}
+			p := r.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
+			if p == nil || len(p.Symbols) != 1 {
+				t.Fatalf("entry not loaded: %+v", p)
+			}
+			if p.Symbols[0].Symbol != tc.wantSymbol || p.Symbols[0].Size != tc.wantSize {
+				t.Errorf("got symbol=%q size=%g, want %q/%g", p.Symbols[0].Symbol, p.Symbols[0].Size, tc.wantSymbol, tc.wantSize)
+			}
+			if p.ConsecutiveFailures != 0 {
+				t.Errorf("legacy row must default ConsecutiveFailures=0, got %d", p.ConsecutiveFailures)
+			}
+			if !p.LastNotifiedAt.IsZero() {
+				t.Errorf("legacy row must default LastNotifiedAt=zero, got %v", p.LastNotifiedAt)
+			}
+		})
 	}
 }
 
@@ -2820,49 +2612,6 @@ func TestRiskState_PendingCircuitClose_SetClearGet(t *testing.T) {
 	r.clearPendingCircuitClose("hyperliquid")
 }
 
-func TestRiskState_PendingCircuitClose_MultiPlatformRoundTrip(t *testing.T) {
-	src := &RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
-		"hyperliquid": {Symbols: []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.1}}},
-		"okx":         {Symbols: []PendingCircuitCloseSymbol{{Symbol: "BTC-USDT-SWAP", Size: 0.01}}},
-	}}
-	blob := src.MarshalPendingCircuitClosesJSON()
-	var dst RiskState
-	dst.UnmarshalPendingCircuitClosesJSON(blob)
-	if dst.getPendingCircuitClose("hyperliquid") == nil {
-		t.Error("hyperliquid entry lost in round-trip")
-	}
-	if dst.getPendingCircuitClose("okx") == nil {
-		t.Error("okx entry lost in round-trip")
-	}
-}
-
-func TestRiskState_PendingCircuitClose_ConsecutiveFailureserRoundTrip(t *testing.T) {
-	notifiedAt := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
-	src := &RiskState{PendingCircuitCloses: map[string]*PendingCircuitClose{
-		PlatformPendingCloseHyperliquid: {
-			Symbols:             []PendingCircuitCloseSymbol{{Symbol: "ETH", Size: 0.25}},
-			ConsecutiveFailures: 7,
-			LastNotifiedAt:      notifiedAt,
-		},
-	}}
-	blob := src.MarshalPendingCircuitClosesJSON()
-	if blob == "" {
-		t.Fatal("expected non-empty JSON blob")
-	}
-	var dst RiskState
-	dst.UnmarshalPendingCircuitClosesJSON(blob)
-	got := dst.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
-	if got == nil {
-		t.Fatal("entry lost in round-trip")
-	}
-	if got.ConsecutiveFailures != 7 {
-		t.Errorf("ConsecutiveFailures: got %d, want 7", got.ConsecutiveFailures)
-	}
-	if !got.LastNotifiedAt.Equal(notifiedAt) {
-		t.Errorf("LastNotifiedAt: got %v, want %v", got.LastNotifiedAt, notifiedAt)
-	}
-}
-
 func TestCheckRisk_ManualStrategyAlwaysAllowed(t *testing.T) {
 	sc := &StrategyConfig{ID: "hl-manual-eth-live", Type: "manual", Platform: "hyperliquid", Symbol: "ETH", Leverage: 10}
 	s := &StrategyState{Type: "manual", RiskState: RiskState{PeakValue: 100, MaxDrawdownPct: 60}}
@@ -2875,21 +2624,6 @@ func TestCheckRisk_ManualStrategyAlwaysAllowed(t *testing.T) {
 	}
 	if s.RiskState.CircuitBreaker {
 		t.Error("CheckRisk must not set CircuitBreaker for manual strategy")
-	}
-}
-
-func TestRiskState_PendingCircuitClose_LegacyShapeDefaultsZeroConsecutiveFailures(t *testing.T) {
-	var r RiskState
-	r.UnmarshalPendingCircuitClosesJSON(`{"hyperliquid":{"symbols":[{"symbol":"ETH","size":0.25}]}}`)
-	got := r.getPendingCircuitClose(PlatformPendingCloseHyperliquid)
-	if got == nil {
-		t.Fatal("entry not loaded")
-	}
-	if got.ConsecutiveFailures != 0 {
-		t.Errorf("legacy row must default ConsecutiveFailures=0, got %d", got.ConsecutiveFailures)
-	}
-	if !got.LastNotifiedAt.IsZero() {
-		t.Errorf("legacy row must default LastNotifiedAt=zero, got %v", got.LastNotifiedAt)
 	}
 }
 
@@ -2968,37 +2702,42 @@ func TestFormatPerStrategyCircuitBreakerBlock_IncludesTriageSections(t *testing.
 	}
 }
 
-func TestCircuitBreakerStrategyLabel_SkipsFlagTimeframe(t *testing.T) {
-	sc := StrategyConfig{
-		ID:       "deribit-btc-options",
-		Type:     "options",
-		Platform: "deribit",
-		Args:     []string{"wheel", "BTC", "--platform=deribit"},
+func TestCircuitBreakerStrategyLabel(t *testing.T) {
+	cases := []struct {
+		name            string
+		sc              StrategyConfig
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name: "skips flag as timeframe",
+			sc: StrategyConfig{ID: "deribit-btc-options", Type: "options", Platform: "deribit",
+				Args: []string{"wheel", "BTC", "--platform=deribit"}},
+			wantContains:    []string{"Deribit", "BTC", "wheel", "options"},
+			wantNotContains: []string{"--platform=deribit"},
+		},
+		{
+			name: "strips spot quote suffix",
+			sc: StrategyConfig{ID: "spot-btc", Type: "spot", Platform: "binanceus",
+				Args: []string{"sma_cross", "BTC/USDT", "30m"}},
+			wantContains:    []string{"BinanceUS, BTC, 30m, sma_cross, spot"},
+			wantNotContains: []string{"BTC/USDT"},
+		},
 	}
-	got := circuitBreakerStrategyLabel(sc)
-	if strings.Contains(got, "--platform=deribit") {
-		t.Fatalf("strategy label rendered flag as timeframe: %q", got)
-	}
-	for _, want := range []string{"Deribit", "BTC", "wheel", "options"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("strategy label missing %q: %q", want, got)
-		}
-	}
-}
-
-func TestCircuitBreakerStrategyLabel_StripsSpotQuoteSuffix(t *testing.T) {
-	sc := StrategyConfig{
-		ID:       "spot-btc",
-		Type:     "spot",
-		Platform: "binanceus",
-		Args:     []string{"sma_cross", "BTC/USDT", "30m"},
-	}
-	got := circuitBreakerStrategyLabel(sc)
-	if !strings.Contains(got, "BinanceUS, BTC, 30m, sma_cross, spot") {
-		t.Fatalf("strategy label = %q, want normalized BTC asset", got)
-	}
-	if strings.Contains(got, "BTC/USDT") {
-		t.Fatalf("strategy label should not render raw spot pair: %q", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := circuitBreakerStrategyLabel(tc.sc)
+			for _, want := range tc.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("strategy label missing %q: %q", want, got)
+				}
+			}
+			for _, unwanted := range tc.wantNotContains {
+				if strings.Contains(got, unwanted) {
+					t.Errorf("strategy label must not contain %q: %q", unwanted, got)
+				}
+			}
+		})
 	}
 }
 
@@ -3281,193 +3020,168 @@ func TestCheckRisk_CircuitBreakerDisabled_ThrottleClearsWhenBreachClears(t *test
 	}
 }
 
-func TestCollectPerpsMarkSymbols_IncludesManualHyperliquid(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "manual-hl-eth", Type: "manual", Platform: "hyperliquid", Symbol: "ETH",
-			Args: []string{"hold", "WRONGCOIN", "1h", "--mode=live"}},
-		{ID: "manual-hl-hype", Type: "manual", Platform: "hyperliquid", Symbol: "HYPE",
-			Args: []string{"hold", "HYPE", "1h", "--mode=paper"}},
-		{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
-		{ID: "manual-hl-btc", Type: "manual", Platform: "hyperliquid", Symbol: "BTC",
-			Args: []string{"hold", "BTC", "1h", "--mode=live"}},
-		{ID: "manual-okx-sol", Type: "manual", Platform: "okx", Symbol: "SOL",
-			Args: []string{"hold", "SOL", "1h", "--mode=live"}},
-		{ID: "manual-hl-empty", Type: "manual", Platform: "hyperliquid", Symbol: "",
-			Args: []string{"hold", "DOGE", "1h", "--mode=live"}},
-	}
-
-	hlCoins, okxCoins := collectPerpsMarkSymbols(strategies)
-
-	wantHL := []string{"BTC", "ETH", "HYPE"}
-	if len(hlCoins) != len(wantHL) {
-		t.Fatalf("hlCoins = %v, want %v", hlCoins, wantHL)
-	}
-	for i, c := range wantHL {
-		if hlCoins[i] != c {
-			t.Errorf("hlCoins[%d] = %q, want %q", i, hlCoins[i], c)
-		}
-	}
-	if len(okxCoins) != 0 {
-		t.Errorf("okxCoins = %v, want empty (manual is hyperliquid-only)", okxCoins)
-	}
-}
-
-func TestCollectFuturesMarkSymbols_IgnoresManual(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "manual-hl-eth", Type: "manual", Platform: "hyperliquid", Symbol: "ETH",
-			Args: []string{"hold", "ETH", "1h", "--mode=live"}},
-		{ID: "ts-trend-es", Type: "futures", Platform: "topstep", Args: []string{"trend", "ES", "1h"}},
-	}
-	syms := collectFuturesMarkSymbols(strategies)
-	if len(syms) != 1 || syms[0] != "ES" {
-		t.Errorf("collectFuturesMarkSymbols = %v, want [ES]", syms)
-	}
-}
-
 func TestCollectMissingMarkPositions(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "manual-hl-eth", Type: "manual", Platform: "hyperliquid", Symbol: "ETH",
-			Args: []string{"hold", "ETH", "1h", "--mode=live"}},
-		{ID: "manual-hl-record", Type: "manual", Platform: "hyperliquid", Symbol: "HYPE",
-			Args: []string{"hold", "HYPE", "1h", "--mode=paper"}},
-		{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
-		{ID: "hl-trend-sol", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "SOL", "1h"}},
-		{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
-		{ID: "deribit-vol-btc", Type: "options", Platform: "deribit", Args: []string{"vol", "BTC"}},
-		{ID: "flat-strategy", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "DOGE", "1h"}},
-		{ID: "not-in-state", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "AVAX", "1h"}},
-	}
-	openSymbols := map[string][]string{
-		"manual-hl-eth":    {"ETH"},
-		"manual-hl-record": {"HYPE"},
-		"hl-trend-btc":     {"BTC"},
-		"hl-trend-sol":     {"SOL"},
-		"sma-btc":          {"BTC/USDT"},
-		"deribit-vol-btc":  {"BTC-PERP"},
-		"flat-strategy":    {},
-	}
-	prices := map[string]float64{
-		"BTC":      67500.0,
-		"BTC/USDT": 67510.0,
-		"ETH":      0,
-	}
-
-	got := collectMissingMarkPositions(strategies, openSymbols, prices)
-	want := []missingMarkPosition{
-		{StrategyID: "manual-hl-eth", Symbol: "ETH", Live: true},
-		{StrategyID: "manual-hl-record", Symbol: "HYPE", Live: false},
-		{StrategyID: "hl-trend-sol", Symbol: "SOL", Live: false},
-	}
-	if len(got) != len(want) {
-		t.Fatalf("collectMissingMarkPositions = %+v, want %+v", got, want)
-	}
-	for i := range want {
-		if got[i].StrategyID != want[i].StrategyID || got[i].Symbol != want[i].Symbol || got[i].Live != want[i].Live {
-			t.Errorf("[%d] = %+v, want %+v", i, got[i], want[i])
+	hlPerps := func(id, coin string, mode string) StrategyConfig {
+		args := []string{"trend", coin, "1h"}
+		if mode != "" {
+			args = append(args, "--mode="+mode)
 		}
+		return StrategyConfig{ID: id, Type: "perps", Platform: "hyperliquid", Args: args}
+	}
+	hlManual := func(id, coin, mode string) StrategyConfig {
+		return StrategyConfig{ID: id, Type: "manual", Platform: "hyperliquid", Symbol: coin,
+			Args: []string{"hold", coin, "1h", "--mode=" + mode}}
+	}
+	type miss struct {
+		strategyID, symbol string
+		live               bool
+		platform, typ      string
+		disabledManagers   int
+	}
+	cases := []struct {
+		name        string
+		strategies  []StrategyConfig
+		openSymbols map[string][]string
+		prices      map[string]float64
+		want        []miss
+	}{
+		{
+			name: "mixed book reports only mark-less HL perps and manual positions",
+			strategies: []StrategyConfig{
+				hlManual("manual-hl-eth", "ETH", "live"),
+				hlManual("manual-hl-record", "HYPE", "paper"),
+				hlPerps("hl-trend-btc", "BTC", ""),
+				hlPerps("hl-trend-sol", "SOL", ""),
+				{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
+				{ID: "deribit-vol-btc", Type: "options", Platform: "deribit", Args: []string{"vol", "BTC"}},
+				hlPerps("flat-strategy", "DOGE", ""),
+				hlPerps("not-in-state", "AVAX", ""),
+			},
+			openSymbols: map[string][]string{
+				"manual-hl-eth":    {"ETH"},
+				"manual-hl-record": {"HYPE"},
+				"hl-trend-btc":     {"BTC"},
+				"hl-trend-sol":     {"SOL"},
+				"sma-btc":          {"BTC/USDT"},
+				"deribit-vol-btc":  {"BTC-PERP"},
+				"flat-strategy":    {},
+			},
+			prices: map[string]float64{"BTC": 67500.0, "BTC/USDT": 67510.0, "ETH": 0},
+			want: []miss{
+				{"manual-hl-eth", "ETH", true, "hyperliquid", "manual", 2},
+				{"manual-hl-record", "HYPE", false, "hyperliquid", "manual", 2},
+				{"hl-trend-sol", "SOL", false, "hyperliquid", "perps", 2},
+			},
+		},
+		{
+			name:        "symbols sorted per strategy",
+			strategies:  []StrategyConfig{hlPerps("hl-trend-btc", "BTC", "")},
+			openSymbols: map[string][]string{"hl-trend-btc": {"SOL", "BTC", "ETH"}},
+			prices:      map[string]float64{},
+			want: []miss{
+				{"hl-trend-btc", "BTC", false, "hyperliquid", "perps", 2},
+				{"hl-trend-btc", "ETH", false, "hyperliquid", "perps", 2},
+				{"hl-trend-btc", "SOL", false, "hyperliquid", "perps", 2},
+			},
+		},
+		{
+			name:       "no open positions",
+			strategies: []StrategyConfig{hlPerps("hl-trend-btc", "BTC", "")},
+		},
+		{
+			name:        "live flag drives escalation",
+			strategies:  []StrategyConfig{hlPerps("hl-live", "BTC", "live"), hlPerps("hl-paper", "SOL", "paper")},
+			openSymbols: map[string][]string{"hl-live": {"BTC"}, "hl-paper": {"SOL"}},
+			prices:      map[string]float64{},
+			want: []miss{
+				{"hl-live", "BTC", true, "hyperliquid", "perps", 2},
+				{"hl-paper", "SOL", false, "hyperliquid", "perps", 2},
+			},
+		},
+		{
+			name:        "record-only manual position under a non-config symbol",
+			strategies:  []StrategyConfig{hlManual("manual-hl", "ETH", "live")},
+			openSymbols: map[string][]string{"manual-hl": {"HYPE"}},
+			prices:      map[string]float64{"ETH": 3400},
+			want:        []miss{{"manual-hl", "HYPE", true, "hyperliquid", "manual", 2}},
+		},
+		{
+			name:        "flat record-only manual is silent",
+			strategies:  []StrategyConfig{hlManual("manual-hl-record", "HYPE", "paper")},
+			openSymbols: map[string][]string{"manual-hl-record": {}},
+		},
+		{
+			name: "carries the venue management surface",
+			strategies: []StrategyConfig{
+				hlPerps("hl-live-btc", "BTC", "live"),
+				{ID: "sma-eth", Type: "spot", Platform: "binanceus", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
+			},
+			openSymbols: map[string][]string{"hl-live-btc": {"BTC"}, "sma-eth": {"ETH"}},
+			prices:      map[string]float64{},
+			want: []miss{
+				{"hl-live-btc", "BTC", true, "hyperliquid", "perps", 2},
+				{"sma-eth", "ETH", true, "binanceus", "spot", 0},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectMissingMarkPositions(tc.strategies, tc.openSymbols, tc.prices)
+			if len(got) != len(tc.want) {
+				t.Fatalf("collectMissingMarkPositions = %+v, want %+v", got, tc.want)
+			}
+			for i, want := range tc.want {
+				g := got[i]
+				if g.StrategyID != want.strategyID || g.Symbol != want.symbol || g.Live != want.live ||
+					g.Platform != want.platform || g.Type != want.typ || len(g.DisabledManagers) != want.disabledManagers {
+					t.Errorf("[%d] = %+v, want %+v", i, g, want)
+				}
+			}
+		})
 	}
 }
 
-func TestCollectMissingMarkPositions_SortsSymbolsPerStrategy(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
+func TestManualOnlyMarkSymbols(t *testing.T) {
+	cases := []struct {
+		name       string
+		strategies []StrategyConfig
+		want       []string
+	}{
+		{
+			name: "excludes coins donated by perps rails",
+			strategies: []StrategyConfig{
+				{ID: "manual-hype", Type: "manual", Platform: "hyperliquid", Symbol: "HYPE",
+					Args: []string{"hold", "HYPE", "1h", "--mode=live"}},
+				{ID: "manual-btc", Type: "manual", Platform: "hyperliquid", Symbol: "BTC",
+					Args: []string{"hold", "BTC", "1h", "--mode=live"}},
+				{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
+				{ID: "manual-sol", Type: "manual", Platform: "hyperliquid", Symbol: "SOL",
+					Args: []string{"hold", "SOL", "1h", "--mode=live"}},
+				{ID: "okx-trend-sol", Type: "perps", Platform: "okx", Args: []string{"trend", "SOL", "1h"}},
+				{ID: "manual-okx", Type: "manual", Platform: "okx", Symbol: "DOGE",
+					Args: []string{"hold", "DOGE", "1h", "--mode=live"}},
+			},
+			want: []string{"HYPE"},
+		},
+		{
+			name: "no manual strategies",
+			strategies: []StrategyConfig{
+				{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
+			},
+		},
 	}
-	openSymbols := map[string][]string{"hl-trend-btc": {"SOL", "BTC", "ETH"}}
-	got := collectMissingMarkPositions(strategies, openSymbols, map[string]float64{})
-	want := []string{"BTC", "ETH", "SOL"}
-	if len(got) != len(want) {
-		t.Fatalf("got %+v, want %d entries", got, len(want))
-	}
-	for i, sym := range want {
-		if got[i].Symbol != sym {
-			t.Errorf("[%d].Symbol = %q, want %q", i, got[i].Symbol, sym)
-		}
-	}
-}
-
-func TestCollectMissingMarkPositions_NoOpenPositions(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
-	}
-	if got := collectMissingMarkPositions(strategies, nil, nil); len(got) != 0 {
-		t.Errorf("collectMissingMarkPositions = %+v, want empty", got)
-	}
-}
-
-func TestCollectMissingMarkPositions_LiveFlagDrivesEscalation(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "hl-live", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h", "--mode=live"}},
-		{ID: "hl-paper", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "SOL", "1h", "--mode=paper"}},
-	}
-	openSymbols := map[string][]string{"hl-live": {"BTC"}, "hl-paper": {"SOL"}}
-	got := collectMissingMarkPositions(strategies, openSymbols, map[string]float64{})
-	if len(got) != 2 {
-		t.Fatalf("collectMissingMarkPositions = %+v, want 2 entries", got)
-	}
-	if !got[0].Live {
-		t.Errorf("live strategy entry %+v: Live = false, want true", got[0])
-	}
-	if got[1].Live {
-		t.Errorf("paper strategy entry %+v: Live = true, want false", got[1])
-	}
-}
-
-func TestCollectMissingMarkPositions_RecordOnlyManualUnderNonSCSymbol(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "manual-hl", Type: "manual", Platform: "hyperliquid", Symbol: "ETH",
-			Args: []string{"hold", "ETH", "1h", "--mode=live"}},
-	}
-	openSymbols := map[string][]string{"manual-hl": {"HYPE"}}
-	got := collectMissingMarkPositions(strategies, openSymbols, map[string]float64{"ETH": 3400})
-	if len(got) != 1 || got[0].Symbol != "HYPE" {
-		t.Fatalf("collectMissingMarkPositions = %+v, want one HYPE miss", got)
-	}
-	if !got[0].Live {
-		t.Errorf("live manual miss %+v: Live = false, want true", got[0])
-	}
-}
-
-func TestCollectMissingMarkPositions_FlatRecordOnlyManualSilent(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "manual-hl-record", Type: "manual", Platform: "hyperliquid", Symbol: "HYPE",
-			Args: []string{"hold", "HYPE", "1h", "--mode=paper"}},
-	}
-	if got := collectMissingMarkPositions(strategies, map[string][]string{"manual-hl-record": {}}, nil); len(got) != 0 {
-		t.Errorf("collectMissingMarkPositions = %+v, want empty", got)
-	}
-}
-
-func TestManualOnlyMarkSymbols_ExcludesPreExistingDonors(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "manual-hype", Type: "manual", Platform: "hyperliquid", Symbol: "HYPE",
-			Args: []string{"hold", "HYPE", "1h", "--mode=live"}},
-		{ID: "manual-btc", Type: "manual", Platform: "hyperliquid", Symbol: "BTC",
-			Args: []string{"hold", "BTC", "1h", "--mode=live"}},
-		{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
-		{ID: "manual-sol", Type: "manual", Platform: "hyperliquid", Symbol: "SOL",
-			Args: []string{"hold", "SOL", "1h", "--mode=live"}},
-		{ID: "okx-trend-sol", Type: "perps", Platform: "okx", Args: []string{"trend", "SOL", "1h"}},
-		{ID: "manual-okx", Type: "manual", Platform: "okx", Symbol: "DOGE",
-			Args: []string{"hold", "DOGE", "1h", "--mode=live"}},
-	}
-	got := manualOnlyMarkSymbols(strategies)
-	want := []string{"HYPE"}
-	if len(got) != len(want) {
-		t.Fatalf("manualOnlyMarkSymbols = %v, want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
-		}
-	}
-}
-
-func TestManualOnlyMarkSymbols_NoManualStrategies(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
-	}
-	if got := manualOnlyMarkSymbols(strategies); len(got) != 0 {
-		t.Errorf("manualOnlyMarkSymbols = %v, want empty", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := manualOnlyMarkSymbols(tc.strategies)
+			if len(got) != len(tc.want) {
+				t.Fatalf("manualOnlyMarkSymbols = %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
 	}
 }
 
@@ -3559,76 +3273,72 @@ func TestSnapshotOpenSymbolsByStrategy(t *testing.T) {
 	}
 }
 
-func TestMissingManualOnlyMarks_IgnoresNonManualOutage(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "manual-hl-hype", Type: "manual", Platform: "hyperliquid", Symbol: "HYPE",
-			Args: []string{"hold", "HYPE", "1h", "--mode=live"}},
-		{ID: "ts-es", Type: "futures", Platform: "topstep", Args: []string{"trend", "ES", "1h"}},
-		{ID: "okx-sol", Type: "perps", Platform: "okx", Args: []string{"trend", "SOL", "1h"}},
-		{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
+func TestMissingManualOnlyMarks(t *testing.T) {
+	manual := func(id, coin string) StrategyConfig {
+		return StrategyConfig{ID: id, Type: "manual", Platform: "hyperliquid", Symbol: coin,
+			Args: []string{"hold", coin, "1h", "--mode=live"}}
 	}
-	openSymbols := map[string][]string{
-		"manual-hl-hype": {"HYPE"},
-		"ts-es":          {"ES"},
-		"okx-sol":        {"SOL"},
-		"sma-btc":        {"BTC/USDT"},
+	cases := []struct {
+		name        string
+		strategies  []StrategyConfig
+		openSymbols map[string][]string
+		prices      map[string]float64
+		want        []string
+	}{
+		{
+			name: "non-manual outages cancel out of the delta and never defer",
+			strategies: []StrategyConfig{
+				manual("manual-hl-hype", "HYPE"),
+				{ID: "ts-es", Type: "futures", Platform: "topstep", Args: []string{"trend", "ES", "1h"}},
+				{ID: "okx-sol", Type: "perps", Platform: "okx", Args: []string{"trend", "SOL", "1h"}},
+				{ID: "sma-btc", Type: "spot", Platform: "binanceus", Args: []string{"sma", "BTC/USDT", "1h"}},
+			},
+			openSymbols: map[string][]string{"manual-hl-hype": {"HYPE"}, "ts-es": {"ES"}, "okx-sol": {"SOL"}, "sma-btc": {"BTC/USDT"}},
+			prices:      map[string]float64{"HYPE": 42.0},
+		},
+		{
+			name:        "manual-only outage defers, sorted",
+			strategies:  []StrategyConfig{manual("manual-hl-hype", "HYPE"), manual("manual-hl-eth", "ETH")},
+			openSymbols: map[string][]string{"manual-hl-hype": {"HYPE"}, "manual-hl-eth": {"ETH"}},
+			prices:      map[string]float64{"ETH": 0},
+			want:        []string{"ETH", "HYPE"},
+		},
+		{
+			name: "no manual-only coin runs immediately",
+			strategies: []StrategyConfig{
+				{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
+				{ID: "sma-eth", Type: "spot", Platform: "binanceus", Args: []string{"sma", "ETH", "1h"}},
+			},
+			openSymbols: map[string][]string{"hl-trend-btc": {"BTC"}, "sma-eth": {"ETH"}},
+			prices:      map[string]float64{},
+		},
+		{
+			name: "donor coin never gates",
+			strategies: []StrategyConfig{
+				manual("manual-hl-btc", "BTC"),
+				{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
+			},
+			openSymbols: map[string][]string{"manual-hl-btc": {"BTC"}},
+			prices:      map[string]float64{},
+		},
+		{
+			name:        "unheld manual coin never gates",
+			strategies:  []StrategyConfig{manual("manual-hl-hype", "HYPE")},
+			openSymbols: map[string][]string{"manual-hl-hype": {}},
+		},
 	}
-	prices := map[string]float64{"HYPE": 42.0}
-	if got := missingManualOnlyMarks(strategies, openSymbols, prices); len(got) != 0 {
-		t.Errorf("missingManualOnlyMarks = %v, want empty — non-manual misses cancel out of the delta and must not defer the migration", got)
-	}
-}
-
-func TestMissingManualOnlyMarks_DefersOnManualOutage(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "manual-hl-hype", Type: "manual", Platform: "hyperliquid", Symbol: "HYPE",
-			Args: []string{"hold", "HYPE", "1h", "--mode=live"}},
-		{ID: "manual-hl-eth", Type: "manual", Platform: "hyperliquid", Symbol: "ETH",
-			Args: []string{"hold", "ETH", "1h", "--mode=live"}},
-	}
-	openSymbols := map[string][]string{"manual-hl-hype": {"HYPE"}, "manual-hl-eth": {"ETH"}}
-	got := missingManualOnlyMarks(strategies, openSymbols, map[string]float64{"ETH": 0})
-	want := []string{"ETH", "HYPE"}
-	if len(got) != len(want) {
-		t.Fatalf("missingManualOnlyMarks = %v, want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
-		}
-	}
-}
-
-func TestMissingManualOnlyMarks_NoManualOnlyCoinsRunsImmediately(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
-		{ID: "sma-eth", Type: "spot", Platform: "binanceus", Args: []string{"sma", "ETH", "1h"}},
-	}
-	openSymbols := map[string][]string{"hl-trend-btc": {"BTC"}, "sma-eth": {"ETH"}}
-	if got := missingManualOnlyMarks(strategies, openSymbols, map[string]float64{}); len(got) != 0 {
-		t.Errorf("missingManualOnlyMarks = %v, want empty — no manual-only coin exists, so nothing gates the migration", got)
-	}
-}
-
-func TestMissingManualOnlyMarks_DonorCoinNeverGates(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "manual-hl-btc", Type: "manual", Platform: "hyperliquid", Symbol: "BTC",
-			Args: []string{"hold", "BTC", "1h", "--mode=live"}},
-		{ID: "hl-trend-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h"}},
-	}
-	openSymbols := map[string][]string{"manual-hl-btc": {"BTC"}}
-	if got := missingManualOnlyMarks(strategies, openSymbols, map[string]float64{}); len(got) != 0 {
-		t.Errorf("missingManualOnlyMarks = %v, want empty — BTC is donated by the perps rail, so it is not a manual-only coin", got)
-	}
-}
-
-func TestMissingManualOnlyMarks_UnheldManualCoinNeverGates(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "manual-hl-hype", Type: "manual", Platform: "hyperliquid", Symbol: "HYPE",
-			Args: []string{"hold", "HYPE", "1h", "--mode=live"}},
-	}
-	if got := missingManualOnlyMarks(strategies, map[string][]string{"manual-hl-hype": {}}, nil); len(got) != 0 {
-		t.Errorf("missingManualOnlyMarks = %v, want empty — the strategy is flat, so its coin cannot move the delta", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := missingManualOnlyMarks(tc.strategies, tc.openSymbols, tc.prices)
+			if len(got) != len(tc.want) {
+				t.Fatalf("missingManualOnlyMarks = %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
 	}
 }
 
@@ -3658,23 +3368,5 @@ func TestMarkGatedManagers_ScopedToHyperliquidPerpsAndManual(t *testing.T) {
 				t.Errorf("markGatedManagers = %v, want empty — this venue runs no mark-gated manager", got)
 			}
 		})
-	}
-}
-
-func TestCollectMissingMarkPositions_CarriesVenueManagementSurface(t *testing.T) {
-	strategies := []StrategyConfig{
-		{ID: "hl-live-btc", Type: "perps", Platform: "hyperliquid", Args: []string{"trend", "BTC", "1h", "--mode=live"}},
-		{ID: "sma-eth", Type: "spot", Platform: "binanceus", Args: []string{"sma", "ETH", "1h", "--mode=live"}},
-	}
-	openSymbols := map[string][]string{"hl-live-btc": {"BTC"}, "sma-eth": {"ETH"}}
-	got := collectMissingMarkPositions(strategies, openSymbols, map[string]float64{})
-	if len(got) != 2 {
-		t.Fatalf("collectMissingMarkPositions = %+v, want 2 entries", got)
-	}
-	if got[0].Platform != "hyperliquid" || got[0].Type != "perps" || len(got[0].DisabledManagers) != 2 {
-		t.Errorf("HL perps miss = %+v, want platform/type stamped and 2 disabled managers", got[0])
-	}
-	if got[1].Platform != "binanceus" || got[1].Type != "spot" || len(got[1].DisabledManagers) != 0 {
-		t.Errorf("spot miss = %+v, want platform/type stamped and NO disabled managers", got[1])
 	}
 }

--- a/scheduler/shared_wallet_audit_test.go
+++ b/scheduler/shared_wallet_audit_test.go
@@ -6,63 +6,40 @@ import (
 	"time"
 )
 
-func TestReportSharedWalletDrift_BelowToleranceRecordsNothing(t *testing.T) {
-	prev := sharedWalletDriftTracker
-	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
-	defer func() { sharedWalletDriftTracker = prev }()
+func TestReportSharedWalletDrift_ToleranceBoundary(t *testing.T) {
+	t.Run("below tolerance records nothing", func(t *testing.T) {
+		useFreshDriftTracker(t)
+		key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+		results := []sharedWalletDriftResult{
+			{Key: key, Drift: 0.004, Balance: 1000, MemberSum: 1000.004},
+		}
+		reportSharedWalletDrift(nil, results)
+		reportSharedWalletDrift(nil, results)
 
-	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
-	results := []sharedWalletDriftResult{
-		{Key: key, Drift: 0.004, Balance: 1000, MemberSum: 1000.004},
-	}
-	reportSharedWalletDrift(nil, results)
-	reportSharedWalletDrift(nil, results)
+		if n := len(sharedWalletDriftTracker.entries); n != 0 {
+			t.Fatalf("below-tolerance drift recorded %d tracker entries, want 0: %+v",
+				n, sharedWalletDriftTracker.entries)
+		}
+	})
+	t.Run("exactly at tolerance does not trip, one cent over confirms", func(t *testing.T) {
+		useFreshDriftTracker(t)
+		exactKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xexact"}
+		ctrlKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xctrl"}
+		results := []sharedWalletDriftResult{
+			{Key: exactKey, Drift: sharedWalletDriftTolerance, Balance: 1000, MemberSum: 1000.01},
+			{Key: ctrlKey, Drift: 0.02, Balance: 1000, MemberSum: 1000.02},
+		}
+		reportSharedWalletDrift(nil, results)
+		reportSharedWalletDrift(nil, results)
 
-	if n := len(sharedWalletDriftTracker.entries); n != 0 {
-		t.Fatalf("below-tolerance drift recorded %d tracker entries, want 0: %+v",
-			n, sharedWalletDriftTracker.entries)
-	}
-}
-
-func TestReportSharedWalletDrift_ExactToleranceDoesNotTrip(t *testing.T) {
-	prev := sharedWalletDriftTracker
-	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
-	defer func() { sharedWalletDriftTracker = prev }()
-
-	exactKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xexact"}
-	ctrlKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xctrl"}
-	results := []sharedWalletDriftResult{
-		{Key: exactKey, Drift: sharedWalletDriftTolerance, Balance: 1000, MemberSum: 1000.01},
-		{Key: ctrlKey, Drift: 0.02, Balance: 1000, MemberSum: 1000.02},
-	}
-	reportSharedWalletDrift(nil, results)
-	reportSharedWalletDrift(nil, results)
-
-	if e := sharedWalletDriftTracker.entries[sharedWalletKeyLabel(exactKey)]; e != nil {
-		t.Fatalf("drift exactly at tolerance must not record/trip (guard is strict >): %+v", e)
-	}
-	ctrl := sharedWalletDriftTracker.entries[sharedWalletKeyLabel(ctrlKey)]
-	if ctrl == nil || ctrl.cycles != 2 || !ctrl.alerted {
-		t.Fatalf("control wallet at $0.02 must confirm and alert on cycle 2: %+v", ctrl)
-	}
-}
-
-func TestSharedWalletDriftTracker_SignFlipReAlerts(t *testing.T) {
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now); notify {
-		t.Fatal("cycle 1 is inside the confirmation window; must not notify")
-	}
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now.Add(time.Second)); !notify {
-		t.Fatal("cycle 2 must fire the confirmation alert (anchor +500 cents)")
-	}
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", -5.00, []string{"BTC"}, now.Add(2*time.Second)); !notify {
-		t.Fatal("sign flip +$5 → -$5 is a 1000-cent move against the anchor; must re-alert")
-	}
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", -5.05, []string{"BTC"}, now.Add(3*time.Second)); notify {
-		t.Fatal("-$5.05 vs the -$5.00 anchor is a 5-cent move (< 10%% ratio); must stay throttled")
-	}
+		if e := sharedWalletDriftTracker.entries[sharedWalletKeyLabel(exactKey)]; e != nil {
+			t.Fatalf("drift exactly at tolerance must not record/trip (guard is strict >): %+v", e)
+		}
+		ctrl := sharedWalletDriftTracker.entries[sharedWalletKeyLabel(ctrlKey)]
+		if ctrl == nil || ctrl.cycles != 2 || !ctrl.alerted {
+			t.Fatalf("control wallet at $0.02 must confirm and alert on cycle 2: %+v", ctrl)
+		}
+	})
 }
 
 func TestSameAccountLiveManualMembers_ExcludesDifferentAccount(t *testing.T) {
@@ -123,53 +100,53 @@ func TestPlanTradeLedgerForStrategy_MigrationOnlyPreservesNetSum(t *testing.T) {
 	}
 }
 
-func TestHyperliquidKillSwitchFillShare_NonPeerFailsClosed(t *testing.T) {
-	peers := []StrategyConfig{
-		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", Args: []string{"chk", "BTC", "--mode=live"}},
-		{ID: "hl-b", Platform: "hyperliquid", Type: "perps", Args: []string{"chk", "BTC", "--mode=live"}},
-	}
-	vq := hlVirtualQuantitySnapshot{"BTC": {"hl-a": 1.0, "hl-b": 1.0}}
+func TestHyperliquidKillSwitchFillShare(t *testing.T) {
+	t.Run("non-peer and zero-virtual-qty peer fail closed", func(t *testing.T) {
+		peers := []StrategyConfig{
+			{ID: "hl-a", Platform: "hyperliquid", Type: "perps", Args: []string{"chk", "BTC", "--mode=live"}},
+			{ID: "hl-b", Platform: "hyperliquid", Type: "perps", Args: []string{"chk", "BTC", "--mode=live"}},
+		}
+		vq := hlVirtualQuantitySnapshot{"BTC": {"hl-a": 1.0, "hl-b": 1.0}}
 
-	outsider := StrategyConfig{ID: "hl-c", Platform: "hyperliquid", Type: "perps",
-		Args: []string{"chk", "ETH", "--mode=live"}}
-	if sz, fee := hyperliquidKillSwitchFillShare(outsider, "BTC", 2.0, 0.2, peers, vq); sz != 0 || fee != 0 {
-		t.Fatalf("non-peer sc must fail closed to (0,0), got (%v,%v)", sz, fee)
-	}
+		outsider := StrategyConfig{ID: "hl-c", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"chk", "ETH", "--mode=live"}}
+		if sz, fee := hyperliquidKillSwitchFillShare(outsider, "BTC", 2.0, 0.2, peers, vq); sz != 0 || fee != 0 {
+			t.Fatalf("non-peer sc must fail closed to (0,0), got (%v,%v)", sz, fee)
+		}
 
-	vqZero := hlVirtualQuantitySnapshot{"BTC": {"hl-a": 0.0, "hl-b": 1.0}}
-	if sz, fee := hyperliquidKillSwitchFillShare(peers[0], "BTC", 2.0, 0.2, peers, vqZero); sz != 0 || fee != 0 {
-		t.Fatalf("zero-virtual-qty peer must fail closed to (0,0), got (%v,%v)", sz, fee)
-	}
-}
+		vqZero := hlVirtualQuantitySnapshot{"BTC": {"hl-a": 0.0, "hl-b": 1.0}}
+		if sz, fee := hyperliquidKillSwitchFillShare(peers[0], "BTC", 2.0, 0.2, peers, vqZero); sz != 0 || fee != 0 {
+			t.Fatalf("zero-virtual-qty peer must fail closed to (0,0), got (%v,%v)", sz, fee)
+		}
+	})
+	t.Run("single peer gets the full fill", func(t *testing.T) {
+		sc := StrategyConfig{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"chk", "BTC", "--mode=live"}}
+		sz, fee := hyperliquidKillSwitchFillShare(sc, "BTC", 1.5, 0.3,
+			[]StrategyConfig{sc}, hlVirtualQuantitySnapshot{})
+		if sz != 1.5 || fee != 0.3 {
+			t.Fatalf("single peer must receive the full fill unchanged, got (%v,%v)", sz, fee)
+		}
+	})
+	t.Run("uneven split sums to the fill totals", func(t *testing.T) {
+		a := StrategyConfig{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"chk", "BTC", "--mode=live"}}
+		b := StrategyConfig{ID: "hl-b", Platform: "hyperliquid", Type: "perps",
+			Args: []string{"chk", "BTC", "--mode=live"}}
+		peers := []StrategyConfig{a, b}
+		vq := hlVirtualQuantitySnapshot{"BTC": {"hl-a": 1.0, "hl-b": 2.0}}
 
-func TestHyperliquidKillSwitchFillShare_SinglePeerGetsFullFill(t *testing.T) {
-	sc := StrategyConfig{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
-		Args: []string{"chk", "BTC", "--mode=live"}}
-	sz, fee := hyperliquidKillSwitchFillShare(sc, "BTC", 1.5, 0.3,
-		[]StrategyConfig{sc}, hlVirtualQuantitySnapshot{})
-	if sz != 1.5 || fee != 0.3 {
-		t.Fatalf("single peer must receive the full fill unchanged, got (%v,%v)", sz, fee)
-	}
-}
+		szA, feeA := hyperliquidKillSwitchFillShare(a, "BTC", 1.0, 0.1, peers, vq)
+		szB, feeB := hyperliquidKillSwitchFillShare(b, "BTC", 1.0, 0.1, peers, vq)
 
-func TestHyperliquidKillSwitchFillShare_UnevenSplitSumsToTotal(t *testing.T) {
-	a := StrategyConfig{ID: "hl-a", Platform: "hyperliquid", Type: "perps",
-		Args: []string{"chk", "BTC", "--mode=live"}}
-	b := StrategyConfig{ID: "hl-b", Platform: "hyperliquid", Type: "perps",
-		Args: []string{"chk", "BTC", "--mode=live"}}
-	peers := []StrategyConfig{a, b}
-	vq := hlVirtualQuantitySnapshot{"BTC": {"hl-a": 1.0, "hl-b": 2.0}}
-
-	szA, feeA := hyperliquidKillSwitchFillShare(a, "BTC", 1.0, 0.1, peers, vq)
-	szB, feeB := hyperliquidKillSwitchFillShare(b, "BTC", 1.0, 0.1, peers, vq)
-
-	if math.Abs(szA-1.0/3.0) > 1e-9 || math.Abs(szB-2.0/3.0) > 1e-9 {
-		t.Errorf("size shares = %v/%v, want 1/3 and 2/3", szA, szB)
-	}
-	if math.Abs(feeA-0.1/3.0) > 1e-9 || math.Abs(feeB-0.2/3.0) > 1e-9 {
-		t.Errorf("fee shares = %v/%v, want 0.1/3 and 0.2/3", feeA, feeB)
-	}
-	if math.Abs((szA+szB)-1.0) > 1e-9 || math.Abs((feeA+feeB)-0.1) > 1e-9 {
-		t.Errorf("shares must sum to the fill totals: sz %v fee %v", szA+szB, feeA+feeB)
-	}
+		if math.Abs(szA-1.0/3.0) > 1e-9 || math.Abs(szB-2.0/3.0) > 1e-9 {
+			t.Errorf("size shares = %v/%v, want 1/3 and 2/3", szA, szB)
+		}
+		if math.Abs(feeA-0.1/3.0) > 1e-9 || math.Abs(feeB-0.2/3.0) > 1e-9 {
+			t.Errorf("fee shares = %v/%v, want 0.1/3 and 0.2/3", feeA, feeB)
+		}
+		if math.Abs((szA+szB)-1.0) > 1e-9 || math.Abs((feeA+feeB)-0.1) > 1e-9 {
+			t.Errorf("shares must sum to the fill totals: sz %v fee %v", szA+szB, feeA+feeB)
+		}
+	})
 }

--- a/scheduler/shared_wallet_ledger_test.go
+++ b/scheduler/shared_wallet_ledger_test.go
@@ -847,120 +847,87 @@ func TestPlanTradeLedgerForStrategy_NoOIDRepairApportionsSharedFillByQty(t *test
 	}
 }
 
-func TestPlanTradeLedgerForStrategy_NoOIDRepairSkipsFillAlreadyOwnedByOIDRow(t *testing.T) {
-	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
-	trades := []TradeBackfillRow{
-		{
-			RowID: 1, Timestamp: base, Symbol: "ETH", Side: "sell", Quantity: 0.3,
-			Price: 3200, Value: 960, TradeType: "perps", IsClose: true,
-			RealizedPnL: 60, ExchangeFee: 0.4, PnLGross: true, FeeSource: FeeSourceUserFills,
-			ExchangeOrderID: "474",
-		},
-		{
-			RowID: 2, Timestamp: base.Add(time.Minute), Symbol: "ETH", Side: "sell", Quantity: 0.2,
-			Price: 3190, Value: 638, TradeType: "perps", IsClose: true,
-			RealizedPnL: 20, PnLGross: true, FeeSource: FeeSourceReconcileAdjustment,
-		},
-	}
-	fills := map[string]HLFillSummary{
-		"474": {Coin: "ETH", LastTimeMS: base.UnixMilli(), Fee: 0.4, ClosedPnLGross: 60, Count: 1, Qty: 0.3, Px: 3200},
-	}
-
-	plan := planTradeLedgerForStrategyWithOIDTotals("hl-a", trades, fills, 1000, 0, nil)
-	if len(plan.Changes) != 0 {
-		t.Fatalf("changes = %+v, want none; no-OID residual must not claim already-owned OID", plan.Changes)
-	}
-	if plan.ReconcileAdjustCount != 1 || plan.ReconcileAdjustMatchedCount != 0 {
-		t.Fatalf("reconcile counts = skipped %d repaired %d, want 1/0", plan.ReconcileAdjustCount, plan.ReconcileAdjustMatchedCount)
-	}
-}
-
-func TestPlanTradeLedgerForStrategy_NoOIDRepairSkipsIncompleteSharedFill(t *testing.T) {
-	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
-	trades := []TradeBackfillRow{
-		{
-			RowID: 1, Timestamp: base, Symbol: "ETH", Side: "sell", Quantity: 0.2,
-			Price: 2000, Value: 400, TradeType: "perps", IsClose: true,
-			RealizedPnL: 10, PnLGross: true, FeeSource: FeeSourceReconcileAdjustment,
-		},
-		{
-			RowID: 2, Timestamp: base.Add(10 * time.Second), Symbol: "ETH", Side: "sell", Quantity: 0.2,
-			Price: 2000, Value: 400, TradeType: "perps", IsClose: true,
-			RealizedPnL: 10, PnLGross: true, FeeSource: FeeSourceReconcileAdjustment,
-		},
-	}
-	fills := map[string]HLFillSummary{
-		"500": {Coin: "ETH", LastTimeMS: base.UnixMilli(), Fee: 1.0, ClosedPnLGross: 50, Qty: 0.5, Px: 2100},
-	}
-
-	plan := planTradeLedgerForStrategyWithOIDTotals("hl-eth", trades, fills, 1000, 1020, nil)
-	if len(plan.Changes) != 0 {
-		t.Fatalf("changes = %+v, want none when no-OID rows do not sum to the fill qty", plan.Changes)
-	}
-	if plan.ReconcileAdjustCount != 2 || plan.ReconcileAdjustMatchedCount != 0 {
-		t.Fatalf("reconcile counts = skipped %d repaired %d, want 2/0", plan.ReconcileAdjustCount, plan.ReconcileAdjustMatchedCount)
-	}
-}
-
-func TestPlanTradeLedgerForStrategy_NoOIDRepairSkipsAmbiguousFill(t *testing.T) {
-	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
-	trades := []TradeBackfillRow{
-		{
-			RowID: 1, Timestamp: base, Symbol: "ETH", Side: "sell", Quantity: 1,
-			Price: 2000, Value: 2000, TradeType: "perps", IsClose: true,
-			RealizedPnL: 10, PnLGross: true, FeeSource: FeeSourceReconcileAdjustment,
-		},
-	}
-	fills := map[string]HLFillSummary{
-		"100": {Coin: "ETH", LastTimeMS: base.UnixMilli(), Fee: 0.4, ClosedPnLGross: 8, Qty: 1, Px: 1990},
-		"101": {Coin: "ETH", LastTimeMS: base.UnixMilli(), Fee: 0.5, ClosedPnLGross: 9, Qty: 1, Px: 1989},
-	}
-
-	plan := planTradeLedgerForStrategyWithOIDTotals("hl-eth", trades, fills, 1000, 1009, nil)
-	if len(plan.Changes) != 0 {
-		t.Fatalf("changes = %+v, want none for ambiguous no-OID repair", plan.Changes)
-	}
-	if plan.ReconcileAdjustCount != 1 || plan.ReconcileAdjustMatchedCount != 0 {
-		t.Fatalf("reconcile counts = skipped %d repaired %d, want 1/0", plan.ReconcileAdjustCount, plan.ReconcileAdjustMatchedCount)
-	}
-}
-
-func TestPlanTradeLedgerForStrategy_NoOIDRepairSkipsFillOwnedBySharedPeer(t *testing.T) {
+func TestPlanTradeLedgerForStrategy_NoOIDRepairSkips(t *testing.T) {
 	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xabc")
 	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
-	tradesA := []TradeBackfillRow{
-		{
-			RowID: 1, Timestamp: base, Symbol: "ETH", Side: "sell", Quantity: 0.3,
-			Price: 3200, Value: 960, TradeType: "perps", IsClose: true,
-			RealizedPnL: 60, ExchangeFee: 0.4, PnLGross: true, FeeSource: FeeSourceUserFills,
-			ExchangeOrderID: "474",
-		},
+	ownedByOID := TradeBackfillRow{
+		RowID: 1, Timestamp: base, Symbol: "ETH", Side: "sell", Quantity: 0.3,
+		Price: 3200, Value: 960, TradeType: "perps", IsClose: true,
+		RealizedPnL: 60, ExchangeFee: 0.4, PnLGross: true, FeeSource: FeeSourceUserFills,
+		ExchangeOrderID: "474",
 	}
-	tradesB := []TradeBackfillRow{
-		{
-			RowID: 2, Timestamp: base.Add(time.Minute), Symbol: "ETH", Side: "sell", Quantity: 0.2,
-			Price: 3190, Value: 638, TradeType: "perps", IsClose: true,
-			RealizedPnL: 20, PnLGross: true, FeeSource: FeeSourceReconcileAdjustment,
-		},
+	residual := TradeBackfillRow{
+		RowID: 2, Timestamp: base.Add(time.Minute), Symbol: "ETH", Side: "sell", Quantity: 0.2,
+		Price: 3190, Value: 638, TradeType: "perps", IsClose: true,
+		RealizedPnL: 20, PnLGross: true, FeeSource: FeeSourceReconcileAdjustment,
 	}
-	strategies := []StrategyConfig{
+	fill474 := map[string]HLFillSummary{
+		"474": {Coin: "ETH", LastTimeMS: base.UnixMilli(), Fee: 0.4, ClosedPnLGross: 60, Count: 1, Qty: 0.3, Px: 3200},
+	}
+	sharedPeers := []StrategyConfig{
 		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
 		{ID: "hl-b", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
 	}
-	totalsByID := tradeLedgerSharedWalletOIDTotals(strategies, map[string][]TradeBackfillRow{
-		"hl-a": tradesA,
-		"hl-b": tradesB,
+	peerTotals := tradeLedgerSharedWalletOIDTotals(sharedPeers, map[string][]TradeBackfillRow{
+		"hl-a": {ownedByOID},
+		"hl-b": {residual},
 	})
-	fills := map[string]HLFillSummary{
-		"474": {Coin: "ETH", LastTimeMS: base.UnixMilli(), Fee: 0.4, ClosedPnLGross: 60, Count: 1, Qty: 0.3, Px: 3200},
-	}
 
-	planB := planTradeLedgerForStrategyWithOIDTotals("hl-b", tradesB, fills, 1000, 1020, totalsByID["hl-b"])
-	if len(planB.Changes) != 0 {
-		t.Fatalf("peer residual changes = %+v, want none because OID is owned by shared peer", planB.Changes)
+	cases := []struct {
+		name        string
+		strategyID  string
+		trades      []TradeBackfillRow
+		fills       map[string]HLFillSummary
+		cash        float64
+		totals      map[string]tradeLedgerOIDTotals
+		wantSkipped int
+	}{
+		{
+			name:       "fill already owned by an OID row in the same strategy",
+			strategyID: "hl-a", trades: []TradeBackfillRow{ownedByOID, residual}, fills: fill474, cash: 0, wantSkipped: 1,
+		},
+		{
+			name:       "no-OID rows do not sum to the fill qty",
+			strategyID: "hl-eth",
+			trades: []TradeBackfillRow{
+				{RowID: 1, Timestamp: base, Symbol: "ETH", Side: "sell", Quantity: 0.2, Price: 2000, Value: 400, TradeType: "perps", IsClose: true,
+					RealizedPnL: 10, PnLGross: true, FeeSource: FeeSourceReconcileAdjustment},
+				{RowID: 2, Timestamp: base.Add(10 * time.Second), Symbol: "ETH", Side: "sell", Quantity: 0.2, Price: 2000, Value: 400, TradeType: "perps", IsClose: true,
+					RealizedPnL: 10, PnLGross: true, FeeSource: FeeSourceReconcileAdjustment},
+			},
+			fills: map[string]HLFillSummary{
+				"500": {Coin: "ETH", LastTimeMS: base.UnixMilli(), Fee: 1.0, ClosedPnLGross: 50, Qty: 0.5, Px: 2100},
+			},
+			cash: 1020, wantSkipped: 2,
+		},
+		{
+			name:       "ambiguous fill (two candidates)",
+			strategyID: "hl-eth",
+			trades: []TradeBackfillRow{
+				{RowID: 1, Timestamp: base, Symbol: "ETH", Side: "sell", Quantity: 1, Price: 2000, Value: 2000, TradeType: "perps", IsClose: true,
+					RealizedPnL: 10, PnLGross: true, FeeSource: FeeSourceReconcileAdjustment},
+			},
+			fills: map[string]HLFillSummary{
+				"100": {Coin: "ETH", LastTimeMS: base.UnixMilli(), Fee: 0.4, ClosedPnLGross: 8, Qty: 1, Px: 1990},
+				"101": {Coin: "ETH", LastTimeMS: base.UnixMilli(), Fee: 0.5, ClosedPnLGross: 9, Qty: 1, Px: 1989},
+			},
+			cash: 1009, wantSkipped: 1,
+		},
+		{
+			name:       "fill owned by a shared-wallet peer",
+			strategyID: "hl-b", trades: []TradeBackfillRow{residual}, fills: fill474, cash: 1020, totals: peerTotals["hl-b"], wantSkipped: 1,
+		},
 	}
-	if planB.ReconcileAdjustCount != 1 || planB.ReconcileAdjustMatchedCount != 0 {
-		t.Fatalf("peer reconcile counts = skipped %d repaired %d, want 1/0", planB.ReconcileAdjustCount, planB.ReconcileAdjustMatchedCount)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := planTradeLedgerForStrategyWithOIDTotals(tc.strategyID, tc.trades, tc.fills, 1000, tc.cash, tc.totals)
+			if len(plan.Changes) != 0 {
+				t.Fatalf("changes = %+v, want none", plan.Changes)
+			}
+			if plan.ReconcileAdjustCount != tc.wantSkipped || plan.ReconcileAdjustMatchedCount != 0 {
+				t.Fatalf("reconcile counts = skipped %d repaired %d, want %d/0", plan.ReconcileAdjustCount, plan.ReconcileAdjustMatchedCount, tc.wantSkipped)
+			}
+		})
 	}
 }
 

--- a/scheduler/shared_wallet_reconcile_cycle_test.go
+++ b/scheduler/shared_wallet_reconcile_cycle_test.go
@@ -250,48 +250,6 @@ func TestDisplayStrategyValue_PrefersSetValue(t *testing.T) {
 	}
 }
 
-func TestSharedWalletDriftTracker_ConfirmThenThrottleThenRecover(t *testing.T) {
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now); notify {
-		t.Fatal("first detection must NOT alert (confirmation window)")
-	}
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now.Add(time.Minute)); !notify {
-		t.Fatal("second consecutive detection must alert")
-	}
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now.Add(2*time.Minute)); notify {
-		t.Error("third identical detection should be throttled")
-	}
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 9.00, []string{"BTC"}, now.Add(3*time.Minute)); !notify {
-		t.Error("materially changed drift should re-alert")
-	}
-	recovered, prior := tr.Clear("hyperliquid/0xabc")
-	if !recovered || prior == 0 {
-		t.Errorf("expected recovery after alerted streak, got recovered=%v prior=%d", recovered, prior)
-	}
-	if r, _ := tr.Clear("okx/none"); r {
-		t.Error("clearing unknown wallet must not report recovery")
-	}
-}
-
-func TestSharedWalletDriftTracker_OneCycleTransientSilent(t *testing.T) {
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 25.00, []string{"BTC"}, now); notify {
-		t.Fatal("single transient detection must not alert")
-	}
-	recovered, _ := tr.Clear("hyperliquid/0xabc")
-	if recovered {
-		t.Error("a never-alerted transient must not fire a recovery notice")
-	}
-}
-
-func TestReportSharedWalletDrift_WithinToleranceNoPanic(t *testing.T) {
-	reportSharedWalletDrift(nil, []sharedWalletDriftResult{
-		{Key: SharedWalletKey{Platform: "hyperliquid", Account: "0x"}, Drift: 0.004, Balance: 100, MemberSum: 100},
-	})
-}
-
 func TestParseOKXPositionsOutput_CarriesUnrealizedPnL(t *testing.T) {
 	stdout := []byte(`{"positions":[{"coin":"BTC","size":0.3,"entry_price":60000,"side":"long","unrealized_pnl":123.45}],"platform":"okx"}`)
 	res, _, err := parseOKXPositionsOutput(stdout, "", nil)
@@ -329,259 +287,287 @@ func TestFetchHyperliquidState_ParsesUnrealizedPnL(t *testing.T) {
 	}
 }
 
-func TestSharedWalletDriftTracker_DistinctConsecutiveTransientsNoAlert(t *testing.T) {
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-	if notify, _, count := tr.Record("hyperliquid/0xabc", 25.00, []string{"BTC"}, now); notify || count != 1 {
-		t.Fatalf("first transient: want no alert at count 1, got notify=%v count=%d", notify, count)
-	}
-	if notify, _, count := tr.Record("hyperliquid/0xabc", 12.00, []string{"ETH"}, now.Add(time.Minute)); notify || count != 2 {
-		t.Fatalf("second distinct transient: want no alert at cycle 2, got notify=%v count=%d", notify, count)
-	}
-	if recovered, _ := tr.Clear("hyperliquid/0xabc"); recovered {
-		t.Error("never-alerted streak must not fire a recovery notice")
-	}
+func useFreshDriftTracker(t *testing.T) {
+	t.Helper()
+	prev := sharedWalletDriftTracker
+	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
+	t.Cleanup(func() { sharedWalletDriftTracker = prev })
 }
 
-func TestSharedWalletDriftTracker_SameOrphanChangingMagnitudeStillAlerts(t *testing.T) {
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 25.00, []string{"SOL"}, now); notify {
-		t.Fatal("first detection must not alert")
-	}
-	if notify, _, count := tr.Record("hyperliquid/0xabc", 31.40, []string{"SOL"}, now.Add(time.Minute)); !notify || count != 2 {
-		t.Fatalf("same orphan second cycle must alert at count 2, got notify=%v count=%d", notify, count)
-	}
+type driftTrackerStep struct {
+	at     time.Duration
+	drift  float64
+	coins  []string
+	notify *bool
+	log    *bool
+	count  int
 }
 
-func TestComputeSubsetDisplayValue_GatedPartialSliceMatchesRows(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-	allStrategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
-	}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-btc": {ID: "hl-btc", Cash: 350, Positions: map[string]*Position{}, SharedWalletValue: 650, SharedWalletValueSet: true},
-		"hl-eth": {ID: "hl-eth", Cash: 500, Positions: map[string]*Position{}, SharedWalletValue: 350, SharedWalletValueSet: true},
-	}}
-	walletBalances := map[SharedWalletKey]float64{{Platform: "hyperliquid", Account: "0xtest"}: 1000}
-	accountShared := detectSharedWallets(allStrategies)
-
-	got, fb := computeSubsetDisplayValue(allStrategies[:1], state, nil, walletBalances, accountShared)
-	if got != 650 {
-		t.Errorf("gated partial slice: want 650 (= row value), got %.2f", got)
-	}
-	if fb {
-		t.Error("gated partial slice: expected usedFallback=false")
-	}
-
-	got, _ = computeSubsetDisplayValue(allStrategies, state, nil, walletBalances, accountShared)
-	if got != 1000 {
-		t.Errorf("gated full wallet: want 1000 (real balance), got %.2f", got)
-	}
-}
-
-func TestComputeSubsetDisplayValue_MixedGatedAndNonShared(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-	allStrategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
-		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000},
-	}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-btc":   {ID: "hl-btc", Cash: 350, Positions: map[string]*Position{}, SharedWalletValue: 650, SharedWalletValueSet: true},
-		"hl-eth":   {ID: "hl-eth", Cash: 500, Positions: map[string]*Position{}, SharedWalletValue: 350, SharedWalletValueSet: true},
-		"spot-btc": {ID: "spot-btc", Cash: 2000, Positions: map[string]*Position{}},
-	}}
-	walletBalances := map[SharedWalletKey]float64{{Platform: "hyperliquid", Account: "0xtest"}: 1000}
-	accountShared := detectSharedWallets(allStrategies)
-
-	got, fb := computeSubsetDisplayValue(allStrategies, state, nil, walletBalances, accountShared)
-	if want := 650.0 + 350.0 + 2000.0; got != want {
-		t.Errorf("mixed subset: want %.2f, got %.2f", want, got)
-	}
-	if fb {
-		t.Error("mixed subset: expected usedFallback=false")
-	}
-}
-
-func TestComputeSubsetDisplayValue_UngatedFallsBackToSubsetSemantics(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-	allStrategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
-	}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-btc": {ID: "hl-btc", Cash: 400, Positions: map[string]*Position{}},
-		"hl-eth": {ID: "hl-eth", Cash: 600, Positions: map[string]*Position{}},
-	}}
-	accountShared := detectSharedWallets(allStrategies)
-	walletBalances := map[SharedWalletKey]float64{{Platform: "hyperliquid", Account: "0xtest"}: 800}
-
-	got, fb := computeSubsetDisplayValue(allStrategies, state, nil, walletBalances, accountShared)
-	if got != 800 || fb {
-		t.Errorf("ungated dedup: want 800/false, got %.2f/%v", got, fb)
-	}
-	got, fb = computeSubsetDisplayValue(allStrategies, state, nil, nil, accountShared)
-	if got != 1000 || !fb {
-		t.Errorf("ungated missing balance: want 1000/true, got %.2f/%v", got, fb)
-	}
-}
-
-func TestComputeSubsetDisplayValue_GatedManualNoDoubleCount(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-	allStrategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
-	}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-btc":    {ID: "hl-btc", Cash: 350, Positions: map[string]*Position{}, SharedWalletValue: 500, SharedWalletValueSet: true},
-		"hl-eth":    {ID: "hl-eth", Cash: 500, Positions: map[string]*Position{}, SharedWalletValue: 300, SharedWalletValueSet: true},
-		"hl-manual": {ID: "hl-manual", Cash: 200, Positions: map[string]*Position{}, SharedWalletValue: 200, SharedWalletValueSet: true},
-	}}
-	walletBalances := map[SharedWalletKey]float64{{Platform: "hyperliquid", Account: "0xtest"}: 1000}
-	accountShared := detectSharedWallets(allStrategies[:2])
-
-	got, _ := computeSubsetDisplayValue(allStrategies, state, nil, walletBalances, accountShared)
-	if got != 1000 {
-		t.Errorf("gated wallet incl. manual: want exactly 1000 (real balance, no double count), got %.2f", got)
-	}
-}
-
-func TestSharedWalletDriftTracker_PersistentOrphanSurvivesChurn(t *testing.T) {
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 25.00, []string{"BTC"}, now); notify {
-		t.Fatal("first detection must not alert")
-	}
-	if notify, _, count := tr.Record("hyperliquid/0xabc", 30.00, []string{"BTC", "DOGE"}, now.Add(time.Minute)); !notify || count != 2 {
-		t.Fatalf("persistent BTC orphan must alert through churn, got notify=%v count=%d", notify, count)
-	}
-	if notify, _, count := tr.Record("hyperliquid/0xabc", 30.00, []string{"BTC", "SHIB"}, now.Add(2*time.Minute)); notify || count != 3 {
-		t.Errorf("already-alerted persistent orphan should be throttled, got notify=%v count=%d", notify, count)
-	}
-}
-
-func TestSharedWalletDriftTracker_NewOrphanAfterAlertReconfirms(t *testing.T) {
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-	tr.Record("hyperliquid/0xabc", 25.00, []string{"BTC"}, now)
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 25.00, []string{"BTC"}, now.Add(time.Minute)); !notify {
-		t.Fatal("BTC orphan must alert on its second cycle")
-	}
-	if notify, _, count := tr.Record("hyperliquid/0xabc", 25.00, []string{"ETH"}, now.Add(2*time.Minute)); notify || count != 3 {
-		t.Fatalf("new orphan's first cycle must not alert, got notify=%v count=%d", notify, count)
-	}
-	if notify, _, count := tr.Record("hyperliquid/0xabc", 25.00, []string{"ETH"}, now.Add(3*time.Minute)); !notify || count != 4 {
-		t.Fatalf("new persistent orphan must re-confirm and alert, got notify=%v count=%d", notify, count)
-	}
-}
-
-func TestSharedWalletDriftTracker_NoOrphanCoinsStillConfirms(t *testing.T) {
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-	if notify, _, _ := tr.Record("okx/acct", 5.00, nil, now); notify {
-		t.Fatal("first detection must not alert")
-	}
-	if notify, _, count := tr.Record("okx/acct", 5.00, nil, now.Add(time.Minute)); !notify || count != 2 {
-		t.Fatalf("coinless drift must alert on second consecutive cycle, got notify=%v count=%d", notify, count)
-	}
-}
-
-func TestSharedWalletDriftTracker_MarkWiggleStaysThrottled(t *testing.T) {
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-	tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now)
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now.Add(time.Minute)); !notify {
-		t.Fatal("confirmation alert must fire on cycle 2")
-	}
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.20, []string{"BTC"}, now.Add(2*time.Minute)); notify {
-		t.Error("+4% mark wiggle must stay throttled")
-	}
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.40, []string{"BTC"}, now.Add(3*time.Minute)); notify {
-		t.Error("+8% cumulative wiggle must stay throttled")
-	}
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.60, []string{"BTC"}, now.Add(4*time.Minute)); !notify {
-		t.Error("+12% cumulative move must re-alert")
-	}
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.65, []string{"BTC"}, now.Add(5*time.Minute)); notify {
-		t.Error("small wiggle vs the NEW anchor must stay throttled")
-	}
-}
-
-func TestSharedWalletDriftTracker_RecoveryCountSurvivesChurn(t *testing.T) {
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-	tr.Record("hyperliquid/0xabc", 25.00, []string{"BTC"}, now)
-	tr.Record("hyperliquid/0xabc", 25.00, []string{"BTC"}, now.Add(time.Minute))
-	tr.Record("hyperliquid/0xabc", 25.00, []string{"BTC"}, now.Add(2*time.Minute))
-	tr.Record("hyperliquid/0xabc", 8.00, []string{"ETH"}, now.Add(3*time.Minute))
-	recovered, prior := tr.Clear("hyperliquid/0xabc")
-	if !recovered || prior != 4 {
-		t.Fatalf("want recovery with 4-cycle duration, got recovered=%v prior=%d", recovered, prior)
-	}
-}
-
-func TestSharedWalletDriftTracker_LogThrottledPerInterval(t *testing.T) {
-	withAlertThrottleInterval(t, time.Hour)
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-	if notify, log, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now); notify || !log {
-		t.Fatalf("onset cycle: want notify=false log=true, got notify=%v log=%v", notify, log)
-	}
-	if notify, log, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now.Add(time.Second)); !notify || !log {
-		t.Fatalf("alert cycle: want notify=true log=true, got notify=%v log=%v", notify, log)
-	}
-	if notify, log, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now.Add(2*time.Second)); notify || log {
-		t.Fatalf("intra-interval cycle: want notify=false log=false, got notify=%v log=%v", notify, log)
-	}
-	if notify, log, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now.Add(30*time.Minute)); notify || log {
-		t.Fatalf("mid-hour stable cycle: want notify=false log=false, got notify=%v log=%v", notify, log)
-	}
-	if notify, log, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now.Add(time.Second+time.Hour)); !notify || !log {
-		t.Fatalf("hourly re-alert cycle: want notify=true log=true, got notify=%v log=%v", notify, log)
-	}
-}
-
-func TestSharedWalletDriftTracker_WorseningDriftLogsWithinInterval(t *testing.T) {
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-	if notify, log, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now); notify || !log {
-		t.Fatalf("onset cycle: want notify=false log=true, got notify=%v log=%v", notify, log)
-	}
-	if notify, log, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"ETH"}, now.Add(time.Second)); notify || log {
-		t.Fatalf("stable churn cycle: want notify=false log=false, got notify=%v log=%v", notify, log)
-	}
-	if notify, log, _ := tr.Record("hyperliquid/0xabc", 20.00, []string{"SOL"}, now.Add(2*time.Second)); notify || !log {
-		t.Fatalf("worsening cycle: want notify=false log=true, got notify=%v log=%v", notify, log)
-	}
-}
-
-func TestSharedWalletDriftTracker_StableDriftRealertsHourlyNotEveryTenth(t *testing.T) {
-	withAlertThrottleInterval(t, time.Hour)
-	tr := &SharedWalletDriftTracker{}
-	now := time.Now().UTC()
-	tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now)
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, now.Add(time.Second)); !notify {
-		t.Fatal("confirmation alert must fire on cycle 2")
-	}
-	base := now.Add(time.Second)
-	for i := 1; i <= 40; i++ {
-		ts := base.Add(time.Duration(i) * 3 * time.Second)
-		if notify, _, count := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, ts); notify {
-			t.Fatalf("stable drift must not re-alert within the hour (cycle count=%d)", count)
+func TestSharedWalletDriftTracker(t *testing.T) {
+	yes, no := new(bool), new(bool)
+	*yes = true
+	btc := []string{"BTC"}
+	stableHour := func() []driftTrackerStep {
+		steps := []driftTrackerStep{
+			{at: 0, drift: 5.00, coins: btc},
+			{at: time.Second, drift: 5.00, coins: btc, notify: yes},
 		}
+		base := time.Second
+		for i := 1; i <= 40; i++ {
+			steps = append(steps, driftTrackerStep{at: base + time.Duration(i)*3*time.Second, drift: 5.00, coins: btc, notify: no})
+		}
+		return append(steps, driftTrackerStep{at: base + time.Hour + time.Second, drift: 5.00, coins: btc, notify: yes})
 	}
-	if notify, _, _ := tr.Record("hyperliquid/0xabc", 5.00, []string{"BTC"}, base.Add(time.Hour+time.Second)); !notify {
-		t.Fatal("stable drift must re-alert once the hourly back-off elapses")
+	cases := []struct {
+		name             string
+		throttle         time.Duration
+		key              string
+		steps            []driftTrackerStep
+		clear            bool
+		wantRecovered    bool
+		wantPriorNonZero bool
+		wantPrior        int
+	}{
+		{
+			name: "confirm then throttle then recover",
+			steps: []driftTrackerStep{
+				{at: 0, drift: 5.00, coins: btc, notify: no},
+				{at: time.Minute, drift: 5.00, coins: btc, notify: yes},
+				{at: 2 * time.Minute, drift: 5.00, coins: btc, notify: no},
+				{at: 3 * time.Minute, drift: 9.00, coins: btc, notify: yes},
+			},
+			clear: true, wantRecovered: true, wantPriorNonZero: true,
+		},
+		{
+			name: "clearing unknown wallet reports no recovery",
+			key:  "okx/none", clear: true, wantRecovered: false,
+		},
+		{
+			name:  "one-cycle transient stays silent and never recovers",
+			steps: []driftTrackerStep{{at: 0, drift: 25.00, coins: btc, notify: no}},
+			clear: true, wantRecovered: false,
+		},
+		{
+			name: "distinct consecutive transients do not alert",
+			steps: []driftTrackerStep{
+				{at: 0, drift: 25.00, coins: btc, notify: no, count: 1},
+				{at: time.Minute, drift: 12.00, coins: []string{"ETH"}, notify: no, count: 2},
+			},
+			clear: true, wantRecovered: false,
+		},
+		{
+			name: "same orphan with changing magnitude still alerts",
+			steps: []driftTrackerStep{
+				{at: 0, drift: 25.00, coins: []string{"SOL"}, notify: no},
+				{at: time.Minute, drift: 31.40, coins: []string{"SOL"}, notify: yes, count: 2},
+			},
+		},
+		{
+			name: "persistent orphan survives churn",
+			steps: []driftTrackerStep{
+				{at: 0, drift: 25.00, coins: btc, notify: no},
+				{at: time.Minute, drift: 30.00, coins: []string{"BTC", "DOGE"}, notify: yes, count: 2},
+				{at: 2 * time.Minute, drift: 30.00, coins: []string{"BTC", "SHIB"}, notify: no, count: 3},
+			},
+		},
+		{
+			name: "new orphan after alert re-confirms",
+			steps: []driftTrackerStep{
+				{at: 0, drift: 25.00, coins: btc},
+				{at: time.Minute, drift: 25.00, coins: btc, notify: yes},
+				{at: 2 * time.Minute, drift: 25.00, coins: []string{"ETH"}, notify: no, count: 3},
+				{at: 3 * time.Minute, drift: 25.00, coins: []string{"ETH"}, notify: yes, count: 4},
+			},
+		},
+		{
+			name: "no orphan coins still confirms",
+			key:  "okx/acct",
+			steps: []driftTrackerStep{
+				{at: 0, drift: 5.00, notify: no},
+				{at: time.Minute, drift: 5.00, notify: yes, count: 2},
+			},
+		},
+		{
+			name: "mark wiggle stays throttled until cumulative move exceeds ratio",
+			steps: []driftTrackerStep{
+				{at: 0, drift: 5.00, coins: btc},
+				{at: time.Minute, drift: 5.00, coins: btc, notify: yes},
+				{at: 2 * time.Minute, drift: 5.20, coins: btc, notify: no},
+				{at: 3 * time.Minute, drift: 5.40, coins: btc, notify: no},
+				{at: 4 * time.Minute, drift: 5.60, coins: btc, notify: yes},
+				{at: 5 * time.Minute, drift: 5.65, coins: btc, notify: no},
+			},
+		},
+		{
+			name: "sign flip re-alerts, small move against new anchor stays throttled",
+			steps: []driftTrackerStep{
+				{at: 0, drift: 5.00, coins: btc, notify: no},
+				{at: time.Second, drift: 5.00, coins: btc, notify: yes},
+				{at: 2 * time.Second, drift: -5.00, coins: btc, notify: yes},
+				{at: 3 * time.Second, drift: -5.05, coins: btc, notify: no},
+			},
+		},
+		{
+			name: "recovery count survives churn",
+			steps: []driftTrackerStep{
+				{at: 0, drift: 25.00, coins: btc},
+				{at: time.Minute, drift: 25.00, coins: btc},
+				{at: 2 * time.Minute, drift: 25.00, coins: btc},
+				{at: 3 * time.Minute, drift: 8.00, coins: []string{"ETH"}},
+			},
+			clear: true, wantRecovered: true, wantPrior: 4,
+		},
+		{
+			name:     "log throttled per interval",
+			throttle: time.Hour,
+			steps: []driftTrackerStep{
+				{at: 0, drift: 5.00, coins: btc, notify: no, log: yes},
+				{at: time.Second, drift: 5.00, coins: btc, notify: yes, log: yes},
+				{at: 2 * time.Second, drift: 5.00, coins: btc, notify: no, log: no},
+				{at: 30 * time.Minute, drift: 5.00, coins: btc, notify: no, log: no},
+				{at: time.Second + time.Hour, drift: 5.00, coins: btc, notify: yes, log: yes},
+			},
+		},
+		{
+			name: "worsening drift logs within interval",
+			steps: []driftTrackerStep{
+				{at: 0, drift: 5.00, coins: btc, notify: no, log: yes},
+				{at: time.Second, drift: 5.00, coins: []string{"ETH"}, notify: no, log: no},
+				{at: 2 * time.Second, drift: 20.00, coins: []string{"SOL"}, notify: no, log: yes},
+			},
+		},
+		{
+			name:     "stable drift re-alerts hourly, not every tenth cycle",
+			throttle: time.Hour,
+			steps:    stableHour(),
+		},
 	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.throttle > 0 {
+				withAlertThrottleInterval(t, tc.throttle)
+			}
+			key := tc.key
+			if key == "" {
+				key = "hyperliquid/0xabc"
+			}
+			tr := &SharedWalletDriftTracker{}
+			now := time.Now().UTC()
+			for i, st := range tc.steps {
+				notify, log, count := tr.Record(key, st.drift, st.coins, now.Add(st.at))
+				if st.notify != nil && notify != *st.notify {
+					t.Fatalf("step %d (drift %v coins %v): notify=%v, want %v (count=%d)", i+1, st.drift, st.coins, notify, *st.notify, count)
+				}
+				if st.log != nil && log != *st.log {
+					t.Fatalf("step %d (drift %v coins %v): log=%v, want %v", i+1, st.drift, st.coins, log, *st.log)
+				}
+				if st.count > 0 && count != st.count {
+					t.Fatalf("step %d (drift %v coins %v): count=%d, want %d", i+1, st.drift, st.coins, count, st.count)
+				}
+			}
+			if tc.clear {
+				recovered, prior := tr.Clear(key)
+				if recovered != tc.wantRecovered {
+					t.Fatalf("Clear: recovered=%v prior=%d, want recovered=%v", recovered, prior, tc.wantRecovered)
+				}
+				if tc.wantPriorNonZero && prior == 0 {
+					t.Fatalf("Clear: prior=%d, want nonzero", prior)
+				}
+				if tc.wantPrior > 0 && prior != tc.wantPrior {
+					t.Fatalf("Clear: prior=%d, want %d", prior, tc.wantPrior)
+				}
+			}
+		})
+	}
+}
+
+func TestComputeSubsetDisplayValue(t *testing.T) {
+	hlKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
+	hlPair := []StrategyConfig{hlLivePerps("hl-btc", "BTC", 500), hlLivePerps("hl-eth", "ETH", 500)}
+	gated := func(cash, value float64) *StrategyState {
+		return &StrategyState{Cash: cash, Positions: map[string]*Position{}, SharedWalletValue: value, SharedWalletValueSet: true}
+	}
+	ungated := func(cash float64) *StrategyState {
+		return &StrategyState{Cash: cash, Positions: map[string]*Position{}}
+	}
+	cases := []struct {
+		name         string
+		strategies   []StrategyConfig
+		states       map[string]*StrategyState
+		balances     map[SharedWalletKey]float64
+		sharedFrom   int
+		subsetN      int
+		want         float64
+		wantFallback *bool
+	}{
+		{"gated partial slice matches row value", hlPair,
+			map[string]*StrategyState{"hl-btc": gated(350, 650), "hl-eth": gated(500, 350)},
+			map[SharedWalletKey]float64{hlKey: 1000}, 2, 1, 650, new(bool)},
+		{"gated full wallet uses real balance", hlPair,
+			map[string]*StrategyState{"hl-btc": gated(350, 650), "hl-eth": gated(500, 350)},
+			map[SharedWalletKey]float64{hlKey: 1000}, 2, 2, 1000, nil},
+		{"mixed gated and non-shared", append(append([]StrategyConfig{}, hlPair...), StrategyConfig{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000}),
+			map[string]*StrategyState{"hl-btc": gated(350, 650), "hl-eth": gated(500, 350), "spot-btc": ungated(2000)},
+			map[SharedWalletKey]float64{hlKey: 1000}, 3, 3, 650 + 350 + 2000, new(bool)},
+		{"ungated dedups against balance", hlPair,
+			map[string]*StrategyState{"hl-btc": ungated(400), "hl-eth": ungated(600)},
+			map[SharedWalletKey]float64{hlKey: 800}, 2, 2, 800, new(bool)},
+		{"ungated missing balance falls back to subset sum", hlPair,
+			map[string]*StrategyState{"hl-btc": ungated(400), "hl-eth": ungated(600)},
+			nil, 2, 2, 1000, func() *bool { b := true; return &b }()},
+		{"gated wallet incl. live manual counts real balance once",
+			append(append([]StrategyConfig{}, hlPair...), hlLiveManual("hl-manual", 200)),
+			map[string]*StrategyState{"hl-btc": gated(350, 500), "hl-eth": gated(500, 300), "hl-manual": gated(200, 200)},
+			map[SharedWalletKey]float64{hlKey: 1000}, 2, 3, 1000, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+			state := &AppState{Strategies: map[string]*StrategyState{}}
+			for id, s := range tc.states {
+				s.ID = id
+				state.Strategies[id] = s
+			}
+			accountShared := detectSharedWallets(tc.strategies[:tc.sharedFrom])
+			got, fb := computeSubsetDisplayValue(tc.strategies[:tc.subsetN], state, nil, tc.balances, accountShared)
+			if got != tc.want {
+				t.Errorf("display value=%.2f, want %.2f", got, tc.want)
+			}
+			if tc.wantFallback != nil && fb != *tc.wantFallback {
+				t.Errorf("usedFallback=%v, want %v", fb, *tc.wantFallback)
+			}
+		})
+	}
+}
+
+func TestFormatSharedWalletJournalAlerts(t *testing.T) {
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
+	t.Run("orphan alert names wallet, coins, and untracked status", func(t *testing.T) {
+		msg := formatSharedWalletJournalOrphanAlert(key, 1000, 1000, 0.0, 2, []string{"BTC", "ETH"})
+		for _, want := range []string{"ORPHAN POSITION", "hyperliquid/0xabc", "BTC, ETH", "NO strategy"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("orphan alert missing %q: %s", want, msg)
+			}
+		}
+	})
+	t.Run("drift alert carries orphan context and never claims within tolerance", func(t *testing.T) {
+		with := formatSharedWalletJournalDriftAlert(key, 1000, 995, 5.00, 2, []string{"BTC"})
+		if strings.Contains(with, "within tolerance") {
+			t.Errorf("over-tolerance drift alert must never claim within tolerance: %s", with)
+		}
+		for _, want := range []string{"DRIFT (exchange journal)", "BTC", "NO strategy"} {
+			if !strings.Contains(with, want) {
+				t.Errorf("drift alert with orphan missing %q: %s", want, with)
+			}
+		}
+		if without := formatSharedWalletJournalDriftAlert(key, 1000, 995, 5.00, 2, nil); strings.Contains(without, "NO strategy") {
+			t.Errorf("no-orphan drift alert must not mention orphans: %s", without)
+		}
+	})
 }
 
 func TestReportSharedWalletDrift_JournalStreakPreservedOnPending(t *testing.T) {
-	prev := sharedWalletDriftTracker
-	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
-	defer func() { sharedWalletDriftTracker = prev }()
+	useFreshDriftTracker(t)
 
 	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
 	jkey := sharedWalletKeyLabel(key) + journalDriftStreakKeySuffix
@@ -612,9 +598,7 @@ func TestReportSharedWalletDrift_JournalStreakPreservedOnPending(t *testing.T) {
 }
 
 func TestReportSharedWalletDrift_JournalOrphanTripsWithoutTotalDrift(t *testing.T) {
-	prev := sharedWalletDriftTracker
-	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
-	defer func() { sharedWalletDriftTracker = prev }()
+	useFreshDriftTracker(t)
 
 	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
 	jkey := sharedWalletKeyLabel(key) + journalDriftStreakKeySuffix
@@ -641,20 +625,8 @@ func TestReportSharedWalletDrift_JournalOrphanTripsWithoutTotalDrift(t *testing.
 	}
 }
 
-func TestFormatSharedWalletJournalOrphanAlert(t *testing.T) {
-	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
-	msg := formatSharedWalletJournalOrphanAlert(key, 1000, 1000, 0.0, 2, []string{"BTC", "ETH"})
-	for _, want := range []string{"ORPHAN POSITION", "hyperliquid/0xabc", "BTC, ETH", "NO strategy"} {
-		if !strings.Contains(msg, want) {
-			t.Errorf("orphan alert missing %q: %s", want, msg)
-		}
-	}
-}
-
 func TestCashflowJournalPersistentPendingFallsBackToLedgerAlarm(t *testing.T) {
-	prevTracker := sharedWalletDriftTracker
-	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
-	defer func() { sharedWalletDriftTracker = prevTracker }()
+	useFreshDriftTracker(t)
 	prevPending := cashflowJournalPendingStreaks
 	cashflowJournalPendingStreaks = &cashflowJournalPendingTracker{}
 	defer func() { cashflowJournalPendingStreaks = prevPending }()
@@ -703,9 +675,7 @@ func TestCashflowJournalPersistentPendingFallsBackToLedgerAlarm(t *testing.T) {
 }
 
 func TestReportSharedWalletDrift_CompoundOrphanAndDriftReportsDrift(t *testing.T) {
-	prev := sharedWalletDriftTracker
-	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
-	defer func() { sharedWalletDriftTracker = prev }()
+	useFreshDriftTracker(t)
 
 	mock := &mockNotifier{}
 	notifier := NewMultiNotifier(notifierBackend{
@@ -736,9 +706,7 @@ func TestReportSharedWalletDrift_CompoundOrphanAndDriftReportsDrift(t *testing.T
 }
 
 func TestReportSharedWalletDrift_JournalGapConfirmsDespiteOrphanChurn(t *testing.T) {
-	prev := sharedWalletDriftTracker
-	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
-	defer func() { sharedWalletDriftTracker = prev }()
+	useFreshDriftTracker(t)
 
 	mock := &mockNotifier{}
 	notifier := NewMultiNotifier(notifierBackend{
@@ -778,9 +746,7 @@ func TestReportSharedWalletDrift_JournalGapConfirmsDespiteOrphanChurn(t *testing
 }
 
 func TestReportSharedWalletDrift_JournalGapBlipDoesNotConfirm(t *testing.T) {
-	prev := sharedWalletDriftTracker
-	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
-	defer func() { sharedWalletDriftTracker = prev }()
+	useFreshDriftTracker(t)
 
 	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
 	jkey := sharedWalletKeyLabel(key) + journalDriftStreakKeySuffix
@@ -797,9 +763,7 @@ func TestReportSharedWalletDrift_JournalGapBlipDoesNotConfirm(t *testing.T) {
 }
 
 func TestReportSharedWalletDrift_BasisSwitchClearsStaleTradeLedgerEntry(t *testing.T) {
-	prev := sharedWalletDriftTracker
-	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
-	defer func() { sharedWalletDriftTracker = prev }()
+	useFreshDriftTracker(t)
 
 	mock := &mockNotifier{}
 	notifier := NewMultiNotifier(notifierBackend{
@@ -852,9 +816,7 @@ func TestReportSharedWalletDrift_BasisSwitchClearsStaleTradeLedgerEntry(t *testi
 }
 
 func TestReportSharedWalletDrift_TradeLedgerBasisPreservesJournalStreak(t *testing.T) {
-	prev := sharedWalletDriftTracker
-	sharedWalletDriftTracker = &SharedWalletDriftTracker{}
-	defer func() { sharedWalletDriftTracker = prev }()
+	useFreshDriftTracker(t)
 
 	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
 	jkey := sharedWalletKeyLabel(key) + journalDriftStreakKeySuffix
@@ -870,21 +832,5 @@ func TestReportSharedWalletDrift_TradeLedgerBasisPreservesJournalStreak(t *testi
 	})
 	if e := sharedWalletDriftTracker.entries[jkey]; e == nil || e.cycles != 1 {
 		t.Fatalf("trade-ledger basis must preserve the journal streak (not clear it): %+v", e)
-	}
-}
-
-func TestFormatSharedWalletJournalDriftAlert_OrphanContext(t *testing.T) {
-	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xabc"}
-	with := formatSharedWalletJournalDriftAlert(key, 1000, 995, 5.00, 2, []string{"BTC"})
-	if strings.Contains(with, "within tolerance") {
-		t.Errorf("over-tolerance drift alert must never claim within tolerance: %s", with)
-	}
-	for _, want := range []string{"DRIFT (exchange journal)", "BTC", "NO strategy"} {
-		if !strings.Contains(with, want) {
-			t.Errorf("drift alert with orphan missing %q: %s", want, with)
-		}
-	}
-	if without := formatSharedWalletJournalDriftAlert(key, 1000, 995, 5.00, 2, nil); strings.Contains(without, "NO strategy") {
-		t.Errorf("no-orphan drift alert must not mention orphans: %s", without)
 	}
 }

--- a/scheduler/shared_wallet_reconcile_test.go
+++ b/scheduler/shared_wallet_reconcile_test.go
@@ -13,110 +13,95 @@ func sumValues(m map[string]float64) float64 {
 	return s
 }
 
-func TestReconcileSharedWallet_DistinctCoins_SumsExact(t *testing.T) {
-	members := []string{"a", "b"}
-	capital := map[string]float64{"a": 600, "b": 400}
-	positions := []SharedWalletPosition{
-		{Coin: "BTC", UnrealizedPnL: 50},
-		{Coin: "ETH", UnrealizedPnL: -20},
+func TestReconcileSharedWalletMemberValues(t *testing.T) {
+	cases := []struct {
+		name        string
+		members     []string
+		capital     map[string]float64
+		positions   []SharedWalletPosition
+		virtualQty  map[string]map[string]float64
+		balance     float64
+		wantDrift   float64
+		wantValues  map[string]float64
+		wantSum     float64
+		sumTol      float64
+		wantOrphans []string
+	}{
+		{
+			name:       "distinct coins sum exact",
+			members:    []string{"a", "b"},
+			capital:    map[string]float64{"a": 600, "b": 400},
+			positions:  []SharedWalletPosition{{Coin: "BTC", UnrealizedPnL: 50}, {Coin: "ETH", UnrealizedPnL: -20}},
+			virtualQty: map[string]map[string]float64{"BTC": {"a": 0.1}, "ETH": {"b": 2.0}},
+			balance:    1030.0,
+			wantValues: map[string]float64{"a": 650, "b": 380},
+			wantSum:    1030.0, sumTol: 0.01,
+		},
+		{
+			name:       "shared coin splits by virtual qty",
+			members:    []string{"a", "b"},
+			capital:    map[string]float64{"a": 500, "b": 500},
+			positions:  []SharedWalletPosition{{Coin: "BTC", UnrealizedPnL: 90}},
+			virtualQty: map[string]map[string]float64{"BTC": {"a": 2.0, "b": 1.0}},
+			balance:    1090.0,
+			wantValues: map[string]float64{"a": 560, "b": 530},
+			wantSum:    1090.0, sumTol: 0.01,
+		},
+		{
+			name:       "orphan position surfaces as drift",
+			members:    []string{"a", "b"},
+			capital:    map[string]float64{"a": 500, "b": 500},
+			positions:  []SharedWalletPosition{{Coin: "BTC", UnrealizedPnL: 40}, {Coin: "SOL", UnrealizedPnL: 25}},
+			virtualQty: map[string]map[string]float64{"BTC": {"a": 1.0}},
+			balance:    1065.0,
+			wantDrift:  25,
+			wantSum:    1065.0 - 25, sumTol: 0.02,
+			wantOrphans: []string{"SOL"},
+		},
+		{
+			name:      "cent residual absorbed, not drifted",
+			members:   []string{"a", "b", "c"},
+			capital:   map[string]float64{"a": 1, "b": 1, "c": 1},
+			positions: []SharedWalletPosition{},
+			balance:   100.00,
+			wantSum:   100.00, sumTol: 0.005,
+		},
+		{
+			name:       "no capital splits equally",
+			members:    []string{"a", "b"},
+			balance:    500.0,
+			wantValues: map[string]float64{"a": 250, "b": 250},
+			wantSum:    500.0, sumTol: 0.01,
+		},
 	}
-	virtualQty := map[string]map[string]float64{
-		"BTC": {"a": 0.1},
-		"ETH": {"b": 2.0},
-	}
-	accountBalance := 1030.0
-
-	res := reconcileSharedWalletMemberValues(members, capital, positions, virtualQty, accountBalance)
-
-	if math.Abs(res.Drift) > 1e-9 {
-		t.Fatalf("expected ~0 drift, got %v", res.Drift)
-	}
-	if got := sumValues(res.Values); math.Abs(got-accountBalance) > 0.01 {
-		t.Fatalf("sum %v != balance %v", got, accountBalance)
-	}
-	if math.Abs(res.Values["a"]-650) > 0.01 {
-		t.Errorf("a = %v, want 650", res.Values["a"])
-	}
-	if math.Abs(res.Values["b"]-380) > 0.01 {
-		t.Errorf("b = %v, want 380", res.Values["b"])
-	}
-}
-
-func TestReconcileSharedWallet_SharedCoin_SplitsByVirtualQty(t *testing.T) {
-	members := []string{"a", "b"}
-	capital := map[string]float64{"a": 500, "b": 500}
-	positions := []SharedWalletPosition{
-		{Coin: "BTC", UnrealizedPnL: 90},
-	}
-	virtualQty := map[string]map[string]float64{
-		"BTC": {"a": 2.0, "b": 1.0},
-	}
-	accountBalance := 1090.0
-
-	res := reconcileSharedWalletMemberValues(members, capital, positions, virtualQty, accountBalance)
-
-	if math.Abs(res.Drift) > 1e-9 {
-		t.Fatalf("expected ~0 drift, got %v", res.Drift)
-	}
-	if math.Abs(res.Values["a"]-560) > 0.01 {
-		t.Errorf("a = %v, want 560", res.Values["a"])
-	}
-	if math.Abs(res.Values["b"]-530) > 0.01 {
-		t.Errorf("b = %v, want 530", res.Values["b"])
-	}
-	if got := sumValues(res.Values); math.Abs(got-accountBalance) > 0.01 {
-		t.Fatalf("sum %v != balance %v", got, accountBalance)
-	}
-}
-
-func TestReconcileSharedWallet_OrphanPosition_SurfacesAsDrift(t *testing.T) {
-	members := []string{"a", "b"}
-	capital := map[string]float64{"a": 500, "b": 500}
-	positions := []SharedWalletPosition{
-		{Coin: "BTC", UnrealizedPnL: 40},
-		{Coin: "SOL", UnrealizedPnL: 25},
-	}
-	virtualQty := map[string]map[string]float64{
-		"BTC": {"a": 1.0},
-	}
-	accountBalance := 1065.0
-
-	res := reconcileSharedWalletMemberValues(members, capital, positions, virtualQty, accountBalance)
-
-	if math.Abs(res.Drift-25) > 0.01 {
-		t.Fatalf("expected drift ~25 (orphan SOL uPnL), got %v", res.Drift)
-	}
-	if got := sumValues(res.Values); math.Abs(got-(accountBalance-25)) > 0.02 {
-		t.Fatalf("sum %v != balance-orphan %v", got, accountBalance-25)
-	}
-	if len(res.OrphanCoins) != 1 || res.OrphanCoins[0] != "SOL" {
-		t.Fatalf("expected OrphanCoins [SOL], got %v", res.OrphanCoins)
-	}
-}
-
-func TestReconcileSharedWallet_CentResidual_AbsorbedNotDrifted(t *testing.T) {
-	members := []string{"a", "b", "c"}
-	capital := map[string]float64{"a": 1, "b": 1, "c": 1}
-	positions := []SharedWalletPosition{}
-	accountBalance := 100.00
-
-	res := reconcileSharedWalletMemberValues(members, capital, positions, nil, accountBalance)
-
-	if math.Abs(res.Drift) > 1e-9 {
-		t.Fatalf("expected ~0 drift, got %v", res.Drift)
-	}
-	if got := roundCents(sumValues(res.Values)); math.Abs(got-100.00) > 1e-9 {
-		t.Fatalf("rounded sum %v != 100.00 (cent residual not absorbed)", got)
-	}
-}
-
-func TestReconcileSharedWallet_NoCapital_EqualSplit(t *testing.T) {
-	members := []string{"a", "b"}
-	res := reconcileSharedWalletMemberValues(members, nil, nil, nil, 500.0)
-	if math.Abs(res.Drift) > 1e-9 {
-		t.Fatalf("expected ~0 drift, got %v", res.Drift)
-	}
-	if math.Abs(res.Values["a"]-250) > 0.01 || math.Abs(res.Values["b"]-250) > 0.01 {
-		t.Errorf("expected 250/250 equal split, got a=%v b=%v", res.Values["a"], res.Values["b"])
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := reconcileSharedWalletMemberValues(tc.members, tc.capital, tc.positions, tc.virtualQty, tc.balance)
+			driftTol := 1e-9
+			if tc.wantDrift != 0 {
+				driftTol = 0.01
+			}
+			if math.Abs(res.Drift-tc.wantDrift) > driftTol {
+				t.Fatalf("drift = %v, want %v", res.Drift, tc.wantDrift)
+			}
+			if got := sumValues(res.Values); math.Abs(got-tc.wantSum) > tc.sumTol {
+				t.Fatalf("sum %v != %v (tol %v)", got, tc.wantSum, tc.sumTol)
+			}
+			for id, want := range tc.wantValues {
+				if math.Abs(res.Values[id]-want) > 0.01 {
+					t.Errorf("%s = %v, want %v", id, res.Values[id], want)
+				}
+			}
+			if tc.wantOrphans != nil {
+				if len(res.OrphanCoins) != len(tc.wantOrphans) {
+					t.Fatalf("OrphanCoins = %v, want %v", res.OrphanCoins, tc.wantOrphans)
+				}
+				for i := range tc.wantOrphans {
+					if res.OrphanCoins[i] != tc.wantOrphans[i] {
+						t.Fatalf("OrphanCoins = %v, want %v", res.OrphanCoins, tc.wantOrphans)
+					}
+				}
+			}
+		})
 	}
 }

--- a/scheduler/shared_wallet_test.go
+++ b/scheduler/shared_wallet_test.go
@@ -18,212 +18,344 @@ func stubFetcher(balances map[SharedWalletKey]float64, errs map[SharedWalletKey]
 	}
 }
 
-func TestDetectSharedWallets_MultipleHLPerps(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+func hlLivePerps(id, symbol string, capital float64) StrategyConfig {
+	return StrategyConfig{ID: id, Platform: "hyperliquid", Type: "perps", Args: []string{"sma", symbol, "1h", "--mode=live"}, Capital: capital}
+}
 
-	strategies := []StrategyConfig{
-		{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-rsi-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
+func hlLiveManual(id string, capital float64) StrategyConfig {
+	return StrategyConfig{ID: id, Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: capital}
+}
 
-	shared := detectSharedWallets(strategies)
-	if len(shared) != 1 {
-		t.Fatalf("expected 1 shared wallet; got %d", len(shared))
+func flatCashState(cash map[string]float64) *AppState {
+	state := &AppState{Strategies: map[string]*StrategyState{}}
+	for id, c := range cash {
+		state.Strategies[id] = &StrategyState{ID: id, Cash: c, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}}
 	}
-	for key, ids := range shared {
-		if key.Platform != "hyperliquid" || key.Account != "0xtest" {
-			t.Errorf("unexpected key %+v", key)
-		}
-		if len(ids) != 2 {
-			t.Errorf("expected 2 strategies in wallet; got %d", len(ids))
-		}
+	return state
+}
+
+func TestWalletKeyFor(t *testing.T) {
+	cases := []struct {
+		name   string
+		env    string
+		envVal string
+		sc     StrategyConfig
+		wantOK bool
+		want   SharedWalletKey
+	}{
+		{"OKX perps live", "OKX_API_KEY", "okx-key-abc",
+			StrategyConfig{ID: "okx-sma-btc", Platform: "okx", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+			true, SharedWalletKey{Platform: "okx", Account: "okx-key-abc"}},
+		{"OKX paper has no key", "OKX_API_KEY", "okx-key-abc",
+			StrategyConfig{ID: "okx-sma-btc", Platform: "okx", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=paper"}},
+			false, SharedWalletKey{}},
+		{"OKX spot not in registry", "OKX_API_KEY", "okx-key-abc",
+			StrategyConfig{ID: "okx-sma-btc", Platform: "okx", Type: "spot", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+			false, SharedWalletKey{}},
+		{"OKX missing env var", "OKX_API_KEY", "",
+			StrategyConfig{ID: "okx-sma-btc", Platform: "okx", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+			false, SharedWalletKey{}},
+		{"TopStep futures live", "TOPSTEP_ACCOUNT_ID", "ts-account-42",
+			StrategyConfig{ID: "ts-sma-es", Platform: "topstep", Type: "futures", Args: []string{"sma", "ES", "15m", "--mode=live"}},
+			true, SharedWalletKey{Platform: "topstep", Account: "ts-account-42"}},
+		{"TopStep paper has no key", "TOPSTEP_ACCOUNT_ID", "ts-account-42",
+			StrategyConfig{ID: "ts-sma-es", Platform: "topstep", Type: "futures", Args: []string{"sma", "ES", "15m", "--mode=paper"}},
+			false, SharedWalletKey{}},
+		{"TopStep missing env var", "TOPSTEP_ACCOUNT_ID", "",
+			StrategyConfig{ID: "ts-sma-es", Platform: "topstep", Type: "futures", Args: []string{"sma", "ES", "15m", "--mode=live"}},
+			false, SharedWalletKey{}},
+		{"Robinhood crypto live", "ROBINHOOD_USERNAME", "rh-user@example.com",
+			StrategyConfig{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot", Args: []string{"sma", "BTC", "1h", "--mode=live"}},
+			true, SharedWalletKey{Platform: "robinhood", Account: "rh-user@example.com"}},
+		{"Robinhood paper has no key", "ROBINHOOD_USERNAME", "rh-user@example.com",
+			StrategyConfig{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot", Args: []string{"sma", "BTC", "1h", "--mode=paper"}},
+			false, SharedWalletKey{}},
+		{"Robinhood options not in registry", "ROBINHOOD_USERNAME", "rh-user@example.com",
+			StrategyConfig{ID: "rh-ccall-spy", Platform: "robinhood", Type: "options", Args: []string{"ccall", "SPY", "1h", "--mode=live"}},
+			false, SharedWalletKey{}},
+		{"HL split-form --mode live recognized", "HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest",
+			StrategyConfig{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode", "live"}},
+			true, SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tc.env, tc.envVal)
+			key, ok := walletKeyFor(tc.sc)
+			if ok != tc.wantOK {
+				t.Fatalf("walletKeyFor ok=%v key=%+v, want ok=%v", ok, key, tc.wantOK)
+			}
+			if ok && key != tc.want {
+				t.Errorf("unexpected key %+v, want %+v", key, tc.want)
+			}
+		})
 	}
 }
 
-func TestDetectSharedWallets_PaperModeIgnored(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=paper"}, Capital: 5000},
-		{ID: "hl-rsi-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=paper"}, Capital: 5000},
-	}
-
-	shared := detectSharedWallets(strategies)
-	if len(shared) != 0 {
-		t.Errorf("expected no shared wallets for paper-mode strategies; got %d", len(shared))
-	}
-}
-
-func TestDetectSharedWallets_SingleStrategyNotShared(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-	}
-
-	shared := detectSharedWallets(strategies)
-	if len(shared) != 0 {
-		t.Errorf("expected single-strategy wallet not to be shared; got %d entries", len(shared))
-	}
-}
-
-func TestWalletKeyFor_OKX_PerpsLive(t *testing.T) {
-	t.Setenv("OKX_API_KEY", "okx-key-abc")
-
-	sc := StrategyConfig{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
-		Args: []string{"sma", "BTC", "1h", "--mode=live"}}
-
-	key, ok := walletKeyFor(sc)
-	if !ok {
-		t.Fatalf("expected OKX perps live to produce a wallet key")
-	}
-	if key.Platform != "okx" || key.Account != "okx-key-abc" {
-		t.Errorf("unexpected key %+v", key)
-	}
-}
-
-func TestWalletKeyFor_OKX_PaperNoKey(t *testing.T) {
-	t.Setenv("OKX_API_KEY", "okx-key-abc")
-
-	sc := StrategyConfig{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
-		Args: []string{"sma", "BTC", "1h", "--mode=paper"}}
-
-	if _, ok := walletKeyFor(sc); ok {
-		t.Errorf("expected no wallet key for paper-mode OKX")
-	}
-}
-
-func TestWalletKeyFor_OKX_SpotNoKey(t *testing.T) {
-	t.Setenv("OKX_API_KEY", "okx-key-abc")
-
-	sc := StrategyConfig{ID: "okx-sma-btc", Platform: "okx", Type: "spot",
-		Args: []string{"sma", "BTC", "1h", "--mode=live"}}
-
-	if _, ok := walletKeyFor(sc); ok {
-		t.Errorf("expected no wallet key for OKX spot (not in registry)")
-	}
-}
-
-func TestWalletKeyFor_OKX_MissingEnvVar(t *testing.T) {
-	t.Setenv("OKX_API_KEY", "")
-
-	sc := StrategyConfig{ID: "okx-sma-btc", Platform: "okx", Type: "perps",
-		Args: []string{"sma", "BTC", "1h", "--mode=live"}}
-
-	if _, ok := walletKeyFor(sc); ok {
-		t.Errorf("expected no wallet key when OKX_API_KEY is unset")
-	}
-}
-
-func TestWalletKeyFor_TopStep_FuturesLive(t *testing.T) {
-	t.Setenv("TOPSTEP_ACCOUNT_ID", "ts-account-42")
-
-	sc := StrategyConfig{ID: "ts-sma-es", Platform: "topstep", Type: "futures",
-		Args: []string{"sma", "ES", "15m", "--mode=live"}}
-
-	key, ok := walletKeyFor(sc)
-	if !ok {
-		t.Fatalf("expected TopStep futures live to produce a wallet key")
-	}
-	if key.Platform != "topstep" || key.Account != "ts-account-42" {
-		t.Errorf("unexpected key %+v", key)
-	}
-}
-
-func TestWalletKeyFor_TopStep_PaperNoKey(t *testing.T) {
-	t.Setenv("TOPSTEP_ACCOUNT_ID", "ts-account-42")
-
-	sc := StrategyConfig{ID: "ts-sma-es", Platform: "topstep", Type: "futures",
-		Args: []string{"sma", "ES", "15m", "--mode=paper"}}
-
-	if _, ok := walletKeyFor(sc); ok {
-		t.Errorf("expected no wallet key for paper-mode TopStep")
-	}
-}
-
-func TestWalletKeyFor_TopStep_MissingEnvVar(t *testing.T) {
-	t.Setenv("TOPSTEP_ACCOUNT_ID", "")
-
-	sc := StrategyConfig{ID: "ts-sma-es", Platform: "topstep", Type: "futures",
-		Args: []string{"sma", "ES", "15m", "--mode=live"}}
-
-	if _, ok := walletKeyFor(sc); ok {
-		t.Errorf("expected no wallet key when TOPSTEP_ACCOUNT_ID is unset")
-	}
-}
-
-func TestWalletKeyFor_Robinhood_CryptoLive(t *testing.T) {
-	t.Setenv("ROBINHOOD_USERNAME", "rh-user@example.com")
-
-	sc := StrategyConfig{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
-		Args: []string{"sma", "BTC", "1h", "--mode=live"}}
-
-	key, ok := walletKeyFor(sc)
-	if !ok {
-		t.Fatalf("expected Robinhood crypto live to produce a wallet key")
-	}
-	if key.Platform != "robinhood" || key.Account != "rh-user@example.com" {
-		t.Errorf("unexpected key %+v", key)
-	}
-}
-
-func TestWalletKeyFor_Robinhood_PaperNoKey(t *testing.T) {
-	t.Setenv("ROBINHOOD_USERNAME", "rh-user@example.com")
-
-	sc := StrategyConfig{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot",
-		Args: []string{"sma", "BTC", "1h", "--mode=paper"}}
-
-	if _, ok := walletKeyFor(sc); ok {
-		t.Errorf("expected no wallet key for paper-mode Robinhood")
-	}
-}
-
-func TestWalletKeyFor_Robinhood_OptionsNoKey(t *testing.T) {
-	t.Setenv("ROBINHOOD_USERNAME", "rh-user@example.com")
-
-	sc := StrategyConfig{ID: "rh-ccall-spy", Platform: "robinhood", Type: "options",
-		Args: []string{"ccall", "SPY", "1h", "--mode=live"}}
-
-	if _, ok := walletKeyFor(sc); ok {
-		t.Errorf("expected no wallet key for Robinhood options (not in registry)")
-	}
-}
-
-func TestDetectSharedWallets_OKXIncludedAfterFetcher(t *testing.T) {
-	t.Setenv("OKX_API_KEY", "okx-key-abc")
-
-	strategies := []StrategyConfig{
+func TestDetectSharedWallets(t *testing.T) {
+	hlPair := []StrategyConfig{hlLivePerps("hl-sma-btc", "BTC", 5000), hlLivePerps("hl-rsi-eth", "ETH", 5000)}
+	okxPair := []StrategyConfig{
 		{ID: "okx-sma-btc", Platform: "okx", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
 		{ID: "okx-rsi-eth", Platform: "okx", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
 	}
-
-	shared := detectSharedWallets(strategies)
-	if len(shared) != 1 {
-		t.Fatalf("expected OKX to be grouped as one shared wallet (phase 2 #360), got %d entries", len(shared))
+	cases := []struct {
+		name          string
+		env           map[string]string
+		strategies    []StrategyConfig
+		want          map[SharedWalletKey]int
+		wantKeyForAll bool
+	}{
+		{"two live HL perps share one wallet", map[string]string{"HYPERLIQUID_ACCOUNT_ADDRESS": "0xtest"}, hlPair,
+			map[SharedWalletKey]int{{Platform: "hyperliquid", Account: "0xtest"}: 2}, false},
+		{"paper HL ignored", map[string]string{"HYPERLIQUID_ACCOUNT_ADDRESS": "0xtest"}, []StrategyConfig{
+			{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=paper"}, Capital: 5000},
+			{ID: "hl-rsi-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=paper"}, Capital: 5000},
+		}, nil, false},
+		{"single live HL not shared", map[string]string{"HYPERLIQUID_ACCOUNT_ADDRESS": "0xtest"}, hlPair[:1], nil, false},
+		{"mixed paper and live HL not shared", map[string]string{"HYPERLIQUID_ACCOUNT_ADDRESS": "0xtest"}, []StrategyConfig{
+			{ID: "hl-paper-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=paper"}, Capital: 5000},
+			hlLivePerps("hl-live-eth", "ETH", 5000),
+		}, nil, false},
+		{"no HL env var", map[string]string{"HYPERLIQUID_ACCOUNT_ADDRESS": ""}, hlPair, nil, false},
+		{"OKX grouped as one wallet (#360)", map[string]string{"OKX_API_KEY": "okx-key-abc"}, okxPair,
+			map[SharedWalletKey]int{{Platform: "okx", Account: "okx-key-abc"}: 2}, true},
+		{"TopStep excluded without balance fetcher, key still recognized (#1106)", map[string]string{"TOPSTEP_ACCOUNT_ID": "ts-account-42"}, []StrategyConfig{
+			{ID: "ts-sma-es", Platform: "topstep", Type: "futures", Args: []string{"sma", "ES", "15m", "--mode=live"}, Capital: 5000},
+			{ID: "ts-rsi-nq", Platform: "topstep", Type: "futures", Args: []string{"rsi", "NQ", "15m", "--mode=live"}, Capital: 5000},
+		}, nil, true},
+		{"Robinhood excluded without balance fetcher", map[string]string{"ROBINHOOD_USERNAME": "rh-user@example.com"}, []StrategyConfig{
+			{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
+			{ID: "rh-rsi-eth", Platform: "robinhood", Type: "spot", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
+		}, nil, false},
+		{"HL and OKX form two wallets", map[string]string{"HYPERLIQUID_ACCOUNT_ADDRESS": "0xhl", "OKX_API_KEY": "okx-key-abc"},
+			append(append([]StrategyConfig{}, hlPair...), okxPair...),
+			map[SharedWalletKey]int{
+				{Platform: "hyperliquid", Account: "0xhl"}: 2,
+				{Platform: "okx", Account: "okx-key-abc"}:  2,
+			}, false},
 	}
-	for _, sc := range strategies {
-		if _, ok := walletKeyFor(sc); !ok {
-			t.Errorf("walletKeyFor should recognize %s", sc.ID)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			shared := detectSharedWallets(tc.strategies)
+			if len(shared) != len(tc.want) {
+				t.Fatalf("expected %d shared wallets; got %d: %+v", len(tc.want), len(shared), shared)
+			}
+			for key, n := range tc.want {
+				if ids, ok := shared[key]; !ok || len(ids) != n {
+					t.Errorf("wallet %+v: ok=%v ids=%v, want %d members", key, ok, ids, n)
+				}
+			}
+			if tc.wantKeyForAll {
+				for _, sc := range tc.strategies {
+					if _, ok := walletKeyFor(sc); !ok {
+						t.Errorf("walletKeyFor should recognize %s", sc.ID)
+					}
+				}
+			}
+		})
 	}
 }
 
-func TestDetectSharedWallets_TopStepExcludedNoFetcher(t *testing.T) {
-	t.Setenv("TOPSTEP_ACCOUNT_ID", "ts-account-42")
-
-	strategies := []StrategyConfig{
-		{ID: "ts-sma-es", Platform: "topstep", Type: "futures", Args: []string{"sma", "ES", "15m", "--mode=live"}, Capital: 5000},
-		{ID: "ts-rsi-nq", Platform: "topstep", Type: "futures", Args: []string{"rsi", "NQ", "15m", "--mode=live"}, Capital: 5000},
+func TestComputeTotalPortfolioValue(t *testing.T) {
+	hlKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
+	hlPair := []StrategyConfig{hlLivePerps("hl-sma-btc", "BTC", 5000), hlLivePerps("hl-rsi-eth", "ETH", 5000)}
+	withManual := []StrategyConfig{hlLivePerps("hl-btc", "BTC", 500), hlLivePerps("hl-eth", "ETH", 500), hlLiveManual("hl-manual", 200)}
+	paperManual := append(append([]StrategyConfig{}, withManual[:2]...), StrategyConfig{
+		ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=paper"}, Capital: 200,
+	})
+	cases := []struct {
+		name         string
+		env          string
+		strategies   []StrategyConfig
+		cash         map[string]float64
+		balances     map[SharedWalletKey]float64
+		sharedFrom   int
+		want         float64
+		wantFallback bool
+	}{
+		{"shared wallet uses real balance (no double count)", "0xtest", hlPair,
+			map[string]float64{"hl-sma-btc": 5000, "hl-rsi-eth": 5000},
+			map[SharedWalletKey]float64{hlKey: 5000}, 0, 5000, false},
+		{"fetch failure falls back to sum of member PVs and signals peak freeze", "0xtest", hlPair,
+			map[string]float64{"hl-sma-btc": 4000, "hl-rsi-eth": 6000},
+			nil, 0, 10000, true},
+		{"mixed shared and non-shared adds real balance to spot PV", "0xtest",
+			append(append([]StrategyConfig{}, hlPair...), StrategyConfig{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000}),
+			map[string]float64{"hl-sma-btc": 5000, "hl-rsi-eth": 5000, "spot-btc": 2000},
+			map[SharedWalletKey]float64{hlKey: 7500}, 0, 9500, false},
+		{"mixed paper and live HL sums PVs, nothing shared", "0xtest", []StrategyConfig{
+			{ID: "hl-paper-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=paper"}, Capital: 5000},
+			hlLivePerps("hl-live-eth", "ETH", 5000),
+		}, map[string]float64{"hl-paper-btc": 5000, "hl-live-eth": 4500}, nil, 0, 9500, false},
+		{"no shared wallets behaves like old sum", "", []StrategyConfig{
+			{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000},
+			{ID: "spot-eth", Platform: "binanceus", Type: "spot", Capital: 3000},
+		}, map[string]float64{"spot-btc": 2000, "spot-eth": 3000}, nil, 0, 5000, false},
+		{"live manual member counts the real balance exactly once", "0xtest", withManual,
+			map[string]float64{"hl-btc": 350, "hl-eth": 500, "hl-manual": 200},
+			map[SharedWalletKey]float64{hlKey: 1000}, 2, 1000, false},
+		{"live manual member fallback sums member PVs once", "0xtest", withManual,
+			map[string]float64{"hl-btc": 400, "hl-eth": 400, "hl-manual": 200},
+			nil, 2, 1000, true},
+		{"paper manual is not deduped against the wallet", "0xtest", paperManual,
+			map[string]float64{"hl-btc": 350, "hl-eth": 500, "hl-manual": 200},
+			map[SharedWalletKey]float64{hlKey: 1000}, 2, 1200, false},
 	}
-
-	shared := detectSharedWallets(strategies)
-	if len(shared) != 0 {
-		t.Fatalf("expected TopStep to stay excluded from detectSharedWallets during the shadow phase (#1106); got %d entries", len(shared))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", tc.env)
+			var accountShared map[SharedWalletKey][]string
+			if tc.sharedFrom > 0 {
+				accountShared = detectSharedWallets(tc.strategies[:tc.sharedFrom])
+			}
+			got, usedFallback := computeTotalPortfolioValue(tc.strategies, flatCashState(tc.cash), nil, tc.balances, accountShared)
+			if got != tc.want {
+				t.Errorf("total=%v, want %v", got, tc.want)
+			}
+			if usedFallback != tc.wantFallback {
+				t.Errorf("usedFallback=%v, want %v", usedFallback, tc.wantFallback)
+			}
+		})
 	}
-	for _, sc := range strategies {
-		if _, ok := walletKeyFor(sc); !ok {
-			t.Errorf("walletKeyFor should still recognize live %s", sc.ID)
+}
+
+func TestFetchSharedWalletBalances(t *testing.T) {
+	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+	strategies := []StrategyConfig{hlLivePerps("hl-sma-btc", "BTC", 5000), hlLivePerps("hl-rsi-eth", "ETH", 5000)}
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
+
+	t.Run("stub returns balance", func(t *testing.T) {
+		balances, errs := fetchSharedWalletBalances(strategies, stubFetcher(map[SharedWalletKey]float64{key: 7777}, nil))
+		if len(errs) != 0 {
+			t.Errorf("expected no errors; got %v", errs)
 		}
+		if balances[key] != 7777 {
+			t.Errorf("expected balance=7777; got %v", balances[key])
+		}
+	})
+	t.Run("records errors and omits balance", func(t *testing.T) {
+		balances, errs := fetchSharedWalletBalances(strategies, stubFetcher(nil, map[SharedWalletKey]error{key: errors.New("boom")}))
+		if len(balances) != 0 {
+			t.Errorf("expected no balances on error; got %v", balances)
+		}
+		if errs[key] == nil {
+			t.Errorf("expected recorded error for key %+v", key)
+		}
+	})
+}
+
+func TestComputeInitialPortfolioPeak(t *testing.T) {
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
+	hlPair := []StrategyConfig{hlLivePerps("hl-sma-btc", "BTC", 5000), hlLivePerps("hl-rsi-eth", "ETH", 5000)}
+	withManual := []StrategyConfig{hlLivePerps("hl-btc", "BTC", 500), hlLivePerps("hl-eth", "ETH", 500), hlLiveManual("hl-manual", 200)}
+	cases := []struct {
+		name       string
+		env        string
+		strategies []StrategyConfig
+		fetcher    WalletBalanceFetcher
+		want       float64
+	}{
+		{"shared wallet uses balance plus non-shared capital", "0xtest",
+			append(append([]StrategyConfig{}, hlPair...), StrategyConfig{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000}),
+			stubFetcher(map[SharedWalletKey]float64{key: 8000}, nil), 10000},
+		{"fetch error falls back to member capital", "0xtest", hlPair,
+			stubFetcher(nil, map[SharedWalletKey]error{key: errors.New("network down")}), 10000},
+		{"legacy capital_pct", "", []StrategyConfig{
+			{ID: "binance-spot", Platform: "binanceus", Type: "spot", Capital: 2500, CapitalPct: 0.5},
+			{ID: "spot-eth", Platform: "binanceus", Type: "spot", Capital: 1000},
+		}, nil, 6000},
+		{"no shared wallets sums capital", "", []StrategyConfig{
+			{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000},
+			{ID: "spot-eth", Platform: "binanceus", Type: "spot", Capital: 3000},
+		}, nil, 5000},
+		{"live manual member: real balance counted once", "0xtest", withManual,
+			stubFetcher(map[SharedWalletKey]float64{key: 1000}, nil), 1000},
+		{"live manual member fallback sums member capital once", "0xtest", withManual,
+			stubFetcher(nil, map[SharedWalletKey]error{key: errors.New("network down")}), 1200},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", tc.env)
+			if got := computeInitialPortfolioPeak(tc.strategies, tc.fetcher); got != tc.want {
+				t.Errorf("peak=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRebaselinePortfolioPeakAfterPrune(t *testing.T) {
+	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
+	spotBTC := StrategyConfig{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 5000}
+	spotETH := StrategyConfig{ID: "spot-eth", Platform: "binanceus", Type: "spot", Capital: 3000}
+	cases := []struct {
+		name       string
+		env        string
+		strategies []StrategyConfig
+		peaks      map[string]float64
+		fetcher    WalletBalanceFetcher
+		want       float64
+	}{
+		{"sums remaining per-strategy peaks", "", []StrategyConfig{spotBTC}, map[string]float64{"spot-btc": 7000}, nil, 7000},
+		{"floors at capital sum when peaks missing", "", []StrategyConfig{spotBTC, spotETH}, map[string]float64{"spot-btc": 0, "spot-eth": 0}, nil, 8000},
+		{"mixed peak and capital fallback", "", []StrategyConfig{spotBTC, spotETH}, map[string]float64{"spot-btc": 6000, "spot-eth": 0}, nil, 9000},
+		{"single perps plus manual sums capital", "0xtest",
+			[]StrategyConfig{hlLivePerps("hl-btc", "BTC", 500), hlLiveManual("hl-manual", 200)},
+			map[string]float64{"hl-btc": 0, "hl-manual": 0}, nil, 700},
+		{"deduped zero-capital manual leaves balance unchanged", "0xtest",
+			[]StrategyConfig{hlLivePerps("hl-btc", "BTC", 500), hlLivePerps("hl-eth", "ETH", 500), hlLiveManual("hl-manual", 0)},
+			map[string]float64{"hl-btc": 0, "hl-eth": 0, "hl-manual": 0},
+			stubFetcher(map[SharedWalletKey]float64{key: 1000}, nil), 1000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", tc.env)
+			state := &AppState{Strategies: map[string]*StrategyState{}}
+			for id, peak := range tc.peaks {
+				state.Strategies[id] = &StrategyState{ID: id, RiskState: RiskState{PeakValue: peak}}
+			}
+			got := rebaselinePortfolioPeakAfterPrune(state, &Config{Strategies: tc.strategies}, tc.fetcher)
+			if got != tc.want {
+				t.Errorf("rebaselined peak=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeSubsetPortfolioValue(t *testing.T) {
+	hlKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
+	hlPair := []StrategyConfig{hlLivePerps("hl-btc", "BTC", 5000), hlLivePerps("hl-eth", "ETH", 5000)}
+	cases := []struct {
+		name         string
+		strategies   []StrategyConfig
+		cash         map[string]float64
+		balances     map[SharedWalletKey]float64
+		subsetN      int
+		want         float64
+		wantFallback bool
+	}{
+		{"fully contained wallet uses real balance", hlPair,
+			map[string]float64{"hl-btc": 5000, "hl-eth": 5000}, map[SharedWalletKey]float64{hlKey: 8000}, 2, 8000, false},
+		{"straddling wallet sums virtual PV of the subset only", hlPair,
+			map[string]float64{"hl-btc": 4000, "hl-eth": 6000}, map[SharedWalletKey]float64{hlKey: 8000}, 1, 4000, false},
+		{"mixed shared and non-shared", append(append([]StrategyConfig{}, hlPair...), StrategyConfig{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000}),
+			map[string]float64{"hl-btc": 5000, "hl-eth": 5000, "spot-btc": 2000}, map[SharedWalletKey]float64{hlKey: 7500}, 3, 9500, false},
+		{"missing balance falls back to member sum", hlPair,
+			map[string]float64{"hl-btc": 4000, "hl-eth": 6000}, nil, 2, 10000, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
+			accountShared := detectSharedWallets(tc.strategies)
+			got, fb := computeSubsetPortfolioValue(tc.strategies[:tc.subsetN], flatCashState(tc.cash), nil, tc.balances, accountShared)
+			if got != tc.want {
+				t.Errorf("subset value=%.2f, want %.2f", got, tc.want)
+			}
+			if fb != tc.wantFallback {
+				t.Errorf("usedFallback=%v, want %v", fb, tc.wantFallback)
+			}
+		})
 	}
 }
 
@@ -255,20 +387,6 @@ func TestDetectTopStepSharedWallet(t *testing.T) {
 	}
 }
 
-func TestDetectSharedWallets_RobinhoodExcludedNoFetcher(t *testing.T) {
-	t.Setenv("ROBINHOOD_USERNAME", "rh-user@example.com")
-
-	strategies := []StrategyConfig{
-		{ID: "rh-sma-btc", Platform: "robinhood", Type: "spot", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "rh-rsi-eth", Platform: "robinhood", Type: "spot", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-
-	shared := detectSharedWallets(strategies)
-	if len(shared) != 0 {
-		t.Errorf("expected Robinhood to be excluded from detectSharedWallets until a balance fetcher exists; got %d entries", len(shared))
-	}
-}
-
 func TestHasSharedWalletBalanceFetcher_HLAndOKX(t *testing.T) {
 	cases := map[string]bool{
 		"hyperliquid": true,
@@ -282,375 +400,6 @@ func TestHasSharedWalletBalanceFetcher_HLAndOKX(t *testing.T) {
 		if got := hasSharedWalletBalanceFetcher(platform); got != want {
 			t.Errorf("hasSharedWalletBalanceFetcher(%q) = %v; want %v", platform, got, want)
 		}
-	}
-}
-
-func TestDetectSharedWallets_MixedHLAndOKX(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xhl")
-	t.Setenv("OKX_API_KEY", "okx-key-abc")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-rsi-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "okx-sma-btc", Platform: "okx", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "okx-rsi-eth", Platform: "okx", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-
-	shared := detectSharedWallets(strategies)
-	if len(shared) != 2 {
-		t.Fatalf("expected 2 shared wallets (HL + OKX); got %d entries %+v", len(shared), shared)
-	}
-	hlKey := SharedWalletKey{Platform: "hyperliquid", Account: "0xhl"}
-	if ids, ok := shared[hlKey]; !ok || len(ids) != 2 {
-		t.Errorf("expected HL wallet with 2 strategies; got ok=%v ids=%v", ok, ids)
-	}
-	okxKey := SharedWalletKey{Platform: "okx", Account: "okx-key-abc"}
-	if ids, ok := shared[okxKey]; !ok || len(ids) != 2 {
-		t.Errorf("expected OKX wallet with 2 strategies; got ok=%v ids=%v", ok, ids)
-	}
-}
-
-func TestWalletKeyFor_SplitModeLiveRecognized(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	sc := StrategyConfig{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps",
-		Args: []string{"sma", "BTC", "1h", "--mode", "live"}}
-
-	key, ok := walletKeyFor(sc)
-	if !ok {
-		t.Fatalf("expected split-form --mode live to be recognized as live")
-	}
-	if key.Platform != "hyperliquid" || key.Account != "0xtest" {
-		t.Errorf("unexpected key %+v", key)
-	}
-}
-
-func TestDetectSharedWallets_NoEnvVar(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-rsi-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-
-	shared := detectSharedWallets(strategies)
-	if len(shared) != 0 {
-		t.Errorf("expected no shared wallets without HYPERLIQUID_ACCOUNT_ADDRESS; got %d", len(shared))
-	}
-}
-
-func TestComputeTotalPortfolioValue_SharedWalletUsesRealBalance(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-rsi-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-sma-btc": {ID: "hl-sma-btc", Cash: 5000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"hl-rsi-eth": {ID: "hl-rsi-eth", Cash: 5000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-		},
-	}
-	walletBalances := map[SharedWalletKey]float64{
-		{Platform: "hyperliquid", Account: "0xtest"}: 5000,
-	}
-
-	got, usedFallback := computeTotalPortfolioValue(strategies, state, nil, walletBalances, nil)
-	want := 5000.0
-	if got != want {
-		t.Errorf("expected total=%v (real wallet balance); got %v (likely double-counted)", want, got)
-	}
-	if usedFallback {
-		t.Errorf("expected usedFallback=false when balance was provided")
-	}
-}
-
-func TestComputeTotalPortfolioValue_FallbackSumsMemberPVs(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-rsi-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-sma-btc": {ID: "hl-sma-btc", Cash: 4000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"hl-rsi-eth": {ID: "hl-rsi-eth", Cash: 6000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-		},
-	}
-
-	got, usedFallback := computeTotalPortfolioValue(strategies, state, nil, nil, nil)
-	want := 10000.0
-	if got != want {
-		t.Errorf("expected fallback total=%v (sum of members); got %v", want, got)
-	}
-	if !usedFallback {
-		t.Errorf("expected usedFallback=true on fetch failure so caller can freeze peak")
-	}
-}
-
-func TestComputeTotalPortfolioValue_FallbackKeepsPeakFreezeSignal(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-a", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-b", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-a": {ID: "hl-a", Cash: 3500, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"hl-b": {ID: "hl-b", Cash: 3500, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-		},
-	}
-
-	got, usedFallback := computeTotalPortfolioValue(strategies, state, nil, nil, nil)
-	if got != 7000 {
-		t.Errorf("expected fallback total=7000 (sum of members); got %v", got)
-	}
-	if !usedFallback {
-		t.Errorf("usedFallback must be true so main.go can freeze peak")
-	}
-}
-
-func TestComputeTotalPortfolioValue_MixedSharedAndNonShared(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-rsi-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000},
-	}
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-sma-btc": {ID: "hl-sma-btc", Cash: 5000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"hl-rsi-eth": {ID: "hl-rsi-eth", Cash: 5000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"spot-btc":   {ID: "spot-btc", Cash: 2000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-		},
-	}
-	walletBalances := map[SharedWalletKey]float64{
-		{Platform: "hyperliquid", Account: "0xtest"}: 7500,
-	}
-
-	got, usedFallback := computeTotalPortfolioValue(strategies, state, nil, walletBalances, nil)
-	want := 9500.0
-	if got != want {
-		t.Errorf("expected mixed total=%v; got %v", want, got)
-	}
-	if usedFallback {
-		t.Errorf("expected usedFallback=false when balance was provided")
-	}
-}
-
-func TestComputeTotalPortfolioValue_MixedPaperAndLiveHL(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-paper-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=paper"}, Capital: 5000},
-		{ID: "hl-live-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-
-	shared := detectSharedWallets(strategies)
-	if len(shared) != 0 {
-		t.Fatalf("expected no shared wallets in mixed paper+live setup; got %d", len(shared))
-	}
-
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-paper-btc": {ID: "hl-paper-btc", Cash: 5000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"hl-live-eth":  {ID: "hl-live-eth", Cash: 4500, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-		},
-	}
-
-	got, usedFallback := computeTotalPortfolioValue(strategies, state, nil, nil, nil)
-	want := 9500.0
-	if got != want {
-		t.Errorf("expected mixed paper+live total=%v; got %v", want, got)
-	}
-	if usedFallback {
-		t.Errorf("expected usedFallback=false; nothing was classified as shared")
-	}
-}
-
-func TestComputeTotalPortfolioValue_NoSharedWalletsBehavesLikeOldSum(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
-
-	strategies := []StrategyConfig{
-		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000},
-		{ID: "spot-eth", Platform: "binanceus", Type: "spot", Capital: 3000},
-	}
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"spot-btc": {ID: "spot-btc", Cash: 2000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"spot-eth": {ID: "spot-eth", Cash: 3000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-		},
-	}
-
-	got, usedFallback := computeTotalPortfolioValue(strategies, state, nil, nil, nil)
-	want := 5000.0
-	if got != want {
-		t.Errorf("expected total=%v; got %v", want, got)
-	}
-	if usedFallback {
-		t.Errorf("expected usedFallback=false when no shared wallets exist")
-	}
-}
-
-func TestFetchSharedWalletBalances_StubReturnsBalance(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-rsi-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
-	fetcher := stubFetcher(map[SharedWalletKey]float64{key: 7777}, nil)
-
-	balances, errs := fetchSharedWalletBalances(strategies, fetcher)
-	if len(errs) != 0 {
-		t.Errorf("expected no errors; got %v", errs)
-	}
-	if balances[key] != 7777 {
-		t.Errorf("expected balance=7777; got %v", balances[key])
-	}
-}
-
-func TestFetchSharedWalletBalances_RecordsErrors(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-rsi-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
-	fetcher := stubFetcher(nil, map[SharedWalletKey]error{key: errors.New("boom")})
-
-	balances, errs := fetchSharedWalletBalances(strategies, fetcher)
-	if len(balances) != 0 {
-		t.Errorf("expected no balances on error; got %v", balances)
-	}
-	if errs[key] == nil {
-		t.Errorf("expected recorded error for key %+v", key)
-	}
-}
-
-func TestComputeInitialPortfolioPeak_SharedWalletUsesBalance(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-rsi-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000},
-	}
-	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
-	fetcher := stubFetcher(map[SharedWalletKey]float64{key: 8000}, nil)
-
-	got := computeInitialPortfolioPeak(strategies, fetcher)
-	want := 10000.0
-	if got != want {
-		t.Errorf("expected peak=%v; got %v", want, got)
-	}
-}
-
-func TestComputeInitialPortfolioPeak_FallbackOnFetchError(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-sma-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-rsi-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
-	fetcher := stubFetcher(nil, map[SharedWalletKey]error{key: errors.New("network down")})
-
-	got := computeInitialPortfolioPeak(strategies, fetcher)
-	want := 10000.0
-	if got != want {
-		t.Errorf("expected fallback peak=%v; got %v", want, got)
-	}
-}
-
-func TestComputeInitialPortfolioPeak_LegacyCapitalPct(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
-
-	strategies := []StrategyConfig{
-		{ID: "binance-spot", Platform: "binanceus", Type: "spot", Capital: 2500, CapitalPct: 0.5},
-		{ID: "spot-eth", Platform: "binanceus", Type: "spot", Capital: 1000},
-	}
-
-	got := computeInitialPortfolioPeak(strategies, nil)
-	want := 6000.0
-	if got != want {
-		t.Errorf("expected legacy capital_pct peak=%v; got %v", want, got)
-	}
-}
-
-func TestComputeInitialPortfolioPeak_NoSharedWalletsSumsCapital(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
-
-	strategies := []StrategyConfig{
-		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000},
-		{ID: "spot-eth", Platform: "binanceus", Type: "spot", Capital: 3000},
-	}
-
-	got := computeInitialPortfolioPeak(strategies, nil)
-	want := 5000.0
-	if got != want {
-		t.Errorf("expected peak=%v; got %v", want, got)
-	}
-}
-
-func TestRebaselinePortfolioPeakAfterPrune_SumsRemainingPerStrategyPeaks(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
-
-	cfg := &Config{Strategies: []StrategyConfig{
-		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 5000},
-	}}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"spot-btc": {ID: "spot-btc", RiskState: RiskState{PeakValue: 7000}},
-	}}
-
-	got := rebaselinePortfolioPeakAfterPrune(state, cfg, nil)
-	want := 7000.0
-	if got != want {
-		t.Errorf("expected rebaselined peak=%v; got %v", want, got)
-	}
-}
-
-func TestRebaselinePortfolioPeakAfterPrune_FloorAtCapitalSum(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
-
-	cfg := &Config{Strategies: []StrategyConfig{
-		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 5000},
-		{ID: "spot-eth", Platform: "binanceus", Type: "spot", Capital: 3000},
-	}}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"spot-btc": {ID: "spot-btc"},
-		"spot-eth": {ID: "spot-eth"},
-	}}
-
-	got := rebaselinePortfolioPeakAfterPrune(state, cfg, nil)
-	want := 8000.0
-	if got != want {
-		t.Errorf("expected floored peak=%v; got %v", want, got)
-	}
-}
-
-func TestRebaselinePortfolioPeakAfterPrune_FallbackToCapitalWhenPeakMissing(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "")
-
-	cfg := &Config{Strategies: []StrategyConfig{
-		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 5000},
-		{ID: "spot-eth", Platform: "binanceus", Type: "spot", Capital: 3000},
-	}}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"spot-btc": {ID: "spot-btc", RiskState: RiskState{PeakValue: 6000}},
-		"spot-eth": {ID: "spot-eth"},
-	}}
-
-	got := rebaselinePortfolioPeakAfterPrune(state, cfg, nil)
-	want := 9000.0
-	if got != want {
-		t.Errorf("expected mixed peak=%v; got %v", want, got)
 	}
 }
 
@@ -713,214 +462,6 @@ func TestRebaselinePortfolioPeakAfterPrune_MatchesRiskPathTotalWithManual(t *tes
 	}
 }
 
-func TestRebaselinePortfolioPeakAfterPrune_SinglePerpsPlusManualSumsManual(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-	cfg := &Config{Strategies: []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
-	}}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-btc":    {ID: "hl-btc"},
-		"hl-manual": {ID: "hl-manual"},
-	}}
-
-	got := rebaselinePortfolioPeakAfterPrune(state, cfg, nil)
-	if got != 700 {
-		t.Errorf("single perps + manual: want 700 (500+200 capital), got %.2f", got)
-	}
-}
-
-func TestRebaselinePortfolioPeakAfterPrune_DedupedManualZeroCapitalUnchanged(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-	cfg := &Config{Strategies: []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 0},
-	}}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-btc":    {ID: "hl-btc"},
-		"hl-eth":    {ID: "hl-eth"},
-		"hl-manual": {ID: "hl-manual"},
-	}}
-	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
-	fetcher := stubFetcher(map[SharedWalletKey]float64{key: 1000}, nil)
-
-	got := rebaselinePortfolioPeakAfterPrune(state, cfg, fetcher)
-	if got != 1000 {
-		t.Errorf("zero-capital manual: want 1000, got %.2f", got)
-	}
-}
-
-func TestComputeSubsetPortfolioValue_FullyContainedWallet(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	allStrategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-btc": {ID: "hl-btc", Cash: 5000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"hl-eth": {ID: "hl-eth", Cash: 5000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-		},
-	}
-	walletBalances := map[SharedWalletKey]float64{
-		{Platform: "hyperliquid", Account: "0xtest"}: 8000,
-	}
-	accountShared := detectSharedWallets(allStrategies)
-
-	got, fb := computeSubsetPortfolioValue(allStrategies, state, nil, walletBalances, accountShared)
-	if got != 8000 {
-		t.Errorf("fully-contained subset: want 8000 (real balance), got %.2f", got)
-	}
-	if fb {
-		t.Errorf("fully-contained subset: expected usedFallback=false")
-	}
-}
-
-func TestComputeSubsetPortfolioValue_StraddlingWalletVirtualSum(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	allStrategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-btc": {ID: "hl-btc", Cash: 4000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"hl-eth": {ID: "hl-eth", Cash: 6000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-		},
-	}
-	walletBalances := map[SharedWalletKey]float64{
-		{Platform: "hyperliquid", Account: "0xtest"}: 8000,
-	}
-	accountShared := detectSharedWallets(allStrategies)
-
-	subset := allStrategies[:1]
-	got, fb := computeSubsetPortfolioValue(subset, state, nil, walletBalances, accountShared)
-	if got != 4000 {
-		t.Errorf("straddling wallet subset: want 4000 (virtual sum of hl-btc only), got %.2f", got)
-	}
-	if fb {
-		t.Errorf("straddling wallet subset: expected usedFallback=false (no dedup attempted)")
-	}
-}
-
-func TestComputeSubsetPortfolioValue_MixedSharedAndNonShared(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	allStrategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000},
-	}
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-btc":   {ID: "hl-btc", Cash: 5000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"hl-eth":   {ID: "hl-eth", Cash: 5000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"spot-btc": {ID: "spot-btc", Cash: 2000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-		},
-	}
-	walletBalances := map[SharedWalletKey]float64{
-		{Platform: "hyperliquid", Account: "0xtest"}: 7500,
-	}
-	accountShared := detectSharedWallets(allStrategies)
-
-	got, fb := computeSubsetPortfolioValue(allStrategies, state, nil, walletBalances, accountShared)
-	want := 7500.0 + 2000.0
-	if got != want {
-		t.Errorf("mixed subset: want %.2f, got %.2f", want, got)
-	}
-	if fb {
-		t.Errorf("mixed subset: expected usedFallback=false")
-	}
-}
-
-func TestComputeSubsetPortfolioValue_MissingBalance(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	allStrategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-	}
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-btc": {ID: "hl-btc", Cash: 4000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"hl-eth": {ID: "hl-eth", Cash: 6000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-		},
-	}
-	accountShared := detectSharedWallets(allStrategies)
-
-	got, fb := computeSubsetPortfolioValue(allStrategies, state, nil, nil, accountShared)
-	if got != 10000 {
-		t.Errorf("missing balance: want 10000 (fallback sum), got %.2f", got)
-	}
-	if !fb {
-		t.Errorf("missing balance: expected usedFallback=true")
-	}
-}
-
-func TestComputeTotalPortfolioValue_DelegatesCorrectly(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-
-	strategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 5000},
-		{ID: "spot-btc", Platform: "binanceus", Type: "spot", Capital: 2000},
-	}
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-btc":   {ID: "hl-btc", Cash: 5000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"hl-eth":   {ID: "hl-eth", Cash: 5000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-			"spot-btc": {ID: "spot-btc", Cash: 2000, Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-		},
-	}
-	walletBalances := map[SharedWalletKey]float64{
-		{Platform: "hyperliquid", Account: "0xtest"}: 9000,
-	}
-
-	got, fb := computeTotalPortfolioValue(strategies, state, nil, walletBalances, nil)
-	want := 9000.0 + 2000.0
-	if got != want {
-		t.Errorf("delegation: want %.2f, got %.2f", want, got)
-	}
-	if fb {
-		t.Errorf("delegation: expected usedFallback=false")
-	}
-}
-
-func TestComputeInitialPortfolioPeak_SharedWalletManualNoDoubleCount(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-	strategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
-	}
-	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
-	fetcher := stubFetcher(map[SharedWalletKey]float64{key: 1000}, nil)
-
-	got := computeInitialPortfolioPeak(strategies, fetcher)
-	if got != 1000 {
-		t.Errorf("peak init incl. manual: want 1000 (real balance, no double count), got %.2f", got)
-	}
-}
-
-func TestComputeInitialPortfolioPeak_SharedWalletManualFallback(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-	strategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
-	}
-	key := SharedWalletKey{Platform: "hyperliquid", Account: "0xtest"}
-	fetcher := stubFetcher(nil, map[SharedWalletKey]error{key: errors.New("network down")})
-
-	got := computeInitialPortfolioPeak(strategies, fetcher)
-	if got != 1200 {
-		t.Errorf("peak init manual fallback: want 1200 (sum member capital once), got %.2f", got)
-	}
-}
-
 func TestComputeInitialPortfolioPeak_MatchesRiskPathTotalOnColdStart(t *testing.T) {
 	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
 	strategies := []StrategyConfig{
@@ -952,77 +493,6 @@ func TestComputeInitialPortfolioPeak_MatchesRiskPathTotalOnColdStart(t *testing.
 	allowed, _, warning, reason := CheckPortfolioRisk(prs, cfg, totalPV, 0, 0, 0)
 	if !allowed || warning || prs.CurrentDrawdownPct != 0 {
 		t.Errorf("flat cold start: allowed=%v warning=%v dd=%.2f reason=%q", allowed, warning, prs.CurrentDrawdownPct, reason)
-	}
-}
-
-func TestComputeTotalPortfolioValue_SharedWalletManualNoDoubleCount(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-	strategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
-	}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-btc":    {ID: "hl-btc", Cash: 350, Positions: map[string]*Position{}},
-		"hl-eth":    {ID: "hl-eth", Cash: 500, Positions: map[string]*Position{}},
-		"hl-manual": {ID: "hl-manual", Cash: 200, Positions: map[string]*Position{}},
-	}}
-	walletBalances := map[SharedWalletKey]float64{{Platform: "hyperliquid", Account: "0xtest"}: 1000}
-	accountShared := detectSharedWallets(strategies[:2])
-
-	got, fb := computeTotalPortfolioValue(strategies, state, nil, walletBalances, accountShared)
-	if got != 1000 {
-		t.Errorf("risk path incl. manual: want exactly 1000 (real balance, no double count), got %.2f", got)
-	}
-	if fb {
-		t.Errorf("risk path incl. manual: expected usedFallback=false")
-	}
-}
-
-func TestComputeTotalPortfolioValue_SharedWalletManualFallback(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-	strategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=live"}, Capital: 200},
-	}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-btc":    {ID: "hl-btc", Cash: 400, Positions: map[string]*Position{}},
-		"hl-eth":    {ID: "hl-eth", Cash: 400, Positions: map[string]*Position{}},
-		"hl-manual": {ID: "hl-manual", Cash: 200, Positions: map[string]*Position{}},
-	}}
-	accountShared := detectSharedWallets(strategies[:2])
-
-	got, fb := computeTotalPortfolioValue(strategies, state, nil, nil, accountShared)
-	if got != 1000 {
-		t.Errorf("risk path manual fallback: want 1000 (sum member PVs once), got %.2f", got)
-	}
-	if !fb {
-		t.Errorf("risk path manual fallback: expected usedFallback=true")
-	}
-}
-
-func TestComputeTotalPortfolioValue_PaperManualNotDeduped(t *testing.T) {
-	t.Setenv("HYPERLIQUID_ACCOUNT_ADDRESS", "0xtest")
-	strategies := []StrategyConfig{
-		{ID: "hl-btc", Platform: "hyperliquid", Type: "perps", Args: []string{"sma", "BTC", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rsi", "ETH", "1h", "--mode=live"}, Capital: 500},
-		{ID: "hl-manual", Platform: "hyperliquid", Type: "manual", Symbol: "SOL", Args: []string{"hold", "SOL", "1h", "--mode=paper"}, Capital: 200},
-	}
-	state := &AppState{Strategies: map[string]*StrategyState{
-		"hl-btc":    {ID: "hl-btc", Cash: 350, Positions: map[string]*Position{}},
-		"hl-eth":    {ID: "hl-eth", Cash: 500, Positions: map[string]*Position{}},
-		"hl-manual": {ID: "hl-manual", Cash: 200, Positions: map[string]*Position{}},
-	}}
-	walletBalances := map[SharedWalletKey]float64{{Platform: "hyperliquid", Account: "0xtest"}: 1000}
-	accountShared := detectSharedWallets(strategies[:2])
-
-	got, fb := computeTotalPortfolioValue(strategies, state, nil, walletBalances, accountShared)
-	if got != 1200 {
-		t.Errorf("paper manual: want 1200 (balance + manual PV), got %.2f", got)
-	}
-	if fb {
-		t.Errorf("paper manual: expected usedFallback=false")
 	}
 }
 

--- a/scheduler/state_test.go
+++ b/scheduler/state_test.go
@@ -20,43 +20,50 @@ func TestNewAppState(t *testing.T) {
 }
 
 func TestNewStrategyState(t *testing.T) {
-	cfg := StrategyConfig{
-		ID:             "test-spot-btc",
-		Type:           "spot",
-		Platform:       "binanceus",
-		Capital:        1000,
-		MaxDrawdownPct: 60,
+	cases := []struct {
+		name        string
+		cfg         StrategyConfig
+		wantCash    float64
+		wantInitial float64
+	}{
+		{
+			name:     "capital seeds cash and initial capital",
+			cfg:      StrategyConfig{ID: "test-spot-btc", Type: "spot", Platform: "binanceus", Capital: 1000, MaxDrawdownPct: 60},
+			wantCash: 1000, wantInitial: 1000,
+		},
+		{
+			name:     "config initial_capital overrides capital",
+			cfg:      StrategyConfig{ID: "hl-sma-btc", Type: "perps", Platform: "hyperliquid", Capital: 600, InitialCapital: 505, MaxDrawdownPct: 10},
+			wantCash: 600, wantInitial: 505,
+		},
+		{
+			name:     "no config initial_capital falls back to capital",
+			cfg:      StrategyConfig{ID: "hl-sma-btc", Type: "perps", Platform: "hyperliquid", Capital: 600, MaxDrawdownPct: 10},
+			wantCash: 600, wantInitial: 600,
+		},
 	}
-	s := NewStrategyState(cfg)
-	if s.ID != "test-spot-btc" {
-		t.Errorf("ID = %q, want %q", s.ID, "test-spot-btc")
-	}
-	if s.Type != "spot" {
-		t.Errorf("Type = %q, want %q", s.Type, "spot")
-	}
-	if s.Platform != "binanceus" {
-		t.Errorf("Platform = %q, want %q", s.Platform, "binanceus")
-	}
-	if s.Cash != 1000 {
-		t.Errorf("Cash = %g, want 1000", s.Cash)
-	}
-	if s.InitialCapital != 1000 {
-		t.Errorf("InitialCapital = %g, want 1000", s.InitialCapital)
-	}
-	if s.Positions == nil {
-		t.Error("Positions should not be nil")
-	}
-	if s.OptionPositions == nil {
-		t.Error("OptionPositions should not be nil")
-	}
-	if s.TradeHistory == nil {
-		t.Error("TradeHistory should not be nil")
-	}
-	if s.RiskState.PeakValue != 1000 {
-		t.Errorf("RiskState.PeakValue = %g, want 1000", s.RiskState.PeakValue)
-	}
-	if s.RiskState.MaxDrawdownPct != 60 {
-		t.Errorf("RiskState.MaxDrawdownPct = %g, want 60", s.RiskState.MaxDrawdownPct)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewStrategyState(tc.cfg)
+			if s.ID != tc.cfg.ID || s.Type != tc.cfg.Type || s.Platform != tc.cfg.Platform {
+				t.Errorf("identity = (%q, %q, %q), want (%q, %q, %q)", s.ID, s.Type, s.Platform, tc.cfg.ID, tc.cfg.Type, tc.cfg.Platform)
+			}
+			if s.Cash != tc.wantCash {
+				t.Errorf("Cash = %g, want %g", s.Cash, tc.wantCash)
+			}
+			if s.InitialCapital != tc.wantInitial {
+				t.Errorf("InitialCapital = %g, want %g", s.InitialCapital, tc.wantInitial)
+			}
+			if s.Positions == nil || s.OptionPositions == nil || s.TradeHistory == nil {
+				t.Errorf("maps and trade history must be initialized: %+v", s)
+			}
+			if s.RiskState.PeakValue != tc.cfg.Capital {
+				t.Errorf("RiskState.PeakValue = %g, want %g", s.RiskState.PeakValue, tc.cfg.Capital)
+			}
+			if s.RiskState.MaxDrawdownPct != tc.cfg.MaxDrawdownPct {
+				t.Errorf("RiskState.MaxDrawdownPct = %g, want %g", s.RiskState.MaxDrawdownPct, tc.cfg.MaxDrawdownPct)
+			}
+		})
 	}
 }
 
@@ -325,124 +332,6 @@ func TestValidateState(t *testing.T) {
 	}
 }
 
-func TestValidatePerpsDirectionConfig(t *testing.T) {
-	state := NewAppState()
-	state.Strategies["hl-triple-ema-eth"] = &StrategyState{
-		ID:   "hl-triple-ema-eth",
-		Type: "perps",
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "short", Multiplier: 1, Leverage: 1},
-		},
-	}
-	state.Strategies["hl-bidir-btc"] = &StrategyState{
-		ID:   "hl-bidir-btc",
-		Type: "perps",
-		Positions: map[string]*Position{
-			"BTC": {Symbol: "BTC", Quantity: 0.1, AvgCost: 60000, Side: "short", Multiplier: 1, Leverage: 1},
-		},
-	}
-	state.Strategies["hl-bear-sol"] = &StrategyState{
-		ID:   "hl-bear-sol",
-		Type: "perps",
-		Positions: map[string]*Position{
-			"SOL": {Symbol: "SOL", Quantity: 1.0, AvgCost: 200, Side: "long", Multiplier: 1, Leverage: 1},
-		},
-	}
-	state.Strategies["bn-sma-btc"] = &StrategyState{
-		ID:   "bn-sma-btc",
-		Type: "spot",
-		Positions: map[string]*Position{
-			"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.01, AvgCost: 60000, Side: "long"},
-		},
-	}
-
-	cfg := &Config{
-		Strategies: []StrategyConfig{
-			{ID: "hl-triple-ema-eth", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong},
-			{ID: "hl-bidir-btc", Type: "perps", Platform: "hyperliquid", Direction: DirectionBoth},
-			{ID: "hl-bear-sol", Type: "perps", Platform: "hyperliquid", Direction: DirectionShort},
-			{ID: "bn-sma-btc", Type: "spot", Platform: "binanceus"},
-		},
-	}
-
-	warnings := ValidatePerpsDirectionConfig(state, cfg)
-	if len(warnings) != 2 {
-		t.Fatalf("want 2 warnings (long-direction short pos + short-direction long pos), got %d: %v", len(warnings), warnings)
-	}
-	joined := strings.Join(warnings, "\n")
-	if !strings.Contains(joined, "hl-triple-ema-eth") {
-		t.Errorf("warnings should name the long-direction strategy, got: %s", joined)
-	}
-	if !strings.Contains(joined, "hl-bear-sol") {
-		t.Errorf("warnings should name the short-direction strategy, got: %s", joined)
-	}
-	if !strings.Contains(joined, "direction=") {
-		t.Errorf("warnings should cite direction in the gap message, got: %s", joined)
-	}
-}
-
-func TestValidatePerpsDirectionConfig_NoConflicts(t *testing.T) {
-	state := NewAppState()
-	state.Strategies["hl-triple-ema-eth"] = &StrategyState{
-		ID:   "hl-triple-ema-eth",
-		Type: "perps",
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "long", Multiplier: 1, Leverage: 1},
-		},
-	}
-	state.Strategies["hl-bear-sol"] = &StrategyState{
-		ID:   "hl-bear-sol",
-		Type: "perps",
-		Positions: map[string]*Position{
-			"SOL": {Symbol: "SOL", Quantity: 1.0, AvgCost: 200, Side: "short", Multiplier: 1, Leverage: 1},
-		},
-	}
-	cfg := &Config{
-		Strategies: []StrategyConfig{
-			{ID: "hl-triple-ema-eth", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong},
-			{ID: "hl-bear-sol", Type: "perps", Platform: "hyperliquid", Direction: DirectionShort},
-		},
-	}
-	if warnings := ValidatePerpsDirectionConfig(state, cfg); len(warnings) != 0 {
-		t.Errorf("want no warnings when sides match direction, got: %v", warnings)
-	}
-}
-
-func TestValidatePerpsDirectionConfig_OrphanState(t *testing.T) {
-	state := NewAppState()
-	state.Strategies["gone"] = &StrategyState{
-		ID:   "gone",
-		Type: "perps",
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, Side: "short", Multiplier: 1, Leverage: 1},
-		},
-	}
-	cfg := &Config{Strategies: []StrategyConfig{}}
-	if warnings := ValidatePerpsDirectionConfig(state, cfg); len(warnings) != 0 {
-		t.Errorf("orphan state should not produce warnings, got: %v", warnings)
-	}
-}
-
-func TestValidatePerpsDirectionConfig_LegacyAllowShortsFallthrough(t *testing.T) {
-	state := NewAppState()
-	state.Strategies["hl-legacy-eth"] = &StrategyState{
-		ID:   "hl-legacy-eth",
-		Type: "perps",
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 2000, Side: "short", Multiplier: 1, Leverage: 1},
-		},
-	}
-	cfg := &Config{
-		Strategies: []StrategyConfig{
-			{ID: "hl-legacy-eth", Type: "perps", Platform: "hyperliquid", AllowShorts: false},
-		},
-	}
-	warnings := ValidatePerpsDirectionConfig(state, cfg)
-	if len(warnings) != 1 {
-		t.Fatalf("legacy AllowShorts=false should map to direction=long and flag the short, got %d warnings: %v", len(warnings), warnings)
-	}
-}
-
 func makeRegimeDirectionalPolicyForValidation() *RegimeDirectionalPolicy {
 	return &RegimeDirectionalPolicy{TrendRegime: map[string]RegimeDirectionalEntry{
 		"trending_up":   {Direction: DirectionLong, InvertSignal: false},
@@ -451,97 +340,143 @@ func makeRegimeDirectionalPolicyForValidation() *RegimeDirectionalPolicy {
 	}}
 }
 
-func TestValidatePerpsDirectionConfig_RegimePolicyStampedTrendingDown(t *testing.T) {
-	state := NewAppState()
-	state.Strategies["hl-mr-hype"] = &StrategyState{
-		ID:   "hl-mr-hype",
-		Type: "perps",
-		Positions: map[string]*Position{
-			"HYPE": {Symbol: "HYPE", Quantity: 1, Side: "short", Regime: "trending_down", Multiplier: 1, Leverage: 1, DirectionCertifiedAtOpen: true,
-				DirectionCertifiedStatesAtOpen: map[string]string{"trending_up": DirectionLong, "trending_down": DirectionShort, "ranging": DirectionLong}},
+func TestValidatePerpsDirectionConfig(t *testing.T) {
+	perpsPos := func(sym string, qty, avg float64, side string) *Position {
+		return &Position{Symbol: sym, Quantity: qty, AvgCost: avg, Side: side, Multiplier: 1, Leverage: 1}
+	}
+	certified := map[string]string{"trending_up": DirectionLong, "trending_down": DirectionShort, "ranging": DirectionLong}
+	stamped := func(regime string) *Position {
+		p := perpsPos("HYPE", 1, 0, "short")
+		p.Regime = regime
+		p.DirectionCertifiedAtOpen = true
+		p.DirectionCertifiedStatesAtOpen = certified
+		return p
+	}
+	cases := []struct {
+		name           string
+		strategies     map[string]*StrategyState
+		cfg            []StrategyConfig
+		wantCount      int
+		wantJoined     []string
+		wantPerWarning [][]string
+	}{
+		{
+			name: "long and short direction conflicts",
+			strategies: map[string]*StrategyState{
+				"hl-triple-ema-eth": {ID: "hl-triple-ema-eth", Type: "perps", Positions: map[string]*Position{"ETH": perpsPos("ETH", 0.5, 2000, "short")}},
+				"hl-bidir-btc":      {ID: "hl-bidir-btc", Type: "perps", Positions: map[string]*Position{"BTC": perpsPos("BTC", 0.1, 60000, "short")}},
+				"hl-bear-sol":       {ID: "hl-bear-sol", Type: "perps", Positions: map[string]*Position{"SOL": perpsPos("SOL", 1.0, 200, "long")}},
+				"bn-sma-btc":        {ID: "bn-sma-btc", Type: "spot", Positions: map[string]*Position{"BTC/USDT": {Symbol: "BTC/USDT", Quantity: 0.01, AvgCost: 60000, Side: "long"}}},
+			},
+			cfg: []StrategyConfig{
+				{ID: "hl-triple-ema-eth", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong},
+				{ID: "hl-bidir-btc", Type: "perps", Platform: "hyperliquid", Direction: DirectionBoth},
+				{ID: "hl-bear-sol", Type: "perps", Platform: "hyperliquid", Direction: DirectionShort},
+				{ID: "bn-sma-btc", Type: "spot", Platform: "binanceus"},
+			},
+			wantCount:  2,
+			wantJoined: []string{"hl-triple-ema-eth", "hl-bear-sol", "direction="},
+		},
+		{
+			name: "no conflicts when sides match direction",
+			strategies: map[string]*StrategyState{
+				"hl-triple-ema-eth": {ID: "hl-triple-ema-eth", Type: "perps", Positions: map[string]*Position{"ETH": perpsPos("ETH", 0.5, 2000, "long")}},
+				"hl-bear-sol":       {ID: "hl-bear-sol", Type: "perps", Positions: map[string]*Position{"SOL": perpsPos("SOL", 1.0, 200, "short")}},
+			},
+			cfg: []StrategyConfig{
+				{ID: "hl-triple-ema-eth", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong},
+				{ID: "hl-bear-sol", Type: "perps", Platform: "hyperliquid", Direction: DirectionShort},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "orphan state without config produces no warning",
+			strategies: map[string]*StrategyState{
+				"gone": {ID: "gone", Type: "perps", Positions: map[string]*Position{"ETH": perpsPos("ETH", 0.5, 0, "short")}},
+			},
+			cfg:       []StrategyConfig{},
+			wantCount: 0,
+		},
+		{
+			name: "legacy allow_shorts=false maps to direction=long",
+			strategies: map[string]*StrategyState{
+				"hl-legacy-eth": {ID: "hl-legacy-eth", Type: "perps", Positions: map[string]*Position{"ETH": perpsPos("ETH", 0.5, 2000, "short")}},
+			},
+			cfg:       []StrategyConfig{{ID: "hl-legacy-eth", Type: "perps", Platform: "hyperliquid", AllowShorts: false}},
+			wantCount: 1,
+		},
+		{
+			name: "regime policy stamped trending_down short does not warn",
+			strategies: map[string]*StrategyState{
+				"hl-mr-hype": {ID: "hl-mr-hype", Type: "perps", Positions: map[string]*Position{"HYPE": stamped("trending_down")}},
+			},
+			cfg: []StrategyConfig{{
+				ID: "hl-mr-hype", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong,
+				RegimeDirectionalPolicy: makeRegimeDirectionalPolicyForValidation(),
+			}},
+			wantCount: 0,
+		},
+		{
+			name: "regime policy stamped trending_up short conflicts",
+			strategies: map[string]*StrategyState{
+				"hl-mr-hype": {ID: "hl-mr-hype", Type: "perps", Positions: map[string]*Position{"HYPE": stamped("trending_up")}},
+			},
+			cfg: []StrategyConfig{{
+				ID: "hl-mr-hype", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong,
+				RegimeDirectionalPolicy: makeRegimeDirectionalPolicyForValidation(),
+			}},
+			wantCount:      1,
+			wantPerWarning: [][]string{{"stamped regime=\"trending_up\""}},
+		},
+		{
+			name: "regime policy uncertified legacy short warns for #1085 migration",
+			strategies: map[string]*StrategyState{
+				"hl-mr-hype": {ID: "hl-mr-hype", Type: "perps", Positions: map[string]*Position{"HYPE": perpsPos("HYPE", 1, 0, "short")}},
+			},
+			cfg: []StrategyConfig{{
+				ID: "hl-mr-hype", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong,
+				RegimeDirectionalPolicy: makeRegimeDirectionalPolicyForValidation(),
+			}},
+			wantCount:      1,
+			wantPerWarning: [][]string{{"DEFAULT-OFF", "#1085"}},
+		},
+		{
+			name: "warning order sorted by symbol",
+			strategies: map[string]*StrategyState{
+				"hl-multi": {ID: "hl-multi", Type: "perps", Positions: map[string]*Position{
+					"ETH": perpsPos("ETH", 1, 0, "short"),
+					"BTC": perpsPos("BTC", 0.1, 0, "short"),
+				}},
+			},
+			cfg:            []StrategyConfig{{ID: "hl-multi", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong}},
+			wantCount:      2,
+			wantPerWarning: [][]string{{" BTC "}, {" ETH "}},
 		},
 	}
-	cfg := &Config{
-		Strategies: []StrategyConfig{{
-			ID: "hl-mr-hype", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong,
-			RegimeDirectionalPolicy: makeRegimeDirectionalPolicyForValidation(),
-		}},
-	}
-	if warnings := ValidatePerpsDirectionConfig(state, cfg); len(warnings) != 0 {
-		t.Fatalf("short under trending_down policy should not warn, got: %v", warnings)
-	}
-}
-
-func TestValidatePerpsDirectionConfig_RegimePolicyStampedTrendingUpConflict(t *testing.T) {
-	state := NewAppState()
-	state.Strategies["hl-mr-hype"] = &StrategyState{
-		ID:   "hl-mr-hype",
-		Type: "perps",
-		Positions: map[string]*Position{
-			"HYPE": {Symbol: "HYPE", Quantity: 1, Side: "short", Regime: "trending_up", Multiplier: 1, Leverage: 1, DirectionCertifiedAtOpen: true,
-				DirectionCertifiedStatesAtOpen: map[string]string{"trending_up": DirectionLong, "trending_down": DirectionShort, "ranging": DirectionLong}},
-		},
-	}
-	cfg := &Config{
-		Strategies: []StrategyConfig{{
-			ID: "hl-mr-hype", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong,
-			RegimeDirectionalPolicy: makeRegimeDirectionalPolicyForValidation(),
-		}},
-	}
-	warnings := ValidatePerpsDirectionConfig(state, cfg)
-	if len(warnings) != 1 {
-		t.Fatalf("want 1 warning for short under trending_up policy, got %d: %v", len(warnings), warnings)
-	}
-	if !strings.Contains(warnings[0], "stamped regime=\"trending_up\"") {
-		t.Errorf("warning should cite stamped regime, got: %s", warnings[0])
-	}
-}
-
-func TestValidatePerpsDirectionConfig_RegimePolicyUncertifiedWarnsForMigration(t *testing.T) {
-	state := NewAppState()
-	state.Strategies["hl-mr-hype"] = &StrategyState{
-		ID:   "hl-mr-hype",
-		Type: "perps",
-		Positions: map[string]*Position{
-			"HYPE": {Symbol: "HYPE", Quantity: 1, Side: "short", Multiplier: 1, Leverage: 1},
-		},
-	}
-	cfg := &Config{
-		Strategies: []StrategyConfig{{
-			ID: "hl-mr-hype", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong,
-			RegimeDirectionalPolicy: makeRegimeDirectionalPolicyForValidation(),
-		}},
-	}
-	warnings := ValidatePerpsDirectionConfig(state, cfg)
-	if len(warnings) != 1 {
-		t.Fatalf("uncertified legacy short must surface for migration, got %d: %v", len(warnings), warnings)
-	}
-	if !strings.Contains(warnings[0], "DEFAULT-OFF") || !strings.Contains(warnings[0], "#1085") {
-		t.Errorf("warning should cite the #1085 default-off migration, got: %s", warnings[0])
-	}
-}
-
-func TestValidatePerpsDirectionConfig_WarningOrderDeterministic(t *testing.T) {
-	state := NewAppState()
-	state.Strategies["hl-multi"] = &StrategyState{
-		ID:   "hl-multi",
-		Type: "perps",
-		Positions: map[string]*Position{
-			"ETH": {Symbol: "ETH", Quantity: 1, Side: "short", Multiplier: 1, Leverage: 1},
-			"BTC": {Symbol: "BTC", Quantity: 0.1, Side: "short", Multiplier: 1, Leverage: 1},
-		},
-	}
-	cfg := &Config{
-		Strategies: []StrategyConfig{{
-			ID: "hl-multi", Type: "perps", Platform: "hyperliquid", Direction: DirectionLong,
-		}},
-	}
-	warnings := ValidatePerpsDirectionConfig(state, cfg)
-	if len(warnings) != 2 {
-		t.Fatalf("want 2 warnings, got %d: %v", len(warnings), warnings)
-	}
-	if !strings.Contains(warnings[0], " BTC ") || !strings.Contains(warnings[1], " ETH ") {
-		t.Errorf("warnings should be sorted by symbol (BTC before ETH), got:\n%s\n%s", warnings[0], warnings[1])
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := NewAppState()
+			for id, s := range tc.strategies {
+				state.Strategies[id] = s
+			}
+			warnings := ValidatePerpsDirectionConfig(state, &Config{Strategies: tc.cfg})
+			if len(warnings) != tc.wantCount {
+				t.Fatalf("want %d warnings, got %d: %v", tc.wantCount, len(warnings), warnings)
+			}
+			joined := strings.Join(warnings, "\n")
+			for _, want := range tc.wantJoined {
+				if !strings.Contains(joined, want) {
+					t.Errorf("warnings should contain %q, got: %s", want, joined)
+				}
+			}
+			for i, wants := range tc.wantPerWarning {
+				for _, want := range wants {
+					if !strings.Contains(warnings[i], want) {
+						t.Errorf("warnings[%d] should contain %q, got: %s", i, want, warnings[i])
+					}
+				}
+			}
+		})
 	}
 }
 
@@ -656,169 +591,126 @@ func TestLoadStateWithDB_MigratesLegacyPerpsMultiplier(t *testing.T) {
 }
 
 func TestSaveStateWithDB(t *testing.T) {
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "state.db")
+	t.Run("persists cycle count", func(t *testing.T) {
+		db, err := OpenStateDB(filepath.Join(t.TempDir(), "state.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
 
-	db, err := OpenStateDB(dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
+		state := &AppState{
+			CycleCount: 3,
+			Strategies: map[string]*StrategyState{
+				"test": {ID: "test", Type: "spot", Cash: 800, InitialCapital: 1000,
+					Positions: make(map[string]*Position), OptionPositions: make(map[string]*OptionPosition), TradeHistory: []Trade{}},
+			},
+		}
+		if err := SaveStateWithDB(state, &Config{}, db); err != nil {
+			t.Fatal(err)
+		}
+		dbState, err := db.LoadState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dbState.CycleCount != 3 {
+			t.Errorf("SQLite CycleCount = %d, want 3", dbState.CycleCount)
+		}
+	})
+	t.Run("closed db returns error", func(t *testing.T) {
+		db, err := OpenStateDB(filepath.Join(t.TempDir(), "state.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		db.Close()
 
-	state := &AppState{
-		CycleCount: 3,
-		Strategies: map[string]*StrategyState{
-			"test": {ID: "test", Type: "spot", Cash: 800, InitialCapital: 1000,
-				Positions: make(map[string]*Position), OptionPositions: make(map[string]*OptionPosition), TradeHistory: []Trade{}},
-		},
-	}
-
-	cfg := &Config{}
-	if err := SaveStateWithDB(state, cfg, db); err != nil {
-		t.Fatal(err)
-	}
-
-	dbState, err := db.LoadState()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dbState.CycleCount != 3 {
-		t.Errorf("SQLite CycleCount = %d, want 3", dbState.CycleCount)
-	}
-}
-
-func TestSaveStateWithDB_Error(t *testing.T) {
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "state.db")
-
-	db, err := OpenStateDB(dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db.Close()
-
-	state := &AppState{CycleCount: 5, Strategies: make(map[string]*StrategyState)}
-	cfg := &Config{}
-	err = SaveStateWithDB(state, cfg, db)
-	if err == nil {
-		t.Error("expected error when SQLite is closed")
-	}
-}
-
-func TestNewStrategyState_ConfigInitialCapital(t *testing.T) {
-	cfg := StrategyConfig{
-		ID:             "hl-sma-btc",
-		Type:           "perps",
-		Platform:       "hyperliquid",
-		Capital:        600,
-		InitialCapital: 505,
-		MaxDrawdownPct: 10,
-	}
-	s := NewStrategyState(cfg)
-	if s.InitialCapital != 505 {
-		t.Errorf("InitialCapital = %g, want 505 (from config)", s.InitialCapital)
-	}
-	if s.Cash != 600 {
-		t.Errorf("Cash = %g, want 600 (from Capital)", s.Cash)
-	}
-}
-
-func TestNewStrategyState_NoConfigInitialCapital(t *testing.T) {
-	cfg := StrategyConfig{
-		ID:             "hl-sma-btc",
-		Type:           "perps",
-		Platform:       "hyperliquid",
-		Capital:        600,
-		MaxDrawdownPct: 10,
-	}
-	s := NewStrategyState(cfg)
-	if s.InitialCapital != 600 {
-		t.Errorf("InitialCapital = %g, want 600 (from Capital fallback)", s.InitialCapital)
-	}
+		state := &AppState{CycleCount: 5, Strategies: make(map[string]*StrategyState)}
+		if err := SaveStateWithDB(state, &Config{}, db); err == nil {
+			t.Error("expected error when SQLite is closed")
+		}
+	})
 }
 
 func TestReconcileConfigInitialCapital(t *testing.T) {
-	dir := t.TempDir()
-	db, err := OpenStateDB(filepath.Join(dir, "state.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	resetInitialCapitalGuardDedup(t)
+	t.Run("config change updates memory and db, untouched strategy stays", func(t *testing.T) {
+		db, err := OpenStateDB(filepath.Join(t.TempDir(), "state.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		resetInitialCapitalGuardDedup(t)
 
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"hl-tema-eth": {
-				ID: "hl-tema-eth", Type: "perps", Platform: "hyperliquid",
-				Cash: 505, InitialCapital: 505,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+		state := &AppState{
+			Strategies: map[string]*StrategyState{
+				"hl-tema-eth": {
+					ID: "hl-tema-eth", Type: "perps", Platform: "hyperliquid",
+					Cash: 505, InitialCapital: 505,
+					Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+				},
+				"silent": {
+					ID: "silent", Type: "spot", Cash: 200, InitialCapital: 200,
+					Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+				},
 			},
-			"silent": {
-				ID: "silent", Type: "spot", Cash: 200, InitialCapital: 200,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{},
+		}
+		if err := db.SaveState(state); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &Config{
+			Strategies: []StrategyConfig{
+				{ID: "hl-tema-eth", Type: "perps", Platform: "hyperliquid", Capital: 1000, InitialCapital: 1000},
+				{ID: "silent", Type: "spot", Capital: 200},
 			},
-		},
-	}
-	if err := db.SaveState(state); err != nil {
-		t.Fatal(err)
-	}
+		}
 
-	cfg := &Config{
-		Strategies: []StrategyConfig{
-			{ID: "hl-tema-eth", Type: "perps", Platform: "hyperliquid", Capital: 1000, InitialCapital: 1000},
-			{ID: "silent", Type: "spot", Capital: 200},
-		},
-	}
+		infos, errs := ReconcileConfigInitialCapital(cfg, state, db)
+		if len(infos) != 1 {
+			t.Fatalf("infos = %d, want 1 (only hl-tema-eth changed)", len(infos))
+		}
+		if len(errs) != 0 {
+			t.Fatalf("errs = %v, want none", errs)
+		}
 
-	infos, errs := ReconcileConfigInitialCapital(cfg, state, db)
-	if len(infos) != 1 {
-		t.Fatalf("infos = %d, want 1 (only hl-tema-eth changed)", len(infos))
-	}
-	if len(errs) != 0 {
-		t.Fatalf("errs = %v, want none", errs)
-	}
+		if got := state.Strategies["hl-tema-eth"].InitialCapital; got != 1000 {
+			t.Errorf("in-memory InitialCapital = %g, want 1000", got)
+		}
+		if got := state.Strategies["silent"].InitialCapital; got != 200 {
+			t.Errorf("untouched strategy InitialCapital = %g, want 200", got)
+		}
 
-	if got := state.Strategies["hl-tema-eth"].InitialCapital; got != 1000 {
-		t.Errorf("in-memory InitialCapital = %g, want 1000", got)
-	}
-	if got := state.Strategies["silent"].InitialCapital; got != 200 {
-		t.Errorf("untouched strategy InitialCapital = %g, want 200", got)
-	}
+		if err := db.SaveState(state); err != nil {
+			t.Fatalf("SaveState after reconcile: %v", err)
+		}
+		loaded, err := db.LoadState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := loaded.Strategies["hl-tema-eth"].InitialCapital; got != 1000 {
+			t.Errorf("persisted InitialCapital = %g, want 1000", got)
+		}
+	})
+	t.Run("no-op when config matches db", func(t *testing.T) {
+		db, err := OpenStateDB(filepath.Join(t.TempDir(), "state.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		resetInitialCapitalGuardDedup(t)
 
-	if err := db.SaveState(state); err != nil {
-		t.Fatalf("SaveState after reconcile: %v", err)
-	}
-	loaded, err := db.LoadState()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := loaded.Strategies["hl-tema-eth"].InitialCapital; got != 1000 {
-		t.Errorf("persisted InitialCapital = %g, want 1000", got)
-	}
-}
-
-func TestReconcileConfigInitialCapital_NoOpWhenAligned(t *testing.T) {
-	dir := t.TempDir()
-	db, err := OpenStateDB(filepath.Join(dir, "state.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	resetInitialCapitalGuardDedup(t)
-
-	state := &AppState{
-		Strategies: map[string]*StrategyState{
-			"s": {ID: "s", Type: "spot", Cash: 1000, InitialCapital: 1000,
-				Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
-		},
-	}
-	if err := db.SaveState(state); err != nil {
-		t.Fatal(err)
-	}
-	cfg := &Config{Strategies: []StrategyConfig{
-		{ID: "s", Type: "spot", Capital: 1000, InitialCapital: 1000},
-	}}
-	if infos, errs := ReconcileConfigInitialCapital(cfg, state, db); len(infos) != 0 || len(errs) != 0 {
-		t.Errorf("infos=%v errs=%v, want none when config matches DB", infos, errs)
-	}
+		state := &AppState{
+			Strategies: map[string]*StrategyState{
+				"s": {ID: "s", Type: "spot", Cash: 1000, InitialCapital: 1000,
+					Positions: map[string]*Position{}, OptionPositions: map[string]*OptionPosition{}},
+			},
+		}
+		if err := db.SaveState(state); err != nil {
+			t.Fatal(err)
+		}
+		cfg := &Config{Strategies: []StrategyConfig{
+			{ID: "s", Type: "spot", Capital: 1000, InitialCapital: 1000},
+		}}
+		if infos, errs := ReconcileConfigInitialCapital(cfg, state, db); len(infos) != 0 || len(errs) != 0 {
+			t.Errorf("infos=%v errs=%v, want none when config matches DB", infos, errs)
+		}
+	})
 }


### PR DESCRIPTION
## Plain simple English

The automatic checks for the money and safety parts of the trading program were larger than needed. This change merges checks that test the same thing into one table and removes checks of small details. Every check that protects money, saved data, or a safety stop stays and still passes. The set is now smaller and easier to change.

## Summary

Phase A of #1485 (Go protected core). Part of #1485; phases B–E follow in their own PRs.

Files: `risk`, `daily_loss`, `exposure_cap`, `notional_cap`, `kill_switch_*`, `hyperliquid_liquidation_guard`, `hyperliquid_fills`, `shared_wallet*`, `db`, `state`, `config*` tests.

| Metric | Before (`a864c355`) | After |
|---|---|---|
| Phase A test lines | 26,825 | 22,967 |
| Phase A `func Test` | 822 | 515 |
| All Go test lines | 97,510 | 93,652 |
| All Go `func Test` | 3,191 | 2,884 |
| Package statement coverage | 70.4% | 70.4% |

Per-file coverage on protected files (mean of per-function coverage from `go tool cover -func`): every protected file is unchanged. `config_reload.go` and `config_migration.go` briefly dropped after the formatter and no-`strategies`-key tests were removed; both were restored (`TestFormatFloatPtrVariants`, `TestMigrateConfigRetainsInertLegacyDiscordKeys/versionless_without_strategies`) and the files are back at 92.1% and 85.4%. The only delta in the package is `model_only_close_alert.go` 71.4% → 75.0% (up).

## Verification

- `go build`, `gofmt -l`, `go vet` clean.
- `go test -count=1 .` from `scheduler`: every test passes except five pre-existing `update_sh_feature_test.go` cases that fail on macOS because `scripts/update.sh:604` uses `declare -A`, which macOS bash 3.2 rejects. They fail identically on `main` and are Phase B scope (updater); CI Linux has bash 5.
- No non-test source changed. The accuracy audit (issue rule 1b) ran on every kept test; findings that led to no edit are in the "Kept-but-flagged" lists below.

## Test edits (disclosure)

Every edit below is a merge (Obsolete-redundant, all assertions carried into the named table) or a removal with the stated case and ground. No test was loosened on a money/state path; the only loosened cases are listed per group.

### report_risk.md
## Files: scheduler/risk_test.go   Before: 3680 / 130   After: 3372 / 80
## Removed
None outright; every vanished name was merged.
## Merged (all assertions carried; several subtests assert more)
- 3 `TestRolloverDailyPnL_*` → `TestRolloverDailyPnL`; 2 `TestRecordTradeResult_*` → `TestRecordTradeResult`; 4 `TestPortfolioNotional_*` → `TestPortfolioNotional`; `TestCollectFuturesMarkSymbols_IgnoresManual` → `TestCollectFuturesMarkSymbols`; 2 `TestCollectPerpsMarkSymbols_*` → `TestCollectPerpsMarkSymbols`; 2 `TestClearLatchedKillSwitchSharedWallet_*NoOp` → `_NoOp`; 6 `TestPerpsMarginDrawdownInputs_*` → one table (tol 1e-3→1e-6); 4 `TestAggregatePerpsMarginInputs_*` → one table; 6 `TestCheckRisk_Perps*/SpotUnchanged` → `TestCheckRisk_DrawdownBasis`; 3 `TestCheckRisk_LiveHL*` → `_LiveHLCircuitBreaker_SharedCoinVsSoleOwner`; 2 `TestCheckRisk_LiveTopStepCB_*` → `_PendingFlatten`; 3 `TestCheckPortfolioRisk_MixedAccount*/PeakZero*` → `_LatchSource`; 4 `TestCheckPortfolioRisk_MarginWarning*/Both*` → `_MarginWarningReasons` (#1448 regression kept as subtest); 3 pending-circuit-close round trips → `_RoundTrip`; 4 unmarshal variants → `_Unmarshal`; 2 `TestCircuitBreakerStrategyLabel_*`; 6 `TestCollectMissingMarkPositions_*`; 2 `TestManualOnlyMarkSymbols_*`; 5 `TestMissingManualOnlyMarks_*`.
## Loosened / rewritten
None.
## Kept-but-flagged
- Warn-band lifecycle family, DM triage-section pins, `_CircuitBreakerDisabled_WarnsOncePerEpisode` log pins (operator-facing, kept), `TestTruncateWarningField_UTF8Safe`.
## Code workarounds found
None.

### report_caps.md
## Files: scheduler/daily_loss_test.go, scheduler/exposure_cap_test.go, scheduler/notional_cap_test.go   Before: 1270 lines / 51 Test funcs (354/18, 689/26, 227/7)   After: 1121 / 31 (327/8, 602/18, 192/5)

Measured with `wc -l` and `grep -c '^func Test'`. Targeted run: `go test -count=1 -run 'DailyLoss|NotionalCap|ExposureCap|ManualStateView|ManualCore|CheckPortfolioRisk_Notional|ConfigValidationDailyLoss|ValidateConfig_ExposureCapBounds|ManualExposure' .` green (79 tests/subtests PASS); `go vet .` clean.

## Removed
- `TestNotionalCapHoldPassesReduceAndManage` (notional_cap_test.go) — case: Obsolete-redundant — ground: the test evaluated `const notionalBlocked = true && pausedBlocksSignal(...)`, so its only real code path is `pausedBlocksSignal` (scheduler/pause.go:3-20); the notional wiring in main.go is not exercised by it — survivor: `TestPausedBlocksSignal` (scheduler/pause_test.go) carries every row: `manage_only_signal0` (0,0,1,long,true,true→false) = "hold open"; `long_sell_pure_close` (-1,0,1,long,true,false→false) = "long-only sell exit" (qty 2 vs 1, same `posQty>0`/`!allowsShort` branch); `long_close_fraction` (-1,0.5,1,long,true,true→false) = "open long partial close"; `flat_buy_fresh_open` (1,0,0,"",true,true→true) = "flat buy" (allowsShort differs, but pause.go:7 returns true on `posQty<=0` before either flag is read); `long_buy_scale_in` (1,0,1,long,true,true→true) = "open long buy add both"; `long_sell_flip_both` (-1,0,1,long,true,true→true) = "long flip to short". The notional-specific guard (main.go must gate on `notionalBlocked && pausedBlocksSignal`, never `continue`) remains in `TestNotionalCapNeverSkipsStrategyCycle` (kept, #1344).

## Merged
- `TestEvaluateDailyLossLimitUnconfigured`, `TestEvaluateDailyLossLimitUSDThreshold`, `TestEvaluateDailyLossLimitPctThreshold`, `TestEvaluateDailyLossLimitPctBasisExcludesSharedWalletPool`, `TestEvaluateDailyLossLimitBothArmsLowerWins`, `TestEvaluateDailyLossLimitStaleDayExcluded`, `TestEvaluateDailyLossLimitWinsOffsetLosses`, `TestEvaluateDailyLossLimitManualStrategyIncluded`, `TestEvaluateDailyLossLimitPctBasisMiss`, `TestEvaluateDailyLossLimitNilStateSkipped` → `TestEvaluateDailyLossLimit` (daily_loss_test.go), 18 subtests — assertions carried: Tripped on every row; Configured=false + LossUSD=900 (max_drawdown-only) and Configured=false (nil config); USD arm below/at threshold and multi-strategy aggregate (loss 550, threshold 500); pct arm basis 5000/threshold 250 tripped and under-threshold not tripped; shared-wallet pool excluded from basis (2000/100, tripped) and all-pool → basis 0 + PctBasisMiss + not tripped; both arms lower-wins (threshold 400 tripped; threshold 1000 not tripped); stale day counts 0 (loss 50); wins offset losses (loss 50; net-positive loss 0); manual type counts (loss 350 tripped); pct-only basis miss inert vs USD arm still enforces (threshold 500 tripped); nil state entry skipped (loss 150 tripped). Rows that formerly mutated `states` between calls are now independent rows with fresh inputs. `dlBool` helper added; `fp` reused from risk_sizing_test.go.
- `TestManualOpenCoreRefusesDailyLossHold`, `TestManualAddCoreRefusesDailyLossHold` → `TestManualCoreRefusesDailyLossHold` (daily_loss_test.go) — assertions carried: execute never called (t.Error in stub), error contains "daily loss limit tripped" for both manual-open and manual-add (add row carries the open long Position).
- `TestManualOpenCoreRefusesNotionalHold`, `TestManualAddCoreRefusesNotionalHold` → `TestManualCoreRefusesNotionalHold` (notional_cap_test.go) — assertions carried: execute never called, error contains "new opens blocked, exits continue" for both open and add.
- `TestEvaluateExposureCap_AllLongBookBlocksLongsOnly` (evaluate half), `TestEvaluateExposureCap_NettingPerAsset`, `TestEvaluateExposureCap_SameAssetNetsBeforeBucketing`, `TestEvaluateExposureCap_DisabledByDefault` (evaluate half), `TestEvaluateExposureCap_FailSafeExclusions`, `TestEvaluateExposureCap_AvgCostFallback`, `TestEvaluateExposureCap_ManualPositionsCounted` → `TestEvaluateExposureCap_Buckets` (exposure_cap_test.go), 8 subtests — assertions carried: Configured; LongUSD/ShortUSD exact values (19000/0, 10000/10000, 10000/0 same-asset netting, 10000 with exclusions, 18200 AvgCost fallback, 12000 manual); LongBlocked/ShortBlocked on every configured row (some rows previously asserted only one flag; both are now asserted with the values the code produces, verified green); disabled (zero thresholds, nil config) → Configured=false and no bucket blocked; SkippedPositions count=2 with both entry strings and `exposureCapSkippedWarning` "2 position(s) excluded"; no skips on AvgCost fallback (len 0 now asserted on every configured row). Helpers `perpsPosState`/`perpsCfg` replace repeated inline fixtures with identical field values.
- `TestExposureCapBlocksSignal_ManageAndReducePassThrough`, `TestExposureCapBlocksSignal_DirectionalIncreases`, plus the `exposureCapBlocksSignal` halves of `..._AllLongBookBlocksLongsOnly` and `..._DisabledByDefault` → `TestExposureCapBlocksSignal` (exposure_cap_test.go), 12 subtests — assertions carried: signal 0 / close action / pure-close sell on long / pure-close buy on short pass under both buckets capped; scale-in add blocked while longs capped; long→short flip passes when only longs capped and is held when shorts capped; fresh short blocked when shorts capped, passes when only longs capped; fresh long on the 19000/15000 book blocked with reason containing "new long opens blocked", "$19000.00", "$15000.00"; fresh short passes on that book; unconfigured status never blocks. The AllLong reason row uses a status equal to the evaluated one (Configured, CapUSD 15000, LongUSD 19000, LongBlocked); the reason string is produced by `exposureCapBlocksSignal`, the same path.
- `TestManualOpenCoreRefusesExposureCap`, `TestManualAddCoreRefusesConcentrationOnly` → `TestManualCoreRefusesExposureCap` (exposure_cap_test.go), 4 subtests — assertions carried: open long refused ("manual-open (long) blocked", execute not called); open short reaches execute while only longs capped; add long refused by concentration-only status ("manual-add (long) blocked", execute not called); add short reaches execute when ETH is long-over-concentrated.

## Loosened / rewritten
- None.

## Kept-but-flagged (audit findings, no edit)
- `TestDailyLossStartupSummaryLine`, `TestExposureCapStartupSummaryLine` — pin boot-log wording (`usd=$500.00`, `pct=5.00%`, `same_direction=$15000.00`, `capped-direction opens only`). Left alone: the line is the operator's boot confirmation of the armed thresholds and the empty-when-disabled branch is behavior; the exact token spelling drives no decision and could be loosened to "contains the threshold numbers" if the lead prefers.
- `TestDailyLossStatusNote`, `TestFormatDailyLossPctBasisMissDM`, `TestExposureCapStatusNote`, `TestExposureCapHoldDetail`, `TestExposureCapAlertMessage_*` — assert operator-surface labels (`TRIPPED`, `armed`, `CANNOT evaluate`, `fully inert`, `USD arm still enforces`, emoji prefixes). Kept as contract: these labels tell the operator whether the gate is enforcing or inert.
- `TestNotionalCapNeverSkipsStrategyCycle` — reads and AST-parses `main.go` relative to the test cwd; holds under `go test` because cwd is the package dir. #1344 regression; kept.
- `TestCheckPortfolioRisk_NotionalCapReasonMentionsExitsContinue` — overlaps `TestCheckPortfolioRisk_NotionalCap` (risk_test.go) on the `nb` flag, but the "exits continue" reason wording (#1344) has no counterpart there; kept.
- `TestExposureCapFieldsHotReloadable` — asserts only that adding both thresholds passes `validateHotReloadCompatible`; the `max_notional_usd` restart-required rejection lives in the hot-reload test file. Kept as-is.
- `TestManualStateViewDailyLossHold` / `TestManualStateViewNotionalHold` — same shape in two files; left separate because each reads a different `manualStateView` field and lives beside its gate.

## Code workarounds found (do NOT fix, report only)
- None found in daily_loss.go, exposure_cap.go, notional_cap.go for these tests.

### report_kill_switch.md
## Files: scheduler/kill_switch_close_test.go, scheduler/kill_switch_manual_test.go, scheduler/kill_switch_reset_dm_test.go, scheduler/kill_switch_limit_orders_test.go   Before: 3891 lines / 108 Test funcs (close 2044/48, manual 546/17, reset_dm 304/13, limit_orders 997/30)   After: 3308 lines / 79 Test funcs (close 1560/28, manual 551/15, reset_dm 231/8, limit_orders 966/28)

All four files green before and after; `go -C scheduler vet .` clean; `gofmt -w` applied. Every assertion on `OnChainConfirmedFlat`, `CanAutoResetWithoutOwner`, fill-share splitting, limit-order cancel/adoption eligibility, reset gating, and operator-facing DM text survived. No file outside the four assigned test files was touched.

## Removed
Nothing was removed as a standalone deletion. Every retired `Test*` function was folded into a survivor carrying all of its assertions (see Merged).

## Merged
- `TestHyperliquidKillSwitchClose_SharedCoinSplitsFillByVirtualQuantity`,`TestHyperliquidKillSwitchClose_SharedCoinPeersSumToReport` → `TestHyperliquidKillSwitchClose_SharedCoinSplitsFillByVirtualQuantity` (kill_switch_close_test.go) — carried: 1 trade per peer; peer qty 1.5 / 0.5; qty sum == 2.0; fee sum == 4.0; both prices == 3000; peer fees 3.0 / 1.0; peer A `ClosedPositions` len 1; peer A `RealizedPnL == -153.0`. Ground: identical two-peer state and fill in both tests; the old "SplitsFill" test asserted a peer-A-only subset plus PnL/ClosedPositions, now in the survivor.
- `TestPlanKillSwitchClose_{OKX,Robinhood,TopStep}{HappyPath,CloseError,FetchFailure,UnconfiguredBlocksReset}` (12 funcs) → `TestPlanKillSwitchClose_PlatformLifecycle` subtests `<Platform>/HappyPath|CloseError|FetchFailure|UnconfiguredBlocksReset` (kill_switch_close_test.go) — carried per platform. HappyPath: confirmed-flat, fetcher called once, closer calls == [coin], DM contains `"<Label> closes: [coin]"`. CloseError: NOT confirmed-flat, `<Platform>CloseReport.Errors[coin]` non-nil, DM contains `LATCHED, RETRYING` + closer error text. FetchFailure: NOT confirmed-flat, closer never called, DM contains `LATCHED, RETRYING`. Unconfigured: NOT confirmed-flat, `<Platform>Unconfigured == [SOL|DOGE|NQ]`, closer calls == [coin], DM contains `manual intervention required`. Per-platform harness builds real `KillSwitchCloseInputs` with the same stub closers/fetchers, so the same code path is reached. Error strings became `<Platform> venue rate limited` / `<Platform> auth failed`; the contract (error text surfaces in DM) is unchanged.
- `TestPlanKillSwitchClose_{HL,OKX,RH,TS}FetcherUnwiredLatches` → `TestPlanKillSwitchClose_FetcherUnwiredLatches` (kill_switch_close_test.go) — carried: NOT confirmed-flat with nil fetcher and platform configured (HL: `HLAddr` set, `HLStateFetched=false`); log contains `<X>Fetcher unwired`.
- `TestPlanKillSwitchClose_DeterministicErrorOrder`,`..._RobinhoodDeterministicErrorOrder`,`..._OKXDeterministicErrorOrder` → `TestPlanKillSwitchClose_DeterministicErrorOrder` subtests `HL|Robinhood|OKX` (kill_switch_close_test.go) — carried: DM identical across 10 runs; coin entries alphabetical (HL BTC<DOGE<ETH<SOL; RH BTC<DOGE<ETH; OKX BTC<ETH<SOL). Order check now also fails when a coin is absent (`idx < 0`).
- `TestPlanKillSwitchClose_HLSuccessOKXFailureStillLatches`,`..._RobinhoodFailureStillLatchesAcrossPlatforms`,`..._TopStepFailureStillLatchesAcrossPlatforms` → `TestPlanKillSwitchClose_PeerPlatformFailureStillLatches` subtests `OKX|Robinhood|TopStep` (kill_switch_close_test.go) — carried: NOT confirmed-flat when the peer venue fails while HL succeeds; HL `ClosedCoins == [ETH]` (previously TopStep-only, now all three); DM contains `LATCHED, RETRYING` (previously OKX-only, now all three); DM contains peer error text (`okx err` / `rh err` / `venue down`).
- `TestPlanKillSwitchClose_HLAndOKXHappyPath` → folded into `TestPlanKillSwitchClose_HLAndOKXAndRobinhoodHappyPath` (kill_switch_close_test.go) — carried: confirmed-flat; HL closer calls == [ETH]; OKX closer calls == [BTC]; DM contains `HL closes: [ETH]` and `OKX closes: [BTC]`.
- `TestPlanKillSwitchClose_OKXSpotSurfacesGap`,`..._RobinhoodOptionsSurfacesGap` → `TestPlanKillSwitchClose_OperatorRequiredGapSuppressesAutoReset` subtests (kill_switch_close_test.go) — carried: presence does NOT block confirmed-flat; `OKXSpotPresent`/`RHOptionsPresent` true; `CanAutoResetWithoutOwner()` false; DM contains `OKX spot` / `Robinhood options`.
- `TestKillSwitchInstanceLabel_UsesConfigDirBasename`,`..._FallsBackWhenPathGivesNothingUseful` → `TestKillSwitchInstanceLabel` (kill_switch_close_test.go) — carried: `live`, `paper-hl-eth`, bare `config.json` → neither `"."` nor `""`.
- `TestFormatKillSwitchResetPrompt_{ConfirmedFlatIncludesContextAndIdentity,LatchedRetryingWarnsProtectionMayBeGone,OmitsAddressWhenHLNotConfigured}` → `TestFormatKillSwitchResetPrompt` (kill_switch_close_test.go) — carried verbatim as want/reject lists: instance label, HL address, reused reason, reused `HL closes: [ETH]`, `does not itself close or protect any position`, no `still retrying` on confirmed-flat; `still retrying` + `stop-losses may already be cancelled` on latched; no dangling `()` and label present when address empty.
- `TestCollectHLKillSwitchStopOIDs_IncludesManualTriggers`,`..._LowerCaseManualSymbolFallsBackToRawKey` → `TestCollectHLKillSwitchStopOIDs` (kill_switch_manual_test.go) — carried: BTC → [333], ETH → [111 222], `sol` → [444] under raw lower-case key; added: no extra coins collected.
- `TestParseKillSwitchResetDMTimeout_{DefaultsToSixHours,ParsesGoDuration,RejectsInvalid,RejectsNonPositive}` → `TestParseKillSwitchResetDMTimeout` (kill_switch_reset_dm_test.go) — carried: `""`→default; default == 6h (implies old `!= 30m`); `"30m"`→30m; `"nonsense"`,`"0"`,`"-1h"` → error.
- `TestLoadConfig_AppliesKillSwitchResetDMTimeout`,`TestLoadConfig_KillSwitchResetDMTimeoutDefaultsToSixHours`,`TestLoadConfig_RejectsInvalidKillSwitchResetDMTimeout` → `TestLoadConfig_KillSwitchResetDMTimeout` subtests (kill_switch_reset_dm_test.go) — carried: `cfg.KillSwitchResetDMTimeout == "45m"` + runtime 45m after apply; omitted → probe OK + empty `Config{}` apply → default; `"nonsense"` → probe error. New shared fixture `writeKillSwitchResetDMConfig(t, field)` replaces five copies of the same JSON (also used by `LoadConfigForProbe_DoesNotMutate...` and `ConcurrentProbeDoesNotRace`; their assertions untouched).
- `TestPlanKillSwitchClose_AdoptionEligibleLimitFillStillDefersToReconciler` → folded into `TestPlanKillSwitchClose_UnadoptedLimitFillKeepsRowAndBlocksFlat` (kill_switch_limit_orders_test.go) — identical setup; carried: NOT confirmed-flat/auto-reset, DM contains `queue row kept so the scheduler books the fill`, DM lacks `NO automatic path can book`. Survivor keeps: row not deleted, row retained with `FilledSize == 0`, DM contains `unadopted fill`.
- `TestPlanKillSwitchClose_OrphanedLimitRowWithFillEscalates` → third case of `TestPlanKillSwitchClose_AdoptionIneligibleLimitFillNamesTheBlock` (kill_switch_limit_orders_test.go) — carried: NOT confirmed-flat/auto-reset; row never auto-deleted; DM contains `NO automatic path can book`, `absent from this config`, `manual intervention required`; DM lacks `queue row kept so the scheduler books the fill`. That negative check now applies to all three ineligible cases and passes.

## Loosened / rewritten
None. Every exact-string check on DM/prompt text naming a state (`LATCHED, RETRYING`), a remediation (`manual intervention required`), or a booking promise was kept verbatim.

## Kept-but-flagged (audit findings, no edit)
- `TestPlanKillSwitchClose_ZeroInputsAreSafe` (close) — near-subset of `TestPlanKillSwitchClose_NoHLConfigured`; differs only by an empty `PortfolioReason`. Left alone as a distinct formatting input.
- `TestPlanKillSwitchClose_PlatformBudgetOverrides` (close) and `TestKillSwitchLimitOrderBudgetFloor` (limit_orders) — pin timeout arithmetic; kept because the floor guarantees one cancel+status round trip fits in the pre-flatten leg.
- `TestHyperliquidRawCoin_ManualSymbolWinsOverArgs` (manual) — looks like a getter pin, but decides which coin the kill switch closes for a `manual` strategy whose `Args[1]` diverges from `Symbol`; kept.
- `TestPlanKillSwitchClose_LimitCancelErrorBlocksFlat` / `_LimitRowDeleteFailureBlocksFlat` / `_LimitOrderCancellerUnwiredBlocksFlat` / `_LimitQueueLoadErrorBlocksFlat` (limit_orders) — same "block flat + auto-reset" shape but each wires a different failing dependency with a distinct side-effect assertion; left separate.
- `TestModelOnlyCloseAlert_ThrottledPerStrategySymbol`, `TestQueueModelOnlyCloseAlert_DrainsAndSkipsEmpty` (manual) — use package-level queue state; order-sensitive if `t.Parallel()` is ever added.

## Code workarounds found (do NOT fix, report only)
None found.

### report_hl_guard_fills.md
## Files: scheduler/hyperliquid_liquidation_guard_test.go, scheduler/hyperliquid_fills_test.go   Before: 2072 + 379 = 2451 lines / 60 + 13 = 73 Test funcs   After: 1672 + 339 = 2011 lines / 38 + 6 = 44 Test funcs

Counts measured with `wc -l` and `grep -c '^func Test'` against `git show origin/main:<path>` (before) and the worktree file (after). All assigned tests green (`go -C <wt>/scheduler test -count=1 -run '<names>' .`); `go vet .` clean.

Audit of the interrupted agent's diff: every removed test is a merge into a table-driven survivor. One non-compliance found and fixed (Loosened / rewritten, item 1). One dead helper branch removed (item 2). No other loosening on prices, quantities, fees, or clamp states.

## Removed
Nothing was removed outright. Every original test function that no longer exists by name is carried by a merged survivor listed below.

## Merged
### hyperliquid_liquidation_guard_test.go
- `TestPlanHyperliquidLiquidationAuditClassification`, `TestPlanHyperliquidLiquidationAuditRearmsUnprotectedScalarOwner`, `TestPlanHyperliquidLiquidationAuditRefusesUnreconciledCoin` → `TestPlanHyperliquidLiquidationAudit` — carried verbatim: action count 2, deterministic sort `a-trailing` then `b-scalar`, every kind `hlAuditTighten`, clamped trigger `2340.5*(1+buffer)`; one `hlAuditRearm` job at trigger 2325; every action `hlAuditRefuse` on `BookConsistent:false`.
- `TestRunHyperliquidLiquidationAuditSkipsPaper`, `...RefusesPhantomOnSharedCoin`, `...NoOpsWithoutOnChainPosition`, `...SkipsWithoutSnapshot`, `...StaleSideSoleOwnerDoesNothing`, `TestAuditRearmSkipsStaleSideSoleOwner` → `TestRunHyperliquidLiquidationAuditNoOpCases` — carried: placement calls 0; `ImmediateFills 0` and `CloseDetails` empty; position `StopLossOID`/`StopLossTriggerPx` untouched (4242/2325, or 0/0 for zeroed-stop rows); no alert key stored where the original asserted it (paper, no-snapshot, both stale-side rows). Paper row now also asserts empty result, untouched trigger, and no alert (stricter).
- `TestRunHyperliquidLiquidationAuditIsIndependentOfSignalResults`, `...HealsConsistentNonDuePosition` → `TestRunHyperliquidLiquidationAuditHealsRegardlessOfDueness` — carried: a placement happens for a non-due 4h trailing-ATR owner and for a non-due 1d static scalar owner.
- `TestRunHyperliquidLiquidationAuditReplacesScalarStop`, `...CancelThenPlaceIsANormalClamp`, `...FilledExternallyReportsFilled`, `...RestingClampEmitsNoClose` → `TestRunHyperliquidLiquidationAuditTightenOutcomes` — carried: `ImmediateFills 0` / no `CloseDetails`, cancel OID 4242, replace size 1.0, replace trigger `2340.5*(1+buffer)`, position oid 9001 at clamped trigger, oid 5150 + `hlLiquidationActionClamped`, external fill books 0 + `hlLiquidationActionFilledOnChain` (plus position stays 4242/2325).
- `TestRunHyperliquidLiquidationAuditFillAtSubmitReportsExited`, `...ImmediateCloseReasonsTheAudit`, `...ReportsBookedCloses` → `TestRunHyperliquidLiquidationAuditImmediateFillBooksClose` — carried on both rows: fills 1 / close details 1, `CloseDetails[0]` SC.ID `hl-eth` / Symbol `ETH` / non-empty Detail, position deleted, `CloseReason == "liquidation_clamp_sl_immediate"`, trade `Details` contains `Liquidation-clamp SL`, `hlLiquidationActionExited`.
- `TestAuditRetriesPlacementItStrippedSameCycle` (2 rows + first-try subtest), `TestAuditRetryAdoptsBookDiffResolvedOID`, `TestAuditRetryOutcomeUnknownKeepsStateAndReportsUnknown`, `TestAuditRetryCapRejectedStillProtectionLost` → `TestAuditRetriesPlacementItStrippedSameCycle` (4 rows + first-try subtest) — carried: exactly 2 placement calls, retry `cancelOID 0`, final oid 9002 / Clamped; book-diff oid 9002 adopted with `StateMutations >= 1`; outcome-unknown keeps 4242/2325 and reports `hlLiquidationActionOutcomeUnknown`; cap-rejected retry clears to 0/0 and reports `hlLiquidationActionProtectionLost`; first-try rest makes 1 call.
- `TestAuditRearmOutcomeUnknownRecordsTriggerAndStops`, `TestAuditRearmCapRejectedStillRetriedNextCycle`, `TestAuditRearmAdoptsBookDiffResolvedOID`, `TestAuditRearmProceedsWithMatchingSideAndUnknownGeometry` → `TestAuditRearmOutcomes` — carried: re-arm passes `cancelOID 0` (now on every row); outcome-unknown: 1 call across 2 passes, oid 0, recorded trigger `2340.5*1.005`, `hlLiquidationActionPlacementUnknown` after each pass; cap-rejected: 2 calls across 2 passes, `hlLiquidationActionRearmFailed`; book-diff: oid 9002, `hlLiquidationActionRearmed`; unknown geometry with matching side: trigger `2400*(1-0.03125)`.
- `TestLiquidationAuditIntervalSeconds`, `TestLiquidationAuditIntervalStrictlyShorterAndCoversManual` → `TestLiquidationAuditIntervalSeconds` — carried: 150, 0 without live HL perps/manual, 7200 for a 14400 fleet (strictly-shorter implied by the exact value), 1800 manual-only, floor `liquidationAuditMinIntervalSeconds` for a 30s fleet, 0 for paper manual.
- `TestHLLiquidationAlertMessageOmitsUnknownGeometry`, message half of `TestOutcomeUnknownIsNotProtectionLost`, `TestLiquidationAlertPlacementUnknownWording` → `TestHLLiquidationAlertMessage` — carried: no `$0.0000`, `NO exchange-side stop`, `**HL POSITION UNPROTECTED**` headline, unprotected true; armed refusal names `$2325.0000`/`$2340.5000`, not unprotected; outcome-unknown headline `OUTCOME UNKNOWN`, contains `could NOT be read`/`may be resting`/`KEPT`, excludes `no exchange-side stop right now`, not unprotected; tighten detail contains `CANCELLED`; fresh placement-unknown contains `Nothing was cancelled`, excludes `old trigger was CANCELLED`, not unprotected.
- `TestHLLiquidationArmClampActionOutcomeUnknown` → folded into `TestOutcomeUnknownIsNotProtectionLost` — carried: outcome-unknown → `hlLiquidationActionPlacementUnknown`; cap rejection → `hlLiquidationActionRearmFailed`; original predicate checks (`hlLiquidationActionUnprotected`, `hlLiquidationMayRetryReplace`) retained.

### hyperliquid_fills_test.go
- `TestLookupHyperliquidFillByOID_AggregatesPartialFills`, `_NoMatchReturnsFalse`, `_EmptyAddressShortCircuits`, `_AccumulatesFilledQty` → `TestLookupHyperliquidFillByOID` — carried: Count 2, Fee 0.80 (tol 1e-3, unchanged), ClosedPnLGross 150.00 (tol 1e-2, unchanged), FilledQty 0.311 (tol 1e-9, unchanged); ok=false on missing OID and on empty address. Every row now asserts Fee/PnL/FilledQty.
- `TestLookupHyperliquidFillByCoinSize_MatchesByCoinAndSize`, `_PicksNewestGroupNotSumOfWindow`, `_AggregatesPartialFillsByAnchorOID`, `_SetsFilledQtyNoOIDCase`, `_AccumulatesFilledQtyWithOID` → `TestLookupHyperliquidFillByCoinSize` — carried: Count 1 / Fee 0.40; OID 200 / Count 1 / Fee 0.50 / PnL 90.00; OID 555 / Count 2 / Fee 0.50 / PnL 70.00; FilledQty 0.211 with nil OID; FilledQty 0.211 summed across OID 77777. Every row now asserts OID, Count, Fee, PnL, FilledQty.

## Loosened / rewritten
1. `TestRunHyperliquidLiquidationAuditNoOpCases/"failed snapshot fetch ..."` — was (interrupted agent's merge): passed `tc.live` (true) as `snapshotFetched`, so the row no longer reached the `!snapshotFetched` early return at `scheduler/hyperliquid_liquidation_guard.go:859` that the original `TestRunHyperliquidLiquidationAuditSkipsWithoutSnapshot` exercised with `false` — now asserts: a `snapshot` table column, `false` for this row and `true` for the others, passed through to `runHyperliquidLiquidationAudit` — ground: the original test on origin/main and the signature (`snapshotFetched bool`, sixth parameter).
2. `assertFillField` (fills helper) — was: skipped the comparison when `want < 0`, a latent way for a table row to assert nothing — now asserts every Fee / ClosedPnLGross / FilledQty value on every row unconditionally — ground: no row uses a negative sentinel; the branch was dead.
3. `TestHLLiquidationAlertMessage` (from `...OmitsUnknownGeometry`) — headline check is `strings.Contains` on `**HL POSITION UNPROTECTED**` where the original used exact equality. Operator wording still pinned; left as the merge wrote it.

## Kept-but-flagged (audit findings, no edit)
- `TestRunHyperliquidLiquidationAuditNoOpCases/"failed snapshot fetch ..."` — even with `snapshotFetched=false` restored, the row cannot fail if the early return were deleted: its on-chain map is empty, so `collectHLLiquidationAuditCandidates` yields no candidate either way. The origin/main test had the same blind spot. A populated on-chain map with `snapshotFetched=false` would make it fail on that defect.
- `TestRunHyperliquidLiquidationAuditKeepsOriginalStopOnFailure` — its `{StopLossFilledExternally: true}` row duplicates the "filled externally" row of `...TightenOutcomes` (both assert 4242/2325 untouched). Kept; the loop is one table over failure classes.
- `TestAuditTightenOutcomeUnknownRecordsTriggerAndStops` — pins `pos.StopLossTriggerPx != 2340.5*1.005` with exact float equality and a literal `1.005` instead of `hlLiquidationStopBufferPct`. A buffer constant change breaks the literal. Left as-is (price contract).
- `TestHLLiquidationShouldNotifyThrottle`, `TestHLLiquidationAlertDueAndClear` — depend on the package-global `hlLiquidationAlerts` map and `effectiveAlertThrottleInterval()`; not `t.Parallel()`-safe. No test in these files calls `t.Parallel()`.
- `TestLookupHyperliquidFillByOID/"empty address short-circuits"` — now spins up a fills server that is never contacted (original did not). Harmless; assertion unchanged.
- `TestReconcileFillLookupSinceMs_BoundsTo24h` — restates `now - hlReconcileFillLookupWindow`. Kept; it pins the backward direction of the reconcile window.

## Code workarounds found (do NOT fix, report only)
None found.

### report_shared_wallet.md
## Files: shared_wallet_test.go, shared_wallet_ledger_test.go, shared_wallet_reconcile_test.go, shared_wallet_reconcile_cycle_test.go, shared_wallet_audit_test.go   Before: 3912 / 145   After: 3257 / 79
## Removed
- `TestComputeTotalPortfolioValue_FallbackKeepsPeakFreezeSignal` — Obsolete-redundant — survivor `TestComputeTotalPortfolioValue/"fetch failure falls back..."` carries total==sum of member cash, usedFallback==true.
- `TestComputeTotalPortfolioValue_DelegatesCorrectly` — Obsolete-redundant — survivor `TestComputeTotalPortfolioValue/"mixed shared and non-shared..."` carries total==balance+spot PV, usedFallback==false.
- `TestReportSharedWalletDrift_WithinToleranceNoPanic` — Obsolete-redundant (asserted nothing) — survivor `TestReportSharedWalletDrift_ToleranceBoundary/"below tolerance records nothing"` carries same call + len(entries)==0.
## Merged
- 11 `TestWalletKeyFor_*` → `TestWalletKeyFor`; 8 `TestDetectSharedWallets_*` (+TopStep #1106 row restored) → `TestDetectSharedWallets`; 8 `TestComputeTotalPortfolioValue_*` → `TestComputeTotalPortfolioValue`; 2 `TestFetchSharedWalletBalances_*`; 6 `TestComputeInitialPortfolioPeak_*`; 5 `TestRebaselinePortfolioPeakAfterPrune_*`; 4 `TestComputeSubsetPortfolioValue_*`; 4 `TestPlanTradeLedgerForStrategy_NoOIDRepairSkips*`; 5 `TestReconcileSharedWallet_*` → `TestReconcileSharedWalletMemberValues`; 13 `TestSharedWalletDriftTracker_*` → `TestSharedWalletDriftTracker`; 4 `TestComputeSubsetDisplayValue_*`; 2 journal alert format tests → `TestFormatSharedWalletJournalAlerts`; 2 `TestReportSharedWalletDrift_*` → `_ToleranceBoundary`; 3 `TestHyperliquidKillSwitchFillShare_*` → one table. Every exact amount/flag/count carried.
## Loosened / rewritten
- None.
## Kept-but-flagged
- `TestHasSharedWalletBalanceFetcher_HLAndOKX`, `TestDisplayStrategyValue_PrefersSetValue` (small accessor pins, kept as gates).
## Code workarounds found
- None.

### report_db_state.md
## Files: scheduler/db_test.go, scheduler/state_test.go   Before: 3319 lines / 80 Test funcs (db 2495/55, state 824/25)   After: 2962 / 54 (db 2246/40, state 716/14)

Counts measured with `wc -l` and `grep -c '^func Test'`. All assigned tests pass (`go test -count=1`), `go vet .` compiles, both files gofmt-clean. Removed nothing outright; every function that disappeared was folded into a table or subtest with its assertions carried.

## Removed
None. No pure duplicate found that another test fully covers.

## Merged
- `TestNewStrategyState`,`TestNewStrategyState_ConfigInitialCapital`,`TestNewStrategyState_NoConfigInitialCapital` → `TestNewStrategyState` (state_test.go) — assertions carried: ID/Type/Platform identity, Cash from Capital (1000, 600, 600), InitialCapital (1000, 505 from config, 600 fallback), non-nil Positions/OptionPositions/TradeHistory, RiskState.PeakValue = Capital, RiskState.MaxDrawdownPct. Peak and MaxDrawdown checks now run on all three cases (previously only the first).
- `TestValidatePerpsDirectionConfig`,`_NoConflicts`,`_OrphanState`,`_LegacyAllowShortsFallthrough`,`_RegimePolicyStampedTrendingDown`,`_RegimePolicyStampedTrendingUpConflict`,`_RegimePolicyUncertifiedWarnsForMigration`,`_WarningOrderDeterministic` → `TestValidatePerpsDirectionConfig` (state_test.go) — assertions carried: warning counts (2/0/0/1/0/1/1/2), joined text contains `hl-triple-ema-eth`, `hl-bear-sol`, `direction=`; `stamped regime="trending_up"` in the conflict warning; `DEFAULT-OFF` + `#1085` in the uncertified warning; ` BTC ` before ` ETH ` ordering. Subtest name keeps `#1085`.
- `TestSaveStateWithDB`,`TestSaveStateWithDB_Error` → `TestSaveStateWithDB` subtests (state_test.go) — CycleCount 3 persisted; closed DB returns error.
- `TestReconcileConfigInitialCapital`,`TestReconcileConfigInitialCapital_NoOpWhenAligned` → `TestReconcileConfigInitialCapital` subtests (state_test.go) — 1 info / 0 errs, in-memory 1000, untouched 200, persisted 1000 after SaveState; no infos/errs when aligned.
- `TestQueryTradeHistory_NoFilter`,`_ByStrategy`,`_BySymbol`,`_LimitClamped` → `TestQueryTradeHistory_Filters` (db_test.go) — total/len 2 with newest (`sell`) first; strategy filter matches every row and nonexistent → 0/0; symbol filter every row `BTC`; limit 9999 → 2 rows.
- `TestTradeExchangeFieldsRoundTrip`,`TestTradeExchangeFields_EmptyByDefault`,`TestQueryTradeHistory_ExchangeFields` → `TestTradeExchangeFieldsRoundTrip` (db_test.go) — ExchangeOrderID/ExchangeFee pairs (1234567890/1.75, 1234567891/1.79, 9876543210/2.50, ""/0) asserted via BOTH `LoadState` and `QueryTradeHistory` for every case (previously each path was checked on one case only).
- `TestSaveState_PreservesInitialCapital`,`_AllowsFirstInitialCapitalWrite`,`_AllowsNewStrategies`,`_AllowsBaselineWhenPrevZero` → `TestSaveState_InitialCapitalGuard` (db_test.go) — in-memory restore (initial 505, cash 632) and persisted (505/632); first write 1000; brand-new 2000 + old 1000; prev-zero baseline 1000. In-memory and persisted initial+cash now asserted for every case.
- `TestSetInitialCapital_ExplicitOverride`,`TestSetInitialCapital_RejectsInvalid` → `TestSetInitialCapital` subtests (db_test.go) — override 750 survives a stale 505 save; rejects 0, negative, unknown id.
- `TestSaveLoadState_LeaderboardSummaries`,`TestSaveLoadState_LastSummaryPost` → `TestSaveLoadState_TimestampMaps` (db_test.go) — 2 entries each, every key present, `time.Equal` per value.
- `TestSaveAndLoadDB_PendingCircuitCloseRoundTrip`,`TestSaveAndLoadDB_LegacyPendingHLJSON_MigratesOnLoad` → `TestSaveAndLoadDB_PendingCircuitClose` subtests (db_test.go) — `getPendingCircuitClose(hyperliquid)` non-nil, 1 symbol, ETH 0.2585, for the typed round trip and for injected legacy `{"coins":[...]}` JSON.
- `TestLifetimeTradeStatsAll_FreshInsert`,`_PartialClosesNetByPositionID`,`_PositionIDScopedByStrategy`,`_BreakevenPositionNeitherWinNorLoss`,`TestLifetimeTradeStats_SurvivesRiskStateReset` → `TestLifetimeTradeStatsAll` (db_test.go) — exact `LifetimeTradeStats{PositionsOpened,Wins,Losses}` per strategy for each case (s1 2/1/1 + s2 1/1/0; 1/1/0; s1 0/1/0 + s2 0/0/1; 0/0/0; 0/1/1), s3 absent from the map and zero from `LifetimeTradeStatsForStrategy`; `LifetimeTradeStatsForStrategy` now cross-checked for every expected strategy (previously only s1 in FreshInsert). `SurvivesRiskStateReset` had a no-op `_ = RiskState{}` line; its real assertion (stats derived from trades rows) is carried as the last subtest.

## Loosened / rewritten
- `TestSaveState_KillSwitchEventsCapped` → renamed `TestSaveState_KillSwitchEventsStoredAsIs` — was: name claimed a cap while the body asserts 60 rows stored — now asserts: unchanged (60 rows stored) — ground: db.go has no cap on `kill_switch_events` (delete-all + insert-all at db.go:1370-1374); the name was misleading, the assertion was correct.

## Kept-but-flagged (audit findings, no edit)
- `TestCorrelationSnapshotRoundTrip` — first half (non-nil, PortfolioGrossUSD 5000) duplicates `TestSaveAndLoadDBRoundTrip`; kept because the reload is the precondition for its unique nil-snapshot-clears assertion.
- `TestLoadState_TradeHistoryBoundedInSQL` — asserts `EXPLAIN QUERY PLAN` names `idx_trades_strategy_timestamp` and has no `SCAN TABLE`. That pins SQLite planner output text, but index use is the documented `LoadState` contract (CLAUDE.md), so left alone.
- `TestRecordClosedPosition_ExecuteSignal`, `TestRecordClosedOptionPosition_ExecuteClose` — wall-clock `DurationSeconds` windows (7100-7300, 10700-11000); tolerant, but a stalled CI could drift. Not changed.
- `TestSaveState_KillSwitchEventsStoredAsIs` — asserts absence of a cap; if a cap is ever intended (the old name suggests one was), this test and db.go both need the change.
- `TestOpenStateDB` — pins table list and `journal_mode=wal`; WAL is an operational contract (concurrent reader during save), kept.

## Code workarounds found (do NOT fix, report only)
None found. No non-test source was edited.

### report_config.md
## Files: scheduler/config_test.go, scheduler/config_audit_test.go, scheduler/config_unknown_keys_test.go, scheduler/config_example_version_test.go, scheduler/config_regime_directional_warn_test.go   Before: 3472 lines / 112 Test funcs   After: 2763 lines / 78 Test funcs

Per file (before -> after, wc -l / grep -c '^func Test'): config_test.go 2813/86 -> 2158/58; config_audit_test.go 220/7 -> 220/7 (untouched); config_unknown_keys_test.go 348/16 -> 290/11; config_example_version_test.go 39/1 -> 39/1 (untouched); config_regime_directional_warn_test.go 52/2 -> 56/1.

Tests green before and after; `go vet .` clean. Seven-owner stop exclusivity tests, every LoadConfig load/migration test, and every unknown-key guard assertion are unchanged in effect.

## Removed
- `TestLoadConfigManualDefaultsStopLossATRMultTo2Point0` (config_test.go) — case: Obsolete-redundant — ground: byte-identical config JSON to the survivor (same manual strategy, no user_defaults, no default_stop_loss_atr_mult), same LoadConfig path (applyManualDefaults -> defaultManualStopLossATRMult) — survivor: `TestLoadConfigManualDefaultsAbsentPreservesHardcodedDefaults` carries: StopLossATRMult != nil and *StopLossATRMult == defaultManualStopLossATRMult, plus the tp_tiers fallback the removed test never asserted.
- `TestKnownStrategyConfigKeysIncludesCircuitBreaker` (config_unknown_keys_test.go) — case: Obsolete-redundant — ground: same knownStrategyConfigKeys() lookup — survivor: `TestKnownStrategyConfigKeysCoversCoreFields` carries: known["circuit_breaker"] (appended to mustHave).
- `TestLoadConfigHLPerpsPeersOnSameCoinMatching` (config_test.go) — case: Obsolete-redundant — ground: byte-identical two-peer JSON to `TestLoadConfigHLPerpsPeersOmittedStopLossDoesNotConflict`, same LoadConfig + EffectiveStopLossPct path — survivor: subtest "omitted stop_loss_* on both same-coin peers does not conflict" of merged `TestLoadConfigHLPerpsPeers` carries: len(cfg.Strategies)==2, EffectiveStopLossPct(sc)==0 for each peer.

## Merged
- `TestLoadConfigLeverageRejectsSpot`,`TestLoadConfigLeverageRejectsOutOfRange`,`TestLoadConfigSizingLeverageRejectsSpot`,`TestLoadConfigSizingLeverageRejectsOutOfRange`,`TestLoadConfigMarginPerTradeUSDRejectsSpot`,`TestLoadConfigMarginPerTradeUSDRejectsNonPositive`,`TestLoadConfigMarginModeRejectsInvalidValue`,`TestLoadConfigMarginModeRejectsSpot` -> `TestLoadConfigPerpsSizingFieldRejections` (config_test.go) — assertions carried: LoadConfig errors and each error contains the exact original substring (leverage is only supported for perps; leverage must be in; sizing_leverage is only supported for perps; sizing_leverage must be in; margin_per_trade_usd is only supported for perps; margin_per_trade_usd must be positive; margin_mode must be; margin_mode is only supported for HL perps) with the same field values (5, 150, 2, 200, 100, 0, "portfolio", "isolated") on the same spot / HL-perps strategy shapes.
- `TestLoadConfigPerpsLeverageDefault`,`TestLoadConfigPerpsLeverageExplicit`,`TestLoadConfigPerpsSizingLeverageExplicit`,`TestLoadConfigSizingLeverageAcceptsFractional`,`TestLoadConfigHLPerpsDefaultsToIsolatedMargin`,`TestLoadConfigHLPerpsExplicitCross` -> `TestLoadConfigPerpsSizingFieldsAccepted` (config_test.go) — assertions carried: Leverage==1 default; Leverage==10 and SizingLeverage==10; EffectiveExchangeLeverage==20 and EffectiveSizingLeverage==2; SizingLeverage==0.5; MarginMode=="isolated" default; MarginMode=="cross" explicit.
- `TestLoadConfigManualOptsOutWhenGlobalDefaultIsZero`,`TestLoadConfigManualExplicitATRMultPreserved`,`TestLoadConfigManualDefaultsStopLossATRMultOverride`,`TestLoadConfigManualDefaultsStopLossATRMultZeroOptsOut` -> `TestLoadConfigManualStopLossATRMultResolution` (config_test.go) — assertions carried: StopLossATRMult nil for default_stop_loss_atr_mult:0; ==2.5 explicit; ==2.25 from user_defaults.manual; nil for user_defaults.manual.stop_loss_atr_mult:0 (nil vs value distinguished in a switch as the originals' Fatal/Errorf pairs did).
- `TestLoadConfigHLPerpsPeersOmittedStopLossDoesNotConflict`,`TestLoadConfigHLPerpsPeersMismatchedMarginMode`,`TestLoadConfigHLPerpsPeersMismatchedLeverage`,`TestLoadConfigHLPerpsPeersMultipleStopLossAllowed`,`TestLoadConfigHLPerpsPeersSingleStopLossAllowed`,`TestLoadConfigHLPerpsPeersDifferentCoinsIndependent`,`TestLoadConfigHLPerpsPeersNoStopLossAllowed`,`TestLoadConfigHLPerpsPeersDefaultedMarginModeMatches` -> `TestLoadConfigHLPerpsPeers` (config_test.go) — assertions carried: both omitted peers EffectiveStopLossPct==0 and len==2; error contains "disagree on margin_mode" AND "ETH"; "disagree on leverage"; two stop_loss_pct owners load; single owner ==3 / omitted peer ==0; different coins with differing leverage+margin_mode load; two stop_loss_pct:0 peers load; defaulted margin_mode peer loads and both report "isolated". Same ids/args/capital/leverage/margin_mode values as the originals.
- `TestConfigValidationDMChannelsInvalidKey`,`TestConfigValidationDMChannelsEmptyValue`,`TestConfigValidationDMChannelsValidKeys`,`TestConfigValidationDMChannelsOrphanSuffix` -> `TestConfigValidationDMChannels` (config_test.go) — assertions carried: error contains "dm_channels key"; contains dm_channels["hyperliquid-paper"]; contains "platform prefix is empty"; valid keys load with Discord.DMChannels hyperliquid=111, hyperliquid-paper=222, Telegram.DMChannels okx-paper=444.
- `TestConfigValidationManualPerpsPeerLeverageMismatchRejected`,`TestConfigValidationManualPerpsPeerMarginModeMismatchRejected` -> `TestConfigValidationManualPerpsPeerMismatchRejected` (config_test.go) — assertions carried: validateConfig error contains "disagree on leverage" (manual 10 vs perps 5) and "disagree on margin_mode" (isolated vs cross, both leverage 5).
- `TestValidateStrategyJSONKeysFlagsInventedTPField`,`TestValidateStrategyJSONKeysHintsLegacyParams`,`TestValidateStrategyJSONKeysHintsStopLossTypos` -> `TestValidateStrategyJSONKeysUnknownFieldHints` (config_unknown_keys_test.go) — assertions carried: exactly 1 error each; contains strategy[hl-momentum-btc]: unknown field "take_profit_atr_mult" and "close_strategy"; contains "open_strategy: {name, params}"; contains "valid SL fields".
- `TestValidateUserDefaultsJSONKeysFlagsUnknownSibling`,`TestValidateUserDefaultsJSONKeysFlagsUnknownManualLeaf` -> `TestValidateUserDefaultsJSONKeysFlagsUnknownKeys` (config_unknown_keys_test.go) — assertions carried: exactly 1 error; contains user_defaults: unknown field "manaul"; contains user_defaults.manual: unknown field "margin".
- `TestLoadConfigRejectsUnknownUserDefaultsManualLeaf`,`TestLoadConfigRejectsUnknownUserDefaultsSibling` -> `TestLoadConfigRejectsUnknownUserDefaultsKeys` (config_unknown_keys_test.go) — assertions carried: LoadConfig (config_version 16, manual strategy) errors naming user_defaults.manual: unknown field "stop_loss_atr_mlt" / user_defaults: unknown field "manaul".
- `TestRegimeDirectionalPolicyWarningsEdgeCases` -> subtests of `TestRegimeDirectionalPolicyWarnings` (config_regime_directional_warn_test.go) — assertions carried: nil config returns nil; no-policy strategies return 0; single-label policy returns exactly 1; original 3-strategy case (exactly 1 warning, names dir-policy, cites #1076, [WARN] prefix) unchanged.

Shared fixtures added in config_test.go: `testSpotStrategyHead`, `testHLPerpsStrategyHead`, `testHLManualStrategyHead` (JSON fragments with the same field values as the inline originals) and a one-line `itoa` wrapper (strconv import added).

## Loosened / rewritten
None.

## Kept-but-flagged (audit findings, no edit)
- `TestLoadConfigDefaults` — pins IntervalSeconds/LogDir/DBFile/AutoUpdate constants; kept whole because the DefaultStopLossATRMult seeding in the same test is a stop-owner contract.
- `TestOrdinal`, `TestStrategyIntervalExceedsGlobalWarning` — pin exact [WARN] wording ("every 3rd portfolio cycle"); the ordinal suffix is the logic under test and the substring is its only observable, so left.
- `TestConfigValidationLeaderboardSummariesDuplicateKey` — pins the "[0]" index in the error text; incidental, left.
- `TestCanonicalizeRegimeBlockAliasPrecedenceDeterministic` (config_audit_test.go) — 50-iteration loop against map-order nondeterminism; legitimate for a Go map fold, kept.
- `TestConfigValidationCompoundAllScalarStopOwnersRejected` / `...ScalarPlusRegime...` — protected seven-owner contract, kept. The trailing_stop_atr_mult_regime vs trailing_stop_atr_mult pair is not asserted in these two tests; not checked whether another file covers it.
- `TestLoadConfigForProbeSkipsLiveCredentialChecks` — also depends on HYPERLIQUID_ACCOUNT_ADDRESS being cleared; correct, kept.

## Code workarounds found (do NOT fix, report only)
None found in the config load, validation, or unknown-key paths exercised by these tests.

### report_config_migration.md
## Files: config_migration_test.go, config_migration_v15/v18/v19_test.go, config_reload_test.go   Before: 4830 / 120   After: 4137 / 69
## Removed
- `TestNewFieldsSinceFieldProperties` — Obsolete-redundant — survivor `TestNewFieldsSince` (superset sweep).
- `TestMigrateConfigAtFloorNeverStripsLegacyNames`, `TestVersionlessConfigWithInertPreFloorKeysMigrates`, `TestMigrateConfigV8PreservesFieldsAtCurrentVersion` — merged into `TestMigrateConfigRetainsInertLegacyDiscordKeys` subtests.
- `TestV19AtomicRenameSitesListsEveryMutationSite` — Incidental constant pin; `v19AtomicRenameSites` (config_migration_v19.go:122) has no non-test reference.
- `TestV19NoticeMentionsBothRenames` — Incidental notice wording; rename asserted by `TestMigrateV19AtrMultRegimeKey`, `TestLoadConfigV19Migrates*`.
- `TestFormatFloatPtr`, `TestFormatFloatPtrUSD`, `TestFormatFloatPtrPct` — Incidental display-formatter pins (config_reload.go change-list strings only).
- `TestValidateHotReloadCompatible_RegimeWindowOnlyChange`, `_SharedWalletPoolModeRequiresRestart`, `TestStrategyRestartShape_RegimeWindowOnlyChange` — Obsolete-redundant — rows in `TestValidateHotReloadCompatible` / `TestStrategyRestartShapeIgnoresHotReloadableFields` carry identical inputs and assertions.
## Merged
- 4 → `TestMigrateConfigWritesValues`; 2 → `TestMigrateConfigRejectsUnreadableInput`; 3 → `TestMigrateConfigV16UserDefaults`; 5 → `TestMigrateV15CloseKeys`; 2 → `TestMigrateV18TrailStopATRRegimeKey`; 2 → `TestNeedsV18TrailStopKeyMigration`; 3 → `TestMigrateV19AtrMultRegimeKey`; 2 → `TestNeedsV19AtrMultRegimeRename`; 2 → `TestV19RenameMap`; 20 `TestApplyHotReloadConfig*` guards → `TestApplyHotReloadConfigOpenPositionGuards` (every error substring and applied value carried; non-mutation now whole-object DeepEqual); 3 → `TestApplyHotReloadConfigTogglesWhileOpen`; 4 → `TestStrategyRestartShapeIgnoresHotReloadableFields`; 2 → `TestPortfolioRiskAccessorsNilSafe`.
## Loosened / rewritten
- `TestLoadConfigV19ReadOnlyLegacyKeyStillAttemptsRewrite` — now uses shared `readOnlyConfigDir` helper; same path and assertion.
## Kept-but-flagged
- Read-only-path tests skip as root / non-enforcing FS.
## Code workarounds found
- None. `v19AtomicRenameSites` is dead non-test code (follow-up candidate).


## Follow-on (unfiled)

- `v19AtomicRenameSites` (`scheduler/config_migration_v19.go:122`) is dead non-test code once its constant pin was removed; delete in a follow-up.
- `update_sh_feature_test.go` macOS bash 3.2 failures: Phase B.

---
Created with LLM: Fable 5 | high | Harness: Claude Code
