### PR TITLE
fix(#1501): reject unconfirmed hyperliquid fills before booking [C97, GPT-5.6 Luna, max]

### DIFF
--- a/scheduler/executor.go
+++ b/scheduler/executor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"sort"
@@ -70,14 +71,16 @@ type HyperliquidExecution struct {
 }
 
 type HyperliquidExecuteResult struct {
-	Execution                 *HyperliquidExecution `json:"execution"`
-	Platform                  string                `json:"platform"`
-	Timestamp                 string                `json:"timestamp"`
-	Error                     string                `json:"error,omitempty"`
-	CancelStopLossError       string                `json:"cancel_stop_loss_error,omitempty"`
-	CancelStopLossSucceeded   bool                  `json:"cancel_stop_loss_succeeded,omitempty"`
-	StopLossError             string                `json:"stop_loss_error,omitempty"`
-	StopLossFilledImmediately bool                  `json:"stop_loss_filled_immediately,omitempty"`
+	Execution                   *HyperliquidExecution `json:"execution"`
+	Platform                    string                `json:"platform"`
+	Timestamp                   string                `json:"timestamp"`
+	Error                       string                `json:"error,omitempty"`
+	CancelStopLossError         string                `json:"cancel_stop_loss_error,omitempty"`
+	CancelStopLossSucceeded     bool                  `json:"cancel_stop_loss_succeeded,omitempty"`
+	CancelStopLossSucceededOIDs []int64               `json:"cancel_stop_loss_succeeded_oids,omitempty"`
+	CancelStopLossFailedOIDs    []int64               `json:"cancel_stop_loss_failed_oids,omitempty"`
+	StopLossError               string                `json:"stop_loss_error,omitempty"`
+	StopLossFilledImmediately   bool                  `json:"stop_loss_filled_immediately,omitempty"`
 }
 
 type HyperliquidStopLossUpdateResult struct {
@@ -328,6 +331,8 @@ func RunHyperliquidExecute(script, symbol, side string, size, stopLossPct float6
 	return parseHyperliquidExecuteOutput(stdout, string(stderr), err)
 }
 
+var runHyperliquidExecuteFn = RunHyperliquidExecute
+
 func RunHyperliquidUpdateStopLoss(script, symbol, side string, size, triggerPx float64, cancelStopLossOID int64) (*HyperliquidStopLossUpdateResult, string, error) {
 	args := []string{
 		"--update-stop-loss",
@@ -438,8 +443,11 @@ func parseHyperliquidUpdateStopLossOutput(stdout []byte, stderrStr string, runEr
 func parseHyperliquidExecuteOutput(stdout []byte, stderrStr string, runErr error) (*HyperliquidExecuteResult, string, error) {
 	if runErr != nil {
 		var result HyperliquidExecuteResult
-		if jsonErr := json.Unmarshal(stdout, &result); jsonErr == nil && result.Error != "" {
-			return &result, stderrStr, nil
+		if jsonErr := json.Unmarshal(stdout, &result); jsonErr == nil {
+			if result.Error != "" {
+				return &result, stderrStr, nil
+			}
+			return &result, stderrStr, fmt.Errorf("execute error: %w (stderr: %s)", runErr, stderrStr)
 		}
 		return nil, stderrStr, fmt.Errorf("execute error: %w (stderr: %s)", runErr, stderrStr)
 	}
@@ -449,6 +457,77 @@ func parseHyperliquidExecuteOutput(stdout []byte, stderrStr string, runErr error
 		return nil, stderrStr, fmt.Errorf("parse execute output: %w (stdout: %s)", err, string(stdout))
 	}
 	return &result, stderrStr, nil
+}
+
+func confirmHyperliquidExecuteFill(res *HyperliquidExecuteResult, err error) (*HyperliquidExecuteResult, error) {
+	if err != nil {
+		return res, err
+	}
+	if res == nil {
+		return res, fmt.Errorf("exchange returned no confirmed fill")
+	}
+	if res.Error != "" {
+		return res, fmt.Errorf("%s", res.Error)
+	}
+	if res.Execution == nil || res.Execution.Fill == nil {
+		return res, fmt.Errorf("exchange returned no confirmed fill")
+	}
+	fill := res.Execution.Fill
+	if !(fill.AvgPx > 0) || !(fill.TotalSz > 0) || math.IsInf(fill.AvgPx, 0) || math.IsInf(fill.TotalSz, 0) {
+		return res, fmt.Errorf("exchange returned no confirmed fill (sz=%.8f px=%.8f)", fill.TotalSz, fill.AvgPx)
+	}
+	return res, nil
+}
+
+func hyperliquidExecuteSucceededCancelOIDs(result *HyperliquidExecuteResult, requested []int64) []int64 {
+	if result == nil {
+		return nil
+	}
+	if len(result.CancelStopLossSucceededOIDs) > 0 {
+		requestedSet := make(map[int64]struct{}, len(requested))
+		for _, oid := range requested {
+			if oid > 0 {
+				requestedSet[oid] = struct{}{}
+			}
+		}
+		if len(requestedSet) == 0 {
+			return nil
+		}
+		seen := make(map[int64]struct{}, len(result.CancelStopLossSucceededOIDs))
+		var out []int64
+		for _, oid := range result.CancelStopLossSucceededOIDs {
+			if oid <= 0 {
+				continue
+			}
+			if len(requestedSet) > 0 {
+				if _, ok := requestedSet[oid]; !ok {
+					continue
+				}
+			}
+			if _, ok := seen[oid]; ok {
+				continue
+			}
+			seen[oid] = struct{}{}
+			out = append(out, oid)
+		}
+		return out
+	}
+	if result.CancelStopLossSucceeded && result.CancelStopLossError == "" {
+		seen := make(map[int64]struct{}, len(requested))
+		var out []int64
+		for _, oid := range requested {
+			if oid <= 0 {
+				continue
+			}
+			if _, ok := seen[oid]; ok {
+				continue
+			}
+			seen[oid] = struct{}{}
+			out = append(out, oid)
+		}
+		return out
+	}
+	return nil
 }
 
 type HyperliquidCloseFill struct {

--- a/scheduler/hedge.go
+++ b/scheduler/hedge.go
@@ -305,7 +305,7 @@ func defaultHedgeExecutor() hedgeExecutor {
 				marginMode = hedgeMarginMode(sc)
 				leverage = hedgeLeverage(sc)
 			}
-			res, stderr, err := RunHyperliquidExecute(sc.Script, coin, side, qty, 0, 0, 0, marginMode, leverage, false, hlExecuteSnapshot{})
+			res, stderr, err := runHyperliquidExecuteFn(sc.Script, coin, side, qty, 0, 0, 0, marginMode, leverage, false, hlExecuteSnapshot{})
 			if stderr != "" {
 				fmt.Printf("[hedge] %s execute stderr: %s\n", coin, stderr)
 			}
@@ -404,14 +404,15 @@ func runHedgeSync(
 	switch action.Kind {
 	case hedgeActionOpen, hedgeActionAdd:
 		res, err := exec.Open(sc, snap.HedgeSymbol, action.Side, action.Qty, action.Kind == hedgeActionOpen)
-		if ok, why := hedgeExecuteConfirmed(res, err); !ok {
-			logger.Error("hedge %s failed on %s: %s", action.Kind, snap.HedgeSymbol, why)
-			notifyLiveExecFailure(notifier, sc, directionOpen, snap.HedgeSymbol, why)
+		res, err = confirmHyperliquidExecuteFill(res, err)
+		if err != nil {
+			logger.Error("hedge %s failed on %s: %s", action.Kind, snap.HedgeSymbol, err)
+			notifyLiveExecFailure(notifier, sc, directionOpen, snap.HedgeSymbol, err.Error())
 			if in.FreshExposureQty > hedgeQtyEpsilon {
-				unwindPrimaryAfterHedgeOpenFailure(sc, s, mu, exec, snap, why, in, notifier, logger)
+				unwindPrimaryAfterHedgeOpenFailure(sc, s, mu, exec, snap, err.Error(), in, notifier, logger)
 			} else {
 				notifyHedgeProblem(notifier, sc, snap.HedgeSymbol,
-					fmt.Sprintf("hedge %s failed: %s — the primary %s position is now under-hedged. The scheduler will retry every cycle; no position was unwound because the primary was not opened this cycle.", action.Kind, why, snap.PrimarySymbol))
+					fmt.Sprintf("hedge %s failed: %s — the primary %s position is now under-hedged. The scheduler will retry every cycle; no position was unwound because the primary was not opened this cycle.", action.Kind, err, snap.PrimarySymbol))
 			}
 			return hedgeActionNone
 		}
@@ -446,25 +447,6 @@ func runHedgeSync(
 		return action.Kind
 	}
 	return hedgeActionNone
-}
-
-func hedgeExecuteConfirmed(res *HyperliquidExecuteResult, err error) (bool, string) {
-	if err != nil {
-		return false, err.Error()
-	}
-	if res == nil {
-		return false, "no execute result returned"
-	}
-	if res.Error != "" {
-		return false, res.Error
-	}
-	if res.Execution == nil || res.Execution.Fill == nil {
-		return false, "execute returned no fill block"
-	}
-	if res.Execution.Fill.TotalSz <= 0 || res.Execution.Fill.AvgPx <= 0 {
-		return false, fmt.Sprintf("execute returned an empty fill (sz=%.8f px=%.8f)", res.Execution.Fill.TotalSz, res.Execution.Fill.AvgPx)
-	}
-	return true, ""
 }
 
 func hedgeCloseConfirmed(res *HyperliquidCloseResult, err error) (bool, string) {

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1091,10 +1091,14 @@ func clearHyperliquidProtectionOIDsMatching(pos *Position, cancelOIDs []int64) {
 	for _, cancelOID := range cancelOIDs {
 		if cancelOID > 0 && pos.StopLossOID == cancelOID {
 			pos.StopLossOID = 0
+			pos.StopLossTriggerPx = 0
 		}
 		for idx, tpOID := range pos.TPOIDs {
 			if cancelOID > 0 && tpOID == cancelOID {
 				pos.TPOIDs[idx] = 0
+				if idx < len(pos.TPArmedTiers) {
+					pos.TPArmedTiers[idx] = false
+				}
 			}
 		}
 	}

--- a/scheduler/hyperliquid_execute_confirmation_test.go
+++ b/scheduler/hyperliquid_execute_confirmation_test.go
@@ -1,0 +1,391 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestConfirmHyperliquidExecuteFill(t *testing.T) {
+	transportErr := errors.New("transport failed")
+	parsed := &HyperliquidExecuteResult{
+		CancelStopLossSucceeded:     true,
+		CancelStopLossSucceededOIDs: []int64{111},
+	}
+	cases := []struct {
+		name          string
+		result        *HyperliquidExecuteResult
+		err           error
+		wantErr       bool
+		wantResult    *HyperliquidExecuteResult
+		wantConfirmed bool
+		contains      string
+	}{
+		{name: "transport error retains parsed result", result: parsed, err: transportErr, wantErr: true, wantResult: parsed, contains: "transport failed"},
+		{name: "nil result", wantErr: true, contains: "exchange returned no confirmed fill"},
+		{name: "top level error", result: &HyperliquidExecuteResult{Error: "rejected"}, wantErr: true, contains: "rejected"},
+		{name: "missing execution", result: &HyperliquidExecuteResult{}, wantErr: true, contains: "exchange returned no confirmed fill"},
+		{name: "missing fill", result: &HyperliquidExecuteResult{Execution: &HyperliquidExecution{}}, wantErr: true, contains: "exchange returned no confirmed fill"},
+		{name: "zero price", result: &HyperliquidExecuteResult{Execution: &HyperliquidExecution{Fill: &HyperliquidFill{AvgPx: 0, TotalSz: 1}}}, wantErr: true, contains: "sz=1.00000000 px=0.00000000"},
+		{name: "zero size", result: &HyperliquidExecuteResult{Execution: &HyperliquidExecution{Fill: &HyperliquidFill{AvgPx: 2000, TotalSz: 0}}}, wantErr: true, contains: "sz=0.00000000 px=2000.00000000"},
+		{name: "nan price", result: &HyperliquidExecuteResult{Execution: &HyperliquidExecution{Fill: &HyperliquidFill{AvgPx: math.NaN(), TotalSz: 1}}}, wantErr: true, contains: "exchange returned no confirmed fill"},
+		{name: "positive fill without oid", result: &HyperliquidExecuteResult{Execution: &HyperliquidExecution{Fill: &HyperliquidFill{AvgPx: 2000, TotalSz: 0.4}}}, wantConfirmed: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := confirmHyperliquidExecuteFill(tc.result, tc.err)
+			if tc.wantConfirmed {
+				if got == nil || got.Execution == nil || got.Execution.Fill == nil {
+					t.Fatalf("result = %+v, want a confirmed fill", got)
+				}
+				if got.Execution.Fill.OID != 0 {
+					t.Fatalf("OID = %d, want absent", got.Execution.Fill.OID)
+				}
+			}
+			if tc.wantResult == parsed && got != parsed {
+				t.Fatalf("result pointer = %p, want parsed result %p", got, parsed)
+			}
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("error = %v, want error=%t", err, tc.wantErr)
+			}
+			if tc.contains != "" && (err == nil || !strings.Contains(err.Error(), tc.contains)) {
+				t.Fatalf("error = %v, want substring %q", err, tc.contains)
+			}
+		})
+	}
+}
+
+func TestParseHyperliquidExecuteOutputRetainsParsedResultOnTransportError(t *testing.T) {
+	stdout := []byte(`{"execution":null,"cancel_stop_loss_succeeded":true,"cancel_stop_loss_succeeded_oids":[111]}`)
+	result, _, parseErr := parseHyperliquidExecuteOutput(stdout, "cancel warning", errors.New("exit status 1"))
+	if parseErr == nil {
+		t.Fatal("parse error = nil, want transport error")
+	}
+	if result == nil || !result.CancelStopLossSucceeded || !reflect.DeepEqual(result.CancelStopLossSucceededOIDs, []int64{111}) {
+		t.Fatalf("parsed cancellation metadata = %+v, want retained metadata", result)
+	}
+	confirmed, confirmErr := confirmHyperliquidExecuteFill(result, parseErr)
+	if confirmed != result || confirmErr == nil {
+		t.Fatalf("confirmed result/error = %p/%v, want parsed result and error", confirmed, confirmErr)
+	}
+}
+
+func TestHyperliquidExecuteCancellationClearsOnlyConfirmedProtection(t *testing.T) {
+	result := &HyperliquidExecuteResult{
+		CancelStopLossSucceeded:     true,
+		CancelStopLossSucceededOIDs: []int64{111, 333, 333, 0},
+		CancelStopLossFailedOIDs:    []int64{222},
+	}
+	requested := []int64{111, 222, 333}
+	if got, want := hyperliquidExecuteSucceededCancelOIDs(result, requested), []int64{111, 333}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("confirmed cancellation OIDs = %v, want %v", got, want)
+	}
+	if got := hyperliquidExecuteSucceededCancelOIDs(result, nil); got != nil {
+		t.Fatalf("unrequested cancellation OIDs = %v, want none", got)
+	}
+
+	pos := &Position{
+		StopLossOID:       111,
+		StopLossTriggerPx: 1900,
+		TPOIDs:            []int64{222, 333},
+		TPArmedTiers:      []bool{true, true},
+	}
+	clearHyperliquidProtectionOIDsMatching(pos, hyperliquidExecuteSucceededCancelOIDs(result, requested))
+	if pos.StopLossOID != 0 || pos.StopLossTriggerPx != 0 {
+		t.Fatalf("stop-loss = %d @ %g, want cleared", pos.StopLossOID, pos.StopLossTriggerPx)
+	}
+	if !reflect.DeepEqual(pos.TPOIDs, []int64{222, 0}) || !reflect.DeepEqual(pos.TPArmedTiers, []bool{true, false}) {
+		t.Fatalf("protection = oids %v armed %v, want only confirmed TP cancellation cleared", pos.TPOIDs, pos.TPArmedTiers)
+	}
+}
+
+func confirmationTestStrategy(direction string) StrategyConfig {
+	return StrategyConfig{
+		ID: "hl-confirmation", Type: "perps", Platform: "hyperliquid", Symbol: "ETH",
+		Script: "shared_scripts/check_hyperliquid.py", Args: []string{"hold", "ETH", "1h", "--mode=live"},
+		Direction: direction, Leverage: 2, SizingLeverage: 1,
+	}
+}
+
+func unconfirmedExecuteResult() *HyperliquidExecuteResult {
+	return &HyperliquidExecuteResult{
+		Execution: &HyperliquidExecution{Fill: &HyperliquidFill{}},
+	}
+}
+
+func confirmationNotifier() (*MultiNotifier, *mockNotifier) {
+	backend := &mockNotifier{}
+	return NewMultiNotifier(notifierBackend{
+		notifier: backend,
+		channels: map[string]string{"alerts": "alerts"},
+		ownerID:  "owner",
+	}), backend
+}
+
+func TestAutomaticHyperliquidExecuteRejectsUnconfirmedOpenCloseFlip(t *testing.T) {
+	originalExecute := runHyperliquidExecuteFn
+	originalThrottle := liveExecThrottle
+	t.Cleanup(func() {
+		runHyperliquidExecuteFn = originalExecute
+		liveExecThrottle = originalThrottle
+	})
+
+	cases := []struct {
+		name    string
+		dir     string
+		signal  int
+		posQty  float64
+		posSide string
+	}{
+		{name: "open", dir: DirectionLong, signal: 1},
+		{name: "close", dir: DirectionLong, signal: -1, posQty: 0.5, posSide: "long"},
+		{name: "flip", dir: DirectionBoth, signal: 1, posQty: 0.5, posSide: "short"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called := 0
+			runHyperliquidExecuteFn = func(script, symbol, side string, size, stopLossPct float64, cancelOID int64, prevPosQty float64, marginMode string, leverage float64, closeFullPosition bool, snapshot hlExecuteSnapshot, extraCancelOIDs ...int64) (*HyperliquidExecuteResult, string, error) {
+				called++
+				return unconfirmedExecuteResult(), "", nil
+			}
+			liveExecThrottle = &LiveExecFailureThrottle{}
+			notifier, backend := confirmationNotifier()
+			sc := confirmationTestStrategy(tc.dir)
+			result := &HyperliquidResult{Symbol: "ETH", Signal: tc.signal, Price: 2000}
+			got, ok := runHyperliquidExecuteOrder(sc, result, 2000, 1000, false, tc.posQty, tc.posSide, 2000, 2, 111, []int64{222}, nil, hlExecuteSnapshot{}, HurstGateDecision{}, notifier, silentStrategyLogger(sc.ID))
+			if ok || got == nil {
+				t.Fatalf("execute result = %+v, ok=%t, want rejected result", got, ok)
+			}
+			if called != 1 {
+				t.Fatalf("execute calls = %d, want 1", called)
+			}
+			key := liveExecKey(sc.ID, sc.Platform, "ETH", directionOpen)
+			if tc.signal == -1 {
+				key = liveExecKey(sc.ID, sc.Platform, "ETH", directionClose)
+			}
+			liveExecThrottle.mu.Lock()
+			entry := liveExecThrottle.entries[key]
+			liveExecThrottle.mu.Unlock()
+			if entry == nil || entry.count != 1 {
+				t.Fatalf("throttle entry = %+v, want one retained failure", entry)
+			}
+			backend.mu.Lock()
+			messages := len(backend.messages)
+			dms := len(backend.dms)
+			backend.mu.Unlock()
+			if messages == 0 || dms == 0 {
+				t.Fatalf("failure notifications = channels %d DMs %d, want both", messages, dms)
+			}
+		})
+	}
+}
+
+func TestHyperliquidScaleInRejectsUnconfirmedBeforeBooking(t *testing.T) {
+	originalExecute := runHyperliquidExecuteFn
+	originalThrottle := liveExecThrottle
+	t.Cleanup(func() {
+		runHyperliquidExecuteFn = originalExecute
+		liveExecThrottle = originalThrottle
+	})
+	runHyperliquidExecuteFn = func(script, symbol, side string, size, stopLossPct float64, cancelOID int64, prevPosQty float64, marginMode string, leverage float64, closeFullPosition bool, snapshot hlExecuteSnapshot, extraCancelOIDs ...int64) (*HyperliquidExecuteResult, string, error) {
+		return unconfirmedExecuteResult(), "", nil
+	}
+	liveExecThrottle = &LiveExecFailureThrottle{}
+	notifier, _ := confirmationNotifier()
+	sc := confirmationTestStrategy(DirectionLong)
+	result := &HyperliquidResult{Symbol: "ETH", Signal: 1, Price: 2000}
+	got, ok := runHyperliquidScaleInOrder(sc, result, 0.1, hlExecuteSnapshot{}, notifier, silentStrategyLogger(sc.ID))
+	if ok || got == nil {
+		t.Fatalf("scale-in result = %+v, ok=%t, want rejected result", got, ok)
+	}
+
+	state := &StrategyState{ID: sc.ID, Type: sc.Type, Platform: sc.Platform, Cash: 1000, Positions: map[string]*Position{
+		"ETH": {Symbol: "ETH", Quantity: 0.4, AvgCost: 2000, Side: "long"},
+	}}
+	trades, detail, trade, alert := executeHyperliquidScaleInDeferredOpen(sc, state, result, unconfirmedExecuteResult(), "BUY", 2000, 0.1, silentStrategyLogger(sc.ID))
+	if trades != 0 || detail != "" || trade != nil || alert != nil {
+		t.Fatalf("unconfirmed scale-in booking = trades %d detail %q trade %+v alert %+v", trades, detail, trade, alert)
+	}
+	if state.Positions["ETH"].Quantity != 0.4 || state.Cash != 1000 {
+		t.Fatalf("state changed after unconfirmed scale-in: position=%+v cash=%g", state.Positions["ETH"], state.Cash)
+	}
+}
+
+func TestHyperliquidResultRejectsUnconfirmedBeforeBooking(t *testing.T) {
+	sc := confirmationTestStrategy(DirectionLong)
+	state := &StrategyState{ID: sc.ID, Type: sc.Type, Platform: sc.Platform, Cash: 1000, Positions: map[string]*Position{}, TradeHistory: []Trade{{StrategyID: sc.ID, Symbol: "ETH", Quantity: 0.2, Price: 2000}}}
+	result := &HyperliquidResult{Symbol: "ETH", Signal: 1, Price: 2000}
+	trades, detail, trade, alert := executeHyperliquidResultDeferredOpen(sc, state, result, unconfirmedExecuteResult(), "BUY", 2000, nil, &Config{}, HurstGateDecision{}, silentStrategyLogger(sc.ID))
+	if trades != 0 || detail != "" || trade != nil || alert != nil {
+		t.Fatalf("unconfirmed result booking = trades %d detail %q trade %+v alert %+v", trades, detail, trade, alert)
+	}
+	if state.Cash != 1000 || len(state.TradeHistory) != 1 || len(state.Positions) != 0 {
+		t.Fatalf("state changed after unconfirmed result: cash=%g trades=%d positions=%v", state.Cash, len(state.TradeHistory), state.Positions)
+	}
+}
+
+func TestHedgeRejectsUnconfirmedOpenAndAdd(t *testing.T) {
+	prev := tradeRecorder
+	tradeRecorder = nil
+	t.Cleanup(func() { tradeRecorder = prev })
+
+	cases := []struct {
+		name       string
+		primaryQty float64
+		hedgeQty   float64
+		freshQty   float64
+	}{
+		{name: "open", primaryQty: 10, freshQty: 10},
+		{name: "add", primaryQty: 15, hedgeQty: 0.4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := hedgeTestConfig()
+			s := hedgeTestState("eth-long")
+			s.Positions["ETH"] = primaryPos(tc.primaryQty, "long")
+			if tc.hedgeQty > 0 {
+				s.Positions["BTC"] = hedgePos(tc.hedgeQty, "short", 10)
+			}
+			var mu sync.RWMutex
+			f := &fakeHedgeExec{openResult: unconfirmedExecuteResult()}
+
+			if kind := runHedgeSync(sc, s, &mu, f.executor(), hedgeSyncInputs{
+				PrimaryPx: testPrimaryPx, HedgePx: testHedgePx, FreshExposureQty: tc.freshQty, Live: true,
+			}, nil, silentStrategyLogger("eth-long")); kind != hedgeActionNone {
+				t.Fatalf("action = %v, want none", kind)
+			}
+			if tc.hedgeQty == 0 {
+				if _, ok := s.Positions["BTC"]; ok {
+					t.Fatal("unconfirmed hedge open created a position")
+				}
+			} else if got := s.Positions["BTC"].Quantity; got != tc.hedgeQty {
+				t.Fatalf("hedge quantity = %g, want %g", got, tc.hedgeQty)
+			}
+		})
+	}
+}
+
+func TestManualLiveExecuteRejectsUnconfirmedWithoutQueueing(t *testing.T) {
+	cases := []string{"open", "add", "close"}
+	for _, action := range cases {
+		t.Run(action, func(t *testing.T) {
+			dir := t.TempDir()
+			dbPath := filepath.Join(dir, "state.db")
+			db, err := OpenStateDB(dbPath)
+			if err != nil {
+				t.Fatalf("OpenStateDB: %v", err)
+			}
+			defer db.Close()
+			strategyID := "hl-manual-confirmation"
+			sc := StrategyConfig{
+				ID: strategyID, Type: "manual", Platform: "hyperliquid", Symbol: "ETH",
+				Script: "shared_scripts/check_hyperliquid.py", Args: []string{"hold", "ETH", "1h", "--mode=live"}, Leverage: 2,
+			}
+			position := &Position{
+				Symbol: "ETH", Quantity: 0.4, InitialQuantity: 0.4, AvgCost: 2000, Side: "long",
+				OwnerStrategyID: strategyID, StopLossOID: 111, StopLossTriggerPx: 1900,
+				TPOIDs: []int64{222, 333}, TPArmedTiers: []bool{true, true},
+			}
+			strategyState := &StrategyState{
+				ID: strategyID, Type: "manual", Platform: "hyperliquid", Cash: 1000,
+				Positions: map[string]*Position{}, TradeHistory: []Trade{{StrategyID: strategyID, Symbol: "ETH", Quantity: 0.2, Price: 2000}},
+			}
+			if action != "open" {
+				strategyState.Positions["ETH"] = position
+			}
+			state := &AppState{Strategies: map[string]*StrategyState{strategyID: strategyState}}
+			if err := db.SaveState(state); err != nil {
+				t.Fatalf("SaveState: %v", err)
+			}
+			cfg := &Config{DBFile: dbPath, Strategies: []StrategyConfig{sc}}
+			deps := newCLIManualCoreDeps(cfg, db, nil)
+			deps.fetchMids = func([]string) (map[string]float64, error) { return map[string]float64{"ETH": 2000}, nil }
+			deps.execute = func(script, symbol, side string, size, stopLossPct float64, cancelOID int64, prevPosQty float64, marginMode string, leverage float64, closeFullPosition bool, snapshot hlExecuteSnapshot, extraCancelOIDs ...int64) (*HyperliquidExecuteResult, string, error) {
+				result := unconfirmedExecuteResult()
+				if action == "close" {
+					result.CancelStopLossSucceeded = true
+					result.CancelStopLossSucceededOIDs = []int64{111, 333}
+				}
+				return result, "", nil
+			}
+
+			var result *manualCoreResult
+			switch action {
+			case "open":
+				result, err = manualOpenCore(deps, sc, manualOpenInputs{StrategyID: strategyID, Margin: 50})
+			case "add":
+				result, err = manualAddCore(deps, sc, manualAddInputs{StrategyID: strategyID, Margin: 50})
+			case "close":
+				result, err = manualCloseCore(deps, sc, manualCloseInputs{StrategyID: strategyID})
+			}
+			if err == nil || result == nil || result.queued || !strings.Contains(err.Error(), "exchange returned no confirmed fill") {
+				t.Fatalf("result=%+v err=%v, want an unconfirmed-fill refusal without queue", result, err)
+			}
+			actions, err := db.LoadPendingManualActions()
+			if err != nil {
+				t.Fatalf("LoadPendingManualActions: %v", err)
+			}
+			if len(actions) != 0 {
+				t.Fatalf("pending actions = %+v, want none", actions)
+			}
+			loaded, err := LoadStateWithDB(cfg, db)
+			if err != nil {
+				t.Fatalf("LoadStateWithDB: %v", err)
+			}
+			loadedStrategy := loaded.Strategies[strategyID]
+			if loadedStrategy.Cash != 1000 || len(loadedStrategy.TradeHistory) != 1 {
+				t.Fatalf("accounting changed: cash=%g trade history=%d", loadedStrategy.Cash, len(loadedStrategy.TradeHistory))
+			}
+			if action == "open" {
+				if loadedStrategy.Positions["ETH"] != nil {
+					t.Fatal("unconfirmed open created a position")
+				}
+				return
+			}
+			loadedPosition := loadedStrategy.Positions["ETH"]
+			if loadedPosition == nil || loadedPosition.Quantity != 0.4 {
+				t.Fatalf("position = %+v, want unchanged quantity", loadedPosition)
+			}
+			if action == "close" {
+				if loadedPosition.StopLossOID != 0 || loadedPosition.StopLossTriggerPx != 0 || !reflect.DeepEqual(loadedPosition.TPOIDs, []int64{222, 0}) || !reflect.DeepEqual(loadedPosition.TPArmedTiers, []bool{true, false}) {
+					t.Fatalf("recorded protection = sl %d @ %g tp %v armed %v, want canceled OIDs cleared", loadedPosition.StopLossOID, loadedPosition.StopLossTriggerPx, loadedPosition.TPOIDs, loadedPosition.TPArmedTiers)
+				}
+			}
+		})
+	}
+}
+
+func TestDaemonManualCloseRejectsUnconfirmedWithoutQueueing(t *testing.T) {
+	ss, db, _ := newTradeActionTestServer(t)
+	stubs := stubTradeDeps(t, ss)
+	stubs.execute = func(script, symbol, side string, size, stopLossPct float64, cancelOID int64, prevPosQty float64, marginMode string, leverage float64, closeFullPosition bool, snapshot hlExecuteSnapshot, extraCancelOIDs ...int64) (*HyperliquidExecuteResult, string, error) {
+		return &HyperliquidExecuteResult{
+			Execution:                   &HyperliquidExecution{Fill: &HyperliquidFill{}},
+			CancelStopLossSucceeded:     true,
+			CancelStopLossSucceededOIDs: []int64{111},
+		}, "", nil
+	}
+	nonce := confirmNonceFor(t, ss, "close", "hl-manual-eth", `{}`)
+	w := tradeActionPost(ss, "/api/strategies/hl-manual-eth/close", fmt.Sprintf(`{"nonce":%q,"params":{}}`, nonce), nil)
+	if w.Code != http.StatusConflict || !strings.Contains(w.Body.String(), "exchange returned no confirmed fill") {
+		t.Fatalf("daemon close status = %d, body %s", w.Code, w.Body.String())
+	}
+	actions, err := db.LoadPendingManualActions()
+	if err != nil {
+		t.Fatalf("LoadPendingManualActions: %v", err)
+	}
+	if len(actions) != 0 {
+		t.Fatalf("pending actions = %+v, want none", actions)
+	}
+	position := ss.state.Strategies["hl-manual-eth"].Positions["ETH"]
+	if position.Quantity != 0.4 || position.StopLossOID != 0 || position.StopLossTriggerPx != 0 {
+		t.Fatalf("daemon state = %+v, want quantity unchanged and canceled SL cleared", position)
+	}
+}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -2081,13 +2081,15 @@ func main() {
 										execResult = er
 									} else {
 										liveExecFailed = true
-										if er != nil && er.CancelStopLossSucceeded && hlStopLossOID > 0 {
+										canceledOIDs := append([]int64{hlStopLossOID}, hlTPOIDs...)
+										canceledOIDs = hyperliquidExecuteSucceededCancelOIDs(er, canceledOIDs)
+										if len(canceledOIDs) > 0 {
 											sym := hyperliquidSymbol(sc.Args)
 											if sym != "" {
 												mu.Lock()
-												if pos, ok3 := stratState.Positions[sym]; ok3 && pos.StopLossOID == hlStopLossOID {
-													pos.StopLossOID = 0
-													logger.Info("cleared stale SL OID=%d after open failed but cancel succeeded", hlStopLossOID)
+												if pos, ok3 := stratState.Positions[sym]; ok3 {
+													clearHyperliquidProtectionOIDsMatching(pos, canceledOIDs)
+													logger.Info("cleared canceled protection OIDs=%v after live execute failed", canceledOIDs)
 												}
 												mu.Unlock()
 											}
@@ -2350,19 +2352,23 @@ func main() {
 								if intentFullClose {
 									extraCancelOIDs = cloneInt64s(pos.TPOIDs)
 								}
-								execResult, execStderr, execErr := RunHyperliquidExecute(
+								execResult, execStderr, execErr := runHyperliquidExecuteFn(
 									sc.Script, sc.Symbol, closeSide, closeQty,
 									0, cancelOID, 0, "", 0, closeFullPosition, hlExecuteSnapshot{}, extraCancelOIDs...,
 								)
 								if execStderr != "" {
 									logger.Info("HL manual close stderr: %s", execStderr)
 								}
+								requestedCancelOIDs := append([]int64{cancelOID}, extraCancelOIDs...)
+								execResult, execErr = confirmHyperliquidExecuteFill(execResult, execErr)
 								if execErr != nil {
 									logger.Error("manual close execute failed: %v", execErr)
-									break
-								}
-								if execResult.Error != "" {
-									logger.Error("manual close HL error: %s", execResult.Error)
+									canceledOIDs := hyperliquidExecuteSucceededCancelOIDs(execResult, requestedCancelOIDs)
+									if len(canceledOIDs) > 0 {
+										mu.Lock()
+										clearHyperliquidProtectionOIDsMatching(stratState.Positions[sc.Symbol], canceledOIDs)
+										mu.Unlock()
+									}
 									break
 								}
 								if execResult.CancelStopLossError != "" {
@@ -3290,7 +3296,7 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	} else if result.CloseFraction == 1.0 {
 		logger.Info("Final-tier close %s shares coin with HL perps peers — using sized close to preserve peer exposure", result.Symbol)
 	}
-	execResult, stderr, err := RunHyperliquidExecute(sc.Script, result.Symbol, side, size, slPct, cancelOID, prevPosQty, marginMode, leverageForOpen, closeFullPosition, walletSnapshot, extraCancelOIDs...)
+	execResult, stderr, err := runHyperliquidExecuteFn(sc.Script, result.Symbol, side, size, slPct, cancelOID, prevPosQty, marginMode, leverageForOpen, closeFullPosition, walletSnapshot, extraCancelOIDs...)
 	if stderr != "" {
 		logger.Info("execute stderr: %s", stderr)
 	}
@@ -3298,14 +3304,10 @@ func runHyperliquidExecuteOrder(sc StrategyConfig, result *HyperliquidResult, pr
 	if side == "sell" {
 		direction = directionClose
 	}
+	execResult, err = confirmHyperliquidExecuteFill(execResult, err)
 	if err != nil {
 		logger.Error("Live execute failed: %v", err)
 		notifyLiveExecFailure(notifier, sc, direction, result.Symbol, err.Error())
-		return execResult, false
-	}
-	if execResult.Error != "" {
-		logger.Error("Live execute returned error: %s", execResult.Error)
-		notifyLiveExecFailure(notifier, sc, direction, result.Symbol, execResult.Error)
 		return execResult, false
 	}
 	clearLiveExecThrottle(sc, direction, result.Symbol)
@@ -3354,6 +3356,11 @@ func executeHyperliquidResult(sc StrategyConfig, s *StrategyState, result *Hyper
 }
 
 func executeHyperliquidResultDeferredOpen(sc StrategyConfig, s *StrategyState, result *HyperliquidResult, execResult *HyperliquidExecuteResult, signalStr string, price float64, regime *RegimeConfig, cfg *Config, hurst HurstGateDecision, logger *StrategyLogger) (int, string, *Trade, *RatchetTriggerAlert) {
+	if execResult != nil {
+		if _, err := confirmHyperliquidExecuteFill(execResult, nil); err != nil {
+			return 0, "", nil, nil
+		}
+	}
 	fillPrice := price
 	var fillQty float64
 	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil && execResult.Execution.Fill.AvgPx > 0 {

--- a/scheduler/manual_core.go
+++ b/scheduler/manual_core.go
@@ -116,7 +116,8 @@ type manualCoreDeps struct {
 	fetchMids   manualMarkFetcher
 	closer      HyperliquidLiveCloser
 
-	lockManualActions func() (release func(), err error)
+	lockManualActions           func() (release func(), err error)
+	reconcileCanceledProtection func(strategyID, symbol string, cancelOIDs []int64) error
 }
 
 func (d manualCoreDeps) acquireManualActionLock() (func(), error) {
@@ -143,14 +144,50 @@ func newManualCoreDeps(cfg *Config, stateDB *StateDB, notifier *MultiNotifier) m
 		cfg:         cfg,
 		stateDB:     stateDB,
 		notifier:    notifier,
-		execute:     RunHyperliquidExecute,
+		execute:     runHyperliquidExecuteFn,
 		updateSL:    RunHyperliquidUpdateStopLoss,
 		cancelOrder: RunHyperliquidCancelOrder,
 		fetchMids:   fetchHyperliquidMids,
 		closer:      defaultHyperliquidForceCloseCloser,
+		reconcileCanceledProtection: func(strategyID, symbol string, cancelOIDs []int64) error {
+			return reconcileCanceledExecuteProtectionInDB(cfg, stateDB, strategyID, symbol, cancelOIDs)
+		},
 		lockManualActions: func() (func(), error) {
 			return acquireManualActionFileLock(cfg.DBFile)
 		},
+	}
+}
+
+func reconcileCanceledExecuteProtectionInDB(cfg *Config, stateDB *StateDB, strategyID, symbol string, cancelOIDs []int64) error {
+	if stateDB == nil || len(cancelOIDs) == 0 {
+		return nil
+	}
+	state, err := LoadStateWithDB(cfg, stateDB)
+	if err != nil {
+		return err
+	}
+	strategy := state.Strategies[strategyID]
+	if strategy == nil {
+		return nil
+	}
+	position := strategy.Positions[symbol]
+	if position == nil {
+		return nil
+	}
+	clearHyperliquidProtectionOIDsMatching(position, cancelOIDs)
+	return SaveStrategyBookWithDB(strategy, stateDB)
+}
+
+func reconcileManualExecuteProtection(d manualCoreDeps, res *manualCoreResult, strategyID, symbol string, executeResult *HyperliquidExecuteResult, requestedCancelOIDs []int64) {
+	if d.reconcileCanceledProtection == nil {
+		return
+	}
+	canceledOIDs := hyperliquidExecuteSucceededCancelOIDs(executeResult, requestedCancelOIDs)
+	if len(canceledOIDs) == 0 {
+		return
+	}
+	if err := d.reconcileCanceledProtection(strategyID, symbol, canceledOIDs); err != nil {
+		res.errf("warning: could not record canceled protection for %s/%s: %v", strategyID, symbol, err)
 	}
 }
 
@@ -493,27 +530,19 @@ func manualOpenCore(d manualCoreDeps, sc StrategyConfig, in manualOpenInputs) (*
 		if execStderr != "" {
 			res.errf("HL execute stderr: %s", execStderr)
 		}
+		execResult, execErr = confirmHyperliquidExecuteFill(execResult, execErr)
 		if execErr != nil {
+			reconcileManualExecuteProtection(d, res, strategyID, sc.Symbol, execResult, nil)
 			return res, manualFailf("error placing order: %v", execErr)
-		}
-		if execResult.Error != "" {
-			return res, manualFailf("error from HL: %s", execResult.Error)
 		}
 
 		fill := execResult.Execution
-		if fill == nil || fill.Fill == nil {
-			return res, manualFailf("error: no fill returned from execute")
-		}
 		resolvedFillPrice = fill.Fill.AvgPx
 		fillQty = fill.Fill.TotalSz
 		fillFee = fill.Fill.Fee
 		if fill.Fill.OID != 0 {
 			exchangeOID = fmt.Sprintf("%d", fill.Fill.OID)
 		}
-		if fillQty <= 0 {
-			fillQty = resolveManualSize(in.Size, in.Notional, in.Margin, resolvedFillPrice, sc.Leverage)
-		}
-
 		if entryATR > 0 && resolvedFillPrice > 0 && entryATR > 0.5*resolvedFillPrice {
 			res.errf("warning: --atr %.4f exceeds 50%% of fill price %.4f — EntryATR will not be stamped", entryATR, resolvedFillPrice)
 			entryATR = 0
@@ -773,24 +802,17 @@ func manualAddCore(d manualCoreDeps, sc StrategyConfig, in manualAddInputs) (*ma
 		if execStderr != "" {
 			res.errf("HL execute stderr: %s", execStderr)
 		}
+		execResult, execErr = confirmHyperliquidExecuteFill(execResult, execErr)
 		if execErr != nil {
+			reconcileManualExecuteProtection(d, res, strategyID, sc.Symbol, execResult, nil)
 			return res, manualFailf("error placing order: %v", execErr)
 		}
-		if execResult.Error != "" {
-			return res, manualFailf("error from HL: %s", execResult.Error)
-		}
 		fill := execResult.Execution
-		if fill == nil || fill.Fill == nil {
-			return res, manualFailf("error: no fill returned from execute")
-		}
 		resolvedFillPrice = fill.Fill.AvgPx
 		fillQty = fill.Fill.TotalSz
 		fillFee = fill.Fill.Fee
 		if fill.Fill.OID != 0 {
 			exchangeOID = fmt.Sprintf("%d", fill.Fill.OID)
-		}
-		if fillQty <= 0 {
-			fillQty = resolveManualSize(in.Size, in.Notional, in.Margin, resolvedFillPrice, sc.Leverage)
 		}
 	}
 
@@ -937,11 +959,11 @@ func manualCloseCore(d manualCoreDeps, sc StrategyConfig, in manualCloseInputs) 
 	if stderr != "" {
 		res.errf("HL close stderr: %s", stderr)
 	}
+	requestedCancelOIDs := append([]int64{cancelOID}, extraCancelOIDs...)
+	execResult, execErr = confirmHyperliquidExecuteFill(execResult, execErr)
 	if execErr != nil {
+		reconcileManualExecuteProtection(d, res, strategyID, sc.Symbol, execResult, requestedCancelOIDs)
 		return res, manualFailf("error placing close order: %v", execErr)
-	}
-	if execResult.Error != "" {
-		return res, manualFailf("error from HL: %s", execResult.Error)
 	}
 	if execResult.CancelStopLossError != "" {
 		res.errf("warning: manual close cancel failed (non-fatal) for %s/%s: %s (sl_oid=%d tp_oids=%v) — verify HL on-chain triggers",
@@ -949,9 +971,6 @@ func manualCloseCore(d manualCoreDeps, sc StrategyConfig, in manualCloseInputs) 
 	}
 
 	fill := execResult.Execution
-	if fill == nil || fill.Fill == nil {
-		return res, manualFailf("error: no fill returned from close execute")
-	}
 
 	fillAvgPx := fill.Fill.AvgPx
 	fillFee := fill.Fill.Fee

--- a/scheduler/scale_in.go
+++ b/scheduler/scale_in.go
@@ -256,18 +256,14 @@ func runHyperliquidScaleInOrder(sc StrategyConfig, result *HyperliquidResult, ad
 		side = "sell"
 	}
 	logger.Info("Placing live scale-in %s %s size=%.6f", side, result.Symbol, addSize)
-	execResult, stderr, err := RunHyperliquidExecute(sc.Script, result.Symbol, side, addSize, 0, 0, 0, "", 0, false, walletSnapshot)
+	execResult, stderr, err := runHyperliquidExecuteFn(sc.Script, result.Symbol, side, addSize, 0, 0, 0, "", 0, false, walletSnapshot)
 	if stderr != "" {
 		logger.Info("execute stderr: %s", stderr)
 	}
+	execResult, err = confirmHyperliquidExecuteFill(execResult, err)
 	if err != nil {
 		logger.Error("Live scale-in failed: %v", err)
 		notifyLiveExecFailure(notifier, sc, directionOpen, result.Symbol, err.Error())
-		return execResult, false
-	}
-	if execResult.Error != "" {
-		logger.Error("Live scale-in returned error: %s", execResult.Error)
-		notifyLiveExecFailure(notifier, sc, directionOpen, result.Symbol, execResult.Error)
 		return execResult, false
 	}
 	clearLiveExecThrottle(sc, directionOpen, result.Symbol)
@@ -280,14 +276,15 @@ func executeHyperliquidScaleInDeferredOpen(sc StrategyConfig, s *StrategyState, 
 	var fillOID string
 	var fillFee float64
 	useFillFee := false
-	if execResult != nil && execResult.Execution != nil && execResult.Execution.Fill != nil {
+	if execResult != nil {
+		confirmed, err := confirmHyperliquidExecuteFill(execResult, nil)
+		if err != nil {
+			return 0, "", nil, nil
+		}
+		execResult = confirmed
 		fill := execResult.Execution.Fill
-		if fill.AvgPx > 0 {
-			fillPrice = fill.AvgPx
-		}
-		if fill.TotalSz > 0 {
-			fillAddQty = fill.TotalSz
-		}
+		fillPrice = fill.AvgPx
+		fillAddQty = fill.TotalSz
 		if fill.OID != 0 {
 			fillOID = fmt.Sprintf("%d", fill.OID)
 		}

--- a/scheduler/ui_trade_actions.go
+++ b/scheduler/ui_trade_actions.go
@@ -72,6 +72,26 @@ func (ss *StatusServer) daemonManualCoreDeps(cfg *Config) manualCoreDeps {
 		defer ss.mu.RUnlock()
 		return manualStateViewFromState(cfg, ss.state, strategyID, symbol), nil
 	}
+	d.reconcileCanceledProtection = func(strategyID, symbol string, cancelOIDs []int64) error {
+		if len(cancelOIDs) == 0 {
+			return nil
+		}
+		ss.mu.Lock()
+		defer ss.mu.Unlock()
+		if ss.state == nil {
+			return fmt.Errorf("state unavailable")
+		}
+		strategy := ss.state.Strategies[strategyID]
+		if strategy == nil {
+			return nil
+		}
+		position := strategy.Positions[symbol]
+		if position == nil {
+			return nil
+		}
+		clearHyperliquidProtectionOIDsMatching(position, cancelOIDs)
+		return SaveStrategyBookWithDB(strategy, ss.stateDB)
+	}
 	return d
 }
 

--- a/shared_scripts/check_hyperliquid.py
+++ b/shared_scripts/check_hyperliquid.py
@@ -624,6 +624,67 @@ def _classify_cancel_response(sdk_response):
     except Exception as e:
         return ("error", f"_classify_cancel_response: {e}")
 
+
+def _extract_execute_fill(sdk_response):
+    if not isinstance(sdk_response, dict) or sdk_response.get("status") != "ok":
+        return None, f"exchange rejected order: {sdk_response}"
+
+    response = sdk_response.get("response")
+    data = response.get("data") if isinstance(response, dict) else None
+    statuses = data.get("statuses") if isinstance(data, dict) else None
+    if not isinstance(statuses, list) or not statuses:
+        return None, "exchange returned no order status"
+
+    status = statuses[0]
+    if not isinstance(status, dict):
+        return None, "exchange returned a malformed order status"
+    if "error" in status:
+        return None, f"exchange rejected order: {status['error']}"
+    if "filled" not in status or not isinstance(status["filled"], dict):
+        return None, "exchange returned no filled status"
+
+    filled = status["filled"]
+    raw_avg_px = filled.get("avgPx")
+    raw_total_sz = filled.get("totalSz")
+    try:
+        avg_px = float(raw_avg_px)
+        total_sz = float(raw_total_sz)
+    except (TypeError, ValueError):
+        return None, f"exchange returned malformed fill values (avgPx={raw_avg_px!r}, totalSz={raw_total_sz!r})"
+    if not math.isfinite(avg_px) or not math.isfinite(total_sz):
+        return None, f"exchange returned malformed fill values (avgPx={raw_avg_px!r}, totalSz={raw_total_sz!r})"
+    if avg_px <= 0 or total_sz <= 0:
+        return None, f"exchange returned no confirmed fill (sz={total_sz:.8f} px={avg_px:.8f})"
+
+    fill = {"avg_px": avg_px, "total_sz": total_sz}
+    oid = filled.get("oid")
+    if oid is not None:
+        try:
+            fill["oid"] = int(oid)
+        except (TypeError, ValueError):
+            print(f"[WARN] ignoring malformed fill oid={oid!r}", file=sys.stderr)
+    fee = filled.get("fee")
+    if fee is not None:
+        try:
+            parsed_fee = float(fee)
+            if math.isfinite(parsed_fee):
+                fill["fee"] = parsed_fee
+        except (TypeError, ValueError):
+            print(f"[WARN] ignoring malformed fill fee={fee!r}", file=sys.stderr)
+    return fill, ""
+
+
+def _add_execute_cancel_metadata(payload, cancel_err, cancel_succeeded, cancel_succeeded_oids, cancel_failed_oids):
+    if cancel_err:
+        payload["cancel_stop_loss_error"] = cancel_err
+    if cancel_succeeded:
+        payload["cancel_stop_loss_succeeded"] = True
+    if cancel_succeeded_oids:
+        payload["cancel_stop_loss_succeeded_oids"] = cancel_succeeded_oids
+    if cancel_failed_oids:
+        payload["cancel_stop_loss_failed_oids"] = cancel_failed_oids
+
+
 def _oid_is_open(open_oids: set[int] | None, oid: int) -> bool:
     return oid > 0 and open_oids is not None and int(oid) in open_oids
 
@@ -1044,6 +1105,8 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
     cancel_oids = [int(oid) for oid in cancel_oids if int(oid or 0) > 0]
     cancel_attempted = len(cancel_oids) > 0
     cancel_succeeded = False
+    cancel_succeeded_oids = []
+    cancel_failed_oids = []
 
     try:
         from adapter import HyperliquidExchangeAdapter
@@ -1101,11 +1164,14 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
                             adapter.cancel_trigger_order(symbol, oid))
                         if kind == "ok":
                             cancel_succeeded = True
+                            cancel_succeeded_oids.append(oid)
                         else:
                             cancel_errors.append(f"{oid}: {payload}")
+                            cancel_failed_oids.append(oid)
                             print(f"[WARN] cancel_trigger_order({symbol}, {oid}) rejected: {payload}", file=sys.stderr)
                     except Exception as ce:
                         cancel_errors.append(f"{oid}: {ce}")
+                        cancel_failed_oids.append(oid)
                         print(f"[WARN] cancel_trigger_order({symbol}, {oid}) failed: {ce}", file=sys.stderr)
             finally:
                 if cancel_errors:
@@ -1118,23 +1184,23 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
         else:
             result = adapter.market_open(symbol, is_buy, size)
 
-        fill = {}
-        try:
-            statuses = result.get("response", {}).get("data", {}).get("statuses", [])
-            if statuses:
-                filled = statuses[0].get("filled", {})
-                fill = {
-                    "avg_px": float(filled.get("avgPx", 0) or 0),
-                    "total_sz": float(filled.get("totalSz", 0) or 0),
-                }
-                oid = filled.get("oid")
-                if oid is not None:
-                    fill["oid"] = int(oid)
-                fee = filled.get("fee")
-                if fee is not None:
-                    fill["fee"] = float(fee)
-        except Exception:
-            pass
+        fill, fill_error = _extract_execute_fill(result)
+        if fill_error:
+            err_payload = {
+                "execution": None,
+                "platform": "hyperliquid",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "error": fill_error,
+            }
+            _add_execute_cancel_metadata(
+                err_payload,
+                cancel_err,
+                cancel_succeeded,
+                cancel_succeeded_oids,
+                cancel_failed_oids,
+            )
+            print(json.dumps(err_payload, cls=SafeEncoder))
+            sys.exit(1)
 
         if fill.get("oid"):
             try:
@@ -1189,10 +1255,13 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
             "platform": "hyperliquid",
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
-        if cancel_err:
-            out["cancel_stop_loss_error"] = cancel_err
-        if cancel_succeeded:
-            out["cancel_stop_loss_succeeded"] = True
+        _add_execute_cancel_metadata(
+            out,
+            cancel_err,
+            cancel_succeeded,
+            cancel_succeeded_oids,
+            cancel_failed_oids,
+        )
         if sl_err:
             out["stop_loss_error"] = sl_err
         if sl_filled_immediately:
@@ -1207,10 +1276,13 @@ def run_execute(symbol, side, size, mode, stop_loss_pct=0.0, cancel_oid=0, prev_
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "error": str(e),
         }
-        if cancel_err:
-            err_payload["cancel_stop_loss_error"] = cancel_err
-        if cancel_succeeded:
-            err_payload["cancel_stop_loss_succeeded"] = True
+        _add_execute_cancel_metadata(
+            err_payload,
+            cancel_err,
+            cancel_succeeded,
+            cancel_succeeded_oids,
+            cancel_failed_oids,
+        )
         print(json.dumps(err_payload, cls=SafeEncoder))
         sys.exit(1)
 

--- a/shared_scripts/test_check_hyperliquid.py
+++ b/shared_scripts/test_check_hyperliquid.py
@@ -22,7 +22,7 @@ def _load_check_module():
 
 class TestFillExtraction:
 
-    def _run_execute_with_mock_response(self, sdk_response, lookup_result=_UNSET):
+    def _run_execute_with_mock_response(self, sdk_response, lookup_result=_UNSET, **execute_kwargs):
         mod, spec = _load_check_module()
         spec.loader.exec_module(mod)
 
@@ -30,6 +30,10 @@ class TestFillExtraction:
         mock_adapter = MagicMock()
         mock_adapter_cls.return_value = mock_adapter
         mock_adapter.market_open.return_value = sdk_response
+        mock_adapter.cancel_trigger_order.return_value = {
+            "status": "ok",
+            "response": {"data": {"statuses": [{}]}},
+        }
         if lookup_result is not _UNSET:
             mock_adapter.lookup_fill_fee_by_oid.return_value = lookup_result
 
@@ -48,9 +52,13 @@ class TestFillExtraction:
 
                 with patch("builtins.__import__", side_effect=mock_import):
                     with patch("sys.stdout", captured):
-                        mod.run_execute("BTC", "buy", 0.01, "live")
+                        exit_code = 0
+                        try:
+                            mod.run_execute("BTC", "buy", 0.01, "live", **execute_kwargs)
+                        except SystemExit as e:
+                            exit_code = e.code
 
-        return json.loads(captured.getvalue())
+        return json.loads(captured.getvalue()), exit_code
 
     def test_fill_with_oid_and_fee(self):
         sdk_response = {
@@ -71,7 +79,8 @@ class TestFillExtraction:
                 },
             },
         }
-        result = self._run_execute_with_mock_response(sdk_response)
+        result, exit_code = self._run_execute_with_mock_response(sdk_response)
+        assert exit_code == 0
         fill = result["execution"]["fill"]
         assert fill["avg_px"] == 55000.5
         assert fill["total_sz"] == 0.01
@@ -96,7 +105,8 @@ class TestFillExtraction:
                 },
             },
         }
-        result = self._run_execute_with_mock_response(sdk_response)
+        result, exit_code = self._run_execute_with_mock_response(sdk_response)
+        assert exit_code == 0
         fill = result["execution"]["fill"]
         assert fill["oid"] == 9876543210
         assert "fee" not in fill
@@ -119,10 +129,11 @@ class TestFillExtraction:
                 },
             },
         }
-        result = self._run_execute_with_mock_response(
+        result, exit_code = self._run_execute_with_mock_response(
             sdk_response,
             lookup_result={"fee": "0.42", "closed_pnl": "3.14"},
         )
+        assert exit_code == 0
         fill = result["execution"]["fill"]
         assert fill["fee"] == 0.42
         assert fill["closed_pnl"] == 3.14
@@ -145,7 +156,8 @@ class TestFillExtraction:
                 },
             },
         }
-        result = self._run_execute_with_mock_response(sdk_response, lookup_result=MagicMock())
+        result, exit_code = self._run_execute_with_mock_response(sdk_response, lookup_result=MagicMock())
+        assert exit_code == 0
         fill = result["execution"]["fill"]
         assert fill["oid"] == 9876543210
         assert "fee" not in fill
@@ -169,10 +181,11 @@ class TestFillExtraction:
                 },
             },
         }
-        result = self._run_execute_with_mock_response(
+        result, exit_code = self._run_execute_with_mock_response(
             sdk_response,
             lookup_result={"fee": MagicMock(), "closed_pnl": MagicMock()},
         )
+        assert exit_code == 0
         fill = result["execution"]["fill"]
         assert fill["oid"] == 9876543210
         assert "fee" not in fill
@@ -195,7 +208,8 @@ class TestFillExtraction:
                 },
             },
         }
-        result = self._run_execute_with_mock_response(sdk_response)
+        result, exit_code = self._run_execute_with_mock_response(sdk_response)
+        assert exit_code == 0
         fill = result["execution"]["fill"]
         assert fill["avg_px"] == 50000.0
         assert fill["total_sz"] == 0.1
@@ -207,8 +221,67 @@ class TestFillExtraction:
             "status": "ok",
             "response": {"type": "order", "data": {"statuses": []}},
         }
-        result = self._run_execute_with_mock_response(sdk_response)
-        assert result["execution"]["fill"] == {}
+        result, exit_code = self._run_execute_with_mock_response(sdk_response)
+        assert exit_code == 1
+        assert result["execution"] is None
+        assert "error" in result
+
+    @pytest.mark.parametrize(
+        "sdk_response",
+        [
+            {"status": "err", "response": "rejected"},
+            {
+                "status": "ok",
+                "response": {"type": "order", "data": {"statuses": [{}]}},
+            },
+            {
+                "status": "ok",
+                "response": {
+                    "type": "order",
+                    "data": {"statuses": [{"filled": {"avgPx": "bad", "totalSz": "0.1"}}]},
+                },
+            },
+            {
+                "status": "ok",
+                "response": {
+                    "type": "order",
+                    "data": {"statuses": [{"filled": {"avgPx": "50000", "totalSz": "bad"}}]},
+                },
+            },
+            {
+                "status": "ok",
+                "response": {
+                    "type": "order",
+                    "data": {"statuses": [{"filled": {"avgPx": "0", "totalSz": "0.1"}}]},
+                },
+            },
+            {
+                "status": "ok",
+                "response": {
+                    "type": "order",
+                    "data": {"statuses": [{"filled": {"avgPx": "50000", "totalSz": "0"}}]},
+                },
+            },
+        ],
+    )
+    def test_unconfirmed_fill_exits_with_error(self, sdk_response):
+        result, exit_code = self._run_execute_with_mock_response(sdk_response)
+        assert exit_code == 1
+        assert result["execution"] is None
+        assert result["error"]
+
+    def test_unconfirmed_fill_preserves_cancel_metadata(self):
+        sdk_response = {
+            "status": "ok",
+            "response": {"type": "order", "data": {"statuses": []}},
+        }
+        result, exit_code = self._run_execute_with_mock_response(
+            sdk_response,
+            cancel_oid=[111, 222],
+        )
+        assert exit_code == 1
+        assert result["cancel_stop_loss_succeeded"] is True
+        assert result["cancel_stop_loss_succeeded_oids"] == [111, 222]
 
 
 class TestMarginMode:
@@ -1452,4 +1525,3 @@ class TestProtectionSyncStopLossTriggerContract:
         assert "stop_loss_oid" not in out
         assert "stop_loss_outcome_unknown" not in out
         assert "no usable status" in out.get("stop_loss_error", "")
-


### PR DESCRIPTION
## Plain simple English

The scheduler now accepts a live Hyperliquid order only when the exchange reports a positive filled size and average price. Failed responses produce an operator error and leave positions, trade records, pending actions, and trade alerts unchanged. Confirmed protection cancellations remain recorded for reconciliation.

## Summary

- Added one Go fill confirmation contract for all live Hyperliquid execute consumers.
- Rejected invalid Python order responses with exit code 1.
- Removed scale-in fallback values and cleared only confirmed-cancelled protection records.
- Added consumer, parser, protection, and Python regression tests.

## Verification

- `uv run --no-sync python -m py_compile shared_scripts/check_hyperliquid.py` passed.
- `uv run --no-sync python -m pytest shared_scripts/test_check_hyperliquid.py -q` passed: 95 tests.
- `go -C scheduler test . -count=1 -timeout 180s` passed.
- `uv run --no-sync python -m pytest shared_scripts/test_close_hyperliquid_position.py shared_scripts/test_check_execute_fees.py -q` passed: 35 tests.

Test edit: `test_fill_empty_statuses` is Outdated. Ground: issue #1501 acceptance criteria require a top-level error and exit code 1. It now asserts both. The helper catches `SystemExit`, and positive-fill tests assert exit code 0.

Closes #1501

---
LLM: GPT-5.6 Luna | max | Harness: Codex CLI