### PR TITLE
fix(#1489): remove unused v19AtomicRenameSites list [C0, Sonnet 5, high]

### DIFF
--- a/scheduler/config_migration_v19.go
+++ b/scheduler/config_migration_v19.go
@@ -119,13 +119,6 @@ func renameV19AtrMultRegimeKeys(block map[string]interface{}, ctx string) (bool,
 	return changed, nil
 }
 
-var v19AtomicRenameSites = []string{
-	"strategies[]",
-	"user_defaults.regime_atr",
-	"user_defaults.manual",
-	"user_defaults.close[]",
-}
-
 func sortedV19RenameMap() []struct {
 	LegacyKey string
 	CanonKey  string


### PR DESCRIPTION
## Plain simple English

One old list, `v19AtomicRenameSites`, is no longer used. Its only test reference was removed in PR #1488. This change deletes the list. v19 migration behavior does not change.

## Summary

- Removed the unused `v19AtomicRenameSites` variable in `scheduler/config_migration_v19.go`.
- No behavior change; only dead code removed.

## Verification

- `go build .` from `scheduler`: passes.
- `go vet .` from `scheduler`: passes.
- `go test ./... -run 'V19|Migration'` from `scheduler`: all pass.
- `go test ./...` from `scheduler`: full suite fails only on pre-existing, unrelated `update.sh` shell tests (`declare -A` requires bash 4+, the local system runs bash 3.2) — unaffected by this change.

Closes #1489

---
Created with LLM: Sonnet 5 | high | Harness: Claude Code
