### PR TITLE
fix(#1499): give each latent regime state a distinct label [C64, Fable 5.1, high]

### DIFF
--- a/backtest/regime_vol_model.py
+++ b/backtest/regime_vol_model.py
@@ -7,13 +7,16 @@ for _p in (_THIS_DIR, os.path.abspath(os.path.join(_THIS_DIR, "..")),
         sys.path.insert(0, _p)
 
 from dataclasses import dataclass
+import math
 
 import numpy as np
 from regime_hmm import stationary_distribution
 
 FEATURES = ["return_eff", "range_eff", "efficiency", "adx"]
 MODEL_TYPE = "unsupervised_vol_regime"
-MODEL_VERSION = 1
+MODEL_VERSION = 2
+NAMING_RULE = "distinct_nearest_cell"
+_RELABEL_PENALTY = 1e6
 
 
 def standardize(features):
@@ -206,6 +209,123 @@ def fit_hmm(z, k, *, seed=0, iters=50, var_floor=1e-3, tol=1e-4, min_soft_mass=1
 FITTERS = {"kmeans": fit_kmeans, "gmm": fit_gmm, "hmm": fit_hmm}
 
 
+def handrule_cells(thresholds):
+    from regime import normalize_composite_thresholds, _DEFAULT_COMPOSITE_THRESHOLDS
+    th = normalize_composite_thresholds(thresholds)
+    rt = float(th["return_eff"])
+    gt = float(th["range_eff"])
+    at = float(th.get("adx", _DEFAULT_COMPOSITE_THRESHOLDS["adx"]))
+    et = float(th.get("efficiency", _DEFAULT_COMPOSITE_THRESHOLDS["efficiency"]))
+    R, G, E, A = "return_eff", "range_eff", "efficiency", "adx"
+    return {
+        "trending_up_clean": [[(R, ">=", rt), (E, ">=", et), (A, ">=", at)]],
+        "trending_up_choppy": [[(R, ">=", rt), (E, "<", et)], [(R, ">=", rt), (A, "<", at)]],
+        "trending_down_clean": [[(R, "<=", -rt), (E, ">=", et), (A, ">=", at)]],
+        "trending_down_choppy": [[(R, "<=", -rt), (E, "<", et)], [(R, "<=", -rt), (A, "<", at)]],
+        "ranging_directional_up": [[(R, ">", 0.0), (R, "<", rt), (A, ">=", at)]],
+        "ranging_directional_down": [[(R, "<", 0.0), (R, ">", -rt), (A, ">=", at)]],
+        "ranging_directional": [[(R, ">=", 0.0), (R, "<=", 0.0), (A, ">=", at)]],
+        "ranging_volatile": [[(R, "<", rt), (R, ">", -rt), (A, "<", at), (G, ">=", gt)]],
+        "ranging_quiet": [[(R, "<", rt), (R, ">", -rt), (A, "<", at), (G, "<", gt)]],
+    }
+
+
+def cell_distance_z(point, scale, cell):
+    best = math.inf
+    for conjunction in cell:
+        acc = 0.0
+        for feat, op, th in conjunction:
+            x = float(point[feat])
+            if op in (">=", ">"):
+                violation = max(0.0, th - x)
+            else:
+                violation = max(0.0, x - th)
+            acc += (violation / float(scale[feat])) ** 2
+        best = min(best, math.sqrt(acc))
+    return best
+
+
+def _min_cost_assignment(cost):
+    cost = np.asarray(cost, dtype=float)
+    n, m = cost.shape
+    if n > m:
+        raise ValueError(f"cannot assign {n} rows to {m} columns distinctly")
+    inf = math.inf
+    u = [0.0] * (n + 1)
+    v = [0.0] * (m + 1)
+    p = [0] * (m + 1)
+    way = [0] * (m + 1)
+    for i in range(1, n + 1):
+        p[0] = i
+        j0 = 0
+        minv = [inf] * (m + 1)
+        used = [False] * (m + 1)
+        while True:
+            used[j0] = True
+            i0 = p[j0]
+            delta = inf
+            j1 = 0
+            for j in range(1, m + 1):
+                if used[j]:
+                    continue
+                cur = cost[i0 - 1, j - 1] - u[i0] - v[j]
+                if cur < minv[j]:
+                    minv[j] = cur
+                    way[j] = j0
+                if minv[j] < delta:
+                    delta = minv[j]
+                    j1 = j
+            for j in range(m + 1):
+                if used[j]:
+                    u[p[j]] += delta
+                    v[j] -= delta
+                else:
+                    minv[j] -= delta
+            j0 = j1
+            if p[j0] == 0:
+                break
+        while True:
+            j1 = way[j0]
+            p[j0] = p[j1]
+            j0 = j1
+            if j0 == 0:
+                break
+    assign = [-1] * n
+    for j in range(1, m + 1):
+        if p[j]:
+            assign[p[j] - 1] = j - 1
+    return assign
+
+
+def assign_distinct_names(raw, feature_stds, handrule_names, thresholds, *,
+                          canonical_indices=(0, 1, 2, 3)):
+    raw = np.asarray(raw, dtype=float)
+    std = np.asarray(feature_stds, dtype=float)
+    k = len(raw)
+    cells = handrule_cells(thresholds)
+    labels = sorted(cells)
+    if k > len(labels):
+        return list(handrule_names), [0.0] * k
+    ri, gi, ei, ai = (int(x) for x in canonical_indices)
+    idx = {"return_eff": ri, "range_eff": gi, "efficiency": ei, "adx": ai}
+    dist = np.zeros((k, len(labels)))
+    cost = np.zeros((k, len(labels)))
+    for i in range(k):
+        point = {f: raw[i, j] for f, j in idx.items()}
+        scale = {f: std[j] for f, j in idx.items()}
+        for li, lab in enumerate(labels):
+            if lab == handrule_names[i]:
+                d, penalty = 0.0, 0.0
+            else:
+                d, penalty = cell_distance_z(point, scale, cells[lab]), _RELABEL_PENALTY
+            dist[i, li] = d
+            cost[i, li] = d + penalty + 1e-9 * li
+    assign = _min_cost_assignment(cost)
+    names = [labels[j] for j in assign]
+    displacement = [float(dist[i, assign[i]]) for i in range(k)]
+    return names, displacement
+
+
 def map_latent_to_names(em_mean_z, feature_means, feature_stds, thresholds,
                         *, canonical_indices=(0, 1, 2, 3)):
     from regime import map_composite_label
@@ -222,13 +342,29 @@ def map_latent_to_names(em_mean_z, feature_means, feature_stds, thresholds,
     raw = em_mean_z * std + mean
     order = sorted(range(len(raw)), key=lambda i: (raw[i, gi], i))
     rank = {i: r for r, i in enumerate(order)}
-    names, mapping = [], {}
+    handrule = [map_composite_label(raw[i, ri], raw[i, ai], raw[i, gi], raw[i, ei], thresholds)
+                for i in range(len(raw))]
+    names, displacement = assign_distinct_names(raw, std, handrule, thresholds,
+                                                canonical_indices=(ri, gi, ei, ai))
+    mapping = {}
     for i in range(len(raw)):
-        name = map_composite_label(raw[i, ri], raw[i, ai], raw[i, gi], raw[i, ei], thresholds)
-        names.append(name)
-        mapping[str(i)] = {"name": name, "centroid_raw": raw[i].tolist(),
+        mapping[str(i)] = {"name": names[i], "handrule_name": handrule[i],
+                           "relabeled": bool(names[i] != handrule[i]),
+                           "displacement_z": float(displacement[i]),
+                           "centroid_raw": raw[i].tolist(),
                            "volatility_rank": int(rank[i])}
     return names, mapping
+
+
+def naming_summary(names, mapping):
+    names = list(names)
+    relabeled = {i: {"from": m["handrule_name"], "to": m["name"],
+                     "displacement_z": m["displacement_z"]}
+                 for i, m in sorted(mapping.items(), key=lambda kv: int(kv[0]))
+                 if m.get("relabeled")}
+    duplicates = sorted({nm for nm in names if names.count(nm) > 1})
+    return {"rule": NAMING_RULE, "distinct": not duplicates,
+            "relabeled": relabeled, "duplicate_names": duplicates}
 
 
 def fit_unsupervised(features, *, family, k, filter_window, period=48,
@@ -261,6 +397,7 @@ def fit_unsupervised(features, *, family, k, filter_window, period=48,
         "transition": transition.tolist(), "init": init.tolist(),
         "filter_window": int(filter_window), "period": int(period),
         "fitted_on": dict(fitted_on or {}), "mapping": mapping,
+        "naming": naming_summary(names, mapping),
     }
 
 

--- a/backtest/research/regime_1080_unsupervised_vol_model.py
+++ b/backtest/research/regime_1080_unsupervised_vol_model.py
@@ -155,6 +155,7 @@ def run_bakeoff(symbol="BTC/USDT", timeframe="1h", *, in_sample="is", held_out="
             "structurally_ineligible": bool(ineligible_reasons[(family, k)]),
             "structural_ineligibility_reason": ineligible_reasons[(family, k)],
             "states": model["states"], "mapping": model["mapping"],
+            "naming": model["naming"],
         })
     for c in candidates:
         c["passes_bonferroni"] = (not c["structurally_ineligible"]

--- a/backtest/research/regime_1083_multi_asset_gate.py
+++ b/backtest/research/regime_1083_multi_asset_gate.py
@@ -211,6 +211,7 @@ def run_cell(
             "k": winner.get("k"),
             "states": model.get("states"),
             "mapping": model.get("mapping"),
+            "naming": model.get("naming"),
             "fitted_on": model.get("fitted_on"),
         }
         economic = economic_gate_fn(

--- a/backtest/research/regime_1095_enriched_vol_model.py
+++ b/backtest/research/regime_1095_enriched_vol_model.py
@@ -181,6 +181,7 @@ def run_bakeoff(symbol="BTC/USDT", timeframe="1h", *, in_sample="is", held_out="
             "structurally_ineligible": bool(ineligible_reasons[(sub_name, family, k)]),
             "structural_ineligibility_reason": ineligible_reasons[(sub_name, family, k)],
             "states": model["states"], "mapping": model["mapping"],
+            "naming": model["naming"],
         })
     for c in candidates:
         c["passes_bonferroni"] = (not c["structurally_ineligible"]

--- a/backtest/tests/test_regime_vol_model.py
+++ b/backtest/tests/test_regime_vol_model.py
@@ -609,3 +609,227 @@ def test_kmeans_path_unaffected_by_neutralizer():
     assert counts.sum() == len(z)
     for j in range(3):
         assert not (np.allclose(mu[j], 0.0, atol=1e-6) and np.allclose(var[j], 1.0, atol=1e-9))
+
+
+def _colliding_feature_matrix(seed=0):
+    rng = np.random.default_rng(seed)
+    centers = np.array([[0.0, 0.02, 0.1, 8.0],
+                        [0.07, 0.14, 0.15, 20.0],
+                        [0.15, 0.20, 0.30, 22.0]], dtype=float)
+    rows = [rng.normal(c, [0.005, 0.01, 0.02, 1.0], size=(150, 4)) for c in centers]
+    return np.vstack([np.full((5, 4), np.nan), *rows])
+
+
+def test_colliding_centroids_share_a_handrule_cell():
+    from regime import map_composite_label, _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    assert map_composite_label(0.07, 20.0, 0.14, 0.15, dict(TH)) == "trending_up_choppy"
+    assert map_composite_label(0.15, 22.0, 0.20, 0.30, dict(TH)) == "trending_up_choppy"
+
+
+@pytest.mark.parametrize("family", ["kmeans", "gmm", "hmm"])
+def test_fitted_model_with_colliding_centroids_keeps_every_latent_state_distinct(family):
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH, VALID_LABELS_COMPOSITE
+    feats = _colliding_feature_matrix()
+    model = rvm.fit_unsupervised(feats, family=family, k=3, filter_window=32,
+                                 thresholds=dict(TH), seed=0)
+    assert model["latent_count"] == 3
+    assert len(set(model["states"])) == 3, model["states"]
+    assert all(s in VALID_LABELS_COMPOSITE for s in model["states"])
+    labels, _ = forward_filter_labels(feats, model)
+    valid = ~np.isnan(feats).any(1)
+    assert len(set(labels[valid].tolist())) == 3
+
+
+def _artifact_candidate(path_tail, subset, family, k):
+    import json
+    here = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(here, "..", "..", "docs", "research", "1218-artifacts", path_tail)
+    with open(path) as fh:
+        report = json.load(fh)
+    for c in report["candidates"]:
+        if c.get("subset", "canonical") == subset and c["family"] == family and c["k"] == k:
+            return c
+    raise AssertionError(f"{subset}:{family}:k={k} missing from {path_tail}")
+
+
+@pytest.mark.parametrize("path_tail,subset,family,k", [
+    ("regime_1095_btc.json", "htf", "hmm", 6),
+    ("regime_1095_eth.json", "canonical", "kmeans", 7),
+    ("regime_1095_eth.json", "funding", "kmeans", 6),
+    ("regime_1095_eth.json", "all_enriched", "kmeans", 6),
+])
+def test_1218_near_miss_centroids_map_to_distinct_names(path_tail, subset, family, k):
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH, VALID_LABELS_COMPOSITE
+    from regime_enriched_features import canonical_indices_for
+    cand = _artifact_candidate(path_tail, subset, family, k)
+    stored = cand["states"]
+    assert len(set(stored)) < len(stored)
+    raw = np.array([cand["mapping"][str(i)]["centroid_raw"] for i in range(k)], dtype=float)
+    d = raw.shape[1]
+    cidx = canonical_indices_for(cand["columns"])
+    names, mapping = rvm.map_latent_to_names(raw, np.zeros(d), np.ones(d), dict(TH),
+                                             canonical_indices=cidx)
+    assert len(set(names)) == k, names
+    assert all(nm in VALID_LABELS_COMPOSITE for nm in names)
+    handrule = [mapping[str(i)]["handrule_name"] for i in range(k)]
+    assert handrule == stored
+    for i in range(k):
+        if stored.count(stored[i]) == 1:
+            assert names[i] == stored[i]
+
+
+def test_handrule_cells_partition_matches_map_composite_label():
+    from regime import map_composite_label, _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    th = dict(TH)
+    cells = rvm.handrule_cells(th)
+    assert set(cells) == {"trending_up_clean", "trending_up_choppy", "trending_down_clean",
+                          "trending_down_choppy", "ranging_directional_up",
+                          "ranging_directional_down", "ranging_directional",
+                          "ranging_volatile", "ranging_quiet"}
+    rng = np.random.default_rng(7)
+    scale = {"return_eff": 1.0, "range_eff": 1.0, "efficiency": 1.0, "adx": 1.0}
+    for _ in range(2000):
+        pt = {"return_eff": float(rng.uniform(-0.2, 0.2)), "range_eff": float(rng.uniform(0, 0.1)),
+              "efficiency": float(rng.uniform(0, 1)), "adx": float(rng.uniform(0, 60))}
+        expected = map_composite_label(pt["return_eff"], pt["adx"], pt["range_eff"],
+                                       pt["efficiency"], th)
+        zero = [lab for lab, cell in cells.items() if rvm.cell_distance_z(pt, scale, cell) == 0.0]
+        assert zero == [expected], (pt, zero, expected)
+
+
+def test_cell_distance_scales_violation_by_feature_std():
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    cells = rvm.handrule_cells(dict(TH))
+    pt = {"return_eff": 0.0, "range_eff": 0.0, "efficiency": 0.0, "adx": 15.0}
+    unit = rvm.cell_distance_z(pt, {"return_eff": 1, "range_eff": 1, "efficiency": 1, "adx": 1},
+                               cells["ranging_directional"])
+    wide = rvm.cell_distance_z(pt, {"return_eff": 1, "range_eff": 1, "efficiency": 1, "adx": 10},
+                               cells["ranging_directional"])
+    assert unit == pytest.approx(10.0)
+    assert wide == pytest.approx(1.0)
+
+
+def test_min_cost_assignment_matches_brute_force():
+    import itertools
+    rng = np.random.default_rng(11)
+    for n, m in [(2, 2), (3, 5), (4, 4), (5, 9)]:
+        for _ in range(20):
+            cost = rng.uniform(0, 10, size=(n, m))
+            assign = rvm._min_cost_assignment(cost)
+            assert sorted(assign) == sorted(set(assign)) and len(assign) == n
+            got = sum(cost[i, assign[i]] for i in range(n))
+            best = min(sum(cost[i, p[i]] for i in range(n))
+                       for p in itertools.permutations(range(m), n))
+            assert got == pytest.approx(best)
+
+
+def test_min_cost_assignment_rejects_more_rows_than_columns():
+    with pytest.raises(ValueError):
+        rvm._min_cost_assignment(np.zeros((3, 2)))
+
+
+def test_uncontested_states_keep_their_handrule_name():
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    th = dict(TH)
+    std = np.ones(4)
+    raw = np.array([[0.0, 0.01, 0.1, 10.0],
+                    [0.10, 0.10, 0.2, 20.0],
+                    [0.20, 0.20, 0.3, 24.0],
+                    [-0.10, 0.10, 0.9, 40.0]], dtype=float)
+    handrule = ["ranging_quiet", "trending_up_choppy", "trending_up_choppy", "trending_down_clean"]
+    names, disp = rvm.assign_distinct_names(raw, std, handrule, th)
+    assert names[0] == "ranging_quiet" and names[3] == "trending_down_clean"
+    assert disp[0] == 0.0 and disp[3] == 0.0
+    assert {names[1], names[2]} >= {"trending_up_choppy"}
+    assert len(set(names)) == 4
+    moved = 1 if names[1] != "trending_up_choppy" else 2
+    assert disp[moved] > 0.0
+    assert disp[3 - moved if moved == 1 else 1] == 0.0
+
+
+def test_collision_moves_the_state_nearest_to_a_free_cell_in_z_units():
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    th = dict(TH)
+    std = np.array([0.05, 0.05, 0.2, 10.0])
+    raw = np.array([[0.10, 0.10, 0.10, 10.0],
+                    [0.10, 0.10, 0.49, 24.9]], dtype=float)
+    handrule = ["trending_up_choppy", "trending_up_choppy"]
+    names, disp = rvm.assign_distinct_names(raw, std, handrule, th)
+    assert names == ["trending_up_choppy", "trending_up_clean"]
+    assert disp[0] == 0.0
+    assert disp[1] == pytest.approx(np.hypot(0.01 / 0.2, 0.1 / 10.0))
+    unit_names, _ = rvm.assign_distinct_names(raw, np.ones(4), handrule, th)
+    assert unit_names[0] == "trending_up_choppy" and unit_names[1] == "ranging_volatile"
+
+
+def test_ranging_collision_relabels_by_range_toward_volatile():
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    th = dict(TH)
+    std = np.ones(4)
+    raw = np.array([[0.0, 0.005, 0.1, 10.0],
+                    [0.0, 0.025, 0.1, 10.0]], dtype=float)
+    names, _ = rvm.assign_distinct_names(raw, std, ["ranging_quiet", "ranging_quiet"], th)
+    assert names == ["ranging_quiet", "ranging_volatile"]
+
+
+def test_assignment_is_deterministic_across_calls_and_row_order():
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    th = dict(TH)
+    std = np.ones(4)
+    raw = np.array([[0.07, 0.14, 0.15, 20.0],
+                    [0.15, 0.20, 0.30, 22.0],
+                    [0.11, 0.18, 0.20, 30.0]], dtype=float)
+    hr = ["trending_up_choppy"] * 3
+    a, _ = rvm.assign_distinct_names(raw, std, hr, th)
+    b, _ = rvm.assign_distinct_names(raw, std, hr, th)
+    assert a == b and len(set(a)) == 3
+    perm = [2, 0, 1]
+    c, _ = rvm.assign_distinct_names(raw[perm], std, hr, th)
+    assert [c[perm.index(i)] for i in range(3)] == a
+
+
+def test_more_states_than_vocabulary_falls_back_to_handrule_names_and_records_duplicates():
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    th = dict(TH)
+    raw = np.tile(np.array([[0.10, 0.10, 0.10, 10.0]]), (10, 1))
+    hr = ["trending_up_choppy"] * 10
+    names, disp = rvm.assign_distinct_names(raw, np.ones(4), hr, th)
+    assert names == hr and disp == [0.0] * 10
+    mapping = {str(i): {"name": names[i], "handrule_name": hr[i], "relabeled": False,
+                        "displacement_z": 0.0} for i in range(10)}
+    summary = rvm.naming_summary(names, mapping)
+    assert summary["distinct"] is False
+    assert summary["duplicate_names"] == ["trending_up_choppy"]
+
+
+def test_fit_unsupervised_records_naming_summary_and_bumps_version():
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    feats = _colliding_feature_matrix()
+    model = rvm.fit_unsupervised(feats, family="kmeans", k=3, filter_window=32,
+                                 thresholds=dict(TH), seed=0)
+    assert model["version"] == 2
+    naming = model["naming"]
+    assert naming["rule"] == "distinct_nearest_cell"
+    assert naming["distinct"] is True and naming["duplicate_names"] == []
+    assert len(naming["relabeled"]) == 1
+    (idx, rec), = naming["relabeled"].items()
+    assert model["mapping"][idx]["relabeled"] is True
+    assert rec["from"] == "trending_up_choppy" and rec["to"] == model["states"][int(idx)]
+    assert rec["to"] != "trending_up_choppy"
+    untouched = [i for i in range(3) if str(i) != idx]
+    for i in untouched:
+        assert model["mapping"][str(i)]["relabeled"] is False
+        assert model["states"][i] == model["mapping"][str(i)]["handrule_name"]
+
+
+def test_non_degeneracy_counts_distinct_decoded_states_after_relabel():
+    from regime import _DEFAULT_COMPOSITE_THRESHOLDS as TH
+    feats = _colliding_feature_matrix()
+    model = rvm.fit_unsupervised(feats, family="kmeans", k=3, filter_window=32,
+                                 thresholds=dict(TH), seed=0)
+    labels, _ = forward_filter_labels(feats, model)
+    valid = ~np.isnan(feats).any(1)
+    thr = rvm.NonDegeneracyThresholds(min_active_labels=3, max_occupancy=1.0,
+                                      min_transition_rate=0.0)
+    rep = rvm.non_degeneracy(labels[valid], thr)
+    assert rep["active_labels"] == 3 and rep["ok"] is True

--- a/docs/research/1499-artifacts/regime_1080_btc.json
+++ b/docs/research/1499-artifacts/regime_1080_btc.json
@@ -1,0 +1,3206 @@
+{
+  "symbol": "BTC/USDT",
+  "timeframe": "1h",
+  "in_sample": "is",
+  "held_out": "oos",
+  "target": "volatility",
+  "candidate_count": 18,
+  "significance_alpha": 0.05,
+  "bonferroni_alpha": 0.005555555555555556,
+  "bonferroni_denominator": 9,
+  "bonferroni_denominator_policy": "structurally ineligible candidates (k < incumbent-derived min_active_labels) are scored for evidence but excluded from the family-wise denominator",
+  "structurally_ineligible": [
+    {
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    }
+  ],
+  "n_perm": 1000,
+  "min_achievable_p_value": 0.000999000999000999,
+  "non_degeneracy_thresholds": {
+    "min_active_labels": 5,
+    "max_occupancy": 0.39199381938880623,
+    "min_transition_rate": 0.0686763372620127
+  },
+  "handrule_held_out": {
+    "kruskal_h": 85.6949486268586,
+    "p_value": 0.005994005994005994,
+    "transition_rate": 0.1373526745240254,
+    "abstained": false,
+    "permutation_steps_to_alpha": 44,
+    "knife_edge": false
+  },
+  "candidates": [
+    {
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 46.59564715827764,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.013986013986013986,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.03513145965548504
+        }
+      },
+      "model_kruskal_h": 46.59564715827764,
+      "model_p_value": 0.013986013986013986,
+      "stability_gain": 0.10222121486854036,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2150,
+          "pct": 0.4871969181962384
+        },
+        "ranging_volatile": {
+          "count": 2263,
+          "pct": 0.5128030818037617
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5682331212805254,
+          "transition_rate": 0.035303776683087026,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.568 > 0.392",
+            "min_transition_rate: 0.0353 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5128030818037617,
+          "transition_rate": 0.03513145965548504,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.513 > 0.392",
+            "min_transition_rate: 0.0351 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5485871812543074,
+          "transition_rate": 0.03526708788052843,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.549 > 0.392",
+            "min_transition_rate: 0.0353 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5087558658578459,
+          "transition_rate": 0.0383470695970696,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.509 > 0.392",
+            "min_transition_rate: 0.0383 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5310681871072842,
+          "transition_rate": 0.03235567970204842,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.531 > 0.392",
+            "min_transition_rate: 0.0324 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.00755126055449094,
+            0.18354201174585266,
+            0.23146087182239317,
+            36.85508276421143
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005683939134586702,
+            0.12318410209359588,
+            0.07791568270198539,
+            21.87381095910724
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 74.70241336495565,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.02097902097902098,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.044424297370806894
+        }
+      },
+      "model_kruskal_h": 74.70241336495565,
+      "model_p_value": 0.02097902097902098,
+      "stability_gain": 0.0929283771532185,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2125,
+          "pct": 0.48153183775209607
+        },
+        "trending_down_choppy": {
+          "count": 1289,
+          "pct": 0.29209154769997736
+        },
+        "trending_up_choppy": {
+          "count": 999,
+          "pct": 0.22637661454792657
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5448389082700595,
+          "transition_rate": 0.04187192118226601,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.545 > 0.392",
+            "min_transition_rate: 0.0419 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.48153183775209607,
+          "transition_rate": 0.044424297370806894,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.482 > 0.392",
+            "min_transition_rate: 0.0444 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5323914541695383,
+          "transition_rate": 0.04032165422171166,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.532 > 0.392",
+            "min_transition_rate: 0.0403 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4841478768455992,
+          "transition_rate": 0.04681776556776557,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.484 > 0.392",
+            "min_transition_rate: 0.0468 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.512217826390505,
+          "transition_rate": 0.04189944134078212,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.512 > 0.392",
+            "min_transition_rate: 0.0419 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00524331067616402,
+            0.12216174978953546,
+            0.07160931828841736,
+            21.96761195888488
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.10475628408767888,
+            0.17786530614441362,
+            0.212300950251665,
+            37.13169664606488
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.12493967054949551,
+            0.18493165309502024,
+            0.25164207675883726,
+            33.985550586827706
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 79.70362241785188,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.02197802197802198,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08363553943789664
+        }
+      },
+      "model_kruskal_h": 79.70362241785188,
+      "model_p_value": 0.02197802197802198,
+      "stability_gain": 0.05371713508612874,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1732,
+          "pct": 0.39247677317017904
+        },
+        "ranging_volatile": {
+          "count": 1089,
+          "pct": 0.2467709041468389
+        },
+        "trending_down_choppy": {
+          "count": 957,
+          "pct": 0.2168592794017675
+        },
+        "trending_up_choppy": {
+          "count": 635,
+          "pct": 0.1438930432812146
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.37779601887954034,
+          "transition_rate": 0.0812807881773399,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.39247677317017904,
+          "transition_rate": 0.08363553943789664,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.392 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3766368022053756,
+          "transition_rate": 0.08902929350947732,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.39487238182442486,
+          "transition_rate": 0.0850503663003663,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.395 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3912031649988364,
+          "transition_rate": 0.0947392923649907,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005304241028108408,
+            0.14228848502567515,
+            0.12727315163306863,
+            26.43549789652893
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.122736288062705,
+            0.18749135701273506,
+            0.24754881783372096,
+            40.02275531027101
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14701434638993968,
+            0.2014930801859868,
+            0.29385455922992165,
+            36.55496800842193
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0019271255101770148,
+            0.11394121664098841,
+            0.04336154333875711,
+            20.51861500846088
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 87.42046346796087,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.014985014985014986,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.10448776065276519
+        }
+      },
+      "model_kruskal_h": 87.42046346796087,
+      "model_p_value": 0.014985014985014986,
+      "stability_gain": 0.0328649138712602,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 803,
+          "pct": 0.1819623838658509
+        },
+        "ranging_directional_up": {
+          "count": 923,
+          "pct": 0.20915476999773397
+        },
+        "ranging_volatile": {
+          "count": 1233,
+          "pct": 0.2794017675050986
+        },
+        "trending_down_choppy": {
+          "count": 857,
+          "pct": 0.1941989576251983
+        },
+        "trending_up_choppy": {
+          "count": 597,
+          "pct": 0.13528212100611828
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.3289554689103222,
+          "transition_rate": 0.10611658456486042,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.2794017675050986,
+          "transition_rate": 0.10448776065276519,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.3421778084079945,
+          "transition_rate": 0.11602527283170591,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.27572393270001144,
+          "transition_rate": 0.11160714285714286,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.31510356062369094,
+          "transition_rate": 0.1191806331471136,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.2268162140843539,
+          "centroid_raw": [
+            0.06858203092811292,
+            0.13660100493347754,
+            0.1434990528874797,
+            24.10252406232175
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13004439074913146,
+            0.19071522685542275,
+            0.26217293250219587,
+            41.18210134496014
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.14048021991941806,
+          "centroid_raw": [
+            -0.06231675737044698,
+            0.1479476962528805,
+            0.12895368181959263,
+            28.84225779849284
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0009132888711901893,
+            0.11753247708653275,
+            0.03996660878847583,
+            21.292055426420568
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14996145956495005,
+            0.2032693542696212,
+            0.29922876998934556,
+            36.86192557168001
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.2268162140843539
+          },
+          "2": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.14048021991941806
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 101.3406413155626,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.007992007992007992,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.11310063463281958
+        }
+      },
+      "model_kruskal_h": 101.3406413155626,
+      "model_p_value": 0.007992007992007992,
+      "stability_gain": 0.024252039891205807,
+      "coverage": {
+        "ranging_directional": {
+          "count": 637,
+          "pct": 0.14434624971674598
+        },
+        "ranging_directional_down": {
+          "count": 503,
+          "pct": 0.11398141853614321
+        },
+        "ranging_directional_up": {
+          "count": 880,
+          "pct": 0.1994108316338092
+        },
+        "ranging_volatile": {
+          "count": 977,
+          "pct": 0.22139134375708136
+        },
+        "trending_down_choppy": {
+          "count": 833,
+          "pct": 0.18876048039882165
+        },
+        "trending_up_choppy": {
+          "count": 583,
+          "pct": 0.1321096759573986
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.26390313974964086,
+          "transition_rate": 0.11350574712643678,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.22139134375708136,
+          "transition_rate": 0.11310063463281958,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.26797610843096714,
+          "transition_rate": 0.11131533601378518,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.21071305940254093,
+          "transition_rate": 0.12076465201465202,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.2566907144519432,
+          "transition_rate": 0.11941340782122906,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.015576564159259062,
+            0.1409264693931202,
+            0.04904287048517281,
+            30.606690861198643
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.8179697163229278,
+          "centroid_raw": [
+            -0.07171639208781058,
+            0.14925489298240077,
+            0.1489040332341788,
+            28.359693348998004
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13247631426400705,
+            0.19218777047541963,
+            0.26669870231960446,
+            41.43178959229569
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0032806352589625698,
+            0.11226572629636841,
+            0.044761126300617696,
+            18.905984474990973
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.23737164234607214,
+          "centroid_raw": [
+            0.07035774771731626,
+            0.1381702946168062,
+            0.1470921661867227,
+            24.452193257436953
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.15079288674498723,
+            0.20385184522988262,
+            0.3007071101257731,
+            36.9852980486165
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.8179697163229278
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.23737164234607214
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 99.2972110932842,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.012987012987012988,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.13395285584768812
+        }
+      },
+      "model_kruskal_h": 99.2972110932842,
+      "model_p_value": 0.012987012987012988,
+      "stability_gain": 0.003399818676337263,
+      "coverage": {
+        "ranging_directional": {
+          "count": 650,
+          "pct": 0.14729209154769998
+        },
+        "ranging_directional_down": {
+          "count": 500,
+          "pct": 0.11330160888284614
+        },
+        "ranging_directional_up": {
+          "count": 643,
+          "pct": 0.14570586902334012
+        },
+        "ranging_volatile": {
+          "count": 907,
+          "pct": 0.20552911851348288
+        },
+        "trending_down_choppy": {
+          "count": 834,
+          "pct": 0.18898708361658736
+        },
+        "trending_up_choppy": {
+          "count": 656,
+          "pct": 0.14865171085429413
+        },
+        "trending_up_clean": {
+          "count": 223,
+          "pct": 0.050532517561749375
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.24646008618920584,
+          "transition_rate": 0.13854679802955666,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.20552911851348288,
+          "transition_rate": 0.13395285584768812,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.2548816907879623,
+          "transition_rate": 0.13015508328546813,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.19880966006638434,
+          "transition_rate": 0.1429716117216117,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.23434954619501977,
+          "transition_rate": 0.14106145251396648,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_up_clean"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0005027356107206483,
+            0.11224814725364951,
+            0.04079247667809589,
+            18.988498426771645
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.32100364406136916,
+          "centroid_raw": [
+            0.06111146207075637,
+            0.1277461692846439,
+            0.1285781254011893,
+            21.72377877665248
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.015831001301463775,
+            0.14171160686435166,
+            0.05017179280590109,
+            30.846818863994507
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1323396028727731,
+            0.1921095054462609,
+            0.2664447892145779,
+            41.419318214636014
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.105654469546394,
+            0.16991364996595193,
+            0.21809980480108276,
+            32.00984351908438
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.8167468923676112,
+          "centroid_raw": [
+            -0.07160917965624518,
+            0.14887466219276577,
+            0.14873261833412502,
+            28.223670437952606
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.334557878987827,
+          "centroid_raw": [
+            0.1858194821022053,
+            0.23319830462351757,
+            0.3611696456239619,
+            40.98326439356847
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.32100364406136916
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.8167468923676112
+          },
+          "6": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.334557878987827
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 41.91704336670409,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.03896103896103896,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.04374433363553944
+        }
+      },
+      "model_kruskal_h": 41.91704336670409,
+      "model_p_value": 0.03896103896103896,
+      "stability_gain": 0.09360834088848595,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2121,
+          "pct": 0.4806254248810333
+        },
+        "ranging_volatile": {
+          "count": 2292,
+          "pct": 0.5193745751189667
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5731582187564129,
+          "transition_rate": 0.038998357963875206,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.573 > 0.392",
+            "min_transition_rate: 0.0390 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5193745751189667,
+          "transition_rate": 0.04374433363553944,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.519 > 0.392",
+            "min_transition_rate: 0.0437 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5569722030783367,
+          "transition_rate": 0.04055140723721999,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.557 > 0.392",
+            "min_transition_rate: 0.0406 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5143641982373812,
+          "transition_rate": 0.04429945054945055,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.514 > 0.392",
+            "min_transition_rate: 0.0443 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5396788457063068,
+          "transition_rate": 0.036080074487895714,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.540 > 0.392",
+            "min_transition_rate: 0.0361 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.005502734254364465,
+            0.18342747882528565,
+            0.23564357528921204,
+            36.44092213232946
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.004075595150556658,
+            0.12384805866393585,
+            0.07637036554941636,
+            22.317461369474312
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 75.42340588750449,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.028971028971028972,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.046010879419764276
+        }
+      },
+      "model_kruskal_h": 75.42340588750449,
+      "model_p_value": 0.028971028971028972,
+      "stability_gain": 0.0913417951042611,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2336,
+          "pct": 0.5293451167006572
+        },
+        "trending_down_choppy": {
+          "count": 1193,
+          "pct": 0.27033763879447087
+        },
+        "trending_up_choppy": {
+          "count": 884,
+          "pct": 0.20031724450487198
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5869074492099323,
+          "transition_rate": 0.04351395730706076,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.587 > 0.392",
+            "min_transition_rate: 0.0435 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5293451167006572,
+          "transition_rate": 0.046010879419764276,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.529 > 0.392",
+            "min_transition_rate: 0.0460 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5816678152997933,
+          "transition_rate": 0.0450315910396324,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.582 > 0.392",
+            "min_transition_rate: 0.0450 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5315325626645302,
+          "transition_rate": 0.0486492673992674,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.532 > 0.392",
+            "min_transition_rate: 0.0486 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5636490574819641,
+          "transition_rate": 0.04306331471135941,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.564 > 0.392",
+            "min_transition_rate: 0.0431 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005075012008396578,
+            0.12542688421784254,
+            0.07731733918469537,
+            22.80853912855038
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11169832379968075,
+            0.18075344293670947,
+            0.22614432446324395,
+            37.95211672005942
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1340999106165127,
+            0.19045167141845493,
+            0.26951698909831107,
+            34.75884620438009
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 79.415234281636,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.014985014985014986,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.11536718041704443
+        }
+      },
+      "model_kruskal_h": 79.415234281636,
+      "model_p_value": 0.014985014985014986,
+      "stability_gain": 0.02198549410698096,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1808,
+          "pct": 0.40969861772037164
+        },
+        "ranging_volatile": {
+          "count": 1099,
+          "pct": 0.2490369363244958
+        },
+        "trending_down_choppy": {
+          "count": 920,
+          "pct": 0.20847496034443688
+        },
+        "trending_up_choppy": {
+          "count": 586,
+          "pct": 0.13278948561069567
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.41719679868664067,
+          "transition_rate": 0.12315270935960591,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.417 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.40969861772037164,
+          "transition_rate": 0.11536718041704443,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.410 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.40167700436480586,
+          "transition_rate": 0.1283170591614015,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.402 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.41066727709740186,
+          "transition_rate": 0.11813186813186813,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.411 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.42168955084942983,
+          "transition_rate": 0.1287243947858473,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.422 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00457184308135086,
+            0.14117198914657933,
+            0.13016782117280135,
+            26.279365223934754
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12806118155554375,
+            0.18917897023958513,
+            0.258518321860861,
+            40.69123511613657
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1531857875320342,
+            0.20370535438544335,
+            0.3062979664033859,
+            36.66833846625733
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0005503865234446904,
+            0.11672577515526995,
+            0.03512918327968835,
+            21.139713393407842
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 89.52822292597193,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.005994005994005994,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12443336355394378
+        }
+      },
+      "model_kruskal_h": 89.52822292597193,
+      "model_p_value": 0.005994005994005994,
+      "stability_gain": 0.012919310970081602,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 767,
+          "pct": 0.17380466802628597
+        },
+        "ranging_directional_up": {
+          "count": 900,
+          "pct": 0.20394289598912305
+        },
+        "ranging_volatile": {
+          "count": 1339,
+          "pct": 0.30342170858826195
+        },
+        "trending_down_choppy": {
+          "count": 839,
+          "pct": 0.19012009970541582
+        },
+        "trending_up_choppy": {
+          "count": 568,
+          "pct": 0.1287106276909132
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.3511184075518161,
+          "transition_rate": 0.12992610837438423,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.30342170858826195,
+          "transition_rate": 0.12443336355394378,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.36928555019526765,
+          "transition_rate": 0.12808730614589317,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3097172942657663,
+          "transition_rate": 0.1324404761904762,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3420991389341401,
+          "transition_rate": 0.1378026070763501,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.23819658826340245,
+          "centroid_raw": [
+            0.0706191130188882,
+            0.1381936326109156,
+            0.14737582484656542,
+            24.579787311899803
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1337649695157418,
+            0.19126000819091887,
+            0.2694825949680144,
+            41.155051147028196
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.1942063769679622,
+          "centroid_raw": [
+            -0.06702725712046893,
+            0.14969901388622933,
+            0.1386605674979722,
+            29.35247888903386
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0004500652671430372,
+            0.11993989131217989,
+            0.04165722618700232,
+            21.900865684325883
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.15276097054683546,
+            0.20293583619438454,
+            0.30517825382212493,
+            36.533061068509596
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.23819658826340245
+          },
+          "2": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.1942063769679622
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 84.91296975004661,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.01098901098901099,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.17225747960108795
+        }
+      },
+      "model_kruskal_h": 84.91296975004661,
+      "model_p_value": 0.01098901098901099,
+      "stability_gain": -0.03490480507706256,
+      "coverage": {
+        "ranging_directional": {
+          "count": 519,
+          "pct": 0.11760707002039429
+        },
+        "ranging_directional_down": {
+          "count": 460,
+          "pct": 0.10423748017221844
+        },
+        "ranging_directional_up": {
+          "count": 946,
+          "pct": 0.2143666440063449
+        },
+        "ranging_volatile": {
+          "count": 1098,
+          "pct": 0.24881033310673012
+        },
+        "trending_down_choppy": {
+          "count": 781,
+          "pct": 0.17697711307500566
+        },
+        "trending_up_choppy": {
+          "count": 609,
+          "pct": 0.1380013596193066
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.28914426431356455,
+          "transition_rate": 0.19232348111658457,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.24881033310673012,
+          "transition_rate": 0.17225747960108795,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.30668504479669195,
+          "transition_rate": 0.17736932797242963,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.2496280187707451,
+          "transition_rate": 0.1823489010989011,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.28508261577845007,
+          "transition_rate": 0.19064245810055866,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.04366630374896207,
+            0.1376664538800906,
+            0.08970357405499844,
+            27.381210974078254
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9333735654114692,
+          "centroid_raw": [
+            -0.08183455114005711,
+            0.15529976336577972,
+            0.16997439493176705,
+            30.400763213013317
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13835159772007966,
+            0.19365601953711425,
+            0.2779414009307426,
+            41.71191129682961
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0028228376070924925,
+            0.11896908510777429,
+            0.03376595501632661,
+            21.585861943722634
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.20595035145335516,
+          "centroid_raw": [
+            0.06629388657860845,
+            0.13569875405916726,
+            0.1385579721518705,
+            24.01400144089481
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1497865291712852,
+            0.20083358057455686,
+            0.2995779001351577,
+            36.23587973180108
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.9333735654114692
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.20595035145335516
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 88.27508376669175,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.011988011988011988,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.19945602901178605
+        }
+      },
+      "model_kruskal_h": 88.27508376669175,
+      "model_p_value": 0.011988011988011988,
+      "stability_gain": -0.062103354487760665,
+      "coverage": {
+        "ranging_directional": {
+          "count": 522,
+          "pct": 0.11828687967369136
+        },
+        "ranging_directional_down": {
+          "count": 473,
+          "pct": 0.10718332200317245
+        },
+        "ranging_directional_up": {
+          "count": 767,
+          "pct": 0.17380466802628597
+        },
+        "ranging_volatile": {
+          "count": 1056,
+          "pct": 0.23929299796057105
+        },
+        "trending_down_choppy": {
+          "count": 781,
+          "pct": 0.17697711307500566
+        },
+        "trending_up_choppy": {
+          "count": 589,
+          "pct": 0.13346929526399276
+        },
+        "trending_up_clean": {
+          "count": 225,
+          "pct": 0.05098572399728076
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.2760106710445311,
+          "transition_rate": 0.2233169129720854,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.23929299796057105,
+          "transition_rate": 0.19945602901178605,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.2963473466574776,
+          "transition_rate": 0.19977024698449167,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.24012819045438938,
+          "transition_rate": 0.20867673992673993,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.27088666511519666,
+          "transition_rate": 0.21508379888268156,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_up_clean"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0022947929224514823,
+            0.11891198434975563,
+            0.03209652576498716,
+            21.592638263884417
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.19520019148818113,
+          "centroid_raw": [
+            0.05956804630290927,
+            0.13165520002611947,
+            0.1252215417900794,
+            23.202130277349845
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.043048333860697556,
+            0.13710792497169225,
+            0.08845741126450657,
+            27.243439041137435
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13835739445423156,
+            0.19366973147017236,
+            0.27794533852303344,
+            41.71623498569485
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.11248705075507764,
+            0.1686760357895703,
+            0.23191841817007863,
+            31.162267944254612
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9313320044823005,
+          "centroid_raw": [
+            -0.08165555504625843,
+            0.15522522322836885,
+            0.16958343466574566,
+            30.383448024235634
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.317505371548311,
+          "centroid_raw": [
+            0.18647829244425287,
+            0.23222873446749664,
+            0.3629435706729254,
+            40.44885185634014
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.19520019148818113
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.9313320044823005
+          },
+          "6": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.317505371548311
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 43.962991375054116,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.03496503496503497,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.03150498640072529
+        }
+      },
+      "model_kruskal_h": 43.962991375054116,
+      "model_p_value": 0.03496503496503497,
+      "stability_gain": 0.10584768812330009,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1857,
+          "pct": 0.42080217539089054
+        },
+        "ranging_volatile": {
+          "count": 2556,
+          "pct": 0.5791978246091094
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.621998768725631,
+          "transition_rate": 0.031609195402298854,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.622 > 0.392",
+            "min_transition_rate: 0.0316 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5791978246091094,
+          "transition_rate": 0.03150498640072529,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.579 > 0.392",
+            "min_transition_rate: 0.0315 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.616815988973122,
+          "transition_rate": 0.03067202757036186,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.617 > 0.392",
+            "min_transition_rate: 0.0307 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.57456792949525,
+          "transition_rate": 0.03514194139194139,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.575 > 0.392",
+            "min_transition_rate: 0.0351 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5985571328834071,
+          "transition_rate": 0.031890130353817506,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.599 > 0.392",
+            "min_transition_rate: 0.0319 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.007813399107477342,
+            0.1904865163031385,
+            0.25024893920736746,
+            38.756658965445794
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.004223863177510036,
+            0.12679850085029357,
+            0.08651636360075063,
+            22.676732378006317
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 82.74029677023464,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.01998001998001998,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.04329102447869447
+        }
+      },
+      "model_kruskal_h": 82.74029677023464,
+      "model_p_value": 0.01998001998001998,
+      "stability_gain": 0.09406165004533092,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2384,
+          "pct": 0.5402220711534104
+        },
+        "trending_down_choppy": {
+          "count": 1178,
+          "pct": 0.2669385905279855
+        },
+        "trending_up_choppy": {
+          "count": 851,
+          "pct": 0.19283933831860411
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5910116971065053,
+          "transition_rate": 0.038998357963875206,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.591 > 0.392",
+            "min_transition_rate: 0.0390 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5402220711534104,
+          "transition_rate": 0.04329102447869447,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.540 > 0.392",
+            "min_transition_rate: 0.0433 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5869515276820584,
+          "transition_rate": 0.041240666283744974,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.587 > 0.392",
+            "min_transition_rate: 0.0412 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5414902140322765,
+          "transition_rate": 0.04475732600732601,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.541 > 0.392",
+            "min_transition_rate: 0.0448 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5696997905515476,
+          "transition_rate": 0.042132216014897576,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.570 > 0.392",
+            "min_transition_rate: 0.0421 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005703862336521655,
+            0.12519971663132562,
+            0.08049942929815943,
+            22.421079141202416
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11063853257456722,
+            0.18172433353657422,
+            0.22361199524957437,
+            38.883719283978984
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.13601736185684565,
+            0.19417634466913342,
+            0.2730405538751525,
+            35.77197895814321
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 83.58545221245913,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.025974025974025976,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.06300997280145058
+        }
+      },
+      "model_kruskal_h": 83.58545221245913,
+      "model_p_value": 0.025974025974025976,
+      "stability_gain": 0.0743427017225748,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1254,
+          "pct": 0.2841604350781781
+        },
+        "ranging_volatile": {
+          "count": 1587,
+          "pct": 0.35961930659415364
+        },
+        "trending_down_choppy": {
+          "count": 845,
+          "pct": 0.19147971901200997
+        },
+        "trending_up_choppy": {
+          "count": 727,
+          "pct": 0.16474053931565827
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.435665914221219,
+          "transition_rate": 0.059113300492610835,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.436 > 0.392",
+            "min_transition_rate: 0.0591 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.35961930659415364,
+          "transition_rate": 0.06300997280145058,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0630 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4182173213875488,
+          "transition_rate": 0.058472142446869615,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.418 > 0.392",
+            "min_transition_rate: 0.0585 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3639693258555568,
+          "transition_rate": 0.06421703296703296,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0642 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.40842448219688154,
+          "transition_rate": 0.06424581005586592,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.408 > 0.392",
+            "min_transition_rate: 0.0642 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.03111499811850684,
+            0.15307317373811,
+            0.12188998091521863,
+            30.741836550340736
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1302364740917169,
+            0.19141786651140588,
+            0.2623080043424838,
+            42.21137888848135
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14437983449509717,
+            0.19822121449445432,
+            0.28923010913455455,
+            35.87490695768459
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.015353963382247897,
+            0.11778292502558124,
+            0.07319223297479473,
+            20.025199288757197
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 90.20063125034358,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.025974025974025976,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08182230281051678
+        }
+      },
+      "model_kruskal_h": 90.20063125034358,
+      "model_p_value": 0.025974025974025976,
+      "stability_gain": 0.05553037171350861,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 849,
+          "pct": 0.19238613188307274
+        },
+        "ranging_directional_up": {
+          "count": 936,
+          "pct": 0.21210061182868797
+        },
+        "ranging_volatile": {
+          "count": 1570,
+          "pct": 0.35576705189213687
+        },
+        "trending_down_choppy": {
+          "count": 778,
+          "pct": 0.1762973034217086
+        },
+        "trending_up_choppy": {
+          "count": 280,
+          "pct": 0.06344890097439383
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.4186332854504412,
+          "transition_rate": 0.0798440065681445,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.419 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.35576705189213687,
+          "transition_rate": 0.08182230281051678,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.42625775327360443,
+          "transition_rate": 0.07466973004020677,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.426 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3542405860135058,
+          "transition_rate": 0.08585164835164835,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.39515941354433326,
+          "transition_rate": 0.08286778398510242,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.395 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5235366958304687,
+          "centroid_raw": [
+            0.09590165406039532,
+            0.16003864948167654,
+            0.1983251334724151,
+            29.19733925358716
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13489948796109844,
+            0.19536643125451025,
+            0.2714127427332896,
+            44.12095875263345
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.18806167110518068,
+          "centroid_raw": [
+            -0.06648851329398535,
+            0.15670579591083997,
+            0.13819415744984556,
+            30.315549124053927
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.008768076157520661,
+            0.1171308289725782,
+            0.061307811092743025,
+            20.64450073774572
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1817757794927396,
+            0.23048051853754312,
+            0.3558671572017239,
+            42.41024516582192
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.5235366958304687
+          },
+          "2": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.18806167110518068
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 95.30505879689554,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.022977022977022976,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.09451495920217588
+        }
+      },
+      "model_kruskal_h": 95.30505879689554,
+      "model_p_value": 0.022977022977022976,
+      "stability_gain": 0.042837715321849504,
+      "coverage": {
+        "ranging_directional": {
+          "count": 612,
+          "pct": 0.13868116927260368
+        },
+        "ranging_directional_down": {
+          "count": 549,
+          "pct": 0.12440516655336506
+        },
+        "ranging_directional_up": {
+          "count": 872,
+          "pct": 0.19759800589168366
+        },
+        "ranging_volatile": {
+          "count": 1390,
+          "pct": 0.3149784726943123
+        },
+        "trending_down_choppy": {
+          "count": 720,
+          "pct": 0.16315431679129844
+        },
+        "trending_up_choppy": {
+          "count": 270,
+          "pct": 0.061182868796736914
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.3650728504001642,
+          "transition_rate": 0.0946223316912972,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.3149784726943123,
+          "transition_rate": 0.09451495920217588,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.3657247875028716,
+          "transition_rate": 0.0861573808156232,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.3102895730800046,
+          "transition_rate": 0.1008470695970696,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.3569932511054224,
+          "transition_rate": 0.09404096834264432,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.015388972835934208,
+            0.1420117187808927,
+            0.07587104500373561,
+            33.50969741647665
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9793158951468397,
+          "centroid_raw": [
+            -0.08586259529252369,
+            0.1626032746940651,
+            0.17600760226413842,
+            26.91447608583654
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13452066957240058,
+            0.19500531338801652,
+            0.27035087691035375,
+            44.899385162738255
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009598950154765945,
+            0.11527523972597871,
+            0.06339269093574985,
+            19.224142413585
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.568465899250082,
+          "centroid_raw": [
+            0.0998408712518566,
+            0.16162666000473427,
+            0.2054539086860961,
+            28.62967818110436
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18206375718516551,
+            0.23071318148135136,
+            0.3562994339378191,
+            42.48038475325567
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.9793158951468397
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.568465899250082
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 104.47995640102272,
+          "handrule_p_value": 0.005994005994005994,
+          "model_p_value": 0.00999000999000999,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12103354487760652
+        }
+      },
+      "model_kruskal_h": 104.47995640102272,
+      "model_p_value": 0.00999000999000999,
+      "stability_gain": 0.016319129646418865,
+      "coverage": {
+        "ranging_directional": {
+          "count": 618,
+          "pct": 0.14004078857919783
+        },
+        "ranging_directional_down": {
+          "count": 477,
+          "pct": 0.10808973487423522
+        },
+        "ranging_directional_up": {
+          "count": 670,
+          "pct": 0.15182415590301382
+        },
+        "ranging_volatile": {
+          "count": 1137,
+          "pct": 0.2576478585995921
+        },
+        "trending_down_choppy": {
+          "count": 734,
+          "pct": 0.16632676184001813
+        },
+        "trending_up_choppy": {
+          "count": 619,
+          "pct": 0.14026739179696351
+        },
+        "trending_up_clean": {
+          "count": 158,
+          "pct": 0.03580330840697938
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.3043299815308845,
+          "transition_rate": 0.12541050903119869,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.2576478585995921,
+          "transition_rate": 0.12103354487760652,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.31541465655869516,
+          "transition_rate": 0.119586444572085,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.25569417420167107,
+          "transition_rate": 0.125,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.29090062834535724,
+          "transition_rate": 0.13128491620111732,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_up_clean"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0034321147789508084,
+            0.11322747175818654,
+            0.04664463482156207,
+            19.566989035448586
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3742740083297316,
+          "centroid_raw": [
+            0.0667489383848353,
+            0.1313339445069582,
+            0.139463683982449,
+            21.42469826004001
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.021288697551426282,
+            0.14361104327825316,
+            0.07901135443885518,
+            34.72073854237792
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13445303668836828,
+            0.19492873657594934,
+            0.2701311805789483,
+            44.647351654445075
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.11599479199967179,
+            0.17885066036634992,
+            0.23715477790820735,
+            32.459086285064295
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.965920917749708,
+          "centroid_raw": [
+            -0.08468817595663619,
+            0.16178340871338243,
+            0.17405884060848012,
+            26.36216187536592
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.2013038548296155,
+          "centroid_raw": [
+            0.19365654195946694,
+            0.24094684356078727,
+            0.3750316921392831,
+            44.14655673534547
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.3742740083297316
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.965920917749708
+          },
+          "6": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.2013038548296155
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    }
+  ],
+  "winner": null
+}

--- a/docs/research/1499-artifacts/regime_1095_btc.json
+++ b/docs/research/1499-artifacts/regime_1095_btc.json
@@ -1,0 +1,17390 @@
+{
+  "issue": 1095,
+  "symbol": "BTC/USDT",
+  "timeframe": "1h",
+  "in_sample": "is",
+  "held_out": "oos",
+  "target": "volatility",
+  "htf_multiple": 4,
+  "candidate_count": 90,
+  "significance_alpha": 0.05,
+  "bonferroni_alpha": 0.0011111111111111111,
+  "bonferroni_denominator": 45,
+  "bonferroni_denominator_policy": "ONE family across all feature-subset ablations (#1095 4b): alpha is divided by the COMBINED structurally-eligible candidate count of the whole subsets x families x K grid; structurally ineligible candidates (k < incumbent-derived min_active_labels) are scored for evidence but excluded (#1160)",
+  "structurally_ineligible": [
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable"
+    }
+  ],
+  "n_perm": 1799,
+  "min_achievable_p_value": 0.0005555555555555556,
+  "non_degeneracy_thresholds": {
+    "min_active_labels": 5,
+    "max_occupancy": 0.39199381938880623,
+    "min_transition_rate": 0.0686763372620127
+  },
+  "subset_status": {
+    "canonical": "ok",
+    "funding": "ok",
+    "volume": "ok",
+    "htf": "ok",
+    "all_enriched": "ok"
+  },
+  "handrule_held_out": {
+    "canonical": {
+      "kruskal_h": 85.6949486268586,
+      "p_value": 0.0044444444444444444,
+      "transition_rate": 0.1373526745240254,
+      "abstained": false,
+      "permutation_steps_to_alpha": 82,
+      "knife_edge": false
+    },
+    "funding": {
+      "kruskal_h": 85.6949486268586,
+      "p_value": 0.0044444444444444444,
+      "transition_rate": 0.1373526745240254,
+      "abstained": false,
+      "permutation_steps_to_alpha": 82,
+      "knife_edge": false
+    },
+    "volume": {
+      "kruskal_h": 85.6949486268586,
+      "p_value": 0.0044444444444444444,
+      "transition_rate": 0.1373526745240254,
+      "abstained": false,
+      "permutation_steps_to_alpha": 82,
+      "knife_edge": false
+    },
+    "htf": {
+      "kruskal_h": 80.47242092503984,
+      "p_value": 0.005,
+      "transition_rate": 0.13860225140712945,
+      "abstained": false,
+      "permutation_steps_to_alpha": 81,
+      "knife_edge": false
+    },
+    "all_enriched": {
+      "kruskal_h": 80.47242092503984,
+      "p_value": 0.005,
+      "transition_rate": 0.13860225140712945,
+      "abstained": false,
+      "permutation_steps_to_alpha": 81,
+      "knife_edge": false
+    }
+  },
+  "baseline_note": "the merged #1080 evidence was measured at n_perm=200 with the incumbent at a knife-edge (OOS p = 10/201); handrule_held_out.canonical re-measures that baseline at this run's resolved n_perm so enriched-vs-baseline and the incumbent-trustworthy verdict share one resolution (#1095 4c)",
+  "ablation": {
+    "canonical": {
+      "status": "ok",
+      "best_kruskal_h": 104.47995640102272,
+      "best_candidate": {
+        "family": "kmeans",
+        "k": 7
+      },
+      "any_ships": false,
+      "separation_gain_vs_canonical": 0.0
+    },
+    "funding": {
+      "status": "ok",
+      "best_kruskal_h": 127.99831649659245,
+      "best_candidate": {
+        "family": "kmeans",
+        "k": 7
+      },
+      "any_ships": false,
+      "separation_gain_vs_canonical": 23.518360095569733
+    },
+    "volume": {
+      "status": "ok",
+      "best_kruskal_h": 165.55203122345847,
+      "best_candidate": {
+        "family": "hmm",
+        "k": 7
+      },
+      "any_ships": false,
+      "separation_gain_vs_canonical": 61.07207482243575
+    },
+    "htf": {
+      "status": "ok",
+      "best_kruskal_h": 179.79624638998575,
+      "best_candidate": {
+        "family": "hmm",
+        "k": 6
+      },
+      "any_ships": true,
+      "separation_gain_vs_canonical": 75.31628998896304
+    },
+    "all_enriched": {
+      "status": "ok",
+      "best_kruskal_h": 236.27466801305673,
+      "best_candidate": {
+        "family": "kmeans",
+        "k": 7
+      },
+      "any_ships": false,
+      "separation_gain_vs_canonical": 131.794711612034
+    }
+  },
+  "candidates": [
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 46.59564715827764,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.02,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.03513145965548504
+        }
+      },
+      "model_kruskal_h": 46.59564715827764,
+      "model_p_value": 0.02,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.10222121486854036,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2150,
+          "pct": 0.4871969181962384
+        },
+        "ranging_volatile": {
+          "count": 2263,
+          "pct": 0.5128030818037617
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5682331212805254,
+          "transition_rate": 0.035303776683087026,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.568 > 0.392",
+            "min_transition_rate: 0.0353 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5128030818037617,
+          "transition_rate": 0.03513145965548504,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.513 > 0.392",
+            "min_transition_rate: 0.0351 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5485871812543074,
+          "transition_rate": 0.03526708788052843,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.549 > 0.392",
+            "min_transition_rate: 0.0353 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5087558658578459,
+          "transition_rate": 0.0383470695970696,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.509 > 0.392",
+            "min_transition_rate: 0.0383 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5310681871072842,
+          "transition_rate": 0.03235567970204842,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.531 > 0.392",
+            "min_transition_rate: 0.0324 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.00755126055449094,
+            0.18354201174585266,
+            0.23146087182239317,
+            36.85508276421143
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005683939134586702,
+            0.12318410209359588,
+            0.07791568270198539,
+            21.87381095910724
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 74.70241336495565,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.021666666666666667,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.044424297370806894
+        }
+      },
+      "model_kruskal_h": 74.70241336495565,
+      "model_p_value": 0.021666666666666667,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.0929283771532185,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2125,
+          "pct": 0.48153183775209607
+        },
+        "trending_down_choppy": {
+          "count": 1289,
+          "pct": 0.29209154769997736
+        },
+        "trending_up_choppy": {
+          "count": 999,
+          "pct": 0.22637661454792657
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5448389082700595,
+          "transition_rate": 0.04187192118226601,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.545 > 0.392",
+            "min_transition_rate: 0.0419 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.48153183775209607,
+          "transition_rate": 0.044424297370806894,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.482 > 0.392",
+            "min_transition_rate: 0.0444 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5323914541695383,
+          "transition_rate": 0.04032165422171166,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.532 > 0.392",
+            "min_transition_rate: 0.0403 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4841478768455992,
+          "transition_rate": 0.04681776556776557,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.484 > 0.392",
+            "min_transition_rate: 0.0468 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.512217826390505,
+          "transition_rate": 0.04189944134078212,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.512 > 0.392",
+            "min_transition_rate: 0.0419 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00524331067616402,
+            0.12216174978953546,
+            0.07160931828841736,
+            21.96761195888488
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.10475628408767888,
+            0.17786530614441362,
+            0.212300950251665,
+            37.13169664606488
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.12493967054949551,
+            0.18493165309502024,
+            0.25164207675883726,
+            33.985550586827706
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 79.70362241785188,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.021111111111111112,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08363553943789664
+        }
+      },
+      "model_kruskal_h": 79.70362241785188,
+      "model_p_value": 0.021111111111111112,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.05371713508612874,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1732,
+          "pct": 0.39247677317017904
+        },
+        "ranging_volatile": {
+          "count": 1089,
+          "pct": 0.2467709041468389
+        },
+        "trending_down_choppy": {
+          "count": 957,
+          "pct": 0.2168592794017675
+        },
+        "trending_up_choppy": {
+          "count": 635,
+          "pct": 0.1438930432812146
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.37779601887954034,
+          "transition_rate": 0.0812807881773399,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.39247677317017904,
+          "transition_rate": 0.08363553943789664,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.392 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3766368022053756,
+          "transition_rate": 0.08902929350947732,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.39487238182442486,
+          "transition_rate": 0.0850503663003663,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.395 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3912031649988364,
+          "transition_rate": 0.0947392923649907,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005304241028108408,
+            0.14228848502567515,
+            0.12727315163306863,
+            26.43549789652893
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.122736288062705,
+            0.18749135701273506,
+            0.24754881783372096,
+            40.02275531027101
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14701434638993968,
+            0.2014930801859868,
+            0.29385455922992165,
+            36.55496800842193
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0019271255101770148,
+            0.11394121664098841,
+            0.04336154333875711,
+            20.51861500846088
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 87.42046346796087,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.01611111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.10448776065276519
+        }
+      },
+      "model_kruskal_h": 87.42046346796087,
+      "model_p_value": 0.01611111111111111,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.0328649138712602,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 803,
+          "pct": 0.1819623838658509
+        },
+        "ranging_directional_up": {
+          "count": 923,
+          "pct": 0.20915476999773397
+        },
+        "ranging_volatile": {
+          "count": 1233,
+          "pct": 0.2794017675050986
+        },
+        "trending_down_choppy": {
+          "count": 857,
+          "pct": 0.1941989576251983
+        },
+        "trending_up_choppy": {
+          "count": 597,
+          "pct": 0.13528212100611828
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.3289554689103222,
+          "transition_rate": 0.10611658456486042,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.2794017675050986,
+          "transition_rate": 0.10448776065276519,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.3421778084079945,
+          "transition_rate": 0.11602527283170591,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.27572393270001144,
+          "transition_rate": 0.11160714285714286,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.31510356062369094,
+          "transition_rate": 0.1191806331471136,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.2268162140843539,
+          "centroid_raw": [
+            0.06858203092811292,
+            0.13660100493347754,
+            0.1434990528874797,
+            24.10252406232175
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13004439074913146,
+            0.19071522685542275,
+            0.26217293250219587,
+            41.18210134496014
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.14048021991941806,
+          "centroid_raw": [
+            -0.06231675737044698,
+            0.1479476962528805,
+            0.12895368181959263,
+            28.84225779849284
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0009132888711901893,
+            0.11753247708653275,
+            0.03996660878847583,
+            21.292055426420568
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14996145956495005,
+            0.2032693542696212,
+            0.29922876998934556,
+            36.86192557168001
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.2268162140843539
+          },
+          "2": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.14048021991941806
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 101.3406413155626,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.007222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.11310063463281958
+        }
+      },
+      "model_kruskal_h": 101.3406413155626,
+      "model_p_value": 0.007222222222222222,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.024252039891205807,
+      "coverage": {
+        "ranging_directional": {
+          "count": 637,
+          "pct": 0.14434624971674598
+        },
+        "ranging_directional_down": {
+          "count": 503,
+          "pct": 0.11398141853614321
+        },
+        "ranging_directional_up": {
+          "count": 880,
+          "pct": 0.1994108316338092
+        },
+        "ranging_volatile": {
+          "count": 977,
+          "pct": 0.22139134375708136
+        },
+        "trending_down_choppy": {
+          "count": 833,
+          "pct": 0.18876048039882165
+        },
+        "trending_up_choppy": {
+          "count": 583,
+          "pct": 0.1321096759573986
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.26390313974964086,
+          "transition_rate": 0.11350574712643678,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.22139134375708136,
+          "transition_rate": 0.11310063463281958,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.26797610843096714,
+          "transition_rate": 0.11131533601378518,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.21071305940254093,
+          "transition_rate": 0.12076465201465202,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.2566907144519432,
+          "transition_rate": 0.11941340782122906,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.015576564159259062,
+            0.1409264693931202,
+            0.04904287048517281,
+            30.606690861198643
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.8179697163229278,
+          "centroid_raw": [
+            -0.07171639208781058,
+            0.14925489298240077,
+            0.1489040332341788,
+            28.359693348998004
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13247631426400705,
+            0.19218777047541963,
+            0.26669870231960446,
+            41.43178959229569
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0032806352589625698,
+            0.11226572629636841,
+            0.044761126300617696,
+            18.905984474990973
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.23737164234607214,
+          "centroid_raw": [
+            0.07035774771731626,
+            0.1381702946168062,
+            0.1470921661867227,
+            24.452193257436953
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.15079288674498723,
+            0.20385184522988262,
+            0.3007071101257731,
+            36.9852980486165
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.8179697163229278
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.23737164234607214
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 99.2972110932842,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.013333333333333334,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.13395285584768812
+        }
+      },
+      "model_kruskal_h": 99.2972110932842,
+      "model_p_value": 0.013333333333333334,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.003399818676337263,
+      "coverage": {
+        "ranging_directional": {
+          "count": 650,
+          "pct": 0.14729209154769998
+        },
+        "ranging_directional_down": {
+          "count": 500,
+          "pct": 0.11330160888284614
+        },
+        "ranging_directional_up": {
+          "count": 643,
+          "pct": 0.14570586902334012
+        },
+        "ranging_volatile": {
+          "count": 907,
+          "pct": 0.20552911851348288
+        },
+        "trending_down_choppy": {
+          "count": 834,
+          "pct": 0.18898708361658736
+        },
+        "trending_up_choppy": {
+          "count": 656,
+          "pct": 0.14865171085429413
+        },
+        "trending_up_clean": {
+          "count": 223,
+          "pct": 0.050532517561749375
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.24646008618920584,
+          "transition_rate": 0.13854679802955666,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.20552911851348288,
+          "transition_rate": 0.13395285584768812,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.2548816907879623,
+          "transition_rate": 0.13015508328546813,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.19880966006638434,
+          "transition_rate": 0.1429716117216117,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.23434954619501977,
+          "transition_rate": 0.14106145251396648,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_up_clean"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0005027356107206483,
+            0.11224814725364951,
+            0.04079247667809589,
+            18.988498426771645
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.32100364406136916,
+          "centroid_raw": [
+            0.06111146207075637,
+            0.1277461692846439,
+            0.1285781254011893,
+            21.72377877665248
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.015831001301463775,
+            0.14171160686435166,
+            0.05017179280590109,
+            30.846818863994507
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1323396028727731,
+            0.1921095054462609,
+            0.2664447892145779,
+            41.419318214636014
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.105654469546394,
+            0.16991364996595193,
+            0.21809980480108276,
+            32.00984351908438
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.8167468923676112,
+          "centroid_raw": [
+            -0.07160917965624518,
+            0.14887466219276577,
+            0.14873261833412502,
+            28.223670437952606
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.334557878987827,
+          "centroid_raw": [
+            0.1858194821022053,
+            0.23319830462351757,
+            0.3611696456239619,
+            40.98326439356847
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.32100364406136916
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.8167468923676112
+          },
+          "6": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.334557878987827
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 41.91704336670409,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.03611111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.04374433363553944
+        }
+      },
+      "model_kruskal_h": 41.91704336670409,
+      "model_p_value": 0.03611111111111111,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.09360834088848595,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2121,
+          "pct": 0.4806254248810333
+        },
+        "ranging_volatile": {
+          "count": 2292,
+          "pct": 0.5193745751189667
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5731582187564129,
+          "transition_rate": 0.038998357963875206,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.573 > 0.392",
+            "min_transition_rate: 0.0390 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5193745751189667,
+          "transition_rate": 0.04374433363553944,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.519 > 0.392",
+            "min_transition_rate: 0.0437 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5569722030783367,
+          "transition_rate": 0.04055140723721999,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.557 > 0.392",
+            "min_transition_rate: 0.0406 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5143641982373812,
+          "transition_rate": 0.04429945054945055,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.514 > 0.392",
+            "min_transition_rate: 0.0443 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5396788457063068,
+          "transition_rate": 0.036080074487895714,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.540 > 0.392",
+            "min_transition_rate: 0.0361 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.005502734254364465,
+            0.18342747882528565,
+            0.23564357528921204,
+            36.44092213232946
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.004075595150556658,
+            0.12384805866393585,
+            0.07637036554941636,
+            22.317461369474312
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 75.42340588750449,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.028888888888888888,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.046010879419764276
+        }
+      },
+      "model_kruskal_h": 75.42340588750449,
+      "model_p_value": 0.028888888888888888,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.0913417951042611,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2336,
+          "pct": 0.5293451167006572
+        },
+        "trending_down_choppy": {
+          "count": 1193,
+          "pct": 0.27033763879447087
+        },
+        "trending_up_choppy": {
+          "count": 884,
+          "pct": 0.20031724450487198
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5869074492099323,
+          "transition_rate": 0.04351395730706076,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.587 > 0.392",
+            "min_transition_rate: 0.0435 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5293451167006572,
+          "transition_rate": 0.046010879419764276,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.529 > 0.392",
+            "min_transition_rate: 0.0460 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5816678152997933,
+          "transition_rate": 0.0450315910396324,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.582 > 0.392",
+            "min_transition_rate: 0.0450 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5315325626645302,
+          "transition_rate": 0.0486492673992674,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.532 > 0.392",
+            "min_transition_rate: 0.0486 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5636490574819641,
+          "transition_rate": 0.04306331471135941,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.564 > 0.392",
+            "min_transition_rate: 0.0431 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005075012008396578,
+            0.12542688421784254,
+            0.07731733918469537,
+            22.80853912855038
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11169832379968075,
+            0.18075344293670947,
+            0.22614432446324395,
+            37.95211672005942
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1340999106165127,
+            0.19045167141845493,
+            0.26951698909831107,
+            34.75884620438009
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 79.415234281636,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.015,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.11536718041704443
+        }
+      },
+      "model_kruskal_h": 79.415234281636,
+      "model_p_value": 0.015,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.02198549410698096,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1808,
+          "pct": 0.40969861772037164
+        },
+        "ranging_volatile": {
+          "count": 1099,
+          "pct": 0.2490369363244958
+        },
+        "trending_down_choppy": {
+          "count": 920,
+          "pct": 0.20847496034443688
+        },
+        "trending_up_choppy": {
+          "count": 586,
+          "pct": 0.13278948561069567
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.41719679868664067,
+          "transition_rate": 0.12315270935960591,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.417 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.40969861772037164,
+          "transition_rate": 0.11536718041704443,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.410 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.40167700436480586,
+          "transition_rate": 0.1283170591614015,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.402 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.41066727709740186,
+          "transition_rate": 0.11813186813186813,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.411 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.42168955084942983,
+          "transition_rate": 0.1287243947858473,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.422 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00457184308135086,
+            0.14117198914657933,
+            0.13016782117280135,
+            26.279365223934754
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12806118155554375,
+            0.18917897023958513,
+            0.258518321860861,
+            40.69123511613657
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1531857875320342,
+            0.20370535438544335,
+            0.3062979664033859,
+            36.66833846625733
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0005503865234446904,
+            0.11672577515526995,
+            0.03512918327968835,
+            21.139713393407842
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 89.52822292597193,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.006666666666666667,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12443336355394378
+        }
+      },
+      "model_kruskal_h": 89.52822292597193,
+      "model_p_value": 0.006666666666666667,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.012919310970081602,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 767,
+          "pct": 0.17380466802628597
+        },
+        "ranging_directional_up": {
+          "count": 900,
+          "pct": 0.20394289598912305
+        },
+        "ranging_volatile": {
+          "count": 1339,
+          "pct": 0.30342170858826195
+        },
+        "trending_down_choppy": {
+          "count": 839,
+          "pct": 0.19012009970541582
+        },
+        "trending_up_choppy": {
+          "count": 568,
+          "pct": 0.1287106276909132
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.3511184075518161,
+          "transition_rate": 0.12992610837438423,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.30342170858826195,
+          "transition_rate": 0.12443336355394378,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.36928555019526765,
+          "transition_rate": 0.12808730614589317,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3097172942657663,
+          "transition_rate": 0.1324404761904762,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3420991389341401,
+          "transition_rate": 0.1378026070763501,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.23819658826340245,
+          "centroid_raw": [
+            0.0706191130188882,
+            0.1381936326109156,
+            0.14737582484656542,
+            24.579787311899803
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1337649695157418,
+            0.19126000819091887,
+            0.2694825949680144,
+            41.155051147028196
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.1942063769679622,
+          "centroid_raw": [
+            -0.06702725712046893,
+            0.14969901388622933,
+            0.1386605674979722,
+            29.35247888903386
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0004500652671430372,
+            0.11993989131217989,
+            0.04165722618700232,
+            21.900865684325883
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.15276097054683546,
+            0.20293583619438454,
+            0.30517825382212493,
+            36.533061068509596
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.23819658826340245
+          },
+          "2": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.1942063769679622
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 84.91296975004661,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.01,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.17225747960108795
+        }
+      },
+      "model_kruskal_h": 84.91296975004661,
+      "model_p_value": 0.01,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.03490480507706256,
+      "coverage": {
+        "ranging_directional": {
+          "count": 519,
+          "pct": 0.11760707002039429
+        },
+        "ranging_directional_down": {
+          "count": 460,
+          "pct": 0.10423748017221844
+        },
+        "ranging_directional_up": {
+          "count": 946,
+          "pct": 0.2143666440063449
+        },
+        "ranging_volatile": {
+          "count": 1098,
+          "pct": 0.24881033310673012
+        },
+        "trending_down_choppy": {
+          "count": 781,
+          "pct": 0.17697711307500566
+        },
+        "trending_up_choppy": {
+          "count": 609,
+          "pct": 0.1380013596193066
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.28914426431356455,
+          "transition_rate": 0.19232348111658457,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.24881033310673012,
+          "transition_rate": 0.17225747960108795,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.30668504479669195,
+          "transition_rate": 0.17736932797242963,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.2496280187707451,
+          "transition_rate": 0.1823489010989011,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.28508261577845007,
+          "transition_rate": 0.19064245810055866,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.04366630374896207,
+            0.1376664538800906,
+            0.08970357405499844,
+            27.381210974078254
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9333735654114692,
+          "centroid_raw": [
+            -0.08183455114005711,
+            0.15529976336577972,
+            0.16997439493176705,
+            30.400763213013317
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13835159772007966,
+            0.19365601953711425,
+            0.2779414009307426,
+            41.71191129682961
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0028228376070924925,
+            0.11896908510777429,
+            0.03376595501632661,
+            21.585861943722634
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.20595035145335516,
+          "centroid_raw": [
+            0.06629388657860845,
+            0.13569875405916726,
+            0.1385579721518705,
+            24.01400144089481
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1497865291712852,
+            0.20083358057455686,
+            0.2995779001351577,
+            36.23587973180108
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.9333735654114692
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.20595035145335516
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 88.27508376669175,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.009444444444444445,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.19945602901178605
+        }
+      },
+      "model_kruskal_h": 88.27508376669175,
+      "model_p_value": 0.009444444444444445,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.062103354487760665,
+      "coverage": {
+        "ranging_directional": {
+          "count": 522,
+          "pct": 0.11828687967369136
+        },
+        "ranging_directional_down": {
+          "count": 473,
+          "pct": 0.10718332200317245
+        },
+        "ranging_directional_up": {
+          "count": 767,
+          "pct": 0.17380466802628597
+        },
+        "ranging_volatile": {
+          "count": 1056,
+          "pct": 0.23929299796057105
+        },
+        "trending_down_choppy": {
+          "count": 781,
+          "pct": 0.17697711307500566
+        },
+        "trending_up_choppy": {
+          "count": 589,
+          "pct": 0.13346929526399276
+        },
+        "trending_up_clean": {
+          "count": 225,
+          "pct": 0.05098572399728076
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.2760106710445311,
+          "transition_rate": 0.2233169129720854,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.23929299796057105,
+          "transition_rate": 0.19945602901178605,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.2963473466574776,
+          "transition_rate": 0.19977024698449167,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.24012819045438938,
+          "transition_rate": 0.20867673992673993,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.27088666511519666,
+          "transition_rate": 0.21508379888268156,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_up_clean"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0022947929224514823,
+            0.11891198434975563,
+            0.03209652576498716,
+            21.592638263884417
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.19520019148818113,
+          "centroid_raw": [
+            0.05956804630290927,
+            0.13165520002611947,
+            0.1252215417900794,
+            23.202130277349845
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.043048333860697556,
+            0.13710792497169225,
+            0.08845741126450657,
+            27.243439041137435
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13835739445423156,
+            0.19366973147017236,
+            0.27794533852303344,
+            41.71623498569485
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.11248705075507764,
+            0.1686760357895703,
+            0.23191841817007863,
+            31.162267944254612
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9313320044823005,
+          "centroid_raw": [
+            -0.08165555504625843,
+            0.15522522322836885,
+            0.16958343466574566,
+            30.383448024235634
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.317505371548311,
+          "centroid_raw": [
+            0.18647829244425287,
+            0.23222873446749664,
+            0.3629435706729254,
+            40.44885185634014
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.19520019148818113
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.9313320044823005
+          },
+          "6": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.317505371548311
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 43.962991375054116,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.03277777777777778,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.03150498640072529
+        }
+      },
+      "model_kruskal_h": 43.962991375054116,
+      "model_p_value": 0.03277777777777778,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.10584768812330009,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1857,
+          "pct": 0.42080217539089054
+        },
+        "ranging_volatile": {
+          "count": 2556,
+          "pct": 0.5791978246091094
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.621998768725631,
+          "transition_rate": 0.031609195402298854,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.622 > 0.392",
+            "min_transition_rate: 0.0316 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5791978246091094,
+          "transition_rate": 0.03150498640072529,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.579 > 0.392",
+            "min_transition_rate: 0.0315 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.616815988973122,
+          "transition_rate": 0.03067202757036186,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.617 > 0.392",
+            "min_transition_rate: 0.0307 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.57456792949525,
+          "transition_rate": 0.03514194139194139,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.575 > 0.392",
+            "min_transition_rate: 0.0351 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5985571328834071,
+          "transition_rate": 0.031890130353817506,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.599 > 0.392",
+            "min_transition_rate: 0.0319 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.007813399107477342,
+            0.1904865163031385,
+            0.25024893920736746,
+            38.756658965445794
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.004223863177510036,
+            0.12679850085029357,
+            0.08651636360075063,
+            22.676732378006317
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 82.74029677023464,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.017777777777777778,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.04329102447869447
+        }
+      },
+      "model_kruskal_h": 82.74029677023464,
+      "model_p_value": 0.017777777777777778,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.09406165004533092,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2384,
+          "pct": 0.5402220711534104
+        },
+        "trending_down_choppy": {
+          "count": 1178,
+          "pct": 0.2669385905279855
+        },
+        "trending_up_choppy": {
+          "count": 851,
+          "pct": 0.19283933831860411
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5910116971065053,
+          "transition_rate": 0.038998357963875206,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.591 > 0.392",
+            "min_transition_rate: 0.0390 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5402220711534104,
+          "transition_rate": 0.04329102447869447,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.540 > 0.392",
+            "min_transition_rate: 0.0433 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5869515276820584,
+          "transition_rate": 0.041240666283744974,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.587 > 0.392",
+            "min_transition_rate: 0.0412 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5414902140322765,
+          "transition_rate": 0.04475732600732601,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.541 > 0.392",
+            "min_transition_rate: 0.0448 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5696997905515476,
+          "transition_rate": 0.042132216014897576,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.570 > 0.392",
+            "min_transition_rate: 0.0421 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005703862336521655,
+            0.12519971663132562,
+            0.08049942929815943,
+            22.421079141202416
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11063853257456722,
+            0.18172433353657422,
+            0.22361199524957437,
+            38.883719283978984
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.13601736185684565,
+            0.19417634466913342,
+            0.2730405538751525,
+            35.77197895814321
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 83.58545221245913,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.02666666666666667,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.06300997280145058
+        }
+      },
+      "model_kruskal_h": 83.58545221245913,
+      "model_p_value": 0.02666666666666667,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.0743427017225748,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1254,
+          "pct": 0.2841604350781781
+        },
+        "ranging_volatile": {
+          "count": 1587,
+          "pct": 0.35961930659415364
+        },
+        "trending_down_choppy": {
+          "count": 845,
+          "pct": 0.19147971901200997
+        },
+        "trending_up_choppy": {
+          "count": 727,
+          "pct": 0.16474053931565827
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.435665914221219,
+          "transition_rate": 0.059113300492610835,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.436 > 0.392",
+            "min_transition_rate: 0.0591 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.35961930659415364,
+          "transition_rate": 0.06300997280145058,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0630 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4182173213875488,
+          "transition_rate": 0.058472142446869615,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.418 > 0.392",
+            "min_transition_rate: 0.0585 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3639693258555568,
+          "transition_rate": 0.06421703296703296,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0642 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.40842448219688154,
+          "transition_rate": 0.06424581005586592,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.408 > 0.392",
+            "min_transition_rate: 0.0642 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.03111499811850684,
+            0.15307317373811,
+            0.12188998091521863,
+            30.741836550340736
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1302364740917169,
+            0.19141786651140588,
+            0.2623080043424838,
+            42.21137888848135
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14437983449509717,
+            0.19822121449445432,
+            0.28923010913455455,
+            35.87490695768459
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.015353963382247897,
+            0.11778292502558124,
+            0.07319223297479473,
+            20.025199288757197
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 90.20063125034358,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.026111111111111113,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08182230281051678
+        }
+      },
+      "model_kruskal_h": 90.20063125034358,
+      "model_p_value": 0.026111111111111113,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.05553037171350861,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 849,
+          "pct": 0.19238613188307274
+        },
+        "ranging_directional_up": {
+          "count": 936,
+          "pct": 0.21210061182868797
+        },
+        "ranging_volatile": {
+          "count": 1570,
+          "pct": 0.35576705189213687
+        },
+        "trending_down_choppy": {
+          "count": 778,
+          "pct": 0.1762973034217086
+        },
+        "trending_up_choppy": {
+          "count": 280,
+          "pct": 0.06344890097439383
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.4186332854504412,
+          "transition_rate": 0.0798440065681445,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.419 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.35576705189213687,
+          "transition_rate": 0.08182230281051678,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.42625775327360443,
+          "transition_rate": 0.07466973004020677,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.426 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3542405860135058,
+          "transition_rate": 0.08585164835164835,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.39515941354433326,
+          "transition_rate": 0.08286778398510242,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.395 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5235366958304687,
+          "centroid_raw": [
+            0.09590165406039532,
+            0.16003864948167654,
+            0.1983251334724151,
+            29.19733925358716
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13489948796109844,
+            0.19536643125451025,
+            0.2714127427332896,
+            44.12095875263345
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.18806167110518068,
+          "centroid_raw": [
+            -0.06648851329398535,
+            0.15670579591083997,
+            0.13819415744984556,
+            30.315549124053927
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.008768076157520661,
+            0.1171308289725782,
+            0.061307811092743025,
+            20.64450073774572
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1817757794927396,
+            0.23048051853754312,
+            0.3558671572017239,
+            42.41024516582192
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.5235366958304687
+          },
+          "2": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.18806167110518068
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 95.30505879689554,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.022222222222222223,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.09451495920217588
+        }
+      },
+      "model_kruskal_h": 95.30505879689554,
+      "model_p_value": 0.022222222222222223,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.042837715321849504,
+      "coverage": {
+        "ranging_directional": {
+          "count": 612,
+          "pct": 0.13868116927260368
+        },
+        "ranging_directional_down": {
+          "count": 549,
+          "pct": 0.12440516655336506
+        },
+        "ranging_directional_up": {
+          "count": 872,
+          "pct": 0.19759800589168366
+        },
+        "ranging_volatile": {
+          "count": 1390,
+          "pct": 0.3149784726943123
+        },
+        "trending_down_choppy": {
+          "count": 720,
+          "pct": 0.16315431679129844
+        },
+        "trending_up_choppy": {
+          "count": 270,
+          "pct": 0.061182868796736914
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.3650728504001642,
+          "transition_rate": 0.0946223316912972,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.3149784726943123,
+          "transition_rate": 0.09451495920217588,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.3657247875028716,
+          "transition_rate": 0.0861573808156232,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.3102895730800046,
+          "transition_rate": 0.1008470695970696,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.3569932511054224,
+          "transition_rate": 0.09404096834264432,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.015388972835934208,
+            0.1420117187808927,
+            0.07587104500373561,
+            33.50969741647665
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9793158951468397,
+          "centroid_raw": [
+            -0.08586259529252369,
+            0.1626032746940651,
+            0.17600760226413842,
+            26.91447608583654
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13452066957240058,
+            0.19500531338801652,
+            0.27035087691035375,
+            44.899385162738255
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009598950154765945,
+            0.11527523972597871,
+            0.06339269093574985,
+            19.224142413585
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.568465899250082,
+          "centroid_raw": [
+            0.0998408712518566,
+            0.16162666000473427,
+            0.2054539086860961,
+            28.62967818110436
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18206375718516551,
+            0.23071318148135136,
+            0.3562994339378191,
+            42.48038475325567
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.9793158951468397
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.568465899250082
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 104.47995640102272,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.009444444444444445,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12103354487760652
+        }
+      },
+      "model_kruskal_h": 104.47995640102272,
+      "model_p_value": 0.009444444444444445,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.016319129646418865,
+      "coverage": {
+        "ranging_directional": {
+          "count": 618,
+          "pct": 0.14004078857919783
+        },
+        "ranging_directional_down": {
+          "count": 477,
+          "pct": 0.10808973487423522
+        },
+        "ranging_directional_up": {
+          "count": 670,
+          "pct": 0.15182415590301382
+        },
+        "ranging_volatile": {
+          "count": 1137,
+          "pct": 0.2576478585995921
+        },
+        "trending_down_choppy": {
+          "count": 734,
+          "pct": 0.16632676184001813
+        },
+        "trending_up_choppy": {
+          "count": 619,
+          "pct": 0.14026739179696351
+        },
+        "trending_up_clean": {
+          "count": 158,
+          "pct": 0.03580330840697938
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.3043299815308845,
+          "transition_rate": 0.12541050903119869,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.2576478585995921,
+          "transition_rate": 0.12103354487760652,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.31541465655869516,
+          "transition_rate": 0.119586444572085,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.25569417420167107,
+          "transition_rate": 0.125,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.29090062834535724,
+          "transition_rate": 0.13128491620111732,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_up_clean"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0034321147789508084,
+            0.11322747175818654,
+            0.04664463482156207,
+            19.566989035448586
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3742740083297316,
+          "centroid_raw": [
+            0.0667489383848353,
+            0.1313339445069582,
+            0.139463683982449,
+            21.42469826004001
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.021288697551426282,
+            0.14361104327825316,
+            0.07901135443885518,
+            34.72073854237792
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13445303668836828,
+            0.19492873657594934,
+            0.2701311805789483,
+            44.647351654445075
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.11599479199967179,
+            0.17885066036634992,
+            0.23715477790820735,
+            32.459086285064295
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.965920917749708,
+          "centroid_raw": [
+            -0.08468817595663619,
+            0.16178340871338243,
+            0.17405884060848012,
+            26.36216187536592
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.2013038548296155,
+          "centroid_raw": [
+            0.19365654195946694,
+            0.24094684356078727,
+            0.3750316921392831,
+            44.14655673534547
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.3742740083297316
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.965920917749708
+          },
+          "6": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.2013038548296155
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 44.019294365907626,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.009444444444444445,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08680870353581142
+        }
+      },
+      "model_kruskal_h": 44.019294365907626,
+      "model_p_value": 0.009444444444444445,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.05054397098821396,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1108,
+          "pct": 0.25107636528438704
+        },
+        "ranging_directional_up": {
+          "count": 3305,
+          "pct": 0.748923634715613
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5762364046788426,
+          "transition_rate": 0.08292282430213464,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.576 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.748923634715613,
+          "transition_rate": 0.08680870353581142,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.749 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.7613960113960114,
+          "transition_rate": 0.053428317008014245,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.761 > 0.392",
+            "min_transition_rate: 0.0534 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5573995650681012,
+          "transition_rate": 0.11172161172161173,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.557 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5161740749360019,
+          "transition_rate": 0.10032588454376164,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.516 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0005951275269955315,
+            0.16983566992439775,
+            0.18936667391916345,
+            32.38926040648409,
+            1.2061334230989697e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.00034592770192922026,
+            0.13315561434758483,
+            0.10868484916066735,
+            25.144117240962885,
+            1.2491200397671366e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 101.88592310314925,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.002777777777777778,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.09111514052583862
+        }
+      },
+      "model_kruskal_h": 101.88592310314925,
+      "model_p_value": 0.002777777777777778,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.04623753399818677,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 966,
+          "pct": 0.21889870836165873
+        },
+        "trending_down_choppy": {
+          "count": 888,
+          "pct": 0.20122365737593473
+        },
+        "trending_up_choppy": {
+          "count": 2559,
+          "pct": 0.5798776342624066
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5105684383336754,
+          "transition_rate": 0.08230706075533661,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.511 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5798776342624066,
+          "transition_rate": 0.09111514052583862,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.580 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.7345085470085471,
+          "transition_rate": 0.05983971504897596,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.735 > 0.392",
+            "min_transition_rate: 0.0598 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5065812063637404,
+          "transition_rate": 0.11652930402930403,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.507 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.463346520828485,
+          "transition_rate": 0.09962756052141528,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.463 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0029250764398177187,
+            0.12807346611138312,
+            0.09358249764555857,
+            23.84156155159805,
+            1.2491175092117759e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12330124718593012,
+            0.18728491811482006,
+            0.24713222270942883,
+            40.38335042382016,
+            9.018919116647993e-06
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.05922726333319109,
+            0.16105046333085837,
+            0.16609763289249052,
+            28.770152852727737,
+            1.3719098432432383e-05
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 99.95456612933776,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.007222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.10335448776065277
+        }
+      },
+      "model_kruskal_h": 99.95456612933776,
+      "model_p_value": 0.007222222222222222,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.033998186763372615,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 956,
+          "pct": 0.2166326761840018
+        },
+        "ranging_volatile": {
+          "count": 1646,
+          "pct": 0.37298889644232947
+        },
+        "trending_down_choppy": {
+          "count": 1042,
+          "pct": 0.23612055291185136
+        },
+        "trending_up_choppy": {
+          "count": 769,
+          "pct": 0.17425787446181737
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5089267391750462,
+          "transition_rate": 0.08641215106732349,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.509 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.37298889644232947,
+          "transition_rate": 0.10335448776065277,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.40188746438746437,
+          "transition_rate": 0.08352626892252894,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.402 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.38136660180840104,
+          "transition_rate": 0.12877747252747251,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.46707004887130554,
+          "transition_rate": 0.10498137802607076,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.467 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.10519060790378862,
+          "centroid_raw": [
+            0.0025012988627732867,
+            0.12835945296895024,
+            0.09373028987353246,
+            23.831482214467236,
+            1.2493108685261146e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12117818179826158,
+            0.18724218638264606,
+            0.24270464978627054,
+            40.07876230241883,
+            8.672272706091769e-06
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.13161438983045504,
+            0.19846040114588467,
+            0.2800544238003103,
+            36.3123293500535,
+            1.8057685019134404e-05
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.008271992636850316,
+            0.12935809107160684,
+            0.07629660353554336,
+            22.631015462229566,
+            1.0839735074366895e-05
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.10519060790378862
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 99.54137520708719,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0044444444444444444,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.11808703535811424
+        }
+      },
+      "model_kruskal_h": 99.54137520708719,
+      "model_p_value": 0.0044444444444444444,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.019265639165911147,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1902,
+          "pct": 0.4309993201903467
+        },
+        "ranging_directional_up": {
+          "count": 644,
+          "pct": 0.14593247224110584
+        },
+        "ranging_volatile": {
+          "count": 452,
+          "pct": 0.10242465443009291
+        },
+        "trending_down_choppy": {
+          "count": 903,
+          "pct": 0.20462270564242013
+        },
+        "trending_up_choppy": {
+          "count": 512,
+          "pct": 0.11602084749603445
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.3143853888774882,
+          "transition_rate": 0.12458949096880131,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.4309993201903467,
+          "transition_rate": 0.11808703535811424,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.431 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.5671296296296297,
+          "transition_rate": 0.08512911843276937,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.567 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.30983175002861396,
+          "transition_rate": 0.16449175824175824,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.2929951128694438,
+          "transition_rate": 0.14315642458100558,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_directional",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.002044191569159528,
+            0.11444686288009942,
+            0.04881182219240644,
+            20.98935011380128,
+            1.2489675787877486e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12994323993457896,
+            0.194523356724364,
+            0.25974918129788316,
+            41.99526062580405,
+            7.880126898181213e-06
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.001556688948217966,
+            0.1500925727992532,
+            0.1613493032722979,
+            28.95971062589657,
+            1.249427865876296e-05
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.11983366732844285,
+          "centroid_raw": [
+            0.0065753129698495625,
+            0.13498168152170148,
+            0.08818733048155322,
+            23.961732486663493,
+            1.3417314397312215e-05
+          ],
+          "volatility_rank": 1
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.163788667080671,
+            0.21403790219465973,
+            0.3235573507004137,
+            37.60505744599055,
+            1.4924474705045348e-05
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "3": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.11983366732844285
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 101.22123908589856,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.007222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12398005439709882
+        }
+      },
+      "model_kruskal_h": 101.22123908589856,
+      "model_p_value": 0.007222222222222222,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.013372620126926568,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1935,
+          "pct": 0.43847722637661457
+        },
+        "ranging_directional_down": {
+          "count": 302,
+          "pct": 0.06843417176523907
+        },
+        "ranging_directional_up": {
+          "count": 397,
+          "pct": 0.08996147745297983
+        },
+        "ranging_volatile": {
+          "count": 438,
+          "pct": 0.09925220938137322
+        },
+        "trending_down_choppy": {
+          "count": 844,
+          "pct": 0.19125311579424428
+        },
+        "trending_up_choppy": {
+          "count": 497,
+          "pct": 0.11262179922954905
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.26390313974964086,
+          "transition_rate": 0.13341543513957307,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.43847722637661457,
+          "transition_rate": 0.12398005439709882,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.438 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.5694444444444444,
+          "transition_rate": 0.0879786286731968,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.569 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.31292205562550074,
+          "transition_rate": 0.16838369963369965,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.2355131487084012,
+          "transition_rate": 0.1527001862197393,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_directional",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.37980541204662577,
+          "centroid_raw": [
+            0.08329985609962952,
+            0.14801586708747,
+            0.17388691212518503,
+            27.268157931605998,
+            1.2493231407176951e-05
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.29610120430764014,
+          "centroid_raw": [
+            -0.07596099787319767,
+            0.1536602769019992,
+            0.1571786304451156,
+            30.88938267499238,
+            1.2491585290273065e-05
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1344216089069359,
+            0.19526905331211256,
+            0.26892389221961777,
+            42.412752270579546,
+            7.5618954744848026e-06
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.1116777880178631,
+          "centroid_raw": [
+            0.005268576190554568,
+            0.13571879681189586,
+            0.08843343484890791,
+            23.954320336973804,
+            1.3226221688280426e-05
+          ],
+          "volatility_rank": 1
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0011734353938729531,
+            0.11512228527704801,
+            0.04614269580646892,
+            21.325841336339312,
+            1.2489294254731375e-05
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1651025633200017,
+            0.21505178955071,
+            0.325251856699979,
+            37.709581775469736,
+            1.5040675066832532e-05
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.37980541204662577
+          },
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.29610120430764014
+          },
+          "3": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.1116777880178631
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 115.30285465520137,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.002777777777777778,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12919310970081596
+        }
+      },
+      "model_kruskal_h": 115.30285465520137,
+      "model_p_value": 0.002777777777777778,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.008159564823209425,
+      "coverage": {
+        "ranging_directional": {
+          "count": 301,
+          "pct": 0.06820756854747337
+        },
+        "ranging_directional_down": {
+          "count": 143,
+          "pct": 0.032404260140493996
+        },
+        "ranging_directional_up": {
+          "count": 1823,
+          "pct": 0.413097665986857
+        },
+        "ranging_volatile": {
+          "count": 445,
+          "pct": 0.10083843190573306
+        },
+        "trending_down_choppy": {
+          "count": 826,
+          "pct": 0.18717425787446182
+        },
+        "trending_up_choppy": {
+          "count": 392,
+          "pct": 0.08882846136415137
+        },
+        "trending_up_clean": {
+          "count": 483,
+          "pct": 0.10944935418082936
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.2657500513030987,
+          "transition_rate": 0.13628899835796388,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.413097665986857,
+          "transition_rate": 0.12919310970081596,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.413 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.3896011396011396,
+          "transition_rate": 0.09670525378450578,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.2800732516882225,
+          "transition_rate": 0.17284798534798534,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.2373749127298115,
+          "transition_rate": 0.16038175046554934,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile",
+        "ranging_directional",
+        "trending_up_clean",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.1513175072988719,
+          "centroid_raw": [
+            0.00992689085332825,
+            0.13437136099657276,
+            0.08567775829333671,
+            23.319078080593094,
+            1.8637482365874289e-06
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.001509959693303531,
+            0.11511970055680001,
+            0.04666071256905534,
+            21.314451096256786,
+            1.2490050528951648e-05
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.8668983494303462,
+          "centroid_raw": [
+            -0.0760062636640181,
+            0.15382307273715193,
+            0.15729005553396122,
+            30.863848390093374,
+            1.2491797042294884e-05
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.6381479861532033,
+          "centroid_raw": [
+            0.16776897338955576,
+            0.2177364495231187,
+            0.3295880088688782,
+            37.90012053898961,
+            1.4274541532699147e-05
+          ],
+          "volatility_rank": 6
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.00035102645680569667,
+            0.1393809146173399,
+            0.10185959523784435,
+            25.862985094233707,
+            3.312798688560992e-05
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.08412323139824346,
+            0.1486727460687213,
+            0.1756133512506836,
+            27.388809313733653,
+            1.2493720589683372e-05
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13555305572012372,
+            0.19604350808373225,
+            0.2707096045723587,
+            42.59038808145708,
+            7.449161216622733e-06
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.1513175072988719
+          },
+          "2": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.8668983494303462
+          },
+          "3": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.6381479861532033
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 45.468858633206764,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.006111111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.0985947416137806
+        }
+      },
+      "model_kruskal_h": 45.468858633206764,
+      "model_p_value": 0.006111111111111111,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.03875793291024479,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1276,
+          "pct": 0.28914570586902333
+        },
+        "ranging_directional_up": {
+          "count": 3137,
+          "pct": 0.7108542941309767
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6542171147137287,
+          "transition_rate": 0.08661740558292283,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.654 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.7108542941309767,
+          "transition_rate": 0.0985947416137806,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.711 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.7402065527065527,
+          "transition_rate": 0.05841495992876224,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.740 > 0.392",
+            "min_transition_rate: 0.0584 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5116172599290374,
+          "transition_rate": 0.11801739926739926,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.512 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5852920642308588,
+          "transition_rate": 0.10754189944134078,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.585 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005823231943276982,
+            0.1648975265747676,
+            0.17250595240963765,
+            30.716076253742347,
+            1.1966989633694842e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0030707670131173417,
+            0.14014206461345993,
+            0.12730562554565786,
+            26.902533488053095,
+            1.249187574376975e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 65.82118031037135,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.10516772438803264
+        }
+      },
+      "model_kruskal_h": 65.82118031037135,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.03218495013599275,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 3107,
+          "pct": 0.7040561975980059
+        },
+        "ranging_volatile": {
+          "count": 962,
+          "pct": 0.21799229549059596
+        },
+        "trending_down_choppy": {
+          "count": 344,
+          "pct": 0.07795150691139814
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.49107326082495384,
+          "transition_rate": 0.10036945812807882,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.491 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.7040561975980059,
+          "transition_rate": 0.10516772438803264,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.704 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.7507122507122507,
+          "transition_rate": 0.060908281389136246,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.751 > 0.392",
+            "min_transition_rate: 0.0609 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5256953187592995,
+          "transition_rate": 0.13038003663003664,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.526 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.45310681871072844,
+          "transition_rate": 0.10963687150837989,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.453 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.007919757006644998,
+            0.1286161660137137,
+            0.09380284323584448,
+            24.007973243838727,
+            1.2490975543795587e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12202345338024273,
+            0.18376038878377868,
+            0.247012613973769,
+            39.81115439441036,
+            1.2488930270028344e-05
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.028257137381009673,
+            0.16500035857786302,
+            0.17674166028381166,
+            30.272397669085464,
+            1.2002233208165244e-05
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 108.76672544243047,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0038888888888888888,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.10879419764279238
+        }
+      },
+      "model_kruskal_h": 108.76672544243047,
+      "model_p_value": 0.0038888888888888888,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.028558476881233003,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1040,
+          "pct": 0.23566734647631996
+        },
+        "ranging_volatile": {
+          "count": 1915,
+          "pct": 0.4339451620213007
+        },
+        "trending_down_choppy": {
+          "count": 914,
+          "pct": 0.20711534103784274
+        },
+        "trending_up_choppy": {
+          "count": 544,
+          "pct": 0.1232721504645366
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5456597578493741,
+          "transition_rate": 0.09339080459770115,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.546 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.4339451620213007,
+          "transition_rate": 0.10879419764279238,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.434 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5671296296296297,
+          "transition_rate": 0.07764915405164738,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.567 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.4146732287970699,
+          "transition_rate": 0.13484432234432234,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.415 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.495927391203165,
+          "transition_rate": 0.11056797020484171,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.496 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0025334159366780682,
+            0.13295308102321934,
+            0.10551938043940132,
+            25.05513725919129,
+            1.2492191073634213e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13060895778691248,
+            0.1922130783272437,
+            0.26197885959437023,
+            41.86607492764555,
+            8.573628473264408e-06
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.16216205592474384,
+            0.21124414824240828,
+            0.32153674075364996,
+            37.61375044576883,
+            1.4596456130861306e-05
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005600476947110686,
+            0.13574058440829218,
+            0.0884455942609299,
+            23.848389308082655,
+            1.3197789166387958e-05
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 74.58769115457835,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.01611111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.13553943789664552
+        }
+      },
+      "model_kruskal_h": 74.58769115457835,
+      "model_p_value": 0.01611111111111111,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.0018132366273798661,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 744,
+          "pct": 0.16859279401767505
+        },
+        "ranging_directional_up": {
+          "count": 1871,
+          "pct": 0.42397462043961026
+        },
+        "ranging_volatile": {
+          "count": 685,
+          "pct": 0.1552232041694992
+        },
+        "trending_down_choppy": {
+          "count": 711,
+          "pct": 0.1611148878314072
+        },
+        "trending_up_choppy": {
+          "count": 402,
+          "pct": 0.09109449354180829
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.38785142622614405,
+          "transition_rate": 0.12027914614121511,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.42397462043961026,
+          "transition_rate": 0.13553943789664552,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.424 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.5498575498575499,
+          "transition_rate": 0.09243098842386464,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.550 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.2991873640837816,
+          "transition_rate": 0.16277472527472528,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3339539213404701,
+          "transition_rate": 0.14269087523277468,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "ranging_directional_up",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.002662285643756873,
+            0.12011293835883124,
+            0.07212871686908184,
+            22.111388225995217,
+            1.2490721478395221e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1215411710621634,
+            0.19062907311368338,
+            0.2421037547937322,
+            39.88094607147281,
+            3.7244491819734127e-06
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.012808000062454862,
+            0.17362232370090142,
+            0.2190521526543061,
+            34.97554337783483,
+            1.2493934336897458e-05
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.10286759076532156,
+          "centroid_raw": [
+            0.008377282588000499,
+            0.13547027418324253,
+            0.09027619331306484,
+            23.857287625201995,
+            1.3083288265336589e-05
+          ],
+          "volatility_rank": 1
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17438877963660418,
+            0.22532750017136166,
+            0.33828581871189023,
+            39.31534804338216,
+            1.7797487993285567e-05
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "3": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.10286759076532156
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 109.1732068200763,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0038888888888888888,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.13259292837715322
+        }
+      },
+      "model_kruskal_h": 109.1732068200763,
+      "model_p_value": 0.0038888888888888888,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.0047597461468721625,
+      "coverage": {
+        "ranging_directional": {
+          "count": 2018,
+          "pct": 0.45728529345116703
+        },
+        "ranging_directional_down": {
+          "count": 297,
+          "pct": 0.06730115567641061
+        },
+        "ranging_directional_up": {
+          "count": 396,
+          "pct": 0.08973487423521415
+        },
+        "ranging_volatile": {
+          "count": 503,
+          "pct": 0.11398141853614321
+        },
+        "trending_down_choppy": {
+          "count": 779,
+          "pct": 0.1765239066394743
+        },
+        "trending_up_choppy": {
+          "count": 420,
+          "pct": 0.09517335146159075
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.2909911758670224,
+          "transition_rate": 0.1405993431855501,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.45728529345116703,
+          "transition_rate": 0.13259292837715322,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.457 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.5795940170940171,
+          "transition_rate": 0.08833481745325023,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.580 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.32104841478768453,
+          "transition_rate": 0.17616758241758243,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.2650686525482895,
+          "transition_rate": 0.16038175046554934,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_directional",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.47207470448878364,
+          "centroid_raw": [
+            0.0913896675222253,
+            0.1535378192708234,
+            0.1902914953120916,
+            28.209013072716683,
+            1.24918641943409e-05
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.38468024633880044,
+          "centroid_raw": [
+            -0.08372726254327184,
+            0.1581822551535291,
+            0.1733032800678975,
+            32.27947553176232,
+            1.2492383702898347e-05
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.14076999479271393,
+            0.19867404296360233,
+            0.27991830525708206,
+            42.87129258146703,
+            7.272513173808918e-06
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.08413637460847327,
+          "centroid_raw": [
+            0.005047884113392871,
+            0.13763962790604972,
+            0.09461425358321693,
+            24.31846042413721,
+            1.2958665450730447e-05
+          ],
+          "volatility_rank": 1
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.000877560070678856,
+            0.11752601019523143,
+            0.05104126683554466,
+            21.949761633926695,
+            1.249004188816237e-05
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17509810228227474,
+            0.22237833704448332,
+            0.3422047516332706,
+            39.0777080944938,
+            1.5288537082004745e-05
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.47207470448878364
+          },
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.38468024633880044
+          },
+          "3": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.08413637460847327
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 98.9793851566119,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.006111111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.17089755213055305
+        }
+      },
+      "model_kruskal_h": 98.9793851566119,
+      "model_p_value": 0.006111111111111111,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.03354487760652766,
+      "coverage": {
+        "ranging_directional": {
+          "count": 297,
+          "pct": 0.06730115567641061
+        },
+        "ranging_directional_down": {
+          "count": 1170,
+          "pct": 0.26512576478586
+        },
+        "ranging_directional_up": {
+          "count": 525,
+          "pct": 0.11896668932698844
+        },
+        "ranging_volatile": {
+          "count": 1082,
+          "pct": 0.24518468162247903
+        },
+        "trending_down_choppy": {
+          "count": 672,
+          "pct": 0.15227736233854522
+        },
+        "trending_up_choppy": {
+          "count": 403,
+          "pct": 0.09132109675957399
+        },
+        "trending_up_clean": {
+          "count": 264,
+          "pct": 0.05982324949014276
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.3010465832136261,
+          "transition_rate": 0.1615353037766831,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.26512576478586,
+          "transition_rate": 0.17089755213055305,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.3579059829059829,
+          "transition_rate": 0.1292965271593945,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.2384113540116745,
+          "transition_rate": 0.19963369963369965,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.2732138701419595,
+          "transition_rate": 0.1841247672253259,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional",
+        "trending_up_clean",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005843684668453983,
+            0.12422729546568657,
+            0.0534207115742925,
+            21.32386242026627,
+            1.0055562862810366e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.26415669222883104,
+          "centroid_raw": [
+            0.0008951474811675947,
+            0.11796889814582336,
+            0.05310523855354783,
+            22.065595501461342,
+            1.2491012617910456e-05
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.972613834633729,
+          "centroid_raw": [
+            -0.08527498478572501,
+            0.1592586804960217,
+            0.17648008393700831,
+            32.56390322256271,
+            1.2492779089074104e-05
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.3352625242223053,
+          "centroid_raw": [
+            0.18596351450582663,
+            0.23197090762548203,
+            0.3610963433347527,
+            40.38637540955899,
+            1.5222269748600865e-05
+          ],
+          "volatility_rank": 6
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0005225055495108225,
+            0.15802136767740757,
+            0.15843246689291357,
+            29.29824101691152,
+            1.4565549486040906e-05
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.09357421494785007,
+            0.1551491457625171,
+            0.19464029574589095,
+            28.500762111457497,
+            1.2491590597644227e-05
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.15080425677099873,
+            0.2043192330179528,
+            0.29796543013337984,
+            44.39216244303837,
+            8.345056034056093e-06
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.26415669222883104
+          },
+          "2": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.972613834633729
+          },
+          "3": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.3352625242223053
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 51.59635348647862,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.015555555555555555,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.028785131459655486
+        }
+      },
+      "model_kruskal_h": 51.59635348647862,
+      "model_p_value": 0.015555555555555555,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.1085675430643699,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1853,
+          "pct": 0.4198957625198278
+        },
+        "ranging_volatile": {
+          "count": 2560,
+          "pct": 0.5801042374801723
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6269238662015185,
+          "transition_rate": 0.032430213464696225,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.627 > 0.392",
+            "min_transition_rate: 0.0324 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5801042374801723,
+          "transition_rate": 0.028785131459655486,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.580 > 0.392",
+            "min_transition_rate: 0.0288 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5085470085470085,
+          "transition_rate": 0.04630454140694568,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.509 > 0.392",
+            "min_transition_rate: 0.0463 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5012017855099005,
+          "transition_rate": 0.048191391941391944,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.501 > 0.392",
+            "min_transition_rate: 0.0482 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5771468466371887,
+          "transition_rate": 0.037011173184357544,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.577 > 0.392",
+            "min_transition_rate: 0.0370 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.007604631459789008,
+            0.19052113399259707,
+            0.24976949410195054,
+            38.7509148774403,
+            1.3018035266272255e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.004124364108160889,
+            0.1267200943339431,
+            0.08661660378338801,
+            22.664626732064427,
+            1.1929952340559215e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 78.20091668304485,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.017222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.04215775158658205
+        }
+      },
+      "model_kruskal_h": 78.20091668304485,
+      "model_p_value": 0.017222222222222222,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.09519492293744333,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2390,
+          "pct": 0.5415816904600045
+        },
+        "trending_down_choppy": {
+          "count": 1184,
+          "pct": 0.26829820983457964
+        },
+        "trending_up_choppy": {
+          "count": 839,
+          "pct": 0.19012009970541582
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5959367945823928,
+          "transition_rate": 0.04043513957307061,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.596 > 0.392",
+            "min_transition_rate: 0.0404 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5415816904600045,
+          "transition_rate": 0.04215775158658205,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.542 > 0.392",
+            "min_transition_rate: 0.0422 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5016025641025641,
+          "transition_rate": 0.061086375779162955,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.502 > 0.392",
+            "min_transition_rate: 0.0611 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4796841020945405,
+          "transition_rate": 0.059065934065934064,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.480 > 0.392",
+            "min_transition_rate: 0.0591 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5613218524552013,
+          "transition_rate": 0.048417132216014895,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.561 > 0.392",
+            "min_transition_rate: 0.0484 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006129540000088855,
+            0.12544009431400055,
+            0.08105066234317512,
+            22.48503633447281,
+            1.2019823793787227e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11118333328501986,
+            0.18166472264981437,
+            0.22475072866160462,
+            38.87152347453755,
+            1.0753210733944953e-05
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1359549128528872,
+            0.19515786476878016,
+            0.2742054113384724,
+            35.95888044342744,
+            1.569422906208718e-05
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 78.85713134735124,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.017222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.07162284678150499
+        }
+      },
+      "model_kruskal_h": 78.85713134735124,
+      "model_p_value": 0.017222222222222222,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.0657298277425204,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1551,
+          "pct": 0.3514615907545887
+        },
+        "ranging_volatile": {
+          "count": 1356,
+          "pct": 0.30727396329027873
+        },
+        "trending_down_choppy": {
+          "count": 897,
+          "pct": 0.20326308633582596
+        },
+        "trending_up_choppy": {
+          "count": 609,
+          "pct": 0.1380013596193066
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3868253642520008,
+          "transition_rate": 0.06670771756978654,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0667 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3514615907545887,
+          "transition_rate": 0.07162284678150499,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.380519943019943,
+          "transition_rate": 0.07853962600178094,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3115485864713288,
+          "transition_rate": 0.08825549450549451,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.37049104026064694,
+          "transition_rate": 0.07960893854748603,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.003991322636565949,
+            0.1490156481519237,
+            0.12301158391356881,
+            29.1810784787515,
+            9.114007395069967e-06
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12517785537576342,
+            0.18839660355440085,
+            0.25242592360494553,
+            41.46073673801311,
+            1.0025462579013906e-05
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1479231285513661,
+            0.20294053780910634,
+            0.29720974566992936,
+            36.829676487610776,
+            1.656024769736842e-05
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.007777709330824391,
+            0.11619296930406725,
+            0.06730779345247091,
+            19.585336122753937,
+            1.4340912975164849e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 102.05779337544118,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.007222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08499546690843154
+        }
+      },
+      "model_kruskal_h": 102.05779337544118,
+      "model_p_value": 0.007222222222222222,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.05235720761559384,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1498,
+          "pct": 0.339451620213007
+        },
+        "ranging_directional_up": {
+          "count": 182,
+          "pct": 0.041241785633355996
+        },
+        "ranging_volatile": {
+          "count": 1267,
+          "pct": 0.2871062769091321
+        },
+        "trending_down_choppy": {
+          "count": 853,
+          "pct": 0.19329254475413551
+        },
+        "trending_up_choppy": {
+          "count": 613,
+          "pct": 0.13890777249036937
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.39092961214857375,
+          "transition_rate": 0.07471264367816093,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.339451620213007,
+          "transition_rate": 0.08499546690843154,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.39351851851851855,
+          "transition_rate": 0.09207479964381123,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.394 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.25134485521346,
+          "transition_rate": 0.12053571428571429,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.35280428205724923,
+          "transition_rate": 0.0893854748603352,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "ranging_directional_up",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.01181474881119112,
+            0.11664109608339576,
+            0.06944302825295973,
+            19.70748407665026,
+            1.1865194246031756e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12828557316021696,
+            0.19015620770254088,
+            0.25774796216766077,
+            41.85218783123385,
+            9.491957687074843e-06
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0164391408822773,
+            0.15082382888964724,
+            0.12208182050688035,
+            30.12254886999107,
+            9.431820575221245e-06
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.015021733647454101,
+            0.15207358757148523,
+            0.13769343043902432,
+            27.442303068827673,
+            5.432950903225807e-05
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14846234497486674,
+            0.2002111232389437,
+            0.29702744255031865,
+            36.07066093809371,
+            1.2874099509001654e-05
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 94.56864879267232,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.013888888888888888,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.09678150498640073
+        }
+      },
+      "model_kruskal_h": 94.56864879267232,
+      "model_p_value": 0.013888888888888888,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.04057116953762466,
+      "coverage": {
+        "ranging_directional": {
+          "count": 874,
+          "pct": 0.19805121232721504
+        },
+        "ranging_directional_down": {
+          "count": 849,
+          "pct": 0.19238613188307274
+        },
+        "ranging_directional_up": {
+          "count": 198,
+          "pct": 0.04486743711760707
+        },
+        "ranging_volatile": {
+          "count": 1398,
+          "pct": 0.3167912984364378
+        },
+        "trending_down_choppy": {
+          "count": 776,
+          "pct": 0.1758440969861772
+        },
+        "trending_up_choppy": {
+          "count": 318,
+          "pct": 0.07205982324949015
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.38846706341063,
+          "transition_rate": 0.09441707717569786,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.3167912984364378,
+          "transition_rate": 0.09678150498640073,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.37589031339031337,
+          "transition_rate": 0.10097951914514693,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.2522605013162413,
+          "transition_rate": 0.1308379120879121,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.34954619501978124,
+          "transition_rate": 0.1059124767225326,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.0642223042937597,
+          "centroid_raw": [
+            0.09330685784605888,
+            0.15773854957037237,
+            0.19290861821172822,
+            28.52902926329717,
+            1.1013742009685231e-05
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.15415148659836533,
+          "centroid_raw": [
+            -0.06351540067217201,
+            0.15476754384336427,
+            0.13387010176343708,
+            30.493831879421556,
+            9.616898437500019e-06
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13476958069226055,
+            0.19510948606774206,
+            0.2702969061687388,
+            43.643643747930426,
+            9.563369360269365e-06
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009611148744759095,
+            0.14949762264331248,
+            0.12991558884201876,
+            26.9019369663364,
+            5.486297414965986e-05
+          ],
+          "volatility_rank": 1
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.007077015310359053,
+            0.1165924092386643,
+            0.0593695619673822,
+            20.43195397158093,
+            1.1538954600301662e-05
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18023357716761523,
+            0.22792929229757075,
+            0.35373917900697194,
+            42.05401175845568,
+            1.478492730375428e-05
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 1.0642223042937597
+          },
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.15415148659836533
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 127.99831649659245,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0022222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.11423390752493201
+        }
+      },
+      "model_kruskal_h": 127.99831649659245,
+      "model_p_value": 0.0022222222222222222,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.023118766999093376,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1093,
+          "pct": 0.24767731701790166
+        },
+        "ranging_directional_down": {
+          "count": 548,
+          "pct": 0.12417856333559936
+        },
+        "ranging_directional_up": {
+          "count": 78,
+          "pct": 0.017675050985723997
+        },
+        "ranging_volatile": {
+          "count": 962,
+          "pct": 0.21799229549059596
+        },
+        "trending_down_choppy": {
+          "count": 751,
+          "pct": 0.1701790165420349
+        },
+        "trending_up_choppy": {
+          "count": 671,
+          "pct": 0.1520507591207795
+        },
+        "trending_up_clean": {
+          "count": 310,
+          "pct": 0.0702469975073646
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.3747178329571106,
+          "transition_rate": 0.1007799671592775,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.24767731701790166,
+          "transition_rate": 0.11423390752493201,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.33262108262108264,
+          "transition_rate": 0.1093499554764025,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.26301934302392127,
+          "transition_rate": 0.14526098901098902,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.32650686525482897,
+          "transition_rate": 0.11592178770949721,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_up_clean",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.08223253190802693,
+          "centroid_raw": [
+            0.005937206462228185,
+            0.1408169916034539,
+            0.0865214107331545,
+            24.48174848135755,
+            -4.442928571428578e-06
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0065852171360181585,
+            0.11659724609580865,
+            0.061833361005573045,
+            20.452693563798007,
+            1.3450249458483687e-05
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.2296361817671326,
+          "centroid_raw": [
+            -0.07013360411824553,
+            0.155644261065367,
+            0.145364155753985,
+            31.29612578384596,
+            1.1763379434167573e-05
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.379078370619093,
+          "centroid_raw": [
+            0.18210150739360656,
+            0.22992394221198592,
+            0.3565383023697811,
+            42.32221739668575,
+            1.410685709090908e-05
+          ],
+          "volatility_rank": 6
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.01551326551691984,
+            0.16576930084665445,
+            0.1584417273866739,
+            30.12500165338281,
+            6.468154270833335e-05
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.09715288997436569,
+            0.16040059842680363,
+            0.20079383026237058,
+            29.21514587495744,
+            1.2480402122015906e-05
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1369229596579905,
+            0.19712326195651747,
+            0.2742097218774999,
+            44.34290850793343,
+            9.337890310786112e-06
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.08223253190802693
+          },
+          "2": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.2296361817671326
+          },
+          "3": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.379078370619093
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 42.25623155836547,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.012777777777777779,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.08499546690843154
+        }
+      },
+      "model_kruskal_h": 42.25623155836547,
+      "model_p_value": 0.012777777777777779,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.05235720761559384,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2341,
+          "pct": 0.5304781327894856
+        },
+        "ranging_volatile": {
+          "count": 2072,
+          "pct": 0.46952186721051437
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5243176687871948,
+          "transition_rate": 0.08087027914614121,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.524 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5304781327894856,
+          "transition_rate": 0.08499546690843154,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.530 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5021824029405008,
+          "transition_rate": 0.07696726019529006,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.502 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5291289916447293,
+          "transition_rate": 0.08562271062271062,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.529 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5026762857807773,
+          "transition_rate": 0.07844506517690875,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.503 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0054107931026439685,
+            0.1782324219870699,
+            0.2204350761131032,
+            35.485750550334316,
+            0.39306159281381653
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00485525845663413,
+            0.12305599153512663,
+            0.07541198606585983,
+            21.88717223001445,
+            -0.24254456707524633
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 83.76485598639556,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.21940163191296463
+        }
+      },
+      "model_kruskal_h": 83.76485598639556,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.08204895738893925,
+      "coverage": {
+        "ranging_directional": {
+          "count": 955,
+          "pct": 0.21640607296623612
+        },
+        "ranging_directional_down": {
+          "count": 1609,
+          "pct": 0.36460457738499885
+        },
+        "ranging_volatile": {
+          "count": 1849,
+          "pct": 0.418989349648765
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4717832957110609,
+          "transition_rate": 0.19068144499178982,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.472 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.418989349648765,
+          "transition_rate": 0.21940163191296463,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.419 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.44704801286469104,
+          "transition_rate": 0.20964962665134979,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.447 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.41432986150852696,
+          "transition_rate": 0.22641941391941392,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.414 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.44728880614382127,
+          "transition_rate": 0.20926443202979517,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.447 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_down",
+        "ranging_directional"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006332780027042223,
+            0.1218846637655425,
+            0.07156814977780115,
+            21.61221470400534,
+            -0.3211838476589461
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.008508132886427846,
+            0.18397249634805946,
+            0.23092199112707218,
+            36.68122365309547,
+            -0.3871463657389423
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": true,
+          "displacement_z": 0.011865058877084545,
+          "centroid_raw": [
+            -0.0010402820515154829,
+            0.15626019911044398,
+            0.17195468451260046,
+            30.39268152240163,
+            1.6652511184454308
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.011865058877084545
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 82.60886177121938,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.006666666666666667,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.12216681776971895
+        }
+      },
+      "model_kruskal_h": 82.60886177121938,
+      "model_p_value": 0.006666666666666667,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.015185856754306434,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1383,
+          "pct": 0.3133922501699524
+        },
+        "ranging_volatile": {
+          "count": 1215,
+          "pct": 0.27532290958531613
+        },
+        "trending_down_choppy": {
+          "count": 1035,
+          "pct": 0.2345343303874915
+        },
+        "trending_up_choppy": {
+          "count": 780,
+          "pct": 0.17675050985723997
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.33921608865175457,
+          "transition_rate": 0.10796387520525452,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3133922501699524,
+          "transition_rate": 0.12216681776971895,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.34091431196875716,
+          "transition_rate": 0.10591614014933946,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.32585555682728623,
+          "transition_rate": 0.11893315018315018,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3374447288806144,
+          "transition_rate": 0.11987895716945997,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.00016414492421066388,
+            0.14293438084469626,
+            0.11735564897029876,
+            26.36054672139753,
+            -0.3685341282575701
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11909178795629934,
+            0.18470609784412909,
+            0.24036108388984306,
+            39.922496926358214,
+            0.3432843827486749
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.13558539127823077,
+            0.19203886807578127,
+            0.27244284981177025,
+            35.17173457458591,
+            0.35281865977835575
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0027043985269420675,
+            0.11358517645866661,
+            0.05201609007281367,
+            20.176102712382338,
+            0.1876138207729863
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 102.45049082055266,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0022222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.21532184950135994
+        }
+      },
+      "model_kruskal_h": 102.45049082055266,
+      "model_p_value": 0.0022222222222222222,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.07796917497733455,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 661,
+          "pct": 0.1497847269431226
+        },
+        "ranging_directional_up": {
+          "count": 1377,
+          "pct": 0.31203263086335825
+        },
+        "ranging_volatile": {
+          "count": 994,
+          "pct": 0.2252435984590981
+        },
+        "trending_down_choppy": {
+          "count": 812,
+          "pct": 0.18400181282574213
+        },
+        "trending_up_choppy": {
+          "count": 569,
+          "pct": 0.1289372309086789
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.3217730350913195,
+          "transition_rate": 0.19930213464696223,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.31203263086335825,
+          "transition_rate": 0.21532184950135994,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.28233402251320927,
+          "transition_rate": 0.20413555427914992,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3090305596886803,
+          "transition_rate": 0.21119505494505494,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.32790318827088666,
+          "transition_rate": 0.21135940409683426,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.007058298766270132,
+            0.1440715787536963,
+            0.13548231570192748,
+            27.583490659606934,
+            2.0049515978930645
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1264078399312074,
+            0.18981001012758175,
+            0.2553730735570897,
+            41.22079610173396,
+            -0.19029942611209064
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0010442031485267031,
+            0.14405312423799116,
+            0.12746152120763013,
+            26.538699281880778,
+            -0.4014395321630921
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0028174101308796324,
+            0.11326187729045303,
+            0.042648278608770296,
+            20.29889071990365,
+            -0.2874232664556113
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1499056259211001,
+            0.2030634316380972,
+            0.29916767267044414,
+            36.936056026728835,
+            -0.07487426886635615
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 126.81317284392571,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.20308250226654578
+        }
+      },
+      "model_kruskal_h": 126.81317284392571,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.0657298277425204,
+      "coverage": {
+        "ranging_directional": {
+          "count": 643,
+          "pct": 0.14570586902334012
+        },
+        "ranging_directional_down": {
+          "count": 532,
+          "pct": 0.12055291185134828
+        },
+        "ranging_directional_up": {
+          "count": 783,
+          "pct": 0.17743031951053706
+        },
+        "ranging_volatile": {
+          "count": 1114,
+          "pct": 0.2524359845909812
+        },
+        "trending_down_choppy": {
+          "count": 777,
+          "pct": 0.1760707002039429
+        },
+        "trending_up_choppy": {
+          "count": 564,
+          "pct": 0.12780421481985044
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.3010465832136261,
+          "transition_rate": 0.2044334975369458,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.2524359845909812,
+          "transition_rate": 0.20308250226654578,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.29807029634734666,
+          "transition_rate": 0.20298678920160826,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.246308801648163,
+          "transition_rate": 0.21142399267399267,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.2846171747730975,
+          "transition_rate": 0.22206703910614525,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.2400698152425573,
+          "centroid_raw": [
+            0.069721597426732,
+            0.1374742314605966,
+            0.1454148021586286,
+            24.068145710273733,
+            -0.3115807011102513
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.7697247293161009,
+          "centroid_raw": [
+            -0.06748645993334564,
+            0.1531081894317299,
+            0.1394487427823104,
+            29.77982501506845,
+            -0.3963891477761488
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13566117555555665,
+            0.1942227789464182,
+            0.27278622216297027,
+            42.60434177197266,
+            -0.06637851179212456
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.000911236690811066,
+            0.11675544295098808,
+            0.040735424946735266,
+            21.105467848698066,
+            -0.31826200702971547
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.012022829831905604,
+            0.1410054963053166,
+            0.12247092753182917,
+            27.088870012486048,
+            2.1691656786981106
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1525403344259837,
+            0.20465183545940197,
+            0.3039191123524573,
+            37.144338576209556,
+            -0.0018512205885163058
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.2400698152425573
+          },
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.7697247293161009
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 165.55203122345847,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.2042157751586582
+        }
+      },
+      "model_kruskal_h": 165.55203122345847,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.06686310063463283,
+      "coverage": {
+        "ranging_directional": {
+          "count": 491,
+          "pct": 0.11126217992295491
+        },
+        "ranging_directional_down": {
+          "count": 557,
+          "pct": 0.1262179922954906
+        },
+        "ranging_directional_up": {
+          "count": 764,
+          "pct": 0.1731248583729889
+        },
+        "ranging_volatile": {
+          "count": 763,
+          "pct": 0.1728982551552232
+        },
+        "trending_down_choppy": {
+          "count": 547,
+          "pct": 0.12395196011783367
+        },
+        "trending_down_clean": {
+          "count": 762,
+          "pct": 0.1726716519374575
+        },
+        "trending_up_choppy": {
+          "count": 529,
+          "pct": 0.11987310219805121
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.20357069567001848,
+          "transition_rate": 0.20853858784893267,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.1731248583729889,
+          "transition_rate": 0.2042157751586582,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.19722030783367792,
+          "transition_rate": 0.21355542791499138,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.1839304108961886,
+          "transition_rate": 0.21943681318681318,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.1999069117989295,
+          "transition_rate": 0.2169459962756052,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional",
+        "ranging_directional_down",
+        "trending_down_clean",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.004830553954339846,
+            0.10793852636247464,
+            0.04642745875774999,
+            18.325359588671766,
+            -0.2774132853799565
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": true,
+          "displacement_z": 0.038148833842680155,
+          "centroid_raw": [
+            -0.0033447408515968552,
+            0.13413048600534483,
+            0.10505978091922258,
+            25.75932806082733,
+            1.9200322226870825
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.01081732851231775,
+            0.13856343255963274,
+            0.047199523432547616,
+            27.8216580568751,
+            -0.3913991110612428
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_clean",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 2.1201433775261105,
+          "centroid_raw": [
+            -0.13990860356973048,
+            0.19586349453436397,
+            0.2794473652553776,
+            42.24297974543726,
+            0.3960064099057716
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.26759073239144593,
+          "centroid_raw": [
+            0.0734579881257146,
+            0.14051276426023815,
+            0.15302910549667914,
+            24.94997256101409,
+            -0.3176095835313854
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.07866989975537447,
+            0.15761164681909104,
+            0.16307104302640998,
+            30.69338717879952,
+            -0.39473031314148166
+          ],
+          "volatility_rank": 4
+        },
+        "6": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1546108247042533,
+            0.20589388833344785,
+            0.3082361082630817,
+            37.03555715917008,
+            0.11289930295353004
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.038148833842680155
+          },
+          "3": {
+            "from": "trending_down_choppy",
+            "to": "trending_down_clean",
+            "displacement_z": 2.1201433775261105
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.26759073239144593
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 65.76737026213414,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0011111111111111111,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.1214868540344515
+        }
+      },
+      "model_kruskal_h": 65.76737026213414,
+      "model_p_value": 0.0011111111111111111,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.015865820489573884,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2356,
+          "pct": 0.533877181055971
+        },
+        "ranging_volatile": {
+          "count": 2057,
+          "pct": 0.466122818944029
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5259593679458239,
+          "transition_rate": 0.11576354679802955,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.526 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.533877181055971,
+          "transition_rate": 0.1214868540344515,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.534 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5134390075809786,
+          "transition_rate": 0.12130959218839747,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.513 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5363397047041318,
+          "transition_rate": 0.12522893772893773,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.536 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5012799627647195,
+          "transition_rate": 0.11568901303538175,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.501 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.003705211201014776,
+            0.1753710721408313,
+            0.21682775697217294,
+            34.672097990089206,
+            0.5018189115986702
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0033552212492258117,
+            0.12558914742842478,
+            0.07863862550956413,
+            22.60658297496903,
+            -0.33762969379878305
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 86.72515965469029,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.23390752493200362
+        }
+      },
+      "model_kruskal_h": 86.72515965469029,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.09655485040797823,
+      "coverage": {
+        "ranging_directional": {
+          "count": 955,
+          "pct": 0.21640607296623612
+        },
+        "ranging_directional_down": {
+          "count": 1640,
+          "pct": 0.37162927713573535
+        },
+        "ranging_volatile": {
+          "count": 1818,
+          "pct": 0.41196464989802856
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.46644777344551613,
+          "transition_rate": 0.20320197044334976,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.466 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.41196464989802856,
+          "transition_rate": 0.23390752493200362,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.412 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.4405008040431886,
+          "transition_rate": 0.22917863296955773,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.441 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4076914272633627,
+          "transition_rate": 0.24358974358974358,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.408 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.44472888061438215,
+          "transition_rate": 0.22672253258845437,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.445 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_down",
+        "ranging_directional"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0049439957436726726,
+            0.12215366781419468,
+            0.069064245079174,
+            21.87422444662534,
+            -0.33165059835736094
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.006295466733469249,
+            0.1808699597222428,
+            0.22868090756654663,
+            35.83447375574681,
+            -0.391227976358501
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": true,
+          "displacement_z": 0.007675485055810951,
+          "centroid_raw": [
+            -0.0006729565713033714,
+            0.15728526340576948,
+            0.17240074775402045,
+            30.340479433526035,
+            1.6929308892512984
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.007675485055810951
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 85.1409067865643,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.005,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.15684496826835903
+        }
+      },
+      "model_kruskal_h": 85.1409067865643,
+      "model_p_value": 0.005,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.019492293744333644,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1429,
+          "pct": 0.32381599818717427
+        },
+        "ranging_volatile": {
+          "count": 1270,
+          "pct": 0.2877860865624292
+        },
+        "trending_down_choppy": {
+          "count": 988,
+          "pct": 0.22388397915250396
+        },
+        "trending_up_choppy": {
+          "count": 726,
+          "pct": 0.16451393609789258
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.35337574389493126,
+          "transition_rate": 0.1481937602627258,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.32381599818717427,
+          "transition_rate": 0.15684496826835903,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.370434183321847,
+          "transition_rate": 0.1514072372199885,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.32619892411582924,
+          "transition_rate": 0.15396062271062272,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.36141494065627183,
+          "transition_rate": 0.15758845437616387,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.00019620787081995198,
+            0.14186004285305484,
+            0.11938759410565326,
+            26.517919696060716,
+            -0.4077277861299529
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12452350077966721,
+            0.18768138160316158,
+            0.2506042538232307,
+            40.38753771992026,
+            0.4431032765975037
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1411961391186137,
+            0.1955931366812646,
+            0.2829577320819609,
+            35.45947843628754,
+            0.4459294083001553
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0022001789970537804,
+            0.11589091042023866,
+            0.05364267097836997,
+            20.74099888184009,
+            0.32843998833733207
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 107.8221828444548,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.2540797824116047
+        }
+      },
+      "model_kruskal_h": 107.8221828444548,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.11672710788757934,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 778,
+          "pct": 0.1762973034217086
+        },
+        "ranging_directional_up": {
+          "count": 1399,
+          "pct": 0.3170179016542035
+        },
+        "ranging_volatile": {
+          "count": 1033,
+          "pct": 0.23408112395196012
+        },
+        "trending_down_choppy": {
+          "count": 738,
+          "pct": 0.1672331747110809
+        },
+        "trending_up_choppy": {
+          "count": 465,
+          "pct": 0.1053704962610469
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.32464600861892057,
+          "transition_rate": 0.2395320197044335,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.3170179016542035,
+          "transition_rate": 0.2540797824116047,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.28405697220307835,
+          "transition_rate": 0.2530729465824239,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.30559688680325053,
+          "transition_rate": 0.2557234432234432,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3383756108913195,
+          "transition_rate": 0.2532588454376164,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.001222206528599256,
+            0.1484632061050328,
+            0.1488005130350307,
+            28.423934099378112,
+            1.9243952426215445
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1301889515577073,
+            0.19088864645128356,
+            0.2632225798256184,
+            41.700310424266306,
+            -0.23244334982435763
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0022445617285649813,
+            0.143686991730312,
+            0.1350552292813441,
+            26.736981186035997,
+            -0.40749977811942445
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0012436942771718597,
+            0.11631025523936103,
+            0.037547368547097504,
+            20.9572952979064,
+            -0.3006418505457218
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.15747255303812177,
+            0.207832392849934,
+            0.3129905631760901,
+            37.06890044591893,
+            -0.22192115760982703
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 112.1905908468234,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.2454669084315503
+        }
+      },
+      "model_kruskal_h": 112.1905908468234,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.10811423390752492,
+      "coverage": {
+        "ranging_directional": {
+          "count": 602,
+          "pct": 0.13641513709494674
+        },
+        "ranging_directional_down": {
+          "count": 661,
+          "pct": 0.1497847269431226
+        },
+        "ranging_directional_up": {
+          "count": 760,
+          "pct": 0.17221844550192614
+        },
+        "ranging_volatile": {
+          "count": 1196,
+          "pct": 0.271017448447768
+        },
+        "trending_down_choppy": {
+          "count": 706,
+          "pct": 0.15998187174257875
+        },
+        "trending_up_choppy": {
+          "count": 488,
+          "pct": 0.11058237026965782
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.3143853888774882,
+          "transition_rate": 0.23399014778325122,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.271017448447768,
+          "transition_rate": 0.2454669084315503,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.3136917068688261,
+          "transition_rate": 0.23653072946582424,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.27000114455762847,
+          "transition_rate": 0.24565018315018314,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.3090528275541075,
+          "transition_rate": 0.24371508379888268,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.2518614670708566,
+          "centroid_raw": [
+            0.07190715308971483,
+            0.1388890018122834,
+            0.14983684962582405,
+            24.648386122954385,
+            -0.3505234497491322
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.8258689590142336,
+          "centroid_raw": [
+            -0.07240896685523976,
+            0.15488203887127244,
+            0.14982002501027533,
+            30.457732632330814,
+            -0.4129503346185499
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13928537550279588,
+            0.19534165097604478,
+            0.27971573455185794,
+            42.60582752195801,
+            -0.14029043159168358
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00027401458771975757,
+            0.11888524219039613,
+            0.04199425535086093,
+            21.613439839738433,
+            -0.3277083331863043
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.007599573514279505,
+            0.1448205428927709,
+            0.1349663480339637,
+            27.812374770673745,
+            2.076383262017738
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1564723204236687,
+            0.20644447601241672,
+            0.3112571163035658,
+            37.014347651455935,
+            -0.12959628256270517
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.2518614670708566
+          },
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.8258689590142336
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 107.40465933865744,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.27810516772438804
+        }
+      },
+      "model_kruskal_h": 107.40465933865744,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.14075249320036265,
+      "coverage": {
+        "ranging_directional": {
+          "count": 685,
+          "pct": 0.1552232041694992
+        },
+        "ranging_directional_down": {
+          "count": 570,
+          "pct": 0.12916383412644458
+        },
+        "ranging_directional_up": {
+          "count": 753,
+          "pct": 0.17063222297756628
+        },
+        "ranging_volatile": {
+          "count": 831,
+          "pct": 0.18830727396329028
+        },
+        "trending_down_choppy": {
+          "count": 457,
+          "pct": 0.10355767051892137
+        },
+        "trending_down_clean": {
+          "count": 615,
+          "pct": 0.13936097892590074
+        },
+        "trending_up_choppy": {
+          "count": 502,
+          "pct": 0.11375481531837751
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.2308639441822286,
+          "transition_rate": 0.2723727422003284,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.18830727396329028,
+          "transition_rate": 0.27810516772438804,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.244543992648748,
+          "transition_rate": 0.2707639287765652,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.1929724161611537,
+          "transition_rate": 0.27850274725274726,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.21805911100767977,
+          "transition_rate": 0.28049348230912474,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional",
+        "ranging_directional_down",
+        "trending_down_clean",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.003983280890632539,
+            0.11444206026814391,
+            0.032869867332448705,
+            20.08250450619047,
+            -0.25201365063363296
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": true,
+          "displacement_z": 0.05544765839004477,
+          "centroid_raw": [
+            -0.004861434268406997,
+            0.14750017191601997,
+            0.14502243591619457,
+            28.385959885267077,
+            2.143247909656711
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.02286555772735001,
+            0.13540514519357824,
+            0.07425470230729386,
+            26.540140782406475,
+            -0.42588207705122694
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_clean",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 2.0169512121570423,
+          "centroid_raw": [
+            -0.14493451934018456,
+            0.19887059497346823,
+            0.29018215998596203,
+            43.06906915695208,
+            -0.11015991186778457
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.2448873720148283,
+          "centroid_raw": [
+            0.07016973043704515,
+            0.13694451021253579,
+            0.14625117593853415,
+            24.06743267333092,
+            -0.3405144860221616
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.08673196184605056,
+            0.16106322663915085,
+            0.18017495648496062,
+            32.37343875995492,
+            -0.4003242893832437
+          ],
+          "volatility_rank": 4
+        },
+        "6": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.15383887019304202,
+            0.20470594205217701,
+            0.3060974736516455,
+            36.66858760120195,
+            -0.21470547267294307
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.05544765839004477
+          },
+          "3": {
+            "from": "trending_down_choppy",
+            "to": "trending_down_clean",
+            "displacement_z": 2.0169512121570423
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.2448873720148283
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 48.210752098189914,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.017222222222222222,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.034224841341795105
+        }
+      },
+      "model_kruskal_h": 48.210752098189914,
+      "model_p_value": 0.017222222222222222,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.10312783318223029,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1867,
+          "pct": 0.42306820756854746
+        },
+        "ranging_volatile": {
+          "count": 2546,
+          "pct": 0.5769317924314525
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6207674943566591,
+          "transition_rate": 0.035303776683087026,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.621 > 0.392",
+            "min_transition_rate: 0.0353 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5769317924314525,
+          "transition_rate": 0.034224841341795105,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.577 > 0.392",
+            "min_transition_rate: 0.0342 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6134849529060418,
+          "transition_rate": 0.033199310740953475,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.613 > 0.392",
+            "min_transition_rate: 0.0332 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5725077257639922,
+          "transition_rate": 0.03743131868131868,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.573 > 0.392",
+            "min_transition_rate: 0.0374 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5966953688619967,
+          "transition_rate": 0.03468342644320298,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.597 > 0.392",
+            "min_transition_rate: 0.0347 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0067150704852833015,
+            0.1902987602378494,
+            0.2501022916631217,
+            38.731517955073315,
+            0.1646670550531507
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0036618358870494742,
+            0.12677829422319212,
+            0.0862855078896715,
+            22.65977771481008,
+            -0.004069080096298271
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 51.140460575386896,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0077777777777777776,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.1455122393472348
+        }
+      },
+      "model_kruskal_h": 51.140460575386896,
+      "model_p_value": 0.0077777777777777776,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.008159564823209425,
+      "coverage": {
+        "ranging_directional": {
+          "count": 402,
+          "pct": 0.09109449354180829
+        },
+        "ranging_directional_down": {
+          "count": 1696,
+          "pct": 0.3843190573306141
+        },
+        "ranging_volatile": {
+          "count": 2315,
+          "pct": 0.5245864491275776
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5672070593063822,
+          "transition_rate": 0.14080459770114942,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.567 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5245864491275776,
+          "transition_rate": 0.1455122393472348,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.525 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5574316563289685,
+          "transition_rate": 0.13130384836300976,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.557 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5229483804509557,
+          "transition_rate": 0.14445970695970695,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.523 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5471259017919479,
+          "transition_rate": 0.14013035381750466,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.547 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_down",
+        "ranging_directional"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0033147714512257245,
+            0.12637785246186234,
+            0.0841726047108727,
+            22.592309534208024,
+            -0.22921716607636208
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.005070819309954485,
+            0.1906893722836201,
+            0.25070572522104656,
+            38.781063251904676,
+            -0.17929348637333012
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": true,
+          "displacement_z": 0.051784653272880315,
+          "centroid_raw": [
+            -0.004540276276906842,
+            0.15233917587939325,
+            0.1628859856155848,
+            29.062003329370235,
+            3.416134249598344
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.051784653272880315
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 83.01928758551912,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.019444444444444445,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.0741160471441523
+        }
+      },
+      "model_kruskal_h": 83.01928758551912,
+      "model_p_value": 0.019444444444444445,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": 0.06323662737987308,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1227,
+          "pct": 0.2780421481985044
+        },
+        "ranging_volatile": {
+          "count": 1614,
+          "pct": 0.36573759347382734
+        },
+        "trending_down_choppy": {
+          "count": 857,
+          "pct": 0.1941989576251983
+        },
+        "trending_up_choppy": {
+          "count": 715,
+          "pct": 0.16202130070246998
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.43730761337984814,
+          "transition_rate": 0.07573891625615764,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.437 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.36573759347382734,
+          "transition_rate": 0.0741160471441523,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.42304158051918217,
+          "transition_rate": 0.07122343480758185,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.423 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.36580061806111935,
+          "transition_rate": 0.07566391941391941,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.409588084710263,
+          "transition_rate": 0.07472067039106145,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.410 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.030980731734981694,
+            0.15313093235809228,
+            0.12227668462183905,
+            30.808395493295137,
+            -0.22087809439122727
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1297283364211666,
+            0.19104076256071856,
+            0.2609350951904761,
+            41.989957984160654,
+            0.3194559812427362
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1442636471029179,
+            0.19850313263976788,
+            0.289099678711903,
+            35.941659302702284,
+            0.161199680146396
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.014959403046504257,
+            0.11822354072106038,
+            0.07383618440485322,
+            20.164113612392256,
+            0.09214181549731532
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 83.13879597234882,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.008333333333333333,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.15820489573889393
+        }
+      },
+      "model_kruskal_h": 83.13879597234882,
+      "model_p_value": 0.008333333333333333,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.020852221214868544,
+      "coverage": {
+        "ranging_directional": {
+          "count": 351,
+          "pct": 0.07953772943575799
+        },
+        "ranging_directional_down": {
+          "count": 1192,
+          "pct": 0.2701110355767052
+        },
+        "ranging_volatile": {
+          "count": 1442,
+          "pct": 0.32676184001812825
+        },
+        "trending_down_choppy": {
+          "count": 787,
+          "pct": 0.1783367323815998
+        },
+        "trending_up_choppy": {
+          "count": 641,
+          "pct": 0.14525266258780875
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.3940077980710035,
+          "transition_rate": 0.1481937602627258,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.394 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.32676184001812825,
+          "transition_rate": 0.15820489573889393,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.38513668734206297,
+          "transition_rate": 0.1401493394600804,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3288314066613254,
+          "transition_rate": 0.149496336996337,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3700255992552944,
+          "transition_rate": 0.15013966480446927,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": true,
+          "displacement_z": 0.0938092256312282,
+          "centroid_raw": [
+            -0.008224826754059226,
+            0.14836523619250247,
+            0.1495004143348548,
+            28.10129827088451,
+            3.5500522278293505
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12982382089032546,
+            0.19146844432439508,
+            0.26198954564539856,
+            42.49045191339893,
+            -0.10223402141576893
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.02850132656995187,
+            0.1530729923509146,
+            0.12325172582338004,
+            30.662592868294393,
+            -0.2632210683967978
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.014742815623017606,
+            0.11748716888828212,
+            0.07110013184664839,
+            19.96758952961688,
+            -0.20646502657061064
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1469722392931596,
+            0.20047132573330181,
+            0.2938271781072868,
+            36.20350719214809,
+            -0.08147034079520854
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.0938092256312282
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 95.89785125343951,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0038888888888888888,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.1659111514052584
+        }
+      },
+      "model_kruskal_h": 95.89785125343951,
+      "model_p_value": 0.0038888888888888888,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.028558476881233003,
+      "coverage": {
+        "ranging_directional": {
+          "count": 763,
+          "pct": 0.1728982551552232
+        },
+        "ranging_directional_down": {
+          "count": 331,
+          "pct": 0.07500566508044414
+        },
+        "ranging_directional_up": {
+          "count": 853,
+          "pct": 0.19329254475413551
+        },
+        "ranging_volatile": {
+          "count": 1474,
+          "pct": 0.33401314298663043
+        },
+        "trending_down_choppy": {
+          "count": 719,
+          "pct": 0.16292771357353275
+        },
+        "trending_up_choppy": {
+          "count": 273,
+          "pct": 0.061862678450033994
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.38826185101580135,
+          "transition_rate": 0.16666666666666666,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.33401314298663043,
+          "transition_rate": 0.1659111514052584,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.39972432804962094,
+          "transition_rate": 0.14485927627800116,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.400 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.3306626988668879,
+          "transition_rate": 0.16597985347985347,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.3716546427740284,
+          "transition_rate": 0.15828677839851024,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5295939422370706,
+          "centroid_raw": [
+            0.0964327297831264,
+            0.16029799318410992,
+            0.1993216054950414,
+            29.166304000193893,
+            -0.19251032620870198
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.7592338157613507,
+          "centroid_raw": [
+            -0.06656665758022923,
+            0.1575051133427173,
+            0.1385151383299591,
+            30.326908194768674,
+            -0.25952046409497154
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1351425705551375,
+            0.19544908340911638,
+            0.27250190214367986,
+            44.49307813242184,
+            -0.08261151329043936
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.008436771317770889,
+            0.11690635129489557,
+            0.06032510392971914,
+            20.649537411275897,
+            -0.21083451391298144
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.011023199316872121,
+            0.14823632835504758,
+            0.1484994121459026,
+            28.0597248699074,
+            3.586155355558356
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18222954434235605,
+            0.2311790364681714,
+            0.35565666744905866,
+            42.721866340461744,
+            0.08410618581275578
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.5295939422370706
+          },
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.7592338157613507
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.6949486268586,
+          "model_kruskal_h": 102.32274484511436,
+          "handrule_p_value": 0.0044444444444444444,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1373526745240254,
+          "model_transition_rate": 0.16795104261106075
+        }
+      },
+      "model_kruskal_h": 102.32274484511436,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.6949486268586,
+      "stability_gain": -0.030598368087035366,
+      "coverage": {
+        "ranging_directional": {
+          "count": 312,
+          "pct": 0.07070020394289599
+        },
+        "ranging_directional_down": {
+          "count": 489,
+          "pct": 0.11080897348742352
+        },
+        "ranging_directional_up": {
+          "count": 570,
+          "pct": 0.12916383412644458
+        },
+        "ranging_volatile": {
+          "count": 1315,
+          "pct": 0.2979832313618853
+        },
+        "trending_down_choppy": {
+          "count": 671,
+          "pct": 0.1520507591207795
+        },
+        "trending_up_choppy": {
+          "count": 793,
+          "pct": 0.17969635168819398
+        },
+        "trending_up_clean": {
+          "count": 263,
+          "pct": 0.05959664627237707
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.34249948696901295,
+          "transition_rate": 0.17467159277504105,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.2979832313618853,
+          "transition_rate": 0.16795104261106075,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.34792097404089134,
+          "transition_rate": 0.15094773118897187,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.29346457594139863,
+          "transition_rate": 0.17227564102564102,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.3388410518966721,
+          "transition_rate": 0.1650372439478585,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_up_clean"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009502779841389662,
+            0.11540491761158422,
+            0.06223819584488684,
+            19.21187577159735,
+            -0.19656558429664686
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": true,
+          "displacement_z": 0.1282661871914719,
+          "centroid_raw": [
+            -0.011245878653777078,
+            0.14849308653314058,
+            0.14888810735684077,
+            28.163363029139703,
+            3.668059532252752
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.015426200429221923,
+            0.14115897308028436,
+            0.07642664334719779,
+            33.75499086159826,
+            -0.2267034289067312
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1348254149554739,
+            0.1949732401786896,
+            0.2716254379984643,
+            45.14459430738758,
+            -0.08205058047413097
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.10093086935829862,
+            0.16213336351153018,
+            0.20731864343222056,
+            28.587062405265073,
+            -0.18349951099968673
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9683077596301544,
+          "centroid_raw": [
+            -0.08489744493656762,
+            0.16355240594301862,
+            0.17457399504129711,
+            26.98279086958344,
+            -0.26211977646803
+          ],
+          "volatility_rank": 4
+        },
+        "6": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.3786953828633948,
+          "centroid_raw": [
+            0.1826358264361191,
+            0.23177990995900066,
+            0.35657814352368117,
+            42.83913840839783,
+            0.08711329922382038
+          ],
+          "volatility_rank": 6
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.1282661871914719
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.9683077596301544
+          },
+          "6": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.3786953828633948
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 60.595760198906646,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.013888888888888888,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.03424015009380863
+        }
+      },
+      "model_kruskal_h": 60.595760198906646,
+      "model_p_value": 0.013888888888888888,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.10436210131332083,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2033,
+          "pct": 0.47667057444314187
+        },
+        "ranging_volatile": {
+          "count": 2232,
+          "pct": 0.5233294255568581
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5729100529100529,
+          "transition_rate": 0.03323454699407282,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.573 > 0.392",
+            "min_transition_rate: 0.0332 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5233294255568581,
+          "transition_rate": 0.03424015009380863,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.523 > 0.392",
+            "min_transition_rate: 0.0342 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5438186492171068,
+          "transition_rate": 0.034708425850181135,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.544 > 0.392",
+            "min_transition_rate: 0.0347 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5054139015019211,
+          "transition_rate": 0.03854215183977643,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.505 > 0.392",
+            "min_transition_rate: 0.0385 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5343456254519161,
+          "transition_rate": 0.029170684667309547,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.534 > 0.392",
+            "min_transition_rate: 0.0292 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.005422062126225129,
+            0.18221547171589036,
+            0.2321585869657425,
+            37.05084597861473,
+            0.17181629006753052
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005556369949216343,
+            0.12317206716390974,
+            0.07730674928196764,
+            21.876216942872663,
+            0.14573301272887362
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 81.2488549528116,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.013888888888888888,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.042917448405253286
+        }
+      },
+      "model_kruskal_h": 81.2488549528116,
+      "model_p_value": 0.013888888888888888,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.09568480300187616,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2063,
+          "pct": 0.48370457209847595
+        },
+        "trending_down_choppy": {
+          "count": 1286,
+          "pct": 0.3015240328253224
+        },
+        "trending_up_choppy": {
+          "count": 916,
+          "pct": 0.21477139507620163
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5367195767195767,
+          "transition_rate": 0.03789161727349703,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.537 > 0.392",
+            "min_transition_rate: 0.0379 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.48370457209847595,
+          "transition_rate": 0.042917448405253286,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.484 > 0.392",
+            "min_transition_rate: 0.0429 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5086468801121757,
+          "transition_rate": 0.0428888629192474,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.509 > 0.392",
+            "min_transition_rate: 0.0429 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.46955408080102456,
+          "transition_rate": 0.04517931998136935,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.470 > 0.392",
+            "min_transition_rate: 0.0452 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5116895637503013,
+          "transition_rate": 0.03953712632594021,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.512 > 0.392",
+            "min_transition_rate: 0.0395 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006108476165882547,
+            0.12198560377914283,
+            0.07123314987246447,
+            21.738777918387175,
+            0.14437414586248998
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1029282369686711,
+            0.17425325893321786,
+            0.20894059294746176,
+            37.344991257417945,
+            0.16639820450621803
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.12348168175352808,
+            0.18450804801563467,
+            0.24928652669865625,
+            34.10603290994657,
+            0.17759616990441265
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 80.28965978331507,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.045,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.04549718574108818
+        }
+      },
+      "model_kruskal_h": 80.28965978331507,
+      "model_p_value": 0.045,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.09310506566604126,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1149,
+          "pct": 0.2694021101992966
+        },
+        "ranging_volatile": {
+          "count": 1179,
+          "pct": 0.27643610785463074
+        },
+        "trending_down_choppy": {
+          "count": 1109,
+          "pct": 0.26002344665885113
+        },
+        "trending_up_choppy": {
+          "count": 828,
+          "pct": 0.19413833528722158
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3136507936507936,
+          "transition_rate": 0.04043183742591024,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0404 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.27643610785463074,
+          "transition_rate": 0.04549718574108818,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0455 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.31046973591960736,
+          "transition_rate": 0.042771999532546456,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0428 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3324019094190243,
+          "transition_rate": 0.04424778761061947,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0442 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.2952518679199807,
+          "transition_rate": 0.040742526518804244,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0407 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006426207047002319,
+            0.12461368033255729,
+            0.07525259951287191,
+            21.73019144912455,
+            0.11796818002663713
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.13049710528156366,
+            0.18921440244922752,
+            0.2630371629530682,
+            35.1815193215839,
+            0.17623077819349106
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11269058799955738,
+            0.1790479723738248,
+            0.22860081892863676,
+            38.372816448768575,
+            0.16211181929951948
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.11546570218579351,
+          "centroid_raw": [
+            0.001260359425370758,
+            0.125418285992311,
+            0.07841508063098973,
+            23.71127615888643,
+            0.18570700152003625
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "3": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.11546570218579351
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 82.01086646632939,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.021666666666666667,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.10459662288930581
+        }
+      },
+      "model_kruskal_h": 82.01086646632939,
+      "model_p_value": 0.021666666666666667,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.03400562851782364,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 774,
+          "pct": 0.18147713950762018
+        },
+        "ranging_directional_up": {
+          "count": 846,
+          "pct": 0.19835873388042205
+        },
+        "ranging_volatile": {
+          "count": 1199,
+          "pct": 0.2811254396248535
+        },
+        "trending_down_choppy": {
+          "count": 852,
+          "pct": 0.19976553341148887
+        },
+        "trending_up_choppy": {
+          "count": 594,
+          "pct": 0.13927315357561548
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.326984126984127,
+          "transition_rate": 0.10668924640135478,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.2811254396248535,
+          "transition_rate": 0.10459662288930581,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.3315026875438187,
+          "transition_rate": 0.11546102606053524,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.2688322272674351,
+          "transition_rate": 0.10922217047042385,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3140515786936611,
+          "transition_rate": 0.12343297974927676,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.1304155323841977,
+          "centroid_raw": [
+            -0.06139458832889615,
+            0.1457658505894175,
+            0.12738579669616823,
+            28.794854622119615,
+            0.1592306710867848
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14649564757365346,
+            0.2016398453818111,
+            0.29270648267067334,
+            36.769195256367595,
+            0.18146137160278392
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.22458777279729114,
+          "centroid_raw": [
+            0.06730906554733715,
+            0.13466367576737215,
+            0.14124124074072777,
+            23.81921747330232,
+            0.15296214795461838
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0006712101074520102,
+            0.11741850735057047,
+            0.03925658245483633,
+            21.26378482625137,
+            0.14359802157534055
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12851154497747153,
+            0.18879330598607613,
+            0.25944320204218496,
+            41.29077013357269,
+            0.16529145599457337
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.1304155323841977
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.22458777279729114
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 179.79624638998575,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0011111111111111111,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.10365853658536585
+        }
+      },
+      "model_kruskal_h": 179.79624638998575,
+      "model_p_value": 0.0011111111111111111,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.0349437148217636,
+      "coverage": {
+        "ranging_directional": {
+          "count": 811,
+          "pct": 0.19015240328253225
+        },
+        "ranging_directional_down": {
+          "count": 675,
+          "pct": 0.15826494724501758
+        },
+        "ranging_directional_up": {
+          "count": 293,
+          "pct": 0.06869871043376319
+        },
+        "ranging_volatile": {
+          "count": 1103,
+          "pct": 0.2586166471277843
+        },
+        "trending_down_choppy": {
+          "count": 842,
+          "pct": 0.1974208675263775
+        },
+        "trending_up_choppy": {
+          "count": 541,
+          "pct": 0.1268464243845252
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.31343915343915346,
+          "transition_rate": 0.09716342082980525,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.2586166471277843,
+          "transition_rate": 0.10365853658536585,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.28628184155176445,
+          "transition_rate": 0.0978146546686923,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.24729304924903947,
+          "transition_rate": 0.10444806707033069,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.26970354302241506,
+          "transition_rate": 0.10607521697203472,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.7977371560742444,
+          "centroid_raw": [
+            0.06905614734257728,
+            0.13609747437858552,
+            0.14486602922736752,
+            23.793133998923317,
+            0.14210686811263487
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0077404701278491845,
+            0.1392333105287102,
+            0.09247821359292337,
+            28.249858605014946,
+            0.23634239639302834
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12950238566429018,
+            0.18932365716204436,
+            0.26136601634949447,
+            41.602492696310755,
+            0.1652716678077228
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00018088788474430583,
+            0.11750418883224496,
+            0.04078193270092595,
+            21.117291911081136,
+            0.13671792927294132
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.15176965840423348,
+            0.20416855907011694,
+            0.3029548765436063,
+            37.259847836744996,
+            0.17909130083629854
+          ],
+          "volatility_rank": 5
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.1827072227915062,
+          "centroid_raw": [
+            -0.06596338680190354,
+            0.14623864135796938,
+            0.13742639022173114,
+            28.434633805963582,
+            0.1487925279521393
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.7977371560742444
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.1827072227915062
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 164.95642206018056,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.11960600375234522
+        }
+      },
+      "model_kruskal_h": 164.95642206018056,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.018996247654784235,
+      "coverage": {
+        "ranging_directional": {
+          "count": 623,
+          "pct": 0.14607268464243844
+        },
+        "ranging_directional_down": {
+          "count": 689,
+          "pct": 0.1615474794841735
+        },
+        "ranging_directional_up": {
+          "count": 276,
+          "pct": 0.06471277842907386
+        },
+        "ranging_volatile": {
+          "count": 1089,
+          "pct": 0.2553341148886284
+        },
+        "trending_down_choppy": {
+          "count": 835,
+          "pct": 0.19577960140679954
+        },
+        "trending_up_choppy": {
+          "count": 580,
+          "pct": 0.13599062133645956
+        },
+        "trending_up_clean": {
+          "count": 173,
+          "pct": 0.04056271981242673
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.29693121693121693,
+          "transition_rate": 0.12023708721422523,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.2553341148886284,
+          "transition_rate": 0.11960600375234522,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.2730778219210096,
+          "transition_rate": 0.11499357251373145,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.23565025032017697,
+          "transition_rate": 0.12377736376339078,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.26223186309954205,
+          "transition_rate": 0.12270973963355834,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_clean",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.11443746234272141,
+            0.1738201852204455,
+            0.23659196208463218,
+            31.34045190058547,
+            0.1482397753527773
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.3646168140583195,
+          "centroid_raw": [
+            0.1848323202616336,
+            0.2345709014869793,
+            0.35791835520087667,
+            41.54995673969141,
+            0.2016293872541328
+          ],
+          "volatility_rank": 6
+        },
+        "2": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.7366919128894944,
+          "centroid_raw": [
+            0.06134305161322433,
+            0.12824474300694366,
+            0.1297889757682802,
+            22.50986992921156,
+            0.14119367758123155
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12893638349382214,
+            0.1890278112556122,
+            0.26026344403910895,
+            41.5656691888101,
+            0.16510011361111174
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0005799466825554292,
+            0.11753119396604639,
+            0.037976657725324325,
+            21.10606523406933,
+            0.1371909032538826
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0018922944892990324,
+            0.14241219133758248,
+            0.10557587353711884,
+            29.88827770303851,
+            0.23718015724822525
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.1624036478355435,
+          "centroid_raw": [
+            -0.0641894349267041,
+            0.14493828867959027,
+            0.13410748762170763,
+            27.70433419894083,
+            0.14368756125577273
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.3646168140583195
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.7366919128894944
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.1624036478355435
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 48.93081374983558,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.019444444444444445,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.040337711069418386
+        }
+      },
+      "model_kruskal_h": 48.93081374983558,
+      "model_p_value": 0.019444444444444445,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.09826454033771106,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 2032,
+          "pct": 0.4764361078546307
+        },
+        "ranging_volatile": {
+          "count": 2233,
+          "pct": 0.5235638921453692
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5752380952380952,
+          "transition_rate": 0.03492802709568162,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.575 > 0.392",
+            "min_transition_rate: 0.0349 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5235638921453692,
+          "transition_rate": 0.040337711069418386,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.524 > 0.392",
+            "min_transition_rate: 0.0403 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5503622341668614,
+          "transition_rate": 0.04055159518522847,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.550 > 0.392",
+            "min_transition_rate: 0.0406 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5070438933519618,
+          "transition_rate": 0.04343269678621332,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.507 > 0.392",
+            "min_transition_rate: 0.0434 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5403711737768137,
+          "transition_rate": 0.034474445515911285,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.540 > 0.392",
+            "min_transition_rate: 0.0345 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0036442413064233245,
+            0.18198425116700076,
+            0.235137263455018,
+            36.68812585667635,
+            0.17098206107440747
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.004215265320590622,
+            0.12366512953951767,
+            0.07601790407494566,
+            22.22137108826002,
+            0.14647807799426538
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 72.3123778225272,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.019444444444444445,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.04549718574108818
+        }
+      },
+      "model_kruskal_h": 72.3123778225272,
+      "model_p_value": 0.019444444444444445,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.09310506566604126,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2279,
+          "pct": 0.5343493552168816
+        },
+        "trending_down_choppy": {
+          "count": 1167,
+          "pct": 0.27362250879249705
+        },
+        "trending_up_choppy": {
+          "count": 819,
+          "pct": 0.19202813599062132
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5906878306878307,
+          "transition_rate": 0.04276037256562235,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.591 > 0.392",
+            "min_transition_rate: 0.0428 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5343493552168816,
+          "transition_rate": 0.04549718574108818,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.534 > 0.392",
+            "min_transition_rate: 0.0455 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5736153306847395,
+          "transition_rate": 0.043122589692649295,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.574 > 0.392",
+            "min_transition_rate: 0.0431 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5247409477238328,
+          "transition_rate": 0.04855612482533768,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.525 > 0.392",
+            "min_transition_rate: 0.0486 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5707399373342974,
+          "transition_rate": 0.0431533269045323,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.571 > 0.392",
+            "min_transition_rate: 0.0432 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005165159046318386,
+            0.12500859273393508,
+            0.07700446468490522,
+            22.776697716235653,
+            0.1479079508196912
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11160488187452618,
+            0.17897555537312446,
+            0.22632128245604174,
+            38.24002491987147,
+            0.16527530168718646
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.13352816563004272,
+            0.1905061617034894,
+            0.268825267036637,
+            34.98326555632588,
+            0.17728646392393616
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 75.29071956741245,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.02277777777777778,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.11374296435272045
+        }
+      },
+      "model_kruskal_h": 75.29071956741245,
+      "model_p_value": 0.02277777777777778,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.024859287054409,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1676,
+          "pct": 0.3929660023446659
+        },
+        "ranging_volatile": {
+          "count": 1094,
+          "pct": 0.25650644783118404
+        },
+        "trending_down_choppy": {
+          "count": 922,
+          "pct": 0.21617819460726848
+        },
+        "trending_up_choppy": {
+          "count": 573,
+          "pct": 0.1343493552168816
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.40613756613756613,
+          "transition_rate": 0.12320067739204064,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.406 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3929660023446659,
+          "transition_rate": 0.11374296435272045,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.393 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.39051180182285583,
+          "transition_rate": 0.1251606871567138,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.40482011875654905,
+          "transition_rate": 0.11877037727061016,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.405 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.4215473608098337,
+          "transition_rate": 0.1289778206364513,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.422 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00032522580087759715,
+            0.11703566606489849,
+            0.03484598009505789,
+            21.18493428449207,
+            0.14334672633536125
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.15115536164249685,
+            0.20273057985030377,
+            0.3025361441634888,
+            36.81835470045956,
+            0.18026639796967966
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1261952250000539,
+            0.1870957073868693,
+            0.25517877678374035,
+            40.77321601931237,
+            0.1649808283099994
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0053454982214461485,
+            0.1393031467290001,
+            0.1289068226452449,
+            26.07860615683028,
+            0.1560898776310799
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 78.55162404979637,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.023333333333333334,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.124765478424015
+        }
+      },
+      "model_kruskal_h": 78.55162404979637,
+      "model_p_value": 0.023333333333333334,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.013836772983114448,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 759,
+          "pct": 0.1779601406799531
+        },
+        "ranging_directional_up": {
+          "count": 829,
+          "pct": 0.19437280187573272
+        },
+        "ranging_volatile": {
+          "count": 1218,
+          "pct": 0.28558030480656504
+        },
+        "trending_down_choppy": {
+          "count": 861,
+          "pct": 0.2018757327080891
+        },
+        "trending_up_choppy": {
+          "count": 598,
+          "pct": 0.14021101992966004
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.32825396825396824,
+          "transition_rate": 0.1339966130397968,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.28558030480656504,
+          "transition_rate": 0.124765478424015,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.3371114746436083,
+          "transition_rate": 0.1314713100385649,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.2798928862498545,
+          "transition_rate": 0.1316953889147648,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.32562063147746445,
+          "transition_rate": 0.1407907425265188,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.14497001864415687,
+          "centroid_raw": [
+            -0.06266623424590431,
+            0.1453721117955732,
+            0.12989205109955906,
+            28.84050378780514,
+            0.1584931198119062
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14731009012691282,
+            0.19941783590689785,
+            0.29509009365525085,
+            36.247417278294364,
+            0.17940261228300056
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.21335445611913384,
+          "centroid_raw": [
+            0.06660824107086313,
+            0.1348016655539671,
+            0.13949916447052998,
+            23.918655063902577,
+            0.15304980192752932
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.000649578542789699,
+            0.1190981514173526,
+            0.03806634100878635,
+            21.692804370359134,
+            0.14515853355001346
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1295030869794064,
+            0.18786939873727887,
+            0.2616854207210891,
+            40.79334830953262,
+            0.16476662041300502
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.14497001864415687
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.21335445611913384
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 81.21433486388196,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.015555555555555555,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.17378048780487804
+        }
+      },
+      "model_kruskal_h": 81.21433486388196,
+      "model_p_value": 0.015555555555555555,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": -0.035178236397748586,
+      "coverage": {
+        "ranging_directional": {
+          "count": 510,
+          "pct": 0.11957796014067995
+        },
+        "ranging_directional_down": {
+          "count": 448,
+          "pct": 0.10504103165298945
+        },
+        "ranging_directional_up": {
+          "count": 864,
+          "pct": 0.2025791324736225
+        },
+        "ranging_volatile": {
+          "count": 1030,
+          "pct": 0.24150058616647127
+        },
+        "trending_down_choppy": {
+          "count": 785,
+          "pct": 0.18405627198124266
+        },
+        "trending_up_choppy": {
+          "count": 628,
+          "pct": 0.14724501758499414
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.2776719576719577,
+          "transition_rate": 0.1964436917866215,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.24150058616647127,
+          "transition_rate": 0.17378048780487804,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.2907221313390979,
+          "transition_rate": 0.18043706906626153,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.2376295261380836,
+          "transition_rate": 0.18246390312063343,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.2762111352133044,
+          "transition_rate": 0.19262295081967212,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.20211646655852328,
+          "centroid_raw": [
+            0.06355910587433766,
+            0.13314990653137498,
+            0.13324530163540393,
+            23.554762896342197,
+            0.15236036527815383
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.04176711143260991,
+            0.13564228962500097,
+            0.08583594246770634,
+            27.098581128671213,
+            0.15797627545437315
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1357191414450745,
+            0.19106748272949772,
+            0.2733067053108982,
+            41.749547975110566,
+            0.1654102193172213
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.002426676594851008,
+            0.118632704840261,
+            0.0319718238170275,
+            21.548566370423522,
+            0.1444385828507743
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1456533502523157,
+            0.1983500246466771,
+            0.2919242293893619,
+            36.07079150049879,
+            0.1791346984130929
+          ],
+          "volatility_rank": 5
+        },
+        "5": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9101254653708971,
+          "centroid_raw": [
+            -0.07951894084974026,
+            0.15233611741169853,
+            0.16551053905665564,
+            30.145269824182076,
+            0.15717956355737572
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.20211646655852328
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.9101254653708971
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 117.77867770127159,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0044444444444444444,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.14704502814258913
+        }
+      },
+      "model_kruskal_h": 117.77867770127159,
+      "model_p_value": 0.0044444444444444444,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": -0.008442776735459678,
+      "coverage": {
+        "ranging_directional": {
+          "count": 680,
+          "pct": 0.15943728018757328
+        },
+        "ranging_directional_down": {
+          "count": 726,
+          "pct": 0.17022274325908557
+        },
+        "ranging_directional_up": {
+          "count": 61,
+          "pct": 0.014302461899179367
+        },
+        "ranging_volatile": {
+          "count": 1240,
+          "pct": 0.29073856975381007
+        },
+        "trending_down_choppy": {
+          "count": 851,
+          "pct": 0.19953106682297772
+        },
+        "trending_up_choppy": {
+          "count": 535,
+          "pct": 0.1254396248534584
+        },
+        "trending_up_clean": {
+          "count": 172,
+          "pct": 0.04032825322391559
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.33206349206349206,
+          "transition_rate": 0.14712108382726502,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.29073856975381007,
+          "transition_rate": 0.14704502814258913,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.3277634961439589,
+          "transition_rate": 0.13965174710763117,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.2865292816393061,
+          "transition_rate": 0.151839776432231,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.3224873463485177,
+          "transition_rate": 0.15911282545805208,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_clean",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.11740293456373885,
+            0.1708547900041789,
+            0.24285663923934225,
+            30.810798348121416,
+            0.14927388112054266
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.2640775720701312,
+          "centroid_raw": [
+            0.189722273136291,
+            0.23584692739898988,
+            0.3683863347255144,
+            41.44064575052818,
+            0.19309183412251962
+          ],
+          "volatility_rank": 6
+        },
+        "2": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.7335524595233291,
+          "centroid_raw": [
+            0.06292572806109802,
+            0.13217271180316592,
+            0.131936231171,
+            23.445547752764654,
+            0.1458885306756457
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13083290563208153,
+            0.1887284592611378,
+            0.2641710741598359,
+            41.04488421241817,
+            0.16510571128645654
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.00028817814704937045,
+            0.11921659011885827,
+            0.038991624277106215,
+            21.816451424010424,
+            0.14449255856286958
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.20106238029507897,
+          "centroid_raw": [
+            0.067567102706303,
+            0.16408229590362372,
+            0.15539445738545807,
+            32.47709289596343,
+            0.2877471612693846
+          ],
+          "volatility_rank": 3
+        },
+        "6": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.17433476078080767,
+          "centroid_raw": [
+            -0.065231873030751,
+            0.1458154092627873,
+            0.13527173457279507,
+            28.96788994263952,
+            0.15682319459393856
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.2640775720701312
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.7335524595233291
+          },
+          "5": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.20106238029507897
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.17433476078080767
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 50.39230073527324,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.026111111111111113,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.0300187617260788
+        }
+      },
+      "model_kruskal_h": 50.39230073527324,
+      "model_p_value": 0.026111111111111113,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.10858348968105065,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1844,
+          "pct": 0.43235638921453695
+        },
+        "ranging_volatile": {
+          "count": 2421,
+          "pct": 0.5676436107854631
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6139682539682539,
+          "transition_rate": 0.03281117696867062,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.614 > 0.392",
+            "min_transition_rate: 0.0328 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5676436107854631,
+          "transition_rate": 0.0300187617260788,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.568 > 0.392",
+            "min_transition_rate: 0.0300 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5986211731713017,
+          "transition_rate": 0.032137431342760314,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.599 > 0.392",
+            "min_transition_rate: 0.0321 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5618814763069042,
+          "transition_rate": 0.034816022356776895,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.562 > 0.392",
+            "min_transition_rate: 0.0348 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5941190648349,
+          "transition_rate": 0.033992285438765674,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.594 > 0.392",
+            "min_transition_rate: 0.0340 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.005165886053750178,
+            0.1884033680413758,
+            0.24716420966136385,
+            38.590667878304394,
+            0.17537566717208808
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.004266444522101502,
+            0.1259583890148398,
+            0.0852855307602728,
+            22.620041398678918,
+            0.14651082539575386
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 78.17046874674816,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.02,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.04127579737335835
+        }
+      },
+      "model_kruskal_h": 78.17046874674816,
+      "model_p_value": 0.02,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.0973264540337711,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2305,
+          "pct": 0.5404454865181711
+        },
+        "trending_down_choppy": {
+          "count": 1173,
+          "pct": 0.27502930832356387
+        },
+        "trending_up_choppy": {
+          "count": 787,
+          "pct": 0.18452520515826495
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5936507936507937,
+          "transition_rate": 0.03725656223539373,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.594 > 0.392",
+            "min_transition_rate: 0.0373 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5404454865181711,
+          "transition_rate": 0.04127579737335835,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.540 > 0.392",
+            "min_transition_rate: 0.0413 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5788735685907922,
+          "transition_rate": 0.039382961318219,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.579 > 0.392",
+            "min_transition_rate: 0.0394 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5306787751775527,
+          "transition_rate": 0.04424778761061947,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.531 > 0.392",
+            "min_transition_rate: 0.0442 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5707399373342974,
+          "transition_rate": 0.03929604628736741,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.571 > 0.392",
+            "min_transition_rate: 0.0393 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0063380669244127354,
+            0.12454751580163806,
+            0.0802512186035826,
+            22.475356221327054,
+            0.14586488007201645
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.10882255182375247,
+            0.17960861301323505,
+            0.22040070833028153,
+            38.814118766572165,
+            0.16944745278382944
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.13620299929044788,
+            0.19423986986768643,
+            0.27326350742241917,
+            35.72745878992036,
+            0.18070118707509875
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": false,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 71.63145196521873,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.07611111111111112,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.04221388367729831
+        }
+      },
+      "model_kruskal_h": 71.63145196521873,
+      "model_p_value": 0.07611111111111112,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.09638836772983114,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 872,
+          "pct": 0.2044548651817116
+        },
+        "ranging_volatile": {
+          "count": 1673,
+          "pct": 0.3922626025791325
+        },
+        "trending_down_choppy": {
+          "count": 1015,
+          "pct": 0.23798358733880423
+        },
+        "trending_up_choppy": {
+          "count": 705,
+          "pct": 0.1652989449003517
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.42518518518518517,
+          "transition_rate": 0.03662150719729043,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.425 > 0.392",
+            "min_transition_rate: 0.0366 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3922626025791325,
+          "transition_rate": 0.04221388367729831,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.392 > 0.392",
+            "min_transition_rate: 0.0422 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.40172937602243514,
+          "transition_rate": 0.036110786490592496,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.402 > 0.392",
+            "min_transition_rate: 0.0361 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3215741064151822,
+          "transition_rate": 0.043782021425244524,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0438 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.37888647866955893,
+          "transition_rate": 0.03712632594021215,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "min_transition_rate: 0.0371 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.008943387362343376,
+            0.1263101211467647,
+            0.08137260534186647,
+            22.031642603888738,
+            0.12664220194826653
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14331699274572973,
+            0.19964746705795727,
+            0.2865891080511613,
+            36.42245901499824,
+            0.17352997437340512
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11711027079906294,
+            0.18299620532247104,
+            0.2370645186689218,
+            40.39686448321347,
+            0.16190354265382634
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.004087949295910411,
+            0.12982597281431374,
+            0.0952642257560351,
+            25.43683896819987,
+            0.20279793794271028
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 122.31549507207637,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.013333333333333334,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.054878048780487805
+        }
+      },
+      "model_kruskal_h": 122.31549507207637,
+      "model_p_value": 0.013333333333333334,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.08372420262664165,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 634,
+          "pct": 0.14865181711606096
+        },
+        "ranging_directional_up": {
+          "count": 750,
+          "pct": 0.17584994138335286
+        },
+        "ranging_volatile": {
+          "count": 1706,
+          "pct": 0.4
+        },
+        "trending_down_choppy": {
+          "count": 1016,
+          "pct": 0.23821805392731535
+        },
+        "trending_up_choppy": {
+          "count": 159,
+          "pct": 0.03728018757327081
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.4505820105820106,
+          "transition_rate": 0.05165114309906858,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.451 > 0.392",
+            "min_transition_rate: 0.0517 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.4,
+          "transition_rate": 0.054878048780487805,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.400 > 0.392",
+            "min_transition_rate: 0.0549 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.4104931058658565,
+          "transition_rate": 0.050952436601612715,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.410 > 0.392",
+            "min_transition_rate: 0.0510 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.33985330073349634,
+          "transition_rate": 0.06392640894271076,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0639 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.40298867196914917,
+          "transition_rate": 0.055207328833172614,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.403 > 0.392",
+            "min_transition_rate: 0.0552 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.009981520261705843,
+            0.13903876708101257,
+            0.10263132035029433,
+            27.696602728710367,
+            0.21464401119101734
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18422045599030623,
+            0.23663220584775102,
+            0.3547325865830753,
+            44.47649880744757,
+            0.2145818660072411
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.6744172433377328,
+          "centroid_raw": [
+            0.1089247822652265,
+            0.1691203060441465,
+            0.2259880849110138,
+            30.444389477762254,
+            0.1474641629179333
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0023487611307535573,
+            0.12206473432881818,
+            0.07245072950936976,
+            21.4070984490523,
+            0.1322880146258575
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11781780660872287,
+            0.1832130149302676,
+            0.23855708634846573,
+            40.294493644425245,
+            0.16055147792053243
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.6744172433377328
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 162.15641417641018,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.07387429643527205
+        }
+      },
+      "model_kruskal_h": 162.15641417641018,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.0647279549718574,
+      "coverage": {
+        "ranging_directional": {
+          "count": 626,
+          "pct": 0.14677608440797185
+        },
+        "ranging_directional_down": {
+          "count": 440,
+          "pct": 0.10316529894490035
+        },
+        "ranging_directional_up": {
+          "count": 805,
+          "pct": 0.18874560375146543
+        },
+        "ranging_volatile": {
+          "count": 1451,
+          "pct": 0.34021101992966
+        },
+        "trending_down_choppy": {
+          "count": 759,
+          "pct": 0.1779601406799531
+        },
+        "trending_up_choppy": {
+          "count": 184,
+          "pct": 0.04314185228604924
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.39894179894179893,
+          "transition_rate": 0.07260795935647756,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.399 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.34021101992966,
+          "transition_rate": 0.07387429643527205,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.3505491937368544,
+          "transition_rate": 0.06275563865840832,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0628 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.2960763767609733,
+          "transition_rate": 0.07848160223567768,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.3461074957821162,
+          "transition_rate": 0.06702025072324011,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0670 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.6290451454643389,
+          "centroid_raw": [
+            0.10496055831556181,
+            0.16555120295529407,
+            0.2181248500905259,
+            29.553331882991394,
+            0.14695965552584747
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.004087744194884096,
+            0.13688834686847534,
+            0.10336743269514449,
+            28.00963211237336,
+            0.2255873821687031
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13352364292808064,
+            0.19339342155801031,
+            0.2681744887360883,
+            44.564810387132745,
+            0.17078099334314234
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.010418593937033642,
+            0.11793560871885704,
+            0.06301526471252078,
+            20.532747173371995,
+            0.13515944185917117
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1810158123802765,
+            0.23298681638290591,
+            0.3506907825835518,
+            43.85029373033703,
+            0.20797813960685818
+          ],
+          "volatility_rank": 5
+        },
+        "5": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.8230395866020414,
+          "centroid_raw": [
+            -0.07191012524556836,
+            0.15756630767654908,
+            0.15139366846159197,
+            30.13957174313361,
+            0.13842161483637871
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.6290451454643389
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.8230395866020414
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 176.0758582222752,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0011111111111111111,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.10084427767354597
+        }
+      },
+      "model_kruskal_h": 176.0758582222752,
+      "model_p_value": 0.0011111111111111111,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.037757973733583486,
+      "coverage": {
+        "ranging_directional": {
+          "count": 658,
+          "pct": 0.15427901524032825
+        },
+        "ranging_directional_down": {
+          "count": 363,
+          "pct": 0.08511137162954278
+        },
+        "ranging_directional_up": {
+          "count": 703,
+          "pct": 0.16483001172332942
+        },
+        "ranging_volatile": {
+          "count": 1148,
+          "pct": 0.2691676436107855
+        },
+        "trending_down_choppy": {
+          "count": 773,
+          "pct": 0.18124267291910903
+        },
+        "trending_up_choppy": {
+          "count": 552,
+          "pct": 0.12942555685814772
+        },
+        "trending_up_clean": {
+          "count": 68,
+          "pct": 0.015943728018757326
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.31703703703703706,
+          "transition_rate": 0.09716342082980525,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.2691676436107855,
+          "transition_rate": 0.10084427767354597,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.28721663940172937,
+          "transition_rate": 0.08647890615870048,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.2390266620095471,
+          "transition_rate": 0.09967396367023754,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.27331887201735355,
+          "transition_rate": 0.09836065573770492,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_clean",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "ranging_directional"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.13108525430979076,
+            0.18792488115075362,
+            0.26745066964033726,
+            33.33895035581687,
+            0.15198076800885837
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.300610422963425,
+          "centroid_raw": [
+            0.19190310851981662,
+            0.24588556408948425,
+            0.36458259473737553,
+            48.10162001318464,
+            0.2379167234018357
+          ],
+          "volatility_rank": 6
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.2799096425510295,
+          "centroid_raw": [
+            0.06885268548289075,
+            0.13470534050921976,
+            0.14517559226905977,
+            23.010005541710253,
+            0.14421802978747833
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1325091732344044,
+            0.1928192777190449,
+            0.26625201180639657,
+            44.13758781617661,
+            0.169387536479396
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0010730353246424856,
+            0.11461123917562842,
+            0.04673772040970288,
+            20.352445799592694,
+            0.1354405100946928
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.010389717164440579,
+            0.13800220030887314,
+            0.1023251187532764,
+            28.614877134758448,
+            0.2289417596248497
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.7777437750540178,
+          "centroid_raw": [
+            -0.0679525665393515,
+            0.15644785139514214,
+            0.14509312405234576,
+            29.683864021541083,
+            0.13662423968671306
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.300610422963425
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.2799096425510295
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.7777437750540178
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 65.33121332306109,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.10834896810506567
+        }
+      },
+      "model_kruskal_h": 65.33121332306109,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.030253283302063783,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1071,
+          "pct": 0.2511137162954279
+        },
+        "ranging_directional_up": {
+          "count": 3194,
+          "pct": 0.7488862837045721
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5847619047619048,
+          "transition_rate": 0.14373412362404742,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.585 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.7488862837045721,
+          "transition_rate": 0.10834896810506567,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.749 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.7658475783475783,
+          "transition_rate": 0.0780053428317008,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.766 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5517522412387939,
+          "transition_rate": 0.14927806241266883,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.552 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5239816823330923,
+          "transition_rate": 0.15549662487945998,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.524 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009076627204931987,
+            0.16222709346375877,
+            0.17106007686953997,
+            30.953495019999615,
+            1.2233118971048373e-05,
+            0.48048647118953736,
+            0.16713193635452617,
+            0.505732211024001
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.004926307433483126,
+            0.13792898784180885,
+            0.12223615804637179,
+            26.358027676250938,
+            1.2489684155711437e-05,
+            -0.24582513142087006,
+            0.14927646237265013,
+            0.493382145276869
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 98.23917918946063,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0011111111111111111,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.099671669793621
+        }
+      },
+      "model_kruskal_h": 98.23917918946063,
+      "model_p_value": 0.0011111111111111111,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.038930581613508444,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 897,
+          "pct": 0.21031652989449004
+        },
+        "trending_down_choppy": {
+          "count": 838,
+          "pct": 0.19648300117233294
+        },
+        "trending_up_choppy": {
+          "count": 2530,
+          "pct": 0.593200468933177
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.49417989417989416,
+          "transition_rate": 0.11240474174428451,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.494 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.593200468933177,
+          "transition_rate": 0.099671669793621,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.593 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.7459045584045584,
+          "transition_rate": 0.07195013357079252,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.746 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5146117126557225,
+          "transition_rate": 0.13775034932463903,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.515 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.45529043142926007,
+          "transition_rate": 0.13187078109932499,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.455 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.003199240300490801,
+            0.12897826329613274,
+            0.09687313690646798,
+            23.992129323131074,
+            1.2488848927714627e-05,
+            -0.20976830326285814,
+            0.14611989624438376,
+            0.48854226228138625
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12411021079299184,
+            0.18666556181285288,
+            0.24879154999864386,
+            41.58911390111493,
+            9.194585603747113e-06,
+            0.23062770459044396,
+            0.16603321661240383,
+            0.5081353779244355
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.053492396152958775,
+            0.15770350134580916,
+            0.15956559397089906,
+            28.361304537827078,
+            1.3654807692767593e-05,
+            0.3560940072477945,
+            0.16750251162014668,
+            0.5083087889788063
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 110.78805703679973,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.005,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.11163227016885553
+        }
+      },
+      "model_kruskal_h": 110.78805703679973,
+      "model_p_value": 0.005,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.02696998123827392,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1863,
+          "pct": 0.4368112543962485
+        },
+        "ranging_volatile": {
+          "count": 823,
+          "pct": 0.19296600234466588
+        },
+        "trending_down_choppy": {
+          "count": 953,
+          "pct": 0.22344665885111373
+        },
+        "trending_up_choppy": {
+          "count": 626,
+          "pct": 0.14677608440797185
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.4632804232804233,
+          "transition_rate": 0.13336155800169347,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.463 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.4368112543962485,
+          "transition_rate": 0.11163227016885553,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.437 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5537749287749287,
+          "transition_rate": 0.09385574354407836,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.554 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3489346838980091,
+          "transition_rate": 0.1626688402421984,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.4345625451916124,
+          "transition_rate": 0.14561234329797493,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.435 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.1025336183290804,
+          "centroid_raw": [
+            0.006187526836043202,
+            0.13337519495413658,
+            0.08935477527913654,
+            23.855612394374,
+            1.329788658687776e-05,
+            0.5522440601295269,
+            0.15726589343340885,
+            0.5053369375544134
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1470760988540473,
+            0.20031675812342664,
+            0.294040520989873,
+            36.84254622935191,
+            1.4334736706299062e-05,
+            0.08455486602468715,
+            0.1819556155887941,
+            0.5105258719196227
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12380046946713888,
+            0.1864872655512803,
+            0.24872279134904812,
+            41.35870334030037,
+            9.058523487076169e-06,
+            0.23214262940804126,
+            0.16535707637530203,
+            0.5087329988595498
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00048635127446202287,
+            0.12806457997877238,
+            0.09230173035332401,
+            23.732966133344434,
+            1.249101195115223e-05,
+            -0.2827336609532065,
+            0.14634424362059528,
+            0.48787856113044364
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.1025336183290804
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 109.23859972367063,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.22045028142589118
+        }
+      },
+      "model_kruskal_h": 109.23859972367063,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": -0.08184803001876173,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 642,
+          "pct": 0.15052754982415006
+        },
+        "ranging_directional_up": {
+          "count": 826,
+          "pct": 0.19366940211019928
+        },
+        "ranging_volatile": {
+          "count": 1471,
+          "pct": 0.34490035169988276
+        },
+        "trending_down_choppy": {
+          "count": 757,
+          "pct": 0.17749120750293082
+        },
+        "trending_up_choppy": {
+          "count": 569,
+          "pct": 0.13341148886283705
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.4586243386243386,
+          "transition_rate": 0.17950889077053345,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.459 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.34490035169988276,
+          "transition_rate": 0.22045028142589118,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.44337606837606836,
+          "transition_rate": 0.18913624220837044,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.443 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3555710792874607,
+          "transition_rate": 0.22193758733115976,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.4345625451916124,
+          "transition_rate": 0.20274831243973,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.435 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.12693982749989285,
+          "centroid_raw": [
+            0.001663779815802321,
+            0.12683851777968735,
+            0.08993180117131053,
+            23.58321233934276,
+            1.2491010434504561e-05,
+            -0.2446480753348578,
+            0.1459372644634823,
+            0.48611306047953645
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14767451206375057,
+            0.2007231094631214,
+            0.2947204848919096,
+            36.984911257663924,
+            1.4576412480732693e-05,
+            -0.10737635165836473,
+            0.18290933101065623,
+            0.51253360841262
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00939899127251157,
+            0.13351684192244848,
+            0.0797794728738666,
+            22.85230702216575,
+            1.348946621164942e-05,
+            -0.33738762955090273,
+            0.16006659708930185,
+            0.5066324571305435
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.018204716374909523,
+            0.15088172547704065,
+            0.1527885562717553,
+            29.81042621116674,
+            1.1723266070943633e-05,
+            2.514418898476785,
+            0.15485185197980664,
+            0.5060588993274386
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12217828704879884,
+            0.1854351644246693,
+            0.24637065599116198,
+            40.966117150743614,
+            9.3501026481642e-06,
+            -0.23548747565193648,
+            0.1659590166800762,
+            0.5105188156348163
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.12693982749989285
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 108.61308209492927,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.21130393996247654
+        }
+      },
+      "model_kruskal_h": 108.61308209492927,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": -0.07270168855534709,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1540,
+          "pct": 0.36107854630715125
+        },
+        "ranging_directional_down": {
+          "count": 543,
+          "pct": 0.1273153575615475
+        },
+        "ranging_directional_up": {
+          "count": 810,
+          "pct": 0.1899179366940211
+        },
+        "ranging_volatile": {
+          "count": 389,
+          "pct": 0.09120750293083235
+        },
+        "trending_down_choppy": {
+          "count": 641,
+          "pct": 0.15029308323563892
+        },
+        "trending_up_choppy": {
+          "count": 342,
+          "pct": 0.08018757327080892
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.29164021164021164,
+          "transition_rate": 0.18014394580863674,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.36107854630715125,
+          "transition_rate": 0.21130393996247654,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.37197293447293445,
+          "transition_rate": 0.15262689225289403,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.25602514844568636,
+          "transition_rate": 0.23090358639962738,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.27789828874427575,
+          "transition_rate": 0.21600771456123433,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.2811748610275747,
+          "centroid_raw": [
+            0.009716964202533164,
+            0.12815382812873918,
+            0.07691031589501593,
+            22.11769907782881,
+            1.0305677434935749e-05,
+            -0.24170909564782336,
+            0.15408960761736662,
+            0.4975103879297595
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0019592157166068726,
+            0.1150108838507464,
+            0.04623913646561251,
+            21.157647128176183,
+            1.2489597362226728e-05,
+            -0.31310219627993496,
+            0.1414678660212572,
+            0.46295037409136475
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12261846447540835,
+            0.18619203013489685,
+            0.24739708520057377,
+            41.504212245994324,
+            8.76417469435844e-06,
+            -0.2462296524247304,
+            0.16604142149062162,
+            0.5064150006974737
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0042149773603653426,
+            0.14241518838626713,
+            0.1414899371978518,
+            26.98840698526918,
+            1.2491768647398908e-05,
+            0.4141753029694708,
+            0.15180760090920814,
+            0.5146932654580526
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1379447824277385,
+            0.19142991926586814,
+            0.2776212818038307,
+            34.630715617910425,
+            1.0862404364540563e-05,
+            -0.28986388093598126,
+            0.17274030017161432,
+            0.5148032968659211
+          ],
+          "volatility_rank": 4
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.046297728139833856,
+            0.19459751083907303,
+            0.2448770961643811,
+            37.60392493605424,
+            2.248025104444023e-05,
+            1.2667870303593698,
+            0.18910369246676978,
+            0.5169601450360208
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.2811748610275747
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 101.18491920459746,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.002777777777777778,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.20098499061913697
+        }
+      },
+      "model_kruskal_h": 101.18491920459746,
+      "model_p_value": 0.002777777777777778,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": -0.062382739212007515,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1555,
+          "pct": 0.3645955451348183
+        },
+        "ranging_directional_down": {
+          "count": 228,
+          "pct": 0.05345838218053927
+        },
+        "ranging_directional_up": {
+          "count": 433,
+          "pct": 0.1015240328253224
+        },
+        "ranging_volatile": {
+          "count": 346,
+          "pct": 0.08112543962485345
+        },
+        "trending_down_choppy": {
+          "count": 783,
+          "pct": 0.1835873388042204
+        },
+        "trending_up_choppy": {
+          "count": 545,
+          "pct": 0.12778429073856976
+        },
+        "trending_up_clean": {
+          "count": 375,
+          "pct": 0.08792497069167643
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.2222222222222222,
+          "transition_rate": 0.19093988145639287,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.3645955451348183,
+          "transition_rate": 0.20098499061913697,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.37375356125356124,
+          "transition_rate": 0.1611754229741763,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.23972522994527884,
+          "transition_rate": 0.2444108057755007,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.2017353579175705,
+          "transition_rate": 0.23191899710703953,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_clean",
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 2.089512478693312,
+          "centroid_raw": [
+            0.1405800513769383,
+            0.1934366321745909,
+            0.2824434180038242,
+            34.509570327338366,
+            1.0652274253958057e-05,
+            -0.2691532273746905,
+            0.16280684488984293,
+            0.5156593847263589
+          ],
+          "volatility_rank": 6
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.09010474742633207,
+            0.189015981016644,
+            0.23322932045120387,
+            36.338469871404776,
+            2.5793474372620837e-05,
+            0.8323409390545984,
+            0.20707400297064724,
+            0.5226281087648599
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.26802936111549885,
+          "centroid_raw": [
+            0.008385865648352735,
+            0.12935773472483997,
+            0.07751260393811864,
+            22.20687746384114,
+            1.018887763480065e-05,
+            -0.25161777798173424,
+            0.15508021119752147,
+            0.49959742708825167
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12951671807662685,
+            0.1903051309700237,
+            0.2556789646680676,
+            41.7240245613345,
+            6.506629803614139e-06,
+            0.5504166163152693,
+            0.16622721411184893,
+            0.4980903396550737
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.019301854761863527,
+          "centroid_raw": [
+            0.0355689570453242,
+            0.13340469780944184,
+            0.13086760457820265,
+            24.784570136945952,
+            1.2489389322273535e-05,
+            0.7026669268321589,
+            0.14246234675914526,
+            0.49830197994939185
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.00059116756356455,
+            0.11528570012408451,
+            0.04182529965177044,
+            21.384646497668474,
+            1.2488375268580186e-05,
+            -0.32934231543185477,
+            0.14241456645035022,
+            0.4646013450165056
+          ],
+          "volatility_rank": 0
+        },
+        "6": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.42798544653257636,
+          "centroid_raw": [
+            -0.08739368988373972,
+            0.1621919157776588,
+            0.18105048264371673,
+            33.334535663711186,
+            1.249070874124379e-05,
+            -0.38902469599526646,
+            0.16213040218929936,
+            0.5252817537732395
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 2.089512478693312
+          },
+          "2": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.26802936111549885
+          },
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.019301854761863527
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.42798544653257636
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 49.88783115833212,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0011111111111111111,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.12218574108818012
+        }
+      },
+      "model_kruskal_h": 49.88783115833212,
+      "model_p_value": 0.0011111111111111111,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.016416510318949334,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1126,
+          "pct": 0.26400937866354046
+        },
+        "ranging_directional_up": {
+          "count": 3139,
+          "pct": 0.7359906213364595
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5934391534391534,
+          "transition_rate": 0.16363251481795088,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.593 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.7359906213364595,
+          "transition_rate": 0.12218574108818012,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.736 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.7628205128205128,
+          "transition_rate": 0.0879786286731968,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.763 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5360344626848295,
+          "transition_rate": 0.17699115044247787,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.536 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5355507351168957,
+          "transition_rate": 0.17864030858244936,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.536 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006603577713852228,
+            0.15826802259662776,
+            0.1612503931963729,
+            29.882048052942746,
+            1.2228231543456626e-05,
+            0.5687895849772008,
+            0.163755155563353,
+            0.5043639708061097
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.003015258803247974,
+            0.14101458886758772,
+            0.12972287422023895,
+            27.165471710103954,
+            1.2489497348310576e-05,
+            -0.2969611811147752,
+            0.15186823530073745,
+            0.49450363637478717
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 64.56786531802754,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.1151500938086304
+        }
+      },
+      "model_kruskal_h": 64.56786531802754,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.023452157598499057,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 3183,
+          "pct": 0.7463071512309496
+        },
+        "ranging_volatile": {
+          "count": 796,
+          "pct": 0.18663540445486518
+        },
+        "trending_down_choppy": {
+          "count": 286,
+          "pct": 0.06705744431418523
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.44317460317460317,
+          "transition_rate": 0.15325994919559696,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.443 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.7463071512309496,
+          "transition_rate": 0.1151500938086304,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.746 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.7811609686609686,
+          "transition_rate": 0.07693677649154052,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.781 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5693328676213761,
+          "transition_rate": 0.16511411271541687,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.569 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.49072065557965777,
+          "transition_rate": 0.16297010607521698,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.491 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.010092591645404762,
+            0.1260884168238325,
+            0.08737995932620374,
+            23.377187136516703,
+            1.2487384112981076e-05,
+            -0.2582527935932555,
+            0.14539134318994876,
+            0.48375354476061455
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11145265210290553,
+            0.1767539881098581,
+            0.228230644288877,
+            38.162845354916236,
+            1.2484662088106311e-05,
+            -0.3122034244176629,
+            0.1652428094253052,
+            0.526358331921058
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.02269858907114923,
+            0.16186835542477182,
+            0.1735597176824129,
+            30.392571099615104,
+            1.225124099110448e-05,
+            0.4699093329233136,
+            0.16557200961346202,
+            0.5054738856144533
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 114.8729849286683,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0022222222222222222,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.12617260787992496
+        }
+      },
+      "model_kruskal_h": 114.8729849286683,
+      "model_p_value": 0.0022222222222222222,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.012429643527204493,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 873,
+          "pct": 0.20468933177022275
+        },
+        "ranging_volatile": {
+          "count": 1987,
+          "pct": 0.4658851113716295
+        },
+        "trending_down_choppy": {
+          "count": 881,
+          "pct": 0.20656506447831183
+        },
+        "trending_up_choppy": {
+          "count": 524,
+          "pct": 0.12286049237983587
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.49693121693121695,
+          "transition_rate": 0.15622353937341235,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.497 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.4658851113716295,
+          "transition_rate": 0.12617260787992496,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.466 > 0.392"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5614316239316239,
+          "transition_rate": 0.10454140694568122,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.561 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3745488415415066,
+          "transition_rate": 0.17454587796925944,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.4567365630272355,
+          "transition_rate": 0.16899710703953713,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.457 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0054302028521880505,
+            0.13328322278066784,
+            0.0909940974213527,
+            24.000008453849208,
+            1.2870991548254633e-05,
+            0.5705124450847061,
+            0.1567203141330449,
+            0.505247570392671
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.16057922385561896,
+            0.21152078421421,
+            0.31768304249718193,
+            38.38399774341271,
+            1.562701440605227e-05,
+            0.22811208726256396,
+            0.1869957343028635,
+            0.5134368067937789
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13145846593870683,
+            0.1908518945942107,
+            0.26342418813634655,
+            42.56570928828447,
+            8.455999006668256e-06,
+            0.3600247140885293,
+            0.16671135909680546,
+            0.5050999635490443
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0018250892459227314,
+            0.1341341197736229,
+            0.109203422184484,
+            25.26393339571929,
+            1.248986671666979e-05,
+            -0.3177883954723716,
+            0.14888035681570178,
+            0.4907216655764685
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 125.84180859612752,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.249765478424015
+        }
+      },
+      "model_kruskal_h": 125.84180859612752,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": -0.11116322701688555,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 830,
+          "pct": 0.19460726846424384
+        },
+        "ranging_directional_up": {
+          "count": 876,
+          "pct": 0.20539273153575616
+        },
+        "ranging_volatile": {
+          "count": 1480,
+          "pct": 0.347010550996483
+        },
+        "trending_down_choppy": {
+          "count": 654,
+          "pct": 0.1533411488862837
+        },
+        "trending_up_choppy": {
+          "count": 425,
+          "pct": 0.09964830011723329
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.48232804232804233,
+          "transition_rate": 0.20766299745977984,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.482 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.347010550996483,
+          "transition_rate": 0.249765478424015,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.44017094017094016,
+          "transition_rate": 0.20943900267141585,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.440 > 0.392"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3723367097450227,
+          "transition_rate": 0.2434792734047508,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.4543263436972764,
+          "transition_rate": 0.22974927675988427,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.454 > 0.392"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.049787919906457714,
+          "centroid_raw": [
+            0.0025359390766297083,
+            0.1304142031100702,
+            0.09901631403559727,
+            24.444312222865438,
+            1.2490571834341849e-05,
+            -0.25246191233050597,
+            0.14737534138507918,
+            0.4895324006975602
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.15709892621274257,
+            0.20872030803803227,
+            0.3111347211634836,
+            37.74957261927129,
+            1.550145667048913e-05,
+            -0.31622991814714163,
+            0.18784822970095397,
+            0.5129186476379954
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.007394329789428668,
+            0.13295865508590218,
+            0.08102376377614812,
+            23.144236221802206,
+            1.3421856167598578e-05,
+            -0.3493698479659906,
+            0.15914286901723562,
+            0.5053902522737324
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.006748157940404737,
+            0.1583215441792507,
+            0.174045580327248,
+            30.74684944075727,
+            1.1343704573281655e-05,
+            2.3062158036459532,
+            0.15859385562088515,
+            0.5064001257082474
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12514268524090943,
+            0.1870310485262891,
+            0.2528922097965481,
+            41.94462724195674,
+            9.227135854217683e-06,
+            -0.3143172075193841,
+            0.16705050275558747,
+            0.5067846877395811
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.049787919906457714
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 126.05553705051716,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.24085365853658536
+        }
+      },
+      "model_kruskal_h": 126.05553705051716,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": -0.1022514071294559,
+      "coverage": {
+        "ranging_directional": {
+          "count": 692,
+          "pct": 0.1622508792497069
+        },
+        "ranging_directional_down": {
+          "count": 386,
+          "pct": 0.09050410316529894
+        },
+        "ranging_directional_up": {
+          "count": 992,
+          "pct": 0.23259085580304806
+        },
+        "ranging_volatile": {
+          "count": 1436,
+          "pct": 0.336694021101993
+        },
+        "trending_down_choppy": {
+          "count": 515,
+          "pct": 0.12075029308323564
+        },
+        "trending_up_choppy": {
+          "count": 244,
+          "pct": 0.05720984759671747
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.4146031746031746,
+          "transition_rate": 0.22459779847586792,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.415 > 0.392"
+          ]
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.336694021101993,
+          "transition_rate": 0.24085365853658536,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.3919159544159544,
+          "transition_rate": 0.21353517364203028,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.3094655955291652,
+          "transition_rate": 0.2633907778295296,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.38009158833453843,
+          "transition_rate": 0.24686595949855353,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.01035203838836714,
+            0.13121473011348286,
+            0.0799525617917564,
+            22.828007525413415,
+            1.0374624980809866e-05,
+            -0.3720599750239506,
+            0.15619924306650979,
+            0.5031485153928156
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.1304604307424208,
+          "centroid_raw": [
+            -0.0030674077974625104,
+            0.1261459145225806,
+            0.08466498175542042,
+            23.5976325706585,
+            1.2491801693936877e-05,
+            -0.3072855336280238,
+            0.1461814768185008,
+            0.48641254766341013
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12083872268538093,
+            0.18341820238402917,
+            0.24492255585550518,
+            40.71124133840322,
+            9.94082105418576e-06,
+            -0.2983461144157551,
+            0.16518622153156431,
+            0.509382429565471
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.00031777300473241697,
+            0.13411502227259758,
+            0.11457494460059961,
+            25.327803350830752,
+            1.1346899703500716e-05,
+            2.1532109656184604,
+            0.147435868329377,
+            0.49777583707117634
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.12641704677841864,
+            0.18216791875905125,
+            0.2585147470662638,
+            33.81727870395507,
+            1.2480474060460017e-05,
+            -0.24156060174347357,
+            0.17046905747053562,
+            0.5084912201483314
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0460460002615433,
+            0.20097789866787683,
+            0.2691750704717024,
+            37.84034848098248,
+            1.869448843007193e-05,
+            0.885274990947392,
+            0.18580452690770538,
+            0.518684656026845
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.1304604307424208
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 122.22544245776226,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.2621951219512195
+        }
+      },
+      "model_kruskal_h": 122.22544245776226,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": -0.12359287054409007,
+      "coverage": {
+        "ranging_directional": {
+          "count": 386,
+          "pct": 0.09050410316529894
+        },
+        "ranging_directional_down": {
+          "count": 607,
+          "pct": 0.14232121922626026
+        },
+        "ranging_directional_up": {
+          "count": 917,
+          "pct": 0.21500586166471278
+        },
+        "ranging_volatile": {
+          "count": 1327,
+          "pct": 0.311137162954279
+        },
+        "trending_down_choppy": {
+          "count": 412,
+          "pct": 0.09660023446658851
+        },
+        "trending_down_clean": {
+          "count": 330,
+          "pct": 0.07737397420867527
+        },
+        "trending_up_choppy": {
+          "count": 286,
+          "pct": 0.06705744431418523
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.3580952380952381,
+          "transition_rate": 0.23221845893310752,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.311137162954279,
+          "transition_rate": 0.2621951219512195,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.3863960113960114,
+          "transition_rate": 0.21602849510240427,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.26499010362091047,
+          "transition_rate": 0.26525384257102935,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.3289949385394071,
+          "transition_rate": 0.24541947926711669,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_clean",
+        "ranging_directional",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.12008837965034845,
+            0.17759724747455838,
+            0.24593059592190064,
+            33.04630364248608,
+            1.2482625263366802e-05,
+            -0.18944672194827197,
+            0.1676656565757821,
+            0.5086592508037543
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.2246111340480704,
+          "centroid_raw": [
+            0.06962459041323812,
+            0.19810552373215257,
+            0.264282610048431,
+            36.879223262846025,
+            1.976533858835515e-05,
+            0.8427904214373613,
+            0.18443055323430926,
+            0.5229685034931656
+          ],
+          "volatility_rank": 6
+        },
+        "2": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.011959945366899873,
+            0.13113347609010845,
+            0.0789491440618929,
+            22.82392592185539,
+            1.0701378347885717e-05,
+            -0.38167267767210167,
+            0.1560039364918797,
+            0.5049136491672934
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_down_clean",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 2.645216709214373,
+          "centroid_raw": [
+            -0.10998484051060174,
+            0.17525413477214624,
+            0.2245844129843468,
+            37.7982886833221,
+            1.2492597168348704e-05,
+            0.15724318885629487,
+            0.16466600007567744,
+            0.5263754081063663
+          ],
+          "volatility_rank": 3
+        },
+        "4": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.23061750565412587,
+          "centroid_raw": [
+            0.009239521678593267,
+            0.12549037428813925,
+            0.08960424541951248,
+            22.71261824410947,
+            1.0999213503109412e-05,
+            1.9970201003383479,
+            0.14668219180254677,
+            0.48248001608445507
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.20020406640472682,
+          "centroid_raw": [
+            0.0014610175258798113,
+            0.12259779438487337,
+            0.0744945154019272,
+            22.77331102578173,
+            1.2491313107811084e-05,
+            -0.3253154562053213,
+            0.1442856562211474,
+            0.4801792013337116
+          ],
+          "volatility_rank": 0
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11213684060547287,
+            0.18218687387708565,
+            0.22449907366189775,
+            39.30424403974392,
+            3.852326693387135e-06,
+            -0.3845157520920447,
+            0.16553096618774132,
+            0.4917126847933808
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.2246111340480704
+          },
+          "3": {
+            "from": "trending_down_choppy",
+            "to": "trending_down_clean",
+            "displacement_z": 2.645216709214373
+          },
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.23061750565412587
+          },
+          "5": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.20020406640472682
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 55.94457810355925,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.013333333333333334,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.0323639774859287
+        }
+      },
+      "model_kruskal_h": 55.94457810355925,
+      "model_p_value": 0.013333333333333334,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.10623827392120075,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1888,
+          "pct": 0.44267291910902695
+        },
+        "ranging_volatile": {
+          "count": 2377,
+          "pct": 0.557327080890973
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6044444444444445,
+          "transition_rate": 0.03365791701947502,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.604 > 0.392",
+            "min_transition_rate: 0.0337 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.557327080890973,
+          "transition_rate": 0.0323639774859287,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.557 > 0.392",
+            "min_transition_rate: 0.0324 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5509259259259259,
+          "transition_rate": 0.04666073018699911,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.551 > 0.392",
+            "min_transition_rate: 0.0467 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5266037955524508,
+          "transition_rate": 0.05414531904983698,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.527 > 0.392",
+            "min_transition_rate: 0.0541 < 0.0687"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5476018317666907,
+          "transition_rate": 0.03881388621022179,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 5",
+            "max_occupancy: 0.548 > 0.392",
+            "min_transition_rate: 0.0388 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.006131465211772973,
+            0.18661296426753177,
+            0.2410214109724183,
+            38.119502792349174,
+            1.3475705825791794e-05,
+            0.14669514782387222,
+            0.17588370442274365,
+            0.5262998022932037
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005143611591940628,
+            0.12504381540769127,
+            0.08381237291967525,
+            22.394062698267703,
+            1.172883747040915e-05,
+            0.004422789222390165,
+            0.14528948451440982,
+            0.4819463490284309
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 79.296983632501,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.02,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.038696060037523454
+        }
+      },
+      "model_kruskal_h": 79.296983632501,
+      "model_p_value": 0.02,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.09990619136960599,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2270,
+          "pct": 0.5322391559202814
+        },
+        "trending_down_choppy": {
+          "count": 1172,
+          "pct": 0.27479484173505275
+        },
+        "trending_up_choppy": {
+          "count": 823,
+          "pct": 0.19296600234466588
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5843386243386244,
+          "transition_rate": 0.04339542760372565,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.584 > 0.392",
+            "min_transition_rate: 0.0434 < 0.0687"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5322391559202814,
+          "transition_rate": 0.038696060037523454,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.532 > 0.392",
+            "min_transition_rate: 0.0387 < 0.0687"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.44533475783475784,
+          "transition_rate": 0.060552092609082814,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.445 > 0.392",
+            "min_transition_rate: 0.0606 < 0.0687"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4544184421935033,
+          "transition_rate": 0.06916627852817886,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.454 > 0.392"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5427813931067728,
+          "transition_rate": 0.048698167791706846,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 5",
+            "max_occupancy: 0.543 > 0.392",
+            "min_transition_rate: 0.0487 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006039712266932352,
+            0.12418719703433945,
+            0.07949745898448322,
+            22.30201589383013,
+            1.1853302175438544e-05,
+            0.0043022482473618895,
+            0.14495377717837754,
+            0.4817653852037289
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.10816298555613138,
+            0.1784818563481863,
+            0.21955262417207272,
+            38.96683064381582,
+            1.0069260336763335e-05,
+            0.1301956890237536,
+            0.1675231861478557,
+            0.5254736347980727
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.12752143992766915,
+            0.19225268858742045,
+            0.2638827890533403,
+            35.23354476426298,
+            1.732167468982625e-05,
+            0.15011738214868436,
+            0.18409782156090196,
+            0.5221473214661131
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 194.7406882824689,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.07152908067542214
+        }
+      },
+      "model_kruskal_h": 194.7406882824689,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.06707317073170731,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 964,
+          "pct": 0.2260257913247362
+        },
+        "ranging_volatile": {
+          "count": 1616,
+          "pct": 0.3788980070339977
+        },
+        "trending_down_choppy": {
+          "count": 998,
+          "pct": 0.2339976553341149
+        },
+        "trending_up_choppy": {
+          "count": 687,
+          "pct": 0.16107854630715124
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3784126984126984,
+          "transition_rate": 0.06922099915325995,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3788980070339977,
+          "transition_rate": 0.07152908067542214,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3529202279202279,
+          "transition_rate": 0.07960819234194123,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3005006403539411,
+          "transition_rate": 0.09443409408476945,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.39720414557724754,
+          "transition_rate": 0.06099324975891996,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 5",
+            "max_occupancy: 0.397 > 0.392",
+            "min_transition_rate: 0.0610 < 0.0687"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=5: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.005714938674555461,
+            0.13886965596357126,
+            0.10245934337822082,
+            26.4666350326848,
+            1.4158465291607332e-05,
+            0.0714156285081279,
+            0.16954290227062402,
+            0.6053063810550499
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1433809236261398,
+            0.19923694656519783,
+            0.28886774055076225,
+            36.60974375882589,
+            1.5097107328244223e-05,
+            0.13713403781160188,
+            0.17859756863265397,
+            0.5065809462352511
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12109715755879447,
+            0.1846509248347497,
+            0.24493444110411192,
+            40.922458456702486,
+            9.602400982800988e-06,
+            0.18082051705283153,
+            0.16302896574729367,
+            0.4991227100371652
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009223250830873494,
+            0.12088080750544186,
+            0.0763871348180761,
+            21.141714666978014,
+            1.1294842378378382e-05,
+            -0.03512749202530743,
+            0.13649680484504753,
+            0.4143006632506554
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 174.5526835714245,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.16604127579737335
+        }
+      },
+      "model_kruskal_h": 174.5526835714245,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": -0.0274390243902439,
+      "coverage": {
+        "ranging_directional": {
+          "count": 875,
+          "pct": 0.205158264947245
+        },
+        "ranging_directional_down": {
+          "count": 336,
+          "pct": 0.07878077373974209
+        },
+        "ranging_volatile": {
+          "count": 1518,
+          "pct": 0.3559202813599062
+        },
+        "trending_down_choppy": {
+          "count": 921,
+          "pct": 0.21594372801875733
+        },
+        "trending_up_choppy": {
+          "count": 615,
+          "pct": 0.14419695193434937
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.35873015873015873,
+          "transition_rate": 0.14775613886536834,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.3559202813599062,
+          "transition_rate": 0.16604127579737335,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.33725071225071224,
+          "transition_rate": 0.1435440783615316,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.28780998952148096,
+          "transition_rate": 0.1679087098276665,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.37020968908170643,
+          "transition_rate": 0.14151398264223722,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009646579900771817,
+            0.12092440885055591,
+            0.07588470612917493,
+            21.161653021683698,
+            1.1214607970604848e-05,
+            -0.20710726907842528,
+            0.1359840949643567,
+            0.41560658227468245
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14597772251420435,
+            0.20159387622780567,
+            0.29312886518074793,
+            37.08245524788754,
+            1.5354534276206273e-05,
+            -0.10611096787477872,
+            0.1811283498906145,
+            0.5086674485329397
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": true,
+          "displacement_z": 0.05861796504437978,
+          "centroid_raw": [
+            -0.005121533977951728,
+            0.13853818816224686,
+            0.10195374507074006,
+            26.329108548332165,
+            1.429508301306681e-05,
+            -0.20576508998676465,
+            0.1710853179641346,
+            0.6053349393915005
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.00701500484401247,
+            0.14989165874943675,
+            0.15490877672772885,
+            28.517666188285062,
+            1.2050453608247425e-05,
+            3.6727890835135732,
+            0.1505115658546251,
+            0.49742003562578835
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12021454780815938,
+            0.18447762597749093,
+            0.24354950437978223,
+            41.07495865549276,
+            9.614572346002625e-06,
+            -0.1290964370301164,
+            0.16354984078280382,
+            0.5011877292317141
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.05861796504437978
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 179.6832995552868,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.17166979362101314
+        }
+      },
+      "model_kruskal_h": 179.6832995552868,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": -0.033067542213883694,
+      "coverage": {
+        "ranging_directional": {
+          "count": 968,
+          "pct": 0.22696365767878077
+        },
+        "ranging_directional_down": {
+          "count": 318,
+          "pct": 0.07456037514654162
+        },
+        "ranging_directional_up": {
+          "count": 156,
+          "pct": 0.0365767878077374
+        },
+        "ranging_volatile": {
+          "count": 1347,
+          "pct": 0.31582649472450175
+        },
+        "trending_down_choppy": {
+          "count": 869,
+          "pct": 0.2037514654161782
+        },
+        "trending_up_choppy": {
+          "count": 607,
+          "pct": 0.14232121922626026
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.3233862433862434,
+          "transition_rate": 0.15050804403048265,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.31582649472450175,
+          "transition_rate": 0.17166979362101314,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.35648148148148145,
+          "transition_rate": 0.15316117542297417,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.22808243101641634,
+          "transition_rate": 0.18770377270610153,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.341528079055194,
+          "transition_rate": 0.15646094503375121,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": true,
+          "displacement_z": 0.038769250271505795,
+          "centroid_raw": [
+            -0.0033873238761342617,
+            0.1369405935772536,
+            0.09882847263957559,
+            26.11711401324242,
+            1.1290768519855598e-05,
+            -0.21212243133903055,
+            0.1613232796403034,
+            0.599306421942793
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.007688854226409722,
+            0.11953587955985104,
+            0.07284845634021382,
+            20.722456592154067,
+            1.159193942247332e-05,
+            -0.2017132695728833,
+            0.1375320831988222,
+            0.4035287194588644
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12049500773308379,
+            0.18463647648575662,
+            0.2438048320200097,
+            41.07576136932494,
+            9.668478055190541e-06,
+            -0.1285906076518008,
+            0.1645645818036436,
+            0.5018043684496868
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.009627830838144634,
+            0.14926404469108434,
+            0.15478427645426346,
+            28.673960765999073,
+            1.1852674368231046e-05,
+            3.7527054258962105,
+            0.1505805605601693,
+            0.49308373263465194
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14412480379956133,
+            0.19755860174363388,
+            0.2884208070044121,
+            36.290888283831606,
+            1.2166317970049911e-05,
+            -0.07714004883183218,
+            0.17511229153178154,
+            0.5031523175956168
+          ],
+          "volatility_rank": 5
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.04219380289106968,
+            0.17607116767764283,
+            0.17854063900215653,
+            31.660024844332877,
+            5.972858055555557e-05,
+            -0.07154413226781514,
+            0.23958421345033742,
+            0.5731564707198075
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.038769250271505795
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 80.47242092503984,
+          "model_kruskal_h": 236.27466801305673,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0005555555555555556,
+          "handrule_transition_rate": 0.13860225140712945,
+          "model_transition_rate": 0.1325046904315197
+        }
+      },
+      "model_kruskal_h": 236.27466801305673,
+      "model_p_value": 0.0005555555555555556,
+      "handrule_kruskal_h": 80.47242092503984,
+      "stability_gain": 0.0060975609756097615,
+      "coverage": {
+        "ranging_directional": {
+          "count": 331,
+          "pct": 0.0776084407971864
+        },
+        "ranging_directional_down": {
+          "count": 669,
+          "pct": 0.15685814771395076
+        },
+        "ranging_directional_up": {
+          "count": 113,
+          "pct": 0.0264947245017585
+        },
+        "ranging_volatile": {
+          "count": 1347,
+          "pct": 0.31582649472450175
+        },
+        "trending_down_choppy": {
+          "count": 540,
+          "pct": 0.12661195779601406
+        },
+        "trending_down_clean": {
+          "count": 623,
+          "pct": 0.14607268464243844
+        },
+        "trending_up_choppy": {
+          "count": 642,
+          "pct": 0.15052754982415006
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.3166137566137566,
+          "transition_rate": 0.13251481795088907,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.31582649472450175,
+          "transition_rate": 0.1325046904315197,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.33885327635327633,
+          "transition_rate": 0.13446126447016918,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.20700896495517523,
+          "transition_rate": 0.1724499301350722,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.3152566883586406,
+          "transition_rate": 0.1446480231436837,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "ranging_directional",
+        "trending_down_clean",
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1489402883935616,
+            0.2012924311357682,
+            0.2978061544483873,
+            36.27088473250324,
+            1.2090324734982332e-05,
+            0.01363011091684884,
+            0.16886657393746218,
+            0.5020557029481972
+          ],
+          "volatility_rank": 6
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.04121557055440176,
+            0.19050360186329127,
+            0.20085967421093529,
+            33.850164245813794,
+            6.891151139240508e-05,
+            0.11642804329327758,
+            0.23204562327238126,
+            0.5686405841413255
+          ],
+          "volatility_rank": 4
+        },
+        "2": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": true,
+          "displacement_z": 0.05689107234003933,
+          "centroid_raw": [
+            0.004970652935683193,
+            0.13324687400533256,
+            0.09691653066082435,
+            27.15848814938913,
+            1.4579370212765924e-05,
+            -0.26380967080980366,
+            0.2158671893453896,
+            0.5630116376291585
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_down_clean",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 2.1323236692331022,
+          "centroid_raw": [
+            -0.13846572215788414,
+            0.1940765854537312,
+            0.2779859876797669,
+            46.67706541952951,
+            9.712790887290159e-06,
+            0.4189146445719133,
+            0.17190567762141332,
+            0.4687967661923006
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.1302795309282207,
+          "centroid_raw": [
+            0.011306356159753665,
+            0.13399672766684406,
+            0.0968289292443475,
+            24.83186853506261,
+            1.157868545246278e-05,
+            0.8668582743860204,
+            0.12954639771832263,
+            0.5911022373462713
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.011930754969862385,
+            0.11895204057284674,
+            0.07283225835393234,
+            20.727411343796135,
+            1.1200547488584453e-05,
+            -0.2124666951520284,
+            0.137920997968429,
+            0.40142759790810956
+          ],
+          "volatility_rank": 0
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.08768446350112788,
+            0.16877489909086948,
+            0.182992537552855,
+            32.35220625582837,
+            9.261960371517037e-06,
+            -0.29262039769121806,
+            0.152580332336748,
+            0.5504924885844862
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "ranging_directional_up",
+            "to": "ranging_directional",
+            "displacement_z": 0.05689107234003933
+          },
+          "3": {
+            "from": "trending_down_choppy",
+            "to": "trending_down_clean",
+            "displacement_z": 2.1323236692331022
+          },
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.1302795309282207
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    }
+  ],
+  "winner": {
+    "subset": "htf",
+    "family": "hmm",
+    "k": 6
+  },
+  "live_wiring_delta": "Enriched models decode from ENRICHED_COLUMNS; live check_regime.py builds only CANONICAL_COLUMNS. Live wiring (#1074) must feed funding_rate + volume_z + htf_range_eff + hurst on-cycle in this exact order, or forward_filter_labels reads garbage."
+}

--- a/docs/research/1499-artifacts/regime_1095_eth.json
+++ b/docs/research/1499-artifacts/regime_1095_eth.json
@@ -1,0 +1,17886 @@
+{
+  "issue": 1095,
+  "symbol": "ETH/USDT",
+  "timeframe": "1h",
+  "in_sample": "is",
+  "held_out": "oos",
+  "target": "volatility",
+  "htf_multiple": 4,
+  "candidate_count": 90,
+  "significance_alpha": 0.05,
+  "bonferroni_alpha": 0.0016666666666666668,
+  "bonferroni_denominator": 30,
+  "bonferroni_denominator_policy": "ONE family across all feature-subset ablations (#1095 4b): alpha is divided by the COMBINED structurally-eligible candidate count of the whole subsets x families x K grid; structurally ineligible candidates (k < incumbent-derived min_active_labels) are scored for evidence but excluded (#1160)",
+  "structurally_ineligible": [
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "hmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "gmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "canonical",
+      "family": "kmeans",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "hmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "gmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "funding",
+      "family": "kmeans",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "volume",
+      "family": "kmeans",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "gmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "htf",
+      "family": "kmeans",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 2,
+      "reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 3,
+      "reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 4,
+      "reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 5,
+      "reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable"
+    }
+  ],
+  "n_perm": 1199,
+  "min_achievable_p_value": 0.0008333333333333334,
+  "non_degeneracy_thresholds": {
+    "min_active_labels": 6,
+    "max_occupancy": 0.39964876501246316,
+    "min_transition_rate": 0.06950028719126938
+  },
+  "subset_status": {
+    "canonical": "ok",
+    "funding": "ok",
+    "volume": "ok",
+    "htf": "ok",
+    "all_enriched": "ok"
+  },
+  "handrule_held_out": {
+    "canonical": {
+      "kruskal_h": 85.21096933007357,
+      "p_value": 0.005833333333333334,
+      "transition_rate": 0.14075249320036265,
+      "abstained": false,
+      "permutation_steps_to_alpha": 53,
+      "knife_edge": false
+    },
+    "funding": {
+      "kruskal_h": 85.21096933007357,
+      "p_value": 0.005833333333333334,
+      "transition_rate": 0.14075249320036265,
+      "abstained": false,
+      "permutation_steps_to_alpha": 53,
+      "knife_edge": false
+    },
+    "volume": {
+      "kruskal_h": 85.21096933007357,
+      "p_value": 0.005833333333333334,
+      "transition_rate": 0.14075249320036265,
+      "abstained": false,
+      "permutation_steps_to_alpha": 53,
+      "knife_edge": false
+    },
+    "htf": {
+      "kruskal_h": 88.72068555027909,
+      "p_value": 0.005,
+      "transition_rate": 0.1425891181988743,
+      "abstained": false,
+      "permutation_steps_to_alpha": 54,
+      "knife_edge": false
+    },
+    "all_enriched": {
+      "kruskal_h": 88.72068555027909,
+      "p_value": 0.005,
+      "transition_rate": 0.1425891181988743,
+      "abstained": false,
+      "permutation_steps_to_alpha": 54,
+      "knife_edge": false
+    }
+  },
+  "baseline_note": "the merged #1080 evidence was measured at n_perm=200 with the incumbent at a knife-edge (OOS p = 10/201); handrule_held_out.canonical re-measures that baseline at this run's resolved n_perm so enriched-vs-baseline and the incumbent-trustworthy verdict share one resolution (#1095 4c)",
+  "ablation": {
+    "canonical": {
+      "status": "ok",
+      "best_kruskal_h": 173.75547851663032,
+      "best_candidate": {
+        "family": "kmeans",
+        "k": 7
+      },
+      "any_ships": true,
+      "separation_gain_vs_canonical": 0.0
+    },
+    "funding": {
+      "status": "ok",
+      "best_kruskal_h": 176.16490796125436,
+      "best_candidate": {
+        "family": "kmeans",
+        "k": 7
+      },
+      "any_ships": true,
+      "separation_gain_vs_canonical": 2.4094294446240383
+    },
+    "volume": {
+      "status": "ok",
+      "best_kruskal_h": 115.22492709619291,
+      "best_candidate": {
+        "family": "hmm",
+        "k": 6
+      },
+      "any_ships": false,
+      "separation_gain_vs_canonical": -58.530551420437405
+    },
+    "htf": {
+      "status": "ok",
+      "best_kruskal_h": 126.16884311616741,
+      "best_candidate": {
+        "family": "gmm",
+        "k": 7
+      },
+      "any_ships": false,
+      "separation_gain_vs_canonical": -47.58663540046291
+    },
+    "all_enriched": {
+      "status": "ok",
+      "best_kruskal_h": 194.30985034415062,
+      "best_candidate": {
+        "family": "kmeans",
+        "k": 7
+      },
+      "any_ships": true,
+      "separation_gain_vs_canonical": 20.5543718275203
+    }
+  },
+  "candidates": [
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 88.93634854019001,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03241160471441523
+        }
+      },
+      "model_kruskal_h": 88.93634854019001,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.10834088848594742,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1902,
+          "pct": 0.4309993201903467
+        },
+        "ranging_volatile": {
+          "count": 2511,
+          "pct": 0.5690006798096533
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5860865996306177,
+          "transition_rate": 0.03201970443349754,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.586 > 0.400",
+            "min_transition_rate: 0.0320 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5690006798096533,
+          "transition_rate": 0.03241160471441523,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.569 > 0.400",
+            "min_transition_rate: 0.0324 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6219848380427292,
+          "transition_rate": 0.02906375646180356,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.622 > 0.400",
+            "min_transition_rate: 0.0291 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5936820418908092,
+          "transition_rate": 0.028960622710622712,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.594 > 0.400",
+            "min_transition_rate: 0.0290 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6143821270653944,
+          "transition_rate": 0.03328677839851024,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.614 > 0.400",
+            "min_transition_rate: 0.0333 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009081372270795909,
+            0.21042919642549873,
+            0.27566644569057003,
+            37.32678127873311
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006783825235659949,
+            0.13709963879586332,
+            0.08763409506775825,
+            21.338046895749788
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 88.0880714597588,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.021666666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.037398005439709885
+        }
+      },
+      "model_kruskal_h": 88.0880714597588,
+      "model_p_value": 0.021666666666666667,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.10335448776065276,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2388,
+          "pct": 0.5411284840244731
+        },
+        "trending_down_choppy": {
+          "count": 1253,
+          "pct": 0.28393383186041243
+        },
+        "trending_up_choppy": {
+          "count": 772,
+          "pct": 0.17493768411511443
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5604350502770368,
+          "transition_rate": 0.034688013136289,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.560 > 0.400",
+            "min_transition_rate: 0.0347 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5411284840244731,
+          "transition_rate": 0.037398005439709885,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.541 > 0.400",
+            "min_transition_rate: 0.0374 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6065931541465656,
+          "transition_rate": 0.03205054566341183,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.607 > 0.400",
+            "min_transition_rate: 0.0321 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5753691198351837,
+          "transition_rate": 0.03456959706959707,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.575 > 0.400",
+            "min_transition_rate: 0.0346 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5920409588084711,
+          "transition_rate": 0.039338919925512104,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.592 > 0.400",
+            "min_transition_rate: 0.0393 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009809026696675521,
+            0.13610801650199172,
+            0.08239149102997922,
+            21.133775277481618
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.15613665271388247,
+            0.21976619999094518,
+            0.30353260787692876,
+            35.92867150555509
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12276377556292303,
+            0.1958398628464102,
+            0.24132326123473935,
+            37.02253219436053
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 96.72479197974462,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.016666666666666666,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.06391659111514053
+        }
+      },
+      "model_kruskal_h": 96.72479197974462,
+      "model_p_value": 0.016666666666666666,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.07683590208522212,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 815,
+          "pct": 0.18468162247903921
+        },
+        "ranging_volatile": {
+          "count": 1780,
+          "pct": 0.40335372762293226
+        },
+        "trending_down_choppy": {
+          "count": 1372,
+          "pct": 0.3108996147745298
+        },
+        "trending_up_choppy": {
+          "count": 446,
+          "pct": 0.10106503512349875
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.40201108146932074,
+          "transition_rate": 0.06691297208538588,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.402 > 0.400",
+            "min_transition_rate: 0.0669 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.40335372762293226,
+          "transition_rate": 0.06391659111514053,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.403 > 0.400",
+            "min_transition_rate: 0.0639 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4655410062026189,
+          "transition_rate": 0.06318207926479034,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.466 > 0.400",
+            "min_transition_rate: 0.0632 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.4337873411926291,
+          "transition_rate": 0.06810897435897435,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.434 > 0.400",
+            "min_transition_rate: 0.0681 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.4335582964859204,
+          "transition_rate": 0.06936685288640596,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.434 > 0.400",
+            "min_transition_rate: 0.0694 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.36764117481280406,
+          "centroid_raw": [
+            0.0824237789453056,
+            0.1600840040441132,
+            0.1648760272970914,
+            22.760947342299332
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1792475502134432,
+            0.23949656299902483,
+            0.3452545568492571,
+            39.917549924650665
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11674581510872285,
+            0.1920592619529609,
+            0.22931729997040026,
+            35.81895665942249
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.00400415942923364,
+            0.1293373214231748,
+            0.060123037795185505,
+            20.98778022017175
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.36764117481280406
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 100.81649805423694,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.008333333333333333,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.10448776065276519
+        }
+      },
+      "model_kruskal_h": 100.81649805423694,
+      "model_p_value": 0.008333333333333333,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.03626473254759746,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 938,
+          "pct": 0.21255381826421935
+        },
+        "ranging_directional_up": {
+          "count": 871,
+          "pct": 0.19737140267391798
+        },
+        "ranging_volatile": {
+          "count": 1423,
+          "pct": 0.3224563788805801
+        },
+        "trending_down_choppy": {
+          "count": 671,
+          "pct": 0.1520507591207795
+        },
+        "trending_up_choppy": {
+          "count": 510,
+          "pct": 0.11556764106050306
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.3154114508516314,
+          "transition_rate": 0.09215927750410509,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.3224563788805801,
+          "transition_rate": 0.10448776065276519,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.38605559384332644,
+          "transition_rate": 0.09339460080413556,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3502346343138377,
+          "transition_rate": 0.09935897435897435,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3637421456830347,
+          "transition_rate": 0.1042830540037244,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.002084359266472704,
+            0.12695355916753648,
+            0.04459697561022739,
+            21.103623157839515
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16451871390310271,
+            0.23211418244427146,
+            0.3191199216579527,
+            41.43197570173985
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3808006552337742,
+          "centroid_raw": [
+            0.07369026830467722,
+            0.15266459060236762,
+            0.1478002056282246,
+            21.46558059034102
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17322062185793166,
+            0.2347025809081095,
+            0.334394728693557,
+            38.921944922771736
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3373087708148056,
+          "centroid_raw": [
+            -0.0849453728312693,
+            0.16434168071526217,
+            0.16887520012474222,
+            30.535980796682484
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.3808006552337742
+          },
+          "4": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.3373087708148056
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 100.66908560929187,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.01,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.135766092475068
+        }
+      },
+      "model_kruskal_h": 100.66908560929187,
+      "model_p_value": 0.01,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.00498640072529466,
+      "coverage": {
+        "ranging_directional": {
+          "count": 618,
+          "pct": 0.14004078857919783
+        },
+        "ranging_directional_down": {
+          "count": 957,
+          "pct": 0.2168592794017675
+        },
+        "ranging_directional_up": {
+          "count": 609,
+          "pct": 0.1380013596193066
+        },
+        "ranging_volatile": {
+          "count": 1300,
+          "pct": 0.29458418309539997
+        },
+        "trending_down_choppy": {
+          "count": 682,
+          "pct": 0.15454339451620214
+        },
+        "trending_up_choppy": {
+          "count": 247,
+          "pct": 0.05597099478812599
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.2909911758670224,
+          "transition_rate": 0.12130541871921183,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.29458418309539997,
+          "transition_rate": 0.135766092475068,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.36538019756489776,
+          "transition_rate": 0.12280298678920161,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.324596543435962,
+          "transition_rate": 0.12934981684981686,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.34116825692343494,
+          "transition_rate": 0.13175046554934824,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.6416231851995514,
+          "centroid_raw": [
+            0.11647251232104845,
+            0.1860963849219834,
+            0.23299237343965015,
+            28.940159981301186
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.7357940847772977,
+          "centroid_raw": [
+            0.058940879363899856,
+            0.14287036863770214,
+            0.11773275898525701,
+            19.583986632040826
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16263000999906319,
+            0.22993512373685987,
+            0.31554832964671353,
+            41.51808149729469
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.20373505691214802,
+            0.25608044126112617,
+            0.3878475127049935,
+            43.46047600343901
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.004570477399312873,
+            0.12769465869300584,
+            0.040622451278830254,
+            21.326740585634063
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.32641208134957644,
+          "centroid_raw": [
+            -0.08381646985294128,
+            0.16307549501565144,
+            0.16672788117819926,
+            30.07744096598905
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.6416231851995514
+          },
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.7357940847772977
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.32641208134957644
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 106.3582323948358,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0075,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.1659111514052584
+        }
+      },
+      "model_kruskal_h": 106.3582323948358,
+      "model_p_value": 0.0075,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.02515865820489574,
+      "coverage": {
+        "ranging_directional": {
+          "count": 737,
+          "pct": 0.16700657149331521
+        },
+        "ranging_directional_down": {
+          "count": 503,
+          "pct": 0.11398141853614321
+        },
+        "ranging_directional_up": {
+          "count": 662,
+          "pct": 0.15001133016088827
+        },
+        "ranging_volatile": {
+          "count": 1018,
+          "pct": 0.23068207568547475
+        },
+        "trending_down_choppy": {
+          "count": 624,
+          "pct": 0.14140040788579197
+        },
+        "trending_up_choppy": {
+          "count": 621,
+          "pct": 0.14072059823249491
+        },
+        "trending_up_clean": {
+          "count": 248,
+          "pct": 0.056197598005891684
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.23578904165811615,
+          "transition_rate": 0.15435139573070608,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.23068207568547475,
+          "transition_rate": 0.1659111514052584,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.28623937514357917,
+          "transition_rate": 0.1688684663986215,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.2597001259013391,
+          "transition_rate": 0.1649496336996337,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.2718175471259018,
+          "transition_rate": 0.17318435754189945,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_clean",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5250281418634164,
+          "centroid_raw": [
+            -0.05439015572981092,
+            0.14981850149119963,
+            0.1074680322940196,
+            24.935501731852657
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00045948030971342067,
+            0.12537499883032158,
+            0.03233668404838011,
+            20.78566169594224
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.11605261643314635,
+            0.1857141439868845,
+            0.23218806732072034,
+            28.85357954190147
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1679662191552873,
+            0.2345633840951214,
+            0.32588214458067366,
+            41.53146505858071
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9505283013166153,
+          "centroid_raw": [
+            0.20349365867337732,
+            0.25595065286201557,
+            0.3874133807669227,
+            43.40521832829283
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4659486471221346,
+          "centroid_raw": [
+            0.05770806927370332,
+            0.14184647121223512,
+            0.11534536679555787,
+            19.660971651274565
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5046426041499887,
+          "centroid_raw": [
+            -0.10228124933118385,
+            0.17168423938484728,
+            0.20359375223750426,
+            34.360375505704916
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.5250281418634164
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.9505283013166153
+          },
+          "5": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.4659486471221346
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.5046426041499887
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 85.04351551149193,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03467815049864007
+        }
+      },
+      "model_kruskal_h": 85.04351551149193,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.10607434270172258,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1855,
+          "pct": 0.42034896895535917
+        },
+        "ranging_volatile": {
+          "count": 2558,
+          "pct": 0.5796510310446409
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5977837061358506,
+          "transition_rate": 0.034482758620689655,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.598 > 0.400",
+            "min_transition_rate: 0.0345 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5796510310446409,
+          "transition_rate": 0.03467815049864007,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.580 > 0.400",
+            "min_transition_rate: 0.0347 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6328968527452332,
+          "transition_rate": 0.029523262492820217,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.633 > 0.400",
+            "min_transition_rate: 0.0295 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6051276181755751,
+          "transition_rate": 0.030334249084249084,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.605 > 0.400",
+            "min_transition_rate: 0.0303 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6267163137072376,
+          "transition_rate": 0.03282122905027933,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.627 > 0.400",
+            "min_transition_rate: 0.0328 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.010878319703770697,
+            0.21164611586166412,
+            0.28047181560115503,
+            37.482512468240124
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005677776447105442,
+            0.13820359282286868,
+            0.08937214352815723,
+            21.64983408667506
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 94.1310011388723,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.015,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03921124206708976
+        }
+      },
+      "model_kruskal_h": 94.1310011388723,
+      "model_p_value": 0.015,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.10154125113327289,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2592,
+          "pct": 0.5873555404486743
+        },
+        "trending_down_choppy": {
+          "count": 1165,
+          "pct": 0.2639927486970315
+        },
+        "trending_up_choppy": {
+          "count": 656,
+          "pct": 0.14865171085429413
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5949107326082496,
+          "transition_rate": 0.03694581280788178,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.595 > 0.400",
+            "min_transition_rate: 0.0369 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5873555404486743,
+          "transition_rate": 0.03921124206708976,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.587 > 0.400",
+            "min_transition_rate: 0.0392 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6428899609464737,
+          "transition_rate": 0.029982768523836877,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.643 > 0.400",
+            "min_transition_rate: 0.0300 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6150852695433215,
+          "transition_rate": 0.03502747252747253,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.615 > 0.400",
+            "min_transition_rate: 0.0350 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6353269723062602,
+          "transition_rate": 0.03794227188081937,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.635 > 0.400",
+            "min_transition_rate: 0.0379 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00993350357720869,
+            0.1388487122353543,
+            0.08933156317592186,
+            21.689840174923358
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.16458343697673314,
+            0.22657302344914865,
+            0.3190475590212749,
+            37.197260344765915
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12864916922841999,
+            0.19887772910320134,
+            0.252402514838336,
+            37.91827005520633
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 84.86176134460948,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.016666666666666666,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.06119673617407072
+        }
+      },
+      "model_kruskal_h": 84.86176134460948,
+      "model_p_value": 0.016666666666666666,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.07955575702629193,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 689,
+          "pct": 0.15612961704056197
+        },
+        "ranging_volatile": {
+          "count": 2168,
+          "pct": 0.49127577611602086
+        },
+        "trending_down_choppy": {
+          "count": 1254,
+          "pct": 0.2841604350781781
+        },
+        "trending_up_choppy": {
+          "count": 302,
+          "pct": 0.06843417176523907
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5156987482043915,
+          "transition_rate": 0.0617816091954023,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.516 > 0.400",
+            "min_transition_rate: 0.0618 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.49127577611602086,
+          "transition_rate": 0.06119673617407072,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.491 > 0.400",
+            "min_transition_rate: 0.0612 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5675396278428669,
+          "transition_rate": 0.058701895462377945,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.568 > 0.400",
+            "min_transition_rate: 0.0587 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.5236351150280416,
+          "transition_rate": 0.061469780219780217,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.524 > 0.400",
+            "min_transition_rate: 0.0615 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.5475913427973005,
+          "transition_rate": 0.06261638733705772,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.548 > 0.400",
+            "min_transition_rate: 0.0626 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5604418028018189,
+          "centroid_raw": [
+            0.10806207677858172,
+            0.17858203019715552,
+            0.21586337686143087,
+            27.197451941543516
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.19688983253049538,
+            0.25090898696124286,
+            0.3766373518311746,
+            42.18161812930413
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12410712222540246,
+            0.19539979701382787,
+            0.2437411141587349,
+            36.90969304580499
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0036004018767343106,
+            0.13520005770351518,
+            0.07444042701120276,
+            21.25988366746528
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.5604418028018189
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 107.35025397443314,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.09383499546690843
+        }
+      },
+      "model_kruskal_h": 107.35025397443314,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.046917497733454216,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 751,
+          "pct": 0.1701790165420349
+        },
+        "ranging_directional_up": {
+          "count": 732,
+          "pct": 0.16587355540448676
+        },
+        "ranging_volatile": {
+          "count": 1920,
+          "pct": 0.43507817811012917
+        },
+        "trending_down_choppy": {
+          "count": 640,
+          "pct": 0.14502605937004306
+        },
+        "trending_up_choppy": {
+          "count": 370,
+          "pct": 0.08384319057330614
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.44551610917299406,
+          "transition_rate": 0.09811165845648605,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.446 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.43507817811012917,
+          "transition_rate": 0.09383499546690843,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.435 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.5086147484493453,
+          "transition_rate": 0.08581275129236071,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.509 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.465377131738583,
+          "transition_rate": 0.0889423076923077,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.465 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.49010937863625786,
+          "transition_rate": 0.09590316573556797,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.490 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00521564562450201,
+            0.13310837077602955,
+            0.06369853578917586,
+            21.07561903487891
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16671713412773503,
+            0.23276041829255367,
+            0.3235663882650076,
+            41.59631177381956
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4615448497573065,
+          "centroid_raw": [
+            0.09781629844418294,
+            0.16952686231878805,
+            0.19545723580328905,
+            25.128472095754045
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18935445591228714,
+            0.24535040991091928,
+            0.363844496788274,
+            41.12338792721511
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.41689284281185796,
+          "centroid_raw": [
+            -0.09319032614407388,
+            0.16790633355011997,
+            0.18500613457568027,
+            32.0690859278418
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.4615448497573065
+          },
+          "4": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.41689284281185796
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 104.45397989848243,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0075,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.14369900271985495
+        }
+      },
+      "model_kruskal_h": 104.45397989848243,
+      "model_p_value": 0.0075,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.0029465095194922963,
+      "coverage": {
+        "ranging_directional": {
+          "count": 574,
+          "pct": 0.13007024699750735
+        },
+        "ranging_directional_down": {
+          "count": 889,
+          "pct": 0.20145026059370044
+        },
+        "ranging_directional_up": {
+          "count": 574,
+          "pct": 0.13007024699750735
+        },
+        "ranging_volatile": {
+          "count": 1457,
+          "pct": 0.33016088828461365
+        },
+        "trending_down_choppy": {
+          "count": 666,
+          "pct": 0.15091774303195105
+        },
+        "trending_up_choppy": {
+          "count": 253,
+          "pct": 0.05733061409472014
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.3143853888774882,
+          "transition_rate": 0.13177339901477833,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.33016088828461365,
+          "transition_rate": 0.14369900271985495,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.3955892487939352,
+          "transition_rate": 0.12808730614589317,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.35687306855900197,
+          "transition_rate": 0.1382783882783883,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.3779380963462881,
+          "transition_rate": 0.14548417132216016,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.6509587551354854,
+          "centroid_raw": [
+            0.11743968246375047,
+            0.18618412861867534,
+            0.23432245665403867,
+            28.83844260287284
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.7409580990081387,
+          "centroid_raw": [
+            0.062420781311295186,
+            0.14395551666209278,
+            0.12509759264041245,
+            19.99407739292834
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16426780580608522,
+            0.23026976919209782,
+            0.3188540061764217,
+            41.426524229098604
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.20216908755599725,
+            0.25464907630538164,
+            0.3856756553634807,
+            43.094632873361434
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.003713350525580302,
+            0.1298794415692209,
+            0.0445964630281495,
+            21.33356061998665
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3555341043009137,
+          "centroid_raw": [
+            -0.08683352733169271,
+            0.16425294629494885,
+            0.17258965226424833,
+            30.65375286106022
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.6509587551354854
+          },
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.7409580990081387
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.3555341043009137
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 107.96478762892002,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.185856754306437
+        }
+      },
+      "model_kruskal_h": 107.96478762892002,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.04510426110607435,
+      "coverage": {
+        "ranging_directional": {
+          "count": 682,
+          "pct": 0.15454339451620214
+        },
+        "ranging_directional_down": {
+          "count": 514,
+          "pct": 0.11647405393156583
+        },
+        "ranging_directional_up": {
+          "count": 672,
+          "pct": 0.15227736233854522
+        },
+        "ranging_volatile": {
+          "count": 1061,
+          "pct": 0.2404260140493995
+        },
+        "trending_down_choppy": {
+          "count": 623,
+          "pct": 0.1411738046680263
+        },
+        "trending_up_choppy": {
+          "count": 593,
+          "pct": 0.1343757081350555
+        },
+        "trending_up_clean": {
+          "count": 268,
+          "pct": 0.06072966236120553
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.24358711266160477,
+          "transition_rate": 0.17282430213464697,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.2404260140493995,
+          "transition_rate": 0.185856754306437,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.29600275671950377,
+          "transition_rate": 0.18759333716255025,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.26782648506352297,
+          "transition_rate": 0.1820054945054945,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.2829881312543635,
+          "transition_rate": 0.19180633147113593,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_clean",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5303413674789599,
+          "centroid_raw": [
+            -0.05491235529257406,
+            0.14905016832420365,
+            0.10886956067338502,
+            24.792243650611887
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.00042039197494952475,
+            0.12708724614606212,
+            0.03251028767244585,
+            21.08585083777254
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.11526680828374247,
+            0.1843040490545302,
+            0.23008750154491792,
+            28.472263709434838
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16826161642289206,
+            0.2339490026259864,
+            0.3265672695041081,
+            41.60478656924272
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9801993798717268,
+          "centroid_raw": [
+            0.2011493524259188,
+            0.2539459194216666,
+            0.38389894945657466,
+            42.907993759298925
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4424994762177583,
+          "centroid_raw": [
+            0.05774302832867487,
+            0.14209562259477096,
+            0.11575414234348351,
+            19.93755287142011
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.49875148556777876,
+          "centroid_raw": [
+            -0.10167092622944164,
+            0.1708230045289953,
+            0.20199084698013434,
+            33.67636374595119
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.5303413674789599
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.9801993798717268
+          },
+          "5": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.4424994762177583
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.49875148556777876
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 74.54171377681814,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.005833333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03014505893019039
+        }
+      },
+      "model_kruskal_h": 74.54171377681814,
+      "model_p_value": 0.005833333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.11060743427017226,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1583,
+          "pct": 0.35871289372309084
+        },
+        "ranging_volatile": {
+          "count": 2830,
+          "pct": 0.6412871062769091
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6601682741637594,
+          "transition_rate": 0.026272577996715927,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.660 > 0.400",
+            "min_transition_rate: 0.0263 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.6412871062769091,
+          "transition_rate": 0.03014505893019039,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.641 > 0.400",
+            "min_transition_rate: 0.0301 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6865380197564898,
+          "transition_rate": 0.022171165996553704,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.687 > 0.400",
+            "min_transition_rate: 0.0222 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6575483575598031,
+          "transition_rate": 0.026213369963369964,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.658 > 0.400",
+            "min_transition_rate: 0.0262 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6788457063067256,
+          "transition_rate": 0.029562383612662942,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.679 > 0.400",
+            "min_transition_rate: 0.0296 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.018036251960858327,
+            0.2229507953439403,
+            0.3013825888317332,
+            40.09144509555085
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.003062090239283801,
+            0.14184767736105997,
+            0.1026983492092417,
+            22.35772892459727
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 98.2194948434244,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.014166666666666666,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03241160471441523
+        }
+      },
+      "model_kruskal_h": 98.2194948434244,
+      "model_p_value": 0.014166666666666666,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.10834088848594742,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2667,
+          "pct": 0.6043507817811012
+        },
+        "trending_down_choppy": {
+          "count": 1139,
+          "pct": 0.2581010650351235
+        },
+        "trending_up_choppy": {
+          "count": 607,
+          "pct": 0.1375481531837752
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.6105068746152268,
+          "transition_rate": 0.031609195402298854,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.611 > 0.400",
+            "min_transition_rate: 0.0316 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.6043507817811012,
+          "transition_rate": 0.03241160471441523,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.604 > 0.400",
+            "min_transition_rate: 0.0324 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6540317022742936,
+          "transition_rate": 0.02745548535324526,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.654 > 0.400",
+            "min_transition_rate: 0.0275 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6298500629506696,
+          "transition_rate": 0.03250915750915751,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.630 > 0.400",
+            "min_transition_rate: 0.0325 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6467302769373982,
+          "transition_rate": 0.03468342644320298,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.647 > 0.400",
+            "min_transition_rate: 0.0347 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.011362761905602299,
+            0.13948930488191816,
+            0.09349591756501334,
+            21.547271489047084
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1686088177698161,
+            0.23155718355300992,
+            0.32655345896492577,
+            38.48640984398101
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1288237459670977,
+            0.20003650102828813,
+            0.2523864791590236,
+            38.69163152773807
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 89.23112853738348,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.015,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.0528105167724388
+        }
+      },
+      "model_kruskal_h": 89.23112853738348,
+      "model_p_value": 0.015,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.08794197642792384,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 735,
+          "pct": 0.16655336505778381
+        },
+        "ranging_volatile": {
+          "count": 2201,
+          "pct": 0.49875368230228867
+        },
+        "trending_down_choppy": {
+          "count": 1198,
+          "pct": 0.27147065488329936
+        },
+        "trending_up_choppy": {
+          "count": 279,
+          "pct": 0.06322229775662815
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5237020316027088,
+          "transition_rate": 0.05295566502463054,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.524 > 0.400",
+            "min_transition_rate: 0.0530 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.49875368230228867,
+          "transition_rate": 0.0528105167724388,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.499 > 0.400",
+            "min_transition_rate: 0.0528 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5755800597289226,
+          "transition_rate": 0.05134979896611143,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.576 > 0.400",
+            "min_transition_rate: 0.0513 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.5260386860478425,
+          "transition_rate": 0.050251831501831504,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.526 > 0.400",
+            "min_transition_rate: 0.0503 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.5485222248080056,
+          "transition_rate": 0.05377094972067039,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.549 > 0.400",
+            "min_transition_rate: 0.0538 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5659691654455097,
+          "centroid_raw": [
+            0.108634714566478,
+            0.18121261302394065,
+            0.21606959995256786,
+            27.51075555259618
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1985382607559364,
+            0.2545877959583349,
+            0.3790544885781678,
+            43.91062392215285
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1276066780274795,
+            0.19950315519926215,
+            0.25008243235716165,
+            38.5348359225141
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0009738566663557522,
+            0.1350933237686613,
+            0.07877189200930211,
+            21.00680315993921
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.5659691654455097
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 118.68640993747795,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.006666666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.07638259292837715
+        }
+      },
+      "model_kruskal_h": 118.68640993747795,
+      "model_p_value": 0.006666666666666667,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.0643699002719855,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 872,
+          "pct": 0.19759800589168366
+        },
+        "ranging_directional_up": {
+          "count": 778,
+          "pct": 0.1762973034217086
+        },
+        "ranging_volatile": {
+          "count": 1866,
+          "pct": 0.4228416043507818
+        },
+        "trending_down_choppy": {
+          "count": 610,
+          "pct": 0.13822796283707228
+        },
+        "trending_up_choppy": {
+          "count": 287,
+          "pct": 0.06503512349875368
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.44982556946439567,
+          "transition_rate": 0.07060755336617405,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.450 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.4228416043507818,
+          "transition_rate": 0.07638259292837715,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.423 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.5034458993797382,
+          "transition_rate": 0.06685812751292361,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.503 > 0.400",
+            "min_transition_rate: 0.0669 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.4604555339361337,
+          "transition_rate": 0.06673534798534798,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.460 > 0.400",
+            "min_transition_rate: 0.0667 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.4728880614382127,
+          "transition_rate": 0.0670391061452514,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.473 > 0.400",
+            "min_transition_rate: 0.0670 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009191844511987594,
+            0.13084227428804987,
+            0.0692237273552371,
+            19.981804648424006
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16735603317690687,
+            0.23621437624780595,
+            0.32310262785697563,
+            44.879939613054454
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5485502640037665,
+          "centroid_raw": [
+            0.10683010686617289,
+            0.1805129457243913,
+            0.21257840434625858,
+            27.421659336547133
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1983762359729188,
+            0.25432938197373917,
+            0.37864456835186844,
+            43.8383526974705
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3912282488334347,
+          "centroid_raw": [
+            -0.09053146019471629,
+            0.1706608917801729,
+            0.17999087918585577,
+            31.904676106393996
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.5485502640037665
+          },
+          "4": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.3912282488334347
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 128.89716015673002,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.005,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.09791477787851315
+        }
+      },
+      "model_kruskal_h": 128.89716015673002,
+      "model_p_value": 0.005,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.042837715321849504,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 912,
+          "pct": 0.20666213460231136
+        },
+        "ranging_directional_up": {
+          "count": 726,
+          "pct": 0.16451393609789258
+        },
+        "ranging_volatile": {
+          "count": 1587,
+          "pct": 0.35961930659415364
+        },
+        "trending_down_choppy": {
+          "count": 603,
+          "pct": 0.13664174031271245
+        },
+        "trending_up_choppy": {
+          "count": 412,
+          "pct": 0.09336052571946522
+        },
+        "trending_up_clean": {
+          "count": 173,
+          "pct": 0.039202356673464764
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.3580956289759902,
+          "transition_rate": 0.09544334975369458,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.35961930659415364,
+          "transition_rate": 0.09791477787851315,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.4238456237077877,
+          "transition_rate": 0.08994830557151062,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.424 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.3882339475792606,
+          "transition_rate": 0.09661172161172162,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.3956248545496858,
+          "transition_rate": 0.1005586592178771,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_clean",
+        "ranging_volatile",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1422368413298863,
+            0.21289257644971257,
+            0.27901163698117537,
+            32.39750509885974
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.39094927573945404,
+          "centroid_raw": [
+            0.07546626101794847,
+            0.15528687999136098,
+            0.15192518804675337,
+            21.471335467391313
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16772808627435506,
+            0.23634953580401558,
+            0.3238008985967664,
+            45.07327087019288
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.763552047750501,
+          "centroid_raw": [
+            0.21490981947085272,
+            0.26520474436350816,
+            0.4095600377751536,
+            49.3623411222127
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0034492118909808054,
+            0.12703359428203576,
+            0.05583583729091948,
+            20.37672494225289
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3940523381438825,
+          "centroid_raw": [
+            -0.09082403738926717,
+            0.1711827970248258,
+            0.18076275143763418,
+            31.87693237025458
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.39094927573945404
+          },
+          "3": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.763552047750501
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.3940523381438825
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "canonical",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 173.75547851663032,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.1056210335448776
+        }
+      },
+      "model_kruskal_h": 173.75547851663032,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.035131459655485045,
+      "coverage": {
+        "ranging_directional": {
+          "count": 649,
+          "pct": 0.1470654883299343
+        },
+        "ranging_directional_down": {
+          "count": 1018,
+          "pct": 0.23068207568547475
+        },
+        "ranging_directional_up": {
+          "count": 634,
+          "pct": 0.1436664400634489
+        },
+        "ranging_volatile": {
+          "count": 1007,
+          "pct": 0.22818944029005211
+        },
+        "trending_down_choppy": {
+          "count": 517,
+          "pct": 0.1171538635848629
+        },
+        "trending_up_choppy": {
+          "count": 415,
+          "pct": 0.0940403353727623
+        },
+        "trending_up_clean": {
+          "count": 173,
+          "pct": 0.039202356673464764
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.24953827211163554,
+          "transition_rate": 0.10611658456486042,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.23068207568547475,
+          "transition_rate": 0.1056210335448776,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.28256374913852517,
+          "transition_rate": 0.10453762205628948,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.2681698523520659,
+          "transition_rate": 0.10989010989010989,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.25133814289038864,
+          "transition_rate": 0.11475791433891992,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_clean",
+        "ranging_directional_up",
+        "ranging_directional"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.029546514429325932,
+            0.15021842384756123,
+            0.08539826780749266,
+            27.07442603443352
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006871018715765001,
+            0.12133272100240955,
+            0.05347745032320514,
+            17.651706806580762
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1424907303657935,
+            0.21338943808886005,
+            0.27917384606948925,
+            32.4850717550184
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.17498712426960858,
+            0.24367786639245714,
+            0.3376706127243908,
+            47.32693000137403
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.763552047750501,
+          "centroid_raw": [
+            0.21490981947085272,
+            0.26520474436350816,
+            0.4095600377751536,
+            49.3623411222127
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.44257070130248277,
+          "centroid_raw": [
+            0.08074894410741987,
+            0.15484594070034033,
+            0.16176795525682527,
+            21.18938247859502
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 1.0481515393558045,
+          "centroid_raw": [
+            -0.10858907178125976,
+            0.17942088565910075,
+            0.2156809905302767,
+            33.85521683446028
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.763552047750501
+          },
+          "5": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.44257070130248277
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 1.0481515393558045
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 91.46984402337512,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.039664551223934724
+        }
+      },
+      "model_kruskal_h": 91.46984402337512,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.10108794197642793,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 2072,
+          "pct": 0.46952186721051437
+        },
+        "ranging_volatile": {
+          "count": 2341,
+          "pct": 0.5304781327894856
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5577672891442643,
+          "transition_rate": 0.042692939244663386,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.558 > 0.400",
+            "min_transition_rate: 0.0427 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5304781327894856,
+          "transition_rate": 0.039664551223934724,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.530 > 0.400",
+            "min_transition_rate: 0.0397 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6527777777777778,
+          "transition_rate": 0.045592163846838826,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.653 > 0.400",
+            "min_transition_rate: 0.0456 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.580977452214719,
+          "transition_rate": 0.07337454212454213,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.581 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5387479636956016,
+          "transition_rate": 0.054702048417132214,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.539 > 0.400",
+            "min_transition_rate: 0.0547 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00907885995580387,
+            0.20470922883932402,
+            0.26154111465892993,
+            36.57895576746782,
+            1.3169489496277385e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0066819257666804206,
+            0.13818259780789646,
+            0.08999450472234209,
+            21.19032849593158,
+            1.0608846375287354e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 108.11837501578339,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.005833333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.04306436990027199
+        }
+      },
+      "model_kruskal_h": 108.11837501578339,
+      "model_p_value": 0.005833333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.09768812330009066,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2255,
+          "pct": 0.5109902560616361
+        },
+        "trending_down_choppy": {
+          "count": 1309,
+          "pct": 0.2966236120552912
+        },
+        "trending_up_choppy": {
+          "count": 849,
+          "pct": 0.19238613188307274
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5339626513441412,
+          "transition_rate": 0.042487684729064036,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.534 > 0.400",
+            "min_transition_rate: 0.0425 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5109902560616361,
+          "transition_rate": 0.04306436990027199,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.511 > 0.400",
+            "min_transition_rate: 0.0431 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.4675925925925926,
+          "transition_rate": 0.057702582368655386,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.468 > 0.400",
+            "min_transition_rate: 0.0577 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4217694860936248,
+          "transition_rate": 0.07818223443223443,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.422 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5392134047009541,
+          "transition_rate": 0.05330540037243948,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.539 > 0.400",
+            "min_transition_rate: 0.0533 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009236835834268292,
+            0.13602891751548107,
+            0.08138230645034174,
+            20.953397888034065,
+            1.0511083978652498e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12087033673816544,
+            0.19499494690240582,
+            0.23789582601806067,
+            36.87996867553251,
+            5.847101545095579e-06
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14300503106280468,
+            0.2112689665668848,
+            0.28425559100693437,
+            34.71913922156307,
+            2.096293462849498e-05
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 102.22076578650558,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.008333333333333333,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.06029011786038078
+        }
+      },
+      "model_kruskal_h": 102.22076578650558,
+      "model_p_value": 0.008333333333333333,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.08046237533998188,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 790,
+          "pct": 0.1790165420348969
+        },
+        "ranging_volatile": {
+          "count": 1852,
+          "pct": 0.4196691593020621
+        },
+        "trending_down_choppy": {
+          "count": 1403,
+          "pct": 0.31792431452526626
+        },
+        "trending_up_choppy": {
+          "count": 368,
+          "pct": 0.08338998413777475
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.4500307818592243,
+          "transition_rate": 0.0650656814449918,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.450 > 0.400",
+            "min_transition_rate: 0.0651 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.4196691593020621,
+          "transition_rate": 0.06029011786038078,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.420 > 0.400",
+            "min_transition_rate: 0.0603 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.33404558404558404,
+          "transition_rate": 0.08708815672306322,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.356186333981916,
+          "transition_rate": 0.09672619047619048,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.4482196881545264,
+          "transition_rate": 0.06634078212290503,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.448 > 0.400",
+            "min_transition_rate: 0.0663 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.40754354142167376,
+          "centroid_raw": [
+            0.09221129934834293,
+            0.1682425945600596,
+            0.18354496536151413,
+            24.894839276602973,
+            1.5017085468682704e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1861247533324776,
+            0.24477803262323994,
+            0.3608476368453506,
+            41.29265553829208,
+            2.3475300598643716e-05
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1180688209125215,
+            0.19291553760066718,
+            0.23238642920290453,
+            36.26910032165665,
+            6.584808529366651e-06
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0002854592383277404,
+            0.13200540071463002,
+            0.06827441962553696,
+            20.815561789880583,
+            1.0321479142077263e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.40754354142167376
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 111.62297133368702,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.10108794197642793
+        }
+      },
+      "model_kruskal_h": 111.62297133368702,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.039664551223934724,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 960,
+          "pct": 0.21753908905506458
+        },
+        "ranging_directional_up": {
+          "count": 883,
+          "pct": 0.20009064128710627
+        },
+        "ranging_volatile": {
+          "count": 1438,
+          "pct": 0.3258554271470655
+        },
+        "trending_down_choppy": {
+          "count": 650,
+          "pct": 0.14729209154769998
+        },
+        "trending_up_choppy": {
+          "count": 482,
+          "pct": 0.10922275096306368
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.3182844243792325,
+          "transition_rate": 0.09051724137931035,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.3258554271470655,
+          "transition_rate": 0.10108794197642793,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.35345441595441596,
+          "transition_rate": 0.10845948352626893,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3472587844797986,
+          "transition_rate": 0.10851648351648352,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3635094251803584,
+          "transition_rate": 0.10754189944134078,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0014201095132754318,
+            0.12678257683853378,
+            0.04536916313520099,
+            21.061513105718813,
+            1.0917807776323243e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16498905683857681,
+            0.2323888901866003,
+            0.3197587731351277,
+            41.65291794440094,
+            1.8439849757245629e-06
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.37587911175831035,
+          "centroid_raw": [
+            0.07567253306637745,
+            0.1546853367112426,
+            0.1515927044764735,
+            21.71943816996984,
+            1.2455824750079583e-05
+          ],
+          "volatility_rank": 1
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17509679657554747,
+            0.235956489186332,
+            0.3379019321386464,
+            39.355369682642966,
+            2.3063231998929107e-05
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3419752528350106,
+          "centroid_raw": [
+            -0.08542882291652075,
+            0.165004801595129,
+            0.16985477043446343,
+            30.558356114897556,
+            8.776105397973161e-06
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.37587911175831035
+          },
+          "4": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.3419752528350106
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 119.8406973040801,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.12194016319129647
+        }
+      },
+      "model_kruskal_h": 119.8406973040801,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.01881233000906618,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1168,
+          "pct": 0.2646725583503286
+        },
+        "ranging_directional_down": {
+          "count": 799,
+          "pct": 0.18105597099478812
+        },
+        "ranging_directional_up": {
+          "count": 516,
+          "pct": 0.11692726036709722
+        },
+        "ranging_volatile": {
+          "count": 810,
+          "pct": 0.18354860639021073
+        },
+        "trending_down_choppy": {
+          "count": 663,
+          "pct": 0.150237933378654
+        },
+        "trending_up_choppy": {
+          "count": 457,
+          "pct": 0.10355767051892137
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.2312743689718859,
+          "transition_rate": 0.11699507389162561,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.2646725583503286,
+          "transition_rate": 0.12194016319129647,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.4236111111111111,
+          "transition_rate": 0.09421193232413179,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.424 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.2860249513563008,
+          "transition_rate": 0.13690476190476192,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.24435652781010006,
+          "transition_rate": 0.13756983240223464,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3573166070837665,
+          "centroid_raw": [
+            0.07034353909138161,
+            0.15456646355539866,
+            0.140307364597493,
+            21.53494486913592,
+            1.248089471955468e-05
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.3078123493919139,
+          "centroid_raw": [
+            0.02918651748765376,
+            0.14400616725167598,
+            0.10723912233676917,
+            23.560439770098053,
+            1.1651691211694165e-05
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16357869429325048,
+            0.23151386935069757,
+            0.3168669675306461,
+            41.88397397903692,
+            1.2676099715209738e-06
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1776723119430366,
+            0.23785564866759662,
+            0.34270628811591275,
+            39.81278748005305,
+            2.2518436628561306e-05
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.006132031337088244,
+            0.12435041116963871,
+            0.04209814611928238,
+            20.45922452241105,
+            1.0950472881496644e-05
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.35827425080293607,
+          "centroid_raw": [
+            -0.08711740800545688,
+            0.16507951835168094,
+            0.17339588711337042,
+            30.640700124083843,
+            9.385232967251094e-06
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.3573166070837665
+          },
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.3078123493919139
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.35827425080293607
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 140.78575858818112,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.13848594741613782
+        }
+      },
+      "model_kruskal_h": 140.78575858818112,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.0022665457842248327,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1166,
+          "pct": 0.2642193519147972
+        },
+        "ranging_directional_down": {
+          "count": 658,
+          "pct": 0.14910491728982553
+        },
+        "ranging_directional_up": {
+          "count": 433,
+          "pct": 0.09811919329254476
+        },
+        "ranging_volatile": {
+          "count": 921,
+          "pct": 0.2087015635622026
+        },
+        "trending_down_choppy": {
+          "count": 607,
+          "pct": 0.1375481531837752
+        },
+        "trending_up_choppy": {
+          "count": 380,
+          "pct": 0.08610922275096307
+        },
+        "trending_up_clean": {
+          "count": 248,
+          "pct": 0.056197598005891684
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.3371639647034681,
+          "transition_rate": 0.12458949096880131,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.2642193519147972,
+          "transition_rate": 0.13848594741613782,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.3181980056980057,
+          "transition_rate": 0.11789848619768477,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.2835069245736523,
+          "transition_rate": 0.16701007326007325,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.3011403304631138,
+          "transition_rate": 0.1478119180633147,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_clean",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.2666835696215145,
+          "centroid_raw": [
+            -0.0016052953577557882,
+            0.13153833674610296,
+            0.06042692413242001,
+            21.909743328905314,
+            8.19722720106653e-06
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.007650357168597174,
+            0.13513779053163852,
+            0.07619011885925982,
+            20.522753936847884,
+            1.2483590002353736e-05
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.11386070772210612,
+            0.1880760311831054,
+            0.2225360355283785,
+            28.500271482933346,
+            1.2482829825791978e-05
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16880686236309317,
+            0.2361887963651028,
+            0.32698187843296933,
+            42.115296684630344,
+            1.3075665515726301e-06
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9558057594468565,
+          "centroid_raw": [
+            0.20196445206833957,
+            0.25596831114228097,
+            0.3867882850509877,
+            43.83850906853738,
+            2.5400449584727188e-05
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4910222202894194,
+          "centroid_raw": [
+            0.100870170126327,
+            0.16976684725111907,
+            0.2052171859105471,
+            26.39547792270933,
+            2.0022375825941747e-05
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4535285358077429,
+          "centroid_raw": [
+            -0.09698580394199934,
+            0.17063864627091835,
+            0.19306186205715106,
+            33.10505251953151,
+            8.125773259030584e-06
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.2666835696215145
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.9558057594468565
+          },
+          "5": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.4910222202894194
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.4535285358077429
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 88.76695378889781,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.056890299184043515
+        }
+      },
+      "model_kruskal_h": 88.76695378889781,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.08386219401631914,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 2210,
+          "pct": 0.50079311126218
+        },
+        "ranging_volatile": {
+          "count": 2203,
+          "pct": 0.4992068887378201
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5512004925097476,
+          "transition_rate": 0.05213464696223317,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.551 > 0.400",
+            "min_transition_rate: 0.0521 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.50079311126218,
+          "transition_rate": 0.056890299184043515,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.501 > 0.400",
+            "min_transition_rate: 0.0569 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6746794871794872,
+          "transition_rate": 0.05200356188780053,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.675 > 0.400",
+            "min_transition_rate: 0.0520 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.591049559345313,
+          "transition_rate": 0.08298992673992674,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.591 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5077961368396555,
+          "transition_rate": 0.07378957169459963,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.508 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00998729724888988,
+            0.2025833185016591,
+            0.25727047055609065,
+            35.98524238263593,
+            1.2632007685074826e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005931506139810398,
+            0.13899972957633738,
+            0.09114260561436283,
+            21.460064588839646,
+            1.1001044382443276e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 101.52847865988224,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0075,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.044424297370806894
+        }
+      },
+      "model_kruskal_h": 101.52847865988224,
+      "model_p_value": 0.0075,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.09632819582955576,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2406,
+          "pct": 0.5452073419442556
+        },
+        "trending_down_choppy": {
+          "count": 1221,
+          "pct": 0.27668252889191025
+        },
+        "trending_up_choppy": {
+          "count": 786,
+          "pct": 0.17811012916383412
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5618715370408373,
+          "transition_rate": 0.043924466338259444,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.562 > 0.400",
+            "min_transition_rate: 0.0439 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5452073419442556,
+          "transition_rate": 0.044424297370806894,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.545 > 0.400",
+            "min_transition_rate: 0.0444 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.45584045584045585,
+          "transition_rate": 0.06268922528940338,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.456 > 0.400",
+            "min_transition_rate: 0.0627 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4517568959597116,
+          "transition_rate": 0.08070054945054946,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.452 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.574121480102397,
+          "transition_rate": 0.04818435754189944,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.574 > 0.400",
+            "min_transition_rate: 0.0482 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009151016794959511,
+            0.13824444392927085,
+            0.08662923547793581,
+            21.438431216360367,
+            1.0614140494224214e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12585959251504458,
+            0.1971188555160777,
+            0.2472757243641353,
+            37.523998185519886,
+            5.8691447850830876e-06
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14736262306261916,
+            0.21585631949326387,
+            0.2944793944409515,
+            35.59637436158426,
+            2.1126607433097627e-05
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 92.08194142313005,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.005,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.0643699002719855
+        }
+      },
+      "model_kruskal_h": 92.08194142313005,
+      "model_p_value": 0.005,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.07638259292837715,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 719,
+          "pct": 0.16292771357353275
+        },
+        "ranging_volatile": {
+          "count": 1985,
+          "pct": 0.44980738726489916
+        },
+        "trending_down_choppy": {
+          "count": 1375,
+          "pct": 0.3115794244278269
+        },
+        "trending_up_choppy": {
+          "count": 334,
+          "pct": 0.07568547473374122
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.48512210137492306,
+          "transition_rate": 0.06588669950738917,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.485 > 0.400",
+            "min_transition_rate: 0.0659 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.44980738726489916,
+          "transition_rate": 0.0643699002719855,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.450 > 0.400",
+            "min_transition_rate: 0.0644 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3575498575498576,
+          "transition_rate": 0.09385574354407836,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3868604784250887,
+          "transition_rate": 0.1043956043956044,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.482895043053293,
+          "transition_rate": 0.07472067039106145,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.483 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.494257929464605,
+          "centroid_raw": [
+            0.10120539136361437,
+            0.17256851651938857,
+            0.20147994194208893,
+            26.017386589656073,
+            1.532369426678423e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18964999849205094,
+            0.24729316116533168,
+            0.367916103130608,
+            41.720190716697864,
+            2.36493652713376e-05
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11993627799070303,
+            0.19302559288270874,
+            0.23586288993424914,
+            36.47462065069479,
+            6.574772427546762e-06
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0027520064755360164,
+            0.1345093098174464,
+            0.0719470562622372,
+            21.04559509230378,
+            1.0554073006294043e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.494257929464605
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 106.01182388742382,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.005833333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.09179510426110607
+        }
+      },
+      "model_kruskal_h": 106.01182388742382,
+      "model_p_value": 0.005833333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.04895738893925658,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 730,
+          "pct": 0.16542034896895536
+        },
+        "ranging_directional_up": {
+          "count": 726,
+          "pct": 0.16451393609789258
+        },
+        "ranging_volatile": {
+          "count": 1934,
+          "pct": 0.43825062315884883
+        },
+        "trending_down_choppy": {
+          "count": 651,
+          "pct": 0.14751869476546567
+        },
+        "trending_up_choppy": {
+          "count": 372,
+          "pct": 0.08429639700883752
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.44490047198850813,
+          "transition_rate": 0.1007799671592775,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.445 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.43825062315884883,
+          "transition_rate": 0.09179510426110607,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.438 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.4337606837606838,
+          "transition_rate": 0.10293855743544078,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.434 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.4384800274693831,
+          "transition_rate": 0.11069139194139194,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.438 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.4919711426576681,
+          "transition_rate": 0.09799813780260708,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.492 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0051602145921585485,
+            0.13310713810427208,
+            0.06381205912523355,
+            21.072668214368942,
+            1.0993883130278907e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16378902797831704,
+            0.2303122032469208,
+            0.3177120893440727,
+            41.40584407217824,
+            1.8284954502282175e-06
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.46236426378172196,
+          "centroid_raw": [
+            0.09790009925898394,
+            0.16955160824311977,
+            0.19511894338180213,
+            24.96377955395569,
+            1.3021306455555915e-05
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18661660523480167,
+            0.2430456678091612,
+            0.3594103754979905,
+            40.89613269976323,
+            2.4941874478587637e-05
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.42274101515136375,
+          "centroid_raw": [
+            -0.09379619999162275,
+            0.16854883702227041,
+            0.18630327020231147,
+            32.0647127514315,
+            8.721409089111776e-06
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.46236426378172196
+          },
+          "4": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.42274101515136375
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 163.74585807215954,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.14437896645512238
+        }
+      },
+      "model_kruskal_h": 163.74585807215954,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.0036264732547597323,
+      "coverage": {
+        "ranging_directional": {
+          "count": 388,
+          "pct": 0.0879220484930886
+        },
+        "ranging_directional_down": {
+          "count": 754,
+          "pct": 0.17085882619533196
+        },
+        "ranging_directional_up": {
+          "count": 1507,
+          "pct": 0.34149104917289824
+        },
+        "ranging_volatile": {
+          "count": 868,
+          "pct": 0.1966915930206209
+        },
+        "trending_down_choppy": {
+          "count": 502,
+          "pct": 0.11375481531837751
+        },
+        "trending_up_choppy": {
+          "count": 394,
+          "pct": 0.08928166779968276
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.32156782269649087,
+          "transition_rate": 0.12931034482758622,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.34149104917289824,
+          "transition_rate": 0.14437896645512238,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.4107905982905983,
+          "transition_rate": 0.11362422083704363,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.411 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.2808744420281561,
+          "transition_rate": 0.16609432234432234,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.28601349778915525,
+          "transition_rate": 0.15828677839851024,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "ranging_directional"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.004236225402467306,
+            0.18373892298467917,
+            0.21095591128244318,
+            30.590545931540486,
+            1.247823131655653e-05
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.21014235539056839,
+          "centroid_raw": [
+            0.00966615921934637,
+            0.13679763726535418,
+            0.08526767748179724,
+            22.56080678889306,
+            9.35922486817239e-06
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.17757369231484119,
+            0.24283940809842633,
+            0.3443881701062005,
+            44.87163307868494,
+            -2.4512521419042734e-06
+          ],
+          "volatility_rank": 5
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18236514615712784,
+            0.24007579748218072,
+            0.3524548628640106,
+            40.17307023371917,
+            2.5312261013006206e-05
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.01010467297437343,
+            0.13336914714836956,
+            0.07278620164702035,
+            20.349367885565673,
+            1.2478055596222514e-05
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9672836289683882,
+          "centroid_raw": [
+            -0.10021111211022146,
+            0.17007229205472307,
+            0.19908586335287387,
+            34.013247938163914,
+            2.483128852992056e-06
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.21014235539056839
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.9672836289683882
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 144.40822227855278,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.14664551223934724
+        }
+      },
+      "model_kruskal_h": 144.40822227855278,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.005893019038984593,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1206,
+          "pct": 0.2732834806254249
+        },
+        "ranging_directional_down": {
+          "count": 635,
+          "pct": 0.1438930432812146
+        },
+        "ranging_directional_up": {
+          "count": 416,
+          "pct": 0.09426693859052798
+        },
+        "ranging_volatile": {
+          "count": 1010,
+          "pct": 0.2288692499433492
+        },
+        "trending_down_choppy": {
+          "count": 578,
+          "pct": 0.13097665986857013
+        },
+        "trending_up_choppy": {
+          "count": 342,
+          "pct": 0.07749830047586675
+        },
+        "trending_up_clean": {
+          "count": 226,
+          "pct": 0.051212327215046455
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.3587112661604761,
+          "transition_rate": 0.13033661740558292,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.2732834806254249,
+          "transition_rate": 0.14664551223934724,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.3392094017094017,
+          "transition_rate": 0.12662511130899376,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.3085727366372897,
+          "transition_rate": 0.1723901098901099,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.3358156853618804,
+          "transition_rate": 0.1580540037243948,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_clean",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.24752681955512315,
+          "centroid_raw": [
+            -0.001224150465838866,
+            0.1325307197863449,
+            0.0635605904916238,
+            22.130148170570873,
+            8.34733468999191e-06
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.008337700286693272,
+            0.13812094084183094,
+            0.08171370507782369,
+            21.022136842343826,
+            1.2477660507296333e-05
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.12472754698501724,
+            0.195351894573375,
+            0.2437701603876654,
+            30.02920100777912,
+            1.2481957612229611e-05
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.17054288846121843,
+            0.23633143384798255,
+            0.33048721305301143,
+            42.1903986366674,
+            1.1327911678390592e-06
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9213265556474758,
+          "centroid_raw": [
+            0.20401400987013807,
+            0.25539300271068316,
+            0.39087222130437815,
+            43.67879780972147,
+            2.5974095200826144e-05
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5207381526520722,
+          "centroid_raw": [
+            0.10394875694437278,
+            0.17162545049296388,
+            0.21094070372912965,
+            26.649254869951626,
+            2.010123796508081e-05
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.49035793041582965,
+          "centroid_raw": [
+            -0.10080134933271243,
+            0.17241696377140125,
+            0.20037004149549195,
+            33.770999670629024,
+            7.852103624121023e-06
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.24752681955512315
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.9213265556474758
+          },
+          "5": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.5207381526520722
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.49035793041582965
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 75.73684460018012,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.031051677243880325
+        }
+      },
+      "model_kruskal_h": 75.73684460018012,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.10970081595648232,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1578,
+          "pct": 0.3575798776342624
+        },
+        "ranging_volatile": {
+          "count": 2835,
+          "pct": 0.6424201223657376
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6661194336137902,
+          "transition_rate": 0.029556650246305417,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.666 > 0.400",
+            "min_transition_rate: 0.0296 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.6424201223657376,
+          "transition_rate": 0.031051677243880325,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.642 > 0.400",
+            "min_transition_rate: 0.0311 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5349002849002849,
+          "transition_rate": 0.04416740872662511,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.535 > 0.400",
+            "min_transition_rate: 0.0442 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5847544923886918,
+          "transition_rate": 0.0451007326007326,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.585 > 0.400",
+            "min_transition_rate: 0.0451 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6804747498254596,
+          "transition_rate": 0.03514897579143389,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.680 > 0.400",
+            "min_transition_rate: 0.0351 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.01856914946809174,
+            0.2230445640632568,
+            0.3015055621125169,
+            40.08054427550777,
+            1.3111961716171655e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.002830585951012359,
+            0.14185367695194778,
+            0.10276120327679909,
+            22.373209024271834,
+            1.1094503275759367e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 99.0954221626107,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.010833333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.0328649138712602
+        }
+      },
+      "model_kruskal_h": 99.0954221626107,
+      "model_p_value": 0.010833333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.10788757932910245,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2661,
+          "pct": 0.6029911624745071
+        },
+        "trending_down_choppy": {
+          "count": 1151,
+          "pct": 0.2608203036483118
+        },
+        "trending_up_choppy": {
+          "count": 601,
+          "pct": 0.13618853387718105
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.6049661399548533,
+          "transition_rate": 0.0361247947454844,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.605 > 0.400",
+            "min_transition_rate: 0.0361 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.6029911624745071,
+          "transition_rate": 0.0328649138712602,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.603 > 0.400",
+            "min_transition_rate: 0.0329 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.49786324786324787,
+          "transition_rate": 0.05627782724844167,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.498 > 0.400",
+            "min_transition_rate: 0.0563 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5515623211628705,
+          "transition_rate": 0.05460164835164835,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.552 > 0.400",
+            "min_transition_rate: 0.0546 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6350942518035839,
+          "transition_rate": 0.04259776536312849,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.635 > 0.400",
+            "min_transition_rate: 0.0426 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.01184533522517588,
+            0.13948627979922618,
+            0.09362526656940051,
+            21.513416699863797,
+            1.1353376746474246e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1272805368341519,
+            0.19951670890903223,
+            0.24966142602973507,
+            38.57974543012017,
+            4.857152657004937e-06
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.16889264586748334,
+            0.23125944351303657,
+            0.32698356589743605,
+            38.437029712091245,
+            2.215001939163488e-05
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 97.52110637617079,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.015833333333333335,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.050090661831368996
+        }
+      },
+      "model_kruskal_h": 97.52110637617079,
+      "model_p_value": 0.015833333333333335,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.09066183136899365,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 726,
+          "pct": 0.16451393609789258
+        },
+        "ranging_volatile": {
+          "count": 2227,
+          "pct": 0.5046453659641967
+        },
+        "trending_down_choppy": {
+          "count": 1212,
+          "pct": 0.274643099932019
+        },
+        "trending_up_choppy": {
+          "count": 248,
+          "pct": 0.056197598005891684
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.5259593679458239,
+          "transition_rate": 0.054187192118226604,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.526 > 0.400",
+            "min_transition_rate: 0.0542 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5046453659641967,
+          "transition_rate": 0.050090661831368996,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.505 > 0.400",
+            "min_transition_rate: 0.0501 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4561965811965812,
+          "transition_rate": 0.07658058771148708,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.456 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.47419022547785283,
+          "transition_rate": 0.07978479853479853,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.474 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.5387479636956016,
+          "transition_rate": 0.05702979515828678,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.539 > 0.400",
+            "min_transition_rate: 0.0570 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.6306418173519025,
+          "centroid_raw": [
+            0.11533483661606628,
+            0.18671851474541556,
+            0.22756848252477363,
+            28.08903406175065,
+            1.3146450977835709e-05
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.19894426680052693,
+            0.25460611040605097,
+            0.381641120082185,
+            44.99955574077237,
+            3.0109591421568714e-05
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12648405916484717,
+            0.19915183773300227,
+            0.24789517294297725,
+            38.36713266404889,
+            4.914975332068419e-06
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0004994277187101142,
+            0.1351205487649349,
+            0.07954498178215749,
+            20.99402223350745,
+            1.1184394402420564e-05
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.6306418173519025
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 121.42819711319316,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.07094288304623754
+        }
+      },
+      "model_kruskal_h": 121.42819711319316,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.06980961015412511,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 911,
+          "pct": 0.20643553138454565
+        },
+        "ranging_directional_up": {
+          "count": 775,
+          "pct": 0.17561749376841151
+        },
+        "ranging_volatile": {
+          "count": 1891,
+          "pct": 0.4285066847949241
+        },
+        "trending_down_choppy": {
+          "count": 587,
+          "pct": 0.13301608882846136
+        },
+        "trending_up_choppy": {
+          "count": 249,
+          "pct": 0.05642420122365738
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.4582392776523702,
+          "transition_rate": 0.0679392446633826,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.458 > 0.400",
+            "min_transition_rate: 0.0679 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.4285066847949241,
+          "transition_rate": 0.07094288304623754,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.429 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.4252136752136752,
+          "transition_rate": 0.09332146037399822,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.425 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.4352752661096486,
+          "transition_rate": 0.09203296703296704,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.435 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.4733535024435653,
+          "transition_rate": 0.06936685288640596,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.473 > 0.400",
+            "min_transition_rate: 0.0694 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.010292925560905143,
+            0.13133297549764386,
+            0.07122216063296463,
+            20.049296208119824,
+            1.1532890567685578e-05
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1667163956090894,
+            0.23571606192428843,
+            0.3221252751502923,
+            44.928027456174846,
+            5.53669367088663e-07
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.6214533140244097,
+          "centroid_raw": [
+            0.11438290265429898,
+            0.18617395833999628,
+            0.22574857506466667,
+            28.11128334307223,
+            1.303897216494844e-05
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.19894191932495203,
+            0.2546229427508011,
+            0.38150657529650567,
+            44.90603941504495,
+            3.0023850000000087e-05
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3882925379696944,
+          "centroid_raw": [
+            -0.09022731894629753,
+            0.1711880291528053,
+            0.17955711132570065,
+            31.902164954813543,
+            8.046830638722539e-06
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.6214533140244097
+          },
+          "4": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.3882925379696944
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 141.18352659382617,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.10154125113327289
+        }
+      },
+      "model_kruskal_h": 141.18352659382617,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.03921124206708976,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 983,
+          "pct": 0.2227509630636755
+        },
+        "ranging_directional_up": {
+          "count": 743,
+          "pct": 0.16836619079990936
+        },
+        "ranging_volatile": {
+          "count": 1514,
+          "pct": 0.3430772716972581
+        },
+        "trending_down_choppy": {
+          "count": 572,
+          "pct": 0.12961704056197598
+        },
+        "trending_up_choppy": {
+          "count": 424,
+          "pct": 0.09607976433265353
+        },
+        "trending_up_clean": {
+          "count": 177,
+          "pct": 0.04010876954452753
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.3509131951569875,
+          "transition_rate": 0.10098522167487685,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.3430772716972581,
+          "transition_rate": 0.10154125113327289,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.28881766381766383,
+          "transition_rate": 0.11380231522707035,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.2958681469611995,
+          "transition_rate": 0.12797619047619047,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.37398184780079125,
+          "transition_rate": 0.10800744878957169,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_clean",
+        "ranging_volatile",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.13860429363850044,
+            0.21176150983687486,
+            0.27073704797584536,
+            32.14013815298176,
+            1.1028239662447262e-05
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.39386665363101825,
+          "centroid_raw": [
+            0.07078262720621878,
+            0.15306710099685564,
+            0.1471755135731529,
+            21.06565716356325,
+            1.6140802983425613e-05
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16728475063416962,
+            0.23625078279937378,
+            0.3230930136010307,
+            45.502636722238805,
+            2.575194225722326e-07
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9076200990891702,
+          "centroid_raw": [
+            0.20431152830110788,
+            0.2545242665216722,
+            0.3924957012191026,
+            46.258365107219916,
+            3.300163314121045e-05
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.004292487520397908,
+            0.12716308525408643,
+            0.055644720328826086,
+            20.582814630293644,
+            1.0094520430107516e-05
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4033464797509252,
+          "centroid_raw": [
+            -0.09178691553447567,
+            0.17250033966175113,
+            0.18289407342707098,
+            31.826250779032893,
+            7.906358858858845e-06
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.39386665363101825
+          },
+          "3": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.9076200990891702
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.4033464797509252
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "funding",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 176.16490796125436,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.1128739800543971
+        }
+      },
+      "model_kruskal_h": 176.16490796125436,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.027878513145965553,
+      "coverage": {
+        "ranging_directional": {
+          "count": 673,
+          "pct": 0.1525039655563109
+        },
+        "ranging_directional_down": {
+          "count": 1072,
+          "pct": 0.2429186494448221
+        },
+        "ranging_directional_up": {
+          "count": 603,
+          "pct": 0.13664174031271245
+        },
+        "ranging_volatile": {
+          "count": 984,
+          "pct": 0.2229775662814412
+        },
+        "trending_down_choppy": {
+          "count": 464,
+          "pct": 0.10514389304328121
+        },
+        "trending_up_choppy": {
+          "count": 440,
+          "pct": 0.0997054158169046
+        },
+        "trending_up_clean": {
+          "count": 177,
+          "pct": 0.04010876954452753
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.24379232505643342,
+          "transition_rate": 0.11227422003284072,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.2429186494448221,
+          "transition_rate": 0.1128739800543971,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.24554843304843305,
+          "transition_rate": 0.12003561887800535,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.2500858418221357,
+          "transition_rate": 0.13564560439560439,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.2569234349546195,
+          "transition_rate": 0.12988826815642457,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_clean",
+        "ranging_directional_up",
+        "ranging_directional"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.029112462585728194,
+            0.15202571763423517,
+            0.09174604146836814,
+            27.073360346952356,
+            8.022831568016598e-06
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0047853847705110085,
+            0.12140181800835509,
+            0.05109806756383231,
+            17.91595394433734,
+            1.0346708598726105e-05
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.13747913233987755,
+            0.2107990114920387,
+            0.26869757430088737,
+            32.000763189455526,
+            1.113494834710744e-05
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.17794272385177815,
+            0.2453692554682022,
+            0.34293829218241506,
+            47.833912228008664,
+            -1.4921021660649879e-06
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.8977050702599544,
+          "centroid_raw": [
+            0.2049752287314198,
+            0.25541930857775746,
+            0.3936701003126737,
+            46.34652633977221,
+            3.251196156069372e-05
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4429521798375601,
+          "centroid_raw": [
+            0.07340658399306892,
+            0.15043405675162164,
+            0.1526979602503703,
+            20.577592625675827,
+            1.7815685438144548e-05
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 1.070064276552341,
+          "centroid_raw": [
+            -0.11085924331945261,
+            0.1819322932895084,
+            0.2199421941000161,
+            34.41595752367807,
+            8.233979118028519e-06
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.8977050702599544
+          },
+          "5": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.4429521798375601
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 1.070064276552341
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 88.60979944692917,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.03467815049864007
+        }
+      },
+      "model_kruskal_h": 88.60979944692917,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.10607434270172258,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1923,
+          "pct": 0.4357579877634262
+        },
+        "ranging_volatile": {
+          "count": 2490,
+          "pct": 0.5642420122365738
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5840344756823312,
+          "transition_rate": 0.03489326765188834,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.584 > 0.400",
+            "min_transition_rate: 0.0349 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5642420122365738,
+          "transition_rate": 0.03467815049864007,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.564 > 0.400",
+            "min_transition_rate: 0.0347 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.620491614978176,
+          "transition_rate": 0.03113153360137852,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.620 > 0.400",
+            "min_transition_rate: 0.0311 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5928808515508756,
+          "transition_rate": 0.03216575091575091,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.593 > 0.400",
+            "min_transition_rate: 0.0322 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6129858040493368,
+          "transition_rate": 0.034217877094972066,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.613 > 0.400",
+            "min_transition_rate: 0.0342 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009931510914565388,
+            0.2104843779272324,
+            0.27595699004578667,
+            37.284530792488354,
+            0.1502122974157241
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006199758546452026,
+            0.13714810837855154,
+            0.08765550642797937,
+            21.386081598446854,
+            -0.07981231885524126
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 105.05239309030549,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.0713961922030825
+        }
+      },
+      "model_kruskal_h": 105.05239309030549,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.06935630099728014,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1720,
+          "pct": 0.3897575345569907
+        },
+        "ranging_directional_up": {
+          "count": 1074,
+          "pct": 0.2433718558803535
+        },
+        "ranging_volatile": {
+          "count": 1619,
+          "pct": 0.36687060956265577
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.4001641699158629,
+          "transition_rate": 0.06834975369458128,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.400 > 0.400",
+            "min_transition_rate: 0.0683 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.3897575345569907,
+          "transition_rate": 0.0713961922030825,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.4290144727773949,
+          "transition_rate": 0.06858127512923608,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.429 > 0.400",
+            "min_transition_rate: 0.0686 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4015108160695891,
+          "transition_rate": 0.07520604395604395,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.402 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.4005119851058878,
+          "transition_rate": 0.07239292364990689,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.401 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009231577629926022,
+            0.12744960287484977,
+            0.06640515603366523,
+            19.82288640656347,
+            -0.1849297672776903
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.043805342405822734,
+            0.23950472431714526,
+            0.33703942274310816,
+            41.35353276422798,
+            0.1731729701712033
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.014806460508330082,
+            0.16822945747012993,
+            0.17127208750193812,
+            28.82513496651536,
+            0.13821837778680887
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 98.19795662655815,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.008333333333333333,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.07683590208522212
+        }
+      },
+      "model_kruskal_h": 98.19795662655815,
+      "model_p_value": 0.008333333333333333,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.06391659111514053,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1564,
+          "pct": 0.3544074325855427
+        },
+        "ranging_volatile": {
+          "count": 1353,
+          "pct": 0.30659415363698167
+        },
+        "trending_down_choppy": {
+          "count": 966,
+          "pct": 0.21889870836165873
+        },
+        "trending_up_choppy": {
+          "count": 530,
+          "pct": 0.12009970541581691
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3476297968397291,
+          "transition_rate": 0.07738095238095238,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3544074325855427,
+          "transition_rate": 0.07683590208522212,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.38628532046864233,
+          "transition_rate": 0.07754164273406089,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3557285109305254,
+          "transition_rate": 0.07577838827838827,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.35629508959739353,
+          "transition_rate": 0.0782122905027933,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.03947325520593337,
+          "centroid_raw": [
+            0.008415417731259017,
+            0.16129753385078846,
+            0.14568644648277854,
+            24.541820610415954,
+            -0.18471166046432339
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17053699009698026,
+            0.23281590185967255,
+            0.32927860561113204,
+            38.452112383624936,
+            0.33362327548808407
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1365147571279726,
+            0.20667757194855438,
+            0.2664033736698018,
+            40.01812376191631,
+            0.14461598430877176
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005364452423341439,
+            0.1235965107812122,
+            0.05814608216492108,
+            20.222300877394577,
+            -0.012286917545887014
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.03947325520593337
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 143.72161027388393,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.14913871260199457
+        }
+      },
+      "model_kruskal_h": 143.72161027388393,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.008386219401631922,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1365,
+          "pct": 0.30931339225016996
+        },
+        "ranging_directional_up": {
+          "count": 491,
+          "pct": 0.11126217992295491
+        },
+        "ranging_volatile": {
+          "count": 1259,
+          "pct": 0.28529345116700655
+        },
+        "trending_down_choppy": {
+          "count": 822,
+          "pct": 0.18626784500339905
+        },
+        "trending_up_choppy": {
+          "count": 476,
+          "pct": 0.10786313165646952
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.32361994664477733,
+          "transition_rate": 0.17282430213464697,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.30931339225016996,
+          "transition_rate": 0.14913871260199457,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.35481277280036755,
+          "transition_rate": 0.16450315910396324,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3243676319102667,
+          "transition_rate": 0.17273351648351648,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3216197346986269,
+          "transition_rate": 0.17830540037243947,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006703190873293222,
+            0.12374138204776075,
+            0.055934288580752736,
+            19.769605394148826,
+            -0.25700316116147115
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.14524290605920803,
+            0.21570330305630403,
+            0.28261989994720194,
+            41.330028743640355,
+            0.16372000135112516
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.007012125074658562,
+            0.16421708936045792,
+            0.1556204760892654,
+            26.38624404150922,
+            -0.46128309116626415
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.175462581153348,
+            0.2368221844581369,
+            0.3382345292324532,
+            39.4616290598842,
+            0.19132649525148693
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.11059403745979748,
+          "centroid_raw": [
+            0.01684499458477651,
+            0.15083047950630898,
+            0.1328215605410502,
+            23.716297698008233,
+            1.3727534325856021
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.11059403745979748
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 115.22492709619291,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.005,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.14120580235720762
+        }
+      },
+      "model_kruskal_h": 115.22492709619291,
+      "model_p_value": 0.005,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.00045330915684496653,
+      "coverage": {
+        "ranging_directional": {
+          "count": 480,
+          "pct": 0.10876954452753229
+        },
+        "ranging_directional_down": {
+          "count": 731,
+          "pct": 0.16564695218672104
+        },
+        "ranging_directional_up": {
+          "count": 950,
+          "pct": 0.21527305687740766
+        },
+        "ranging_volatile": {
+          "count": 1089,
+          "pct": 0.2467709041468389
+        },
+        "trending_down_choppy": {
+          "count": 642,
+          "pct": 0.14547926580557444
+        },
+        "trending_up_choppy": {
+          "count": 521,
+          "pct": 0.11806027645592568
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.2520008208495793,
+          "transition_rate": 0.1268472906403941,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.2467709041468389,
+          "transition_rate": 0.14120580235720762,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.2985297495979784,
+          "transition_rate": 0.1437105112004595,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.2741215520201442,
+          "transition_rate": 0.13198260073260074,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.28089364673027695,
+          "transition_rate": 0.15339851024208567,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "ranging_directional"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.38240928716579337,
+          "centroid_raw": [
+            0.0714607837399639,
+            0.15068051113574135,
+            0.14317946201528806,
+            21.26889515640951,
+            0.04299006141161928
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0025392083597263453,
+            0.12476983195411018,
+            0.03591561618200684,
+            20.606671367681983,
+            -0.16169419711215172
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1662391541858888,
+            0.2323169722053023,
+            0.3228388864307934,
+            41.4289225165903,
+            0.3263809887151658
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1722278885663252,
+            0.23385624517888498,
+            0.33292250729246625,
+            38.8585420338676,
+            0.20570896021215257
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.04383977897408171,
+          "centroid_raw": [
+            -0.05454182503878871,
+            0.1500937064017533,
+            0.1078805295778515,
+            25.02177749408476,
+            0.10464420648872107
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9819384936738405,
+          "centroid_raw": [
+            -0.10172936409544782,
+            0.1721476578318134,
+            0.2022681146190766,
+            34.3214246196568,
+            -0.23626105939052808
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.38240928716579337
+          },
+          "4": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.04383977897408171
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.9819384936738405
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 113.08055695659823,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.16953762466001812
+        }
+      },
+      "model_kruskal_h": 113.08055695659823,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.028785131459655472,
+      "coverage": {
+        "ranging_directional": {
+          "count": 741,
+          "pct": 0.167912984364378
+        },
+        "ranging_directional_down": {
+          "count": 481,
+          "pct": 0.10899614774529798
+        },
+        "ranging_directional_up": {
+          "count": 643,
+          "pct": 0.14570586902334012
+        },
+        "ranging_volatile": {
+          "count": 1015,
+          "pct": 0.23000226603217766
+        },
+        "trending_down_choppy": {
+          "count": 646,
+          "pct": 0.1463856786766372
+        },
+        "trending_up_choppy": {
+          "count": 637,
+          "pct": 0.14434624971674598
+        },
+        "trending_up_clean": {
+          "count": 250,
+          "pct": 0.05665080444142307
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.23291606813051507,
+          "transition_rate": 0.16194581280788178,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.23000226603217766,
+          "transition_rate": 0.16953762466001812,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.28348265563978864,
+          "transition_rate": 0.1710511200459506,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.25741101064438593,
+          "transition_rate": 0.1671245421245421,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.2678612985804049,
+          "transition_rate": 0.1804003724394786,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_clean",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0005439425378389474,
+            0.1252519608187645,
+            0.03237182181645801,
+            20.73079396843752,
+            -0.12903868118577894
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5249280421234478,
+          "centroid_raw": [
+            -0.05438274257064293,
+            0.1496380622672627,
+            0.10762187545397324,
+            24.98896366797629,
+            0.09354846578001938
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.114858377982165,
+            0.1836962131013481,
+            0.22998169911668132,
+            28.56269667726767,
+            0.3296479486178314
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16579462316726049,
+            0.23187842431589206,
+            0.32201717440543975,
+            41.41276808176311,
+            0.33747987213425856
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9862519015478628,
+          "centroid_raw": [
+            0.2011884136943275,
+            0.25617406245298513,
+            0.3831820502833389,
+            43.243892581659935,
+            0.09180285231713531
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4722382645143066,
+          "centroid_raw": [
+            0.05748876643499691,
+            0.1414544637118303,
+            0.11485562297087015,
+            19.58316697914081,
+            -0.10626485440992507
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4982949928911904,
+          "centroid_raw": [
+            -0.1016236333388963,
+            0.17200801495846468,
+            0.2020249348618816,
+            34.26834445177817,
+            -0.256971125677373
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.5249280421234478
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.9862519015478628
+          },
+          "5": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.4722382645143066
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.4982949928911904
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 108.98999258173535,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.062330009066183134
+        }
+      },
+      "model_kruskal_h": 108.98999258173535,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.07842248413417952,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1992,
+          "pct": 0.451393609789259
+        },
+        "ranging_volatile": {
+          "count": 2421,
+          "pct": 0.548606390210741
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5665914221218962,
+          "transition_rate": 0.06568144499178982,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.567 > 0.400",
+            "min_transition_rate: 0.0657 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.548606390210741,
+          "transition_rate": 0.062330009066183134,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.549 > 0.400",
+            "min_transition_rate: 0.0623 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5994716287617735,
+          "transition_rate": 0.061688684663986214,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.599 > 0.400",
+            "min_transition_rate: 0.0617 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5781160581435275,
+          "transition_rate": 0.061469780219780217,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.578 > 0.400",
+            "min_transition_rate: 0.0615 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5925063998138236,
+          "transition_rate": 0.0728584729981378,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.593 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.011126609600200366,
+            0.20707009712376603,
+            0.2686774644745883,
+            36.50223919432127,
+            0.336833839870164
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0052272847118849785,
+            0.13777086105731418,
+            0.08816356875591594,
+            21.551982429068584,
+            -0.22261860676982673
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 135.39457623129056,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.16092475067996373
+        }
+      },
+      "model_kruskal_h": 135.39457623129056,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.02017225747960108,
+      "coverage": {
+        "ranging_directional": {
+          "count": 595,
+          "pct": 0.1348289145705869
+        },
+        "ranging_directional_up": {
+          "count": 1566,
+          "pct": 0.3548606390210741
+        },
+        "ranging_volatile": {
+          "count": 2252,
+          "pct": 0.510310446408339
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5308844654217115,
+          "transition_rate": 0.173440065681445,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.531 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.510310446408339,
+          "transition_rate": 0.16092475067996373,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.510 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.5622559154606018,
+          "transition_rate": 0.16082711085582999,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.562 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5370264392812178,
+          "transition_rate": 0.17479395604395603,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.537 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5543402373749128,
+          "transition_rate": 0.18272811918063314,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.554 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006172053280091608,
+            0.13665922590339108,
+            0.08466293843544677,
+            21.225595762447135,
+            -0.3092034321383168
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.011961635855633878,
+            0.214151782751413,
+            0.2827240375913968,
+            38.185519846906836,
+            -0.30888158947867644
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": true,
+          "displacement_z": 0.04546170346783267,
+          "centroid_raw": [
+            0.0047098573019325966,
+            0.1756372676037407,
+            0.19697604796214363,
+            29.70472552521564,
+            1.64813214578484
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "ranging_directional_up",
+            "to": "ranging_directional",
+            "displacement_z": 0.04546170346783267
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 100.60812994793741,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.11786038077969176
+        }
+      },
+      "model_kruskal_h": 100.60812994793741,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.022892112420670893,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1381,
+          "pct": 0.31293904373442105
+        },
+        "ranging_volatile": {
+          "count": 1673,
+          "pct": 0.37910718332200316
+        },
+        "trending_down_choppy": {
+          "count": 835,
+          "pct": 0.18921368683435305
+        },
+        "trending_up_choppy": {
+          "count": 524,
+          "pct": 0.11874008610922275
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.410014364867638,
+          "transition_rate": 0.12602627257799673,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.410 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.37910718332200316,
+          "transition_rate": 0.11786038077969176,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4564668045026419,
+          "transition_rate": 0.11051120045950603,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.456 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.41913700354812866,
+          "transition_rate": 0.11813186813186813,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.419 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.42355131487084013,
+          "transition_rate": 0.12197392923649907,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.424 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.004692006561165264,
+            0.16383232723139374,
+            0.16235482496425496,
+            27.017239946673218,
+            -0.4187191490415647
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17278454046245995,
+            0.23198741403402603,
+            0.3339599243836496,
+            38.31333066444121,
+            0.47588516857323954
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1480139190301913,
+            0.21626213582347298,
+            0.2885495636076294,
+            40.42920546177693,
+            0.4069005546673823
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006043959474664448,
+            0.12908150181070174,
+            0.06146541475535555,
+            20.53051547414164,
+            0.07058756083349929
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 138.70295130566956,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.19265639165911153
+        }
+      },
+      "model_kruskal_h": 138.70295130566956,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.051903898458748876,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1307,
+          "pct": 0.2961704056197598
+        },
+        "ranging_directional_up": {
+          "count": 578,
+          "pct": 0.13097665986857013
+        },
+        "ranging_volatile": {
+          "count": 1360,
+          "pct": 0.3081803761613415
+        },
+        "trending_down_choppy": {
+          "count": 736,
+          "pct": 0.1667799682755495
+        },
+        "trending_up_choppy": {
+          "count": 432,
+          "pct": 0.09789259007477906
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.32485122101374925,
+          "transition_rate": 0.22844827586206898,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.3081803761613415,
+          "transition_rate": 0.19265639165911153,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.3591775786813692,
+          "transition_rate": 0.21148765077541642,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3378734119262905,
+          "transition_rate": 0.22264194139194138,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.34652082848498955,
+          "transition_rate": 0.22951582867783984,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005351250801701119,
+            0.12715595699342316,
+            0.05367334642097259,
+            20.201766387975937,
+            -0.37397317213587655
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.15857077006383724,
+            0.2260458414583939,
+            0.30841504823782845,
+            41.906114510062686,
+            0.30856211207240397
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.010861117572208727,
+            0.16759016666855292,
+            0.17286363987685144,
+            28.223502042470322,
+            -0.46937266052978605
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18416290033339877,
+            0.2420345345778605,
+            0.3545414260334847,
+            40.45136640785693,
+            0.23223750273378208
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.1404190598984702,
+          "centroid_raw": [
+            0.015155169478344704,
+            0.14752433258421613,
+            0.12392602533086028,
+            23.370108601011047,
+            1.2797587692679688
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.1404190598984702
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 132.1030660898614,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.1956029011786038
+        }
+      },
+      "model_kruskal_h": 132.1030660898614,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.054850407978241145,
+      "coverage": {
+        "ranging_directional": {
+          "count": 509,
+          "pct": 0.11534103784273737
+        },
+        "ranging_directional_down": {
+          "count": 630,
+          "pct": 0.14276002719238612
+        },
+        "ranging_directional_up": {
+          "count": 635,
+          "pct": 0.1438930432812146
+        },
+        "ranging_volatile": {
+          "count": 1584,
+          "pct": 0.3589394969408566
+        },
+        "trending_down_choppy": {
+          "count": 672,
+          "pct": 0.15227736233854522
+        },
+        "trending_up_choppy": {
+          "count": 383,
+          "pct": 0.08678903240426014
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.3656884875846501,
+          "transition_rate": 0.2229064039408867,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.3589394969408566,
+          "transition_rate": 0.1956029011786038,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.4066161268090972,
+          "transition_rate": 0.2105686387133831,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.407 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.3846858189309832,
+          "transition_rate": 0.2132554945054945,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.4056318361647661,
+          "transition_rate": 0.22905027932960895,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.406 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy",
+        "ranging_directional",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.47061216219204866,
+          "centroid_raw": [
+            0.0987556769632895,
+            0.17073840854507488,
+            0.1972169600653029,
+            25.375980192077886,
+            -0.29422034945567027
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006022350496790466,
+            0.1320679489089706,
+            0.06180904193844665,
+            20.711607845833626,
+            -0.4264677901489847
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1632711280723551,
+            0.22942847484362133,
+            0.31729553710001024,
+            41.626317657995074,
+            0.33930853244690573
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18704145094989,
+            0.243436951176063,
+            0.3599719342078359,
+            40.762032957894604,
+            0.28723639807121876
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.15894266091012857,
+          "centroid_raw": [
+            0.003791644628224203,
+            0.14343640367483473,
+            0.10169749772366159,
+            23.204674513168897,
+            1.420553137566423
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4253976561136781,
+          "centroid_raw": [
+            -0.09407142944587808,
+            0.16917468325665427,
+            0.18659783700350774,
+            32.32327594580013,
+            -0.40120886954572943
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.47061216219204866
+          },
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.15894266091012857
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.4253976561136781
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 113.57423463585837,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.2126019945602901
+        }
+      },
+      "model_kruskal_h": 113.57423463585837,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.07184950135992746,
+      "coverage": {
+        "ranging_directional": {
+          "count": 480,
+          "pct": 0.10876954452753229
+        },
+        "ranging_directional_down": {
+          "count": 734,
+          "pct": 0.16632676184001813
+        },
+        "ranging_directional_up": {
+          "count": 491,
+          "pct": 0.11126217992295491
+        },
+        "ranging_volatile": {
+          "count": 1221,
+          "pct": 0.27668252889191025
+        },
+        "trending_down_choppy": {
+          "count": 691,
+          "pct": 0.15658282347609337
+        },
+        "trending_up_choppy": {
+          "count": 521,
+          "pct": 0.11806027645592568
+        },
+        "trending_up_clean": {
+          "count": 275,
+          "pct": 0.06231588488556537
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.2630822901703263,
+          "transition_rate": 0.22639573070607552,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.27668252889191025,
+          "transition_rate": 0.2126019945602901,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.32368481507006663,
+          "transition_rate": 0.21941412981045377,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.3006752890008012,
+          "transition_rate": 0.23351648351648352,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.31347451710495694,
+          "transition_rate": 0.2527932960893855,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_clean",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0029786860286036883,
+            0.12823669171429322,
+            0.041911590736689916,
+            20.95595483341993,
+            -0.3814498868509362
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.1158469279551875,
+          "centroid_raw": [
+            -0.003839813580491595,
+            0.14546125554532283,
+            0.1066824686669588,
+            23.72600299992314,
+            1.5744499989004275
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.11794939282616225,
+            0.18777105737061717,
+            0.234637575238553,
+            29.136662192550933,
+            -0.11656118465543035
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1610174449404235,
+            0.2275967814303901,
+            0.31310165106504106,
+            41.47081351353459,
+            0.31305755525433393
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9939369765836635,
+          "centroid_raw": [
+            0.19982118425557363,
+            0.25247057622647323,
+            0.38227178110394167,
+            42.71787087329132,
+            0.27054491562978406
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.45202156403124144,
+          "centroid_raw": [
+            0.062247890635821236,
+            0.14360017724166732,
+            0.12509914664580354,
+            19.935861023874523,
+            -0.37443882757608543
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3729835416107443,
+          "centroid_raw": [
+            -0.08864129856460465,
+            0.16615995449819118,
+            0.17583845094520315,
+            31.065334978645865,
+            -0.43701905105258754
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.1158469279551875
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.9939369765836635
+          },
+          "5": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.45202156403124144
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.3729835416107443
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": false,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 71.87235107580818,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.010833333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.031958295557570265
+        }
+      },
+      "model_kruskal_h": 71.87235107580818,
+      "model_p_value": 0.010833333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.10879419764279238,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1582,
+          "pct": 0.35848629050532516
+        },
+        "ranging_volatile": {
+          "count": 2831,
+          "pct": 0.6415137094946748
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6618099733223887,
+          "transition_rate": 0.027914614121510674,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.662 > 0.400",
+            "min_transition_rate: 0.0279 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.6415137094946748,
+          "transition_rate": 0.031958295557570265,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.642 > 0.400",
+            "min_transition_rate: 0.0320 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6883758327590168,
+          "transition_rate": 0.02469844916714532,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.688 > 0.400",
+            "min_transition_rate: 0.0247 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6559459768799359,
+          "transition_rate": 0.027815934065934064,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.656 > 0.400",
+            "min_transition_rate: 0.0278 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6825692343495462,
+          "transition_rate": 0.029562383612662942,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.683 > 0.400",
+            "min_transition_rate: 0.0296 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.019521377793891945,
+            0.22360552879904153,
+            0.3026848803593148,
+            40.05796647627371,
+            0.18967788311770528
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0024771130675424156,
+            0.14196527381023197,
+            0.10312058306106797,
+            22.46199548369064,
+            -0.06395142504393973
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 94.49959125848181,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.12216681776971895
+        }
+      },
+      "model_kruskal_h": 94.49959125848181,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.018585675430643697,
+      "coverage": {
+        "ranging_directional": {
+          "count": 372,
+          "pct": 0.08429639700883752
+        },
+        "ranging_directional_up": {
+          "count": 1416,
+          "pct": 0.32087015635622024
+        },
+        "ranging_volatile": {
+          "count": 2625,
+          "pct": 0.5948334466349422
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.6084547506669403,
+          "transition_rate": 0.13669950738916256,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.608 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5948334466349422,
+          "transition_rate": 0.12216681776971895,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.595 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6308293131173903,
+          "transition_rate": 0.12360712234348076,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.631 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6037541490214032,
+          "transition_rate": 0.1353021978021978,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.604 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6283453572259716,
+          "transition_rate": 0.14338919925512103,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.628 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.002700579838683737,
+            0.14142506821994602,
+            0.1015346969862079,
+            22.277067002976278,
+            -0.27731223962594387
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.020849147745431063,
+            0.2247971054558101,
+            0.3034313586855756,
+            40.495460657537414,
+            -0.13265575002530663
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": true,
+          "displacement_z": 0.017647273436703744,
+          "centroid_raw": [
+            0.0018282671636770222,
+            0.16895588464392536,
+            0.17854176827156532,
+            28.19315292805376,
+            2.770720513308974
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "ranging_directional_up",
+            "to": "ranging_directional",
+            "displacement_z": 0.017647273436703744
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 101.14008416173783,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.0883952855847688
+        }
+      },
+      "model_kruskal_h": 101.14008416173783,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.05235720761559384,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1426,
+          "pct": 0.32313618853387716
+        },
+        "ranging_volatile": {
+          "count": 1642,
+          "pct": 0.3720824835712667
+        },
+        "trending_down_choppy": {
+          "count": 873,
+          "pct": 0.19782460910944935
+        },
+        "trending_up_choppy": {
+          "count": 472,
+          "pct": 0.10695671878540676
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.41617073671249744,
+          "transition_rate": 0.09523809523809523,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.416 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3720824835712667,
+          "transition_rate": 0.0883952855847688,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4492304158051918,
+          "transition_rate": 0.0800689259046525,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.449 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.41490214032276523,
+          "transition_rate": 0.08836996336996338,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.415 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.41331161275308353,
+          "transition_rate": 0.09101489757914338,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.413 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.005663130430038441,
+            0.16607980086525428,
+            0.15620301193460653,
+            27.039602936334646,
+            -0.32922146230698474
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17943301624198163,
+            0.23882457338892915,
+            0.34613444514083047,
+            40.08117595833316,
+            0.29660432911604734
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.14013948299828016,
+            0.20976939295638453,
+            0.27266510874509403,
+            40.81568481190444,
+            0.17330413525364616
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009463908450059233,
+            0.12824518245989425,
+            0.07008091792127144,
+            19.563130415646917,
+            0.09447942435529398
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 133.5413237347875,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.1373526745240254
+        }
+      },
+      "model_kruskal_h": 133.5413237347875,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": 0.003399818676337263,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 1342,
+          "pct": 0.304101518241559
+        },
+        "ranging_directional_up": {
+          "count": 327,
+          "pct": 0.07409925220938138
+        },
+        "ranging_volatile": {
+          "count": 1580,
+          "pct": 0.3580330840697938
+        },
+        "trending_down_choppy": {
+          "count": 743,
+          "pct": 0.16836619079990936
+        },
+        "trending_up_choppy": {
+          "count": 421,
+          "pct": 0.09539995467935644
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.39872768315206236,
+          "transition_rate": 0.1473727422003284,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.3580330840697938,
+          "transition_rate": 0.1373526745240254,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.42637261658626235,
+          "transition_rate": 0.1360137851809305,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.426 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.39967952386402655,
+          "transition_rate": 0.15739468864468864,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.400 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.39166860600418896,
+          "transition_rate": 0.16457169459962756,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.012824237708183162,
+            0.12941658577436485,
+            0.07148720771563859,
+            19.252747896872204,
+            -0.25786935156708013
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.15091225282139828,
+            0.2207984710037759,
+            0.29207259605107794,
+            42.75236597219731,
+            -0.020865083605882098
+          ],
+          "volatility_rank": 3
+        },
+        "2": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.014230132840734747,
+            0.1679557245723894,
+            0.1660458307004641,
+            28.967453343994826,
+            -0.3073701733214702
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18170081800851656,
+            0.24126230993341552,
+            0.34954351280388885,
+            40.60093556331208,
+            0.021388841216556737
+          ],
+          "volatility_rank": 4
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009529732375554054,
+            0.16135036177547815,
+            0.15796168558442955,
+            26.57418910993238,
+            2.8875167588250923
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 150.06325299008313,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.14528558476881234
+        }
+      },
+      "model_kruskal_h": 150.06325299008313,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.004533091568449693,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 784,
+          "pct": 0.17765692272830275
+        },
+        "ranging_directional_up": {
+          "count": 314,
+          "pct": 0.07115341037842737
+        },
+        "ranging_volatile": {
+          "count": 1765,
+          "pct": 0.39995467935644685
+        },
+        "trending_down_choppy": {
+          "count": 582,
+          "pct": 0.1318830727396329
+        },
+        "trending_up_choppy": {
+          "count": 688,
+          "pct": 0.15590301382279628
+        },
+        "trending_up_clean": {
+          "count": 280,
+          "pct": 0.06344890097439383
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.4252000820849579,
+          "transition_rate": 0.1463464696223317,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.425 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.39995467935644685,
+          "transition_rate": 0.14528558476881234,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.400 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.4735814380886745,
+          "transition_rate": 0.1456634118322803,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.474 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.43241387203845716,
+          "transition_rate": 0.15212912087912087,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.432 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.44263439609029553,
+          "transition_rate": 0.1610800744878957,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.443 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_clean",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1076826455759808,
+            0.1814784757777106,
+            0.21389970522422797,
+            27.868472575174607,
+            -0.19515328962351466
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009204998707918232,
+            0.13125069148645063,
+            0.07005728359023154,
+            19.91361454035915,
+            -0.2779724364875021
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.17033067574268174,
+            0.2387689879054511,
+            0.3291049665686582,
+            45.469208533575596,
+            0.13705381448107734
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.0100845694388283,
+          "centroid_raw": [
+            0.1993372284197829,
+            0.25547651647507114,
+            0.38035915747580035,
+            44.09779490171881,
+            0.04507044226184777
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.011763274414507084,
+            0.1588766216416314,
+            0.15221848363032958,
+            26.003598355319426,
+            2.8302336712709537
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4118930343341285,
+          "centroid_raw": [
+            -0.09267234325582244,
+            0.17233173386804115,
+            0.1839456354895932,
+            32.38449062993427,
+            -0.2957035579692628
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "3": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.0100845694388283
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.4118930343341285
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "volume",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "volume_z"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 85.21096933007357,
+          "model_kruskal_h": 158.043994927124,
+          "handrule_p_value": 0.005833333333333334,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.14075249320036265,
+          "model_transition_rate": 0.16341795104261106
+        }
+      },
+      "model_kruskal_h": 158.043994927124,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 85.21096933007357,
+      "stability_gain": -0.02266545784224841,
+      "coverage": {
+        "ranging_directional": {
+          "count": 657,
+          "pct": 0.14887831407205981
+        },
+        "ranging_directional_down": {
+          "count": 825,
+          "pct": 0.18694765465669613
+        },
+        "ranging_directional_up": {
+          "count": 304,
+          "pct": 0.06888737820077045
+        },
+        "ranging_volatile": {
+          "count": 1484,
+          "pct": 0.33627917516428735
+        },
+        "trending_down_choppy": {
+          "count": 588,
+          "pct": 0.13324269204622705
+        },
+        "trending_up_choppy": {
+          "count": 379,
+          "pct": 0.08588261953319737
+        },
+        "trending_up_clean": {
+          "count": 176,
+          "pct": 0.03988216632676184
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.3363431151241535,
+          "transition_rate": 0.16461412151067323,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.33627917516428735,
+          "transition_rate": 0.16341795104261106,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.40041350792556857,
+          "transition_rate": 0.15944859276278,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.400 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.36694517568959595,
+          "transition_rate": 0.17101648351648352,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.36723295322317895,
+          "transition_rate": 0.18319366852886407,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "trending_down_choppy",
+        "trending_up_clean",
+        "ranging_directional",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.003927887776013113,
+            0.12728597650747844,
+            0.05592424300691538,
+            20.331487570843304,
+            -0.25202369180026685
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.01071468832996898,
+            0.15948323598374547,
+            0.1526087450761904,
+            26.40199464025296,
+            2.933985995727722
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1419194447812552,
+            0.21326751768050994,
+            0.27774909845069573,
+            32.415889697196086,
+            -0.07816486920492356
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16977686795831398,
+            0.2383367039773286,
+            0.32784766156826817,
+            45.530306245798556,
+            0.13866588025901452
+          ],
+          "volatility_rank": 5
+        },
+        "4": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.7732715162914682,
+          "centroid_raw": [
+            0.21409238284675647,
+            0.2647248950756555,
+            0.40840880208626984,
+            49.2133804284486,
+            0.09110775212678958
+          ],
+          "volatility_rank": 6
+        },
+        "5": {
+          "name": "ranging_directional",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.784480065980724,
+          "centroid_raw": [
+            0.07452418752317462,
+            0.15468808193665623,
+            0.15032821214042338,
+            21.367133947918582,
+            -0.27666812281263947
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4135305874028697,
+          "centroid_raw": [
+            -0.09284199464786871,
+            0.17250523430633025,
+            0.18463939364259868,
+            32.17434848508409,
+            -0.29387533482783434
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.7732715162914682
+          },
+          "5": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.784480065980724
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.4135305874028697
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 113.41290084465982,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.028377110694183864
+        }
+      },
+      "model_kruskal_h": 113.41290084465982,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.11421200750469043,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1764,
+          "pct": 0.41359906213364594
+        },
+        "ranging_volatile": {
+          "count": 2501,
+          "pct": 0.586400937866354
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5995767195767195,
+          "transition_rate": 0.029212531752751906,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.600 > 0.400",
+            "min_transition_rate: 0.0292 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.586400937866354,
+          "transition_rate": 0.028377110694183864,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.586 > 0.400",
+            "min_transition_rate: 0.0284 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6403365272259873,
+          "transition_rate": 0.026527988781114877,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.640 > 0.400",
+            "min_transition_rate: 0.0265 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6034462684829432,
+          "transition_rate": 0.027130880298090358,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.603 > 0.400",
+            "min_transition_rate: 0.0271 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6302723547842853,
+          "transition_rate": 0.030617164898746385,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.630 > 0.400",
+            "min_transition_rate: 0.0306 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.013548544438709035,
+            0.2114457323052713,
+            0.2785143201304661,
+            37.86212327356053,
+            0.1867675919018435
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006089672070217427,
+            0.13752984372397697,
+            0.090769362700906,
+            21.447076363020663,
+            0.16053420709262323
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 112.99503074386848,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.036585365853658534
+        }
+      },
+      "model_kruskal_h": 112.99503074386848,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.10600375234521575,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2351,
+          "pct": 0.5512309495896834
+        },
+        "trending_down_choppy": {
+          "count": 1247,
+          "pct": 0.29237983587338806
+        },
+        "trending_up_choppy": {
+          "count": 667,
+          "pct": 0.1563892145369285
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5574603174603174,
+          "transition_rate": 0.03408128704487722,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.557 > 0.400",
+            "min_transition_rate: 0.0341 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5512309495896834,
+          "transition_rate": 0.036585365853658534,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.551 > 0.400",
+            "min_transition_rate: 0.0366 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.613811638233232,
+          "transition_rate": 0.03120252424915274,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.614 > 0.400",
+            "min_transition_rate: 0.0312 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5794621026894865,
+          "transition_rate": 0.03295295761527713,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.579 > 0.400",
+            "min_transition_rate: 0.0330 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6001446131597975,
+          "transition_rate": 0.03929604628736741,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.600 > 0.400",
+            "min_transition_rate: 0.0393 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.011433566697571824,
+            0.1356038210475926,
+            0.08381902484615578,
+            21.096104051910224,
+            0.16042505268297721
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11989689681320748,
+            0.1932952258605128,
+            0.23591241556785927,
+            36.79803580236397,
+            0.17276265612819425
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.15782052075783357,
+            0.22203450408286451,
+            0.30701042644840715,
+            36.41507125351555,
+            0.19802975597828829
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 139.1215503877629,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.04362101313320826
+        }
+      },
+      "model_kruskal_h": 139.1215503877629,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.09896810506566603,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 871,
+          "pct": 0.20422039859320046
+        },
+        "ranging_volatile": {
+          "count": 1695,
+          "pct": 0.3974208675263775
+        },
+        "trending_down_choppy": {
+          "count": 1164,
+          "pct": 0.27291910902696365
+        },
+        "trending_up_choppy": {
+          "count": 535,
+          "pct": 0.1254396248534584
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.36,
+          "transition_rate": 0.03640982218458933,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "min_transition_rate: 0.0364 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3974208675263775,
+          "transition_rate": 0.04362101313320826,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "min_transition_rate: 0.0436 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4239308249591026,
+          "transition_rate": 0.03716255697090102,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.424 > 0.400",
+            "min_transition_rate: 0.0372 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3328676213761788,
+          "transition_rate": 0.036679087098276664,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "min_transition_rate: 0.0367 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3882863340563991,
+          "transition_rate": 0.0431533269045323,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "min_transition_rate: 0.0432 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17057138134983119,
+            0.2330383263682429,
+            0.3298866676533155,
+            38.712525050540776,
+            0.1972807740001682
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.11012868839075184,
+          "centroid_raw": [
+            0.027017371400157794,
+            0.14923808367244645,
+            0.11048440080618219,
+            23.712693856242996,
+            0.20504974192048334
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12428939083338897,
+            0.19457179330688198,
+            0.24429286601599937,
+            37.518749301924586,
+            0.17066430263550275
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00669183354146224,
+            0.13239433990716115,
+            0.08069382114011932,
+            20.205028633506036,
+            0.13682697776137365
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.11012868839075184
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 124.03926368075736,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.10154784240150094
+        }
+      },
+      "model_kruskal_h": 124.03926368075736,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.04104127579737335,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 924,
+          "pct": 0.21664712778429074
+        },
+        "ranging_directional_up": {
+          "count": 813,
+          "pct": 0.1906213364595545
+        },
+        "ranging_volatile": {
+          "count": 1418,
+          "pct": 0.3324736225087925
+        },
+        "trending_down_choppy": {
+          "count": 657,
+          "pct": 0.1540445486518171
+        },
+        "trending_up_choppy": {
+          "count": 453,
+          "pct": 0.10621336459554513
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.31682539682539684,
+          "transition_rate": 0.08890770533446232,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.3324736225087925,
+          "transition_rate": 0.10154784240150094,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.39132974994157516,
+          "transition_rate": 0.0925558022671497,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.34963325183374083,
+          "transition_rate": 0.09653004191895669,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3755121716076163,
+          "transition_rate": 0.10318225650916105,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.33596670767954034,
+          "centroid_raw": [
+            -0.08474554577303862,
+            0.16450674526784406,
+            0.16826538446308545,
+            30.167918724719,
+            0.1599486365875838
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3743190537069537,
+          "centroid_raw": [
+            0.07479718234117903,
+            0.15302714345732393,
+            0.15037983482160466,
+            21.640039454585967,
+            0.17046897962730037
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17443739565388167,
+            0.23606007955347866,
+            0.3365778537568653,
+            39.22554998789569,
+            0.20045951378616464
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0014764536096485877,
+            0.1265961720819987,
+            0.045303135129644886,
+            20.985955541623195,
+            0.15903862153014392
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16341226173776444,
+            0.22795659399038104,
+            0.3178982028821827,
+            42.746053783300056,
+            0.19037968556758672
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.33596670767954034
+          },
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.3743190537069537
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 142.94414795496232,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.07668855534709193
+        }
+      },
+      "model_kruskal_h": 142.94414795496232,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.06590056285178236,
+      "coverage": {
+        "ranging_directional": {
+          "count": 379,
+          "pct": 0.08886283704572098
+        },
+        "ranging_directional_down": {
+          "count": 711,
+          "pct": 0.16670574443141853
+        },
+        "ranging_directional_up": {
+          "count": 653,
+          "pct": 0.15310668229777258
+        },
+        "ranging_volatile": {
+          "count": 1565,
+          "pct": 0.3669402110199297
+        },
+        "trending_down_choppy": {
+          "count": 649,
+          "pct": 0.15216881594372803
+        },
+        "trending_up_choppy": {
+          "count": 308,
+          "pct": 0.07221570926143024
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.3456084656084656,
+          "transition_rate": 0.07303132938187976,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.3669402110199297,
+          "transition_rate": 0.07668855534709193,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.3857209628417855,
+          "transition_rate": 0.06836508122005376,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0684 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.30713703574339274,
+          "transition_rate": 0.0732417326502096,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.3603277898288744,
+          "transition_rate": 0.07569913211186113,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "ranging_directional",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.193246897115381,
+            0.24900901823045368,
+            0.3702833679266134,
+            41.896460171431826,
+            0.20447643412262412
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.39979401024807487,
+          "centroid_raw": [
+            -0.09134654049147946,
+            0.16714757137595787,
+            0.18084088407987145,
+            32.139562983437564,
+            0.1580259913824633
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5048860610137633,
+          "centroid_raw": [
+            0.1022151193619331,
+            0.17595072270888984,
+            0.20427457800238502,
+            26.80489107099741,
+            0.17964144108299399
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0075025976847429765,
+            0.13065103881762147,
+            0.0672561670368558,
+            19.69857955984334,
+            0.14063448490016647
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.18252916860439505,
+          "centroid_raw": [
+            0.007353847540222034,
+            0.13786934711862878,
+            0.07372989911131711,
+            23.03495326806372,
+            0.22088375384774958
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16406174753039376,
+            0.2293112559689225,
+            0.31905798572301214,
+            42.80317933163424,
+            0.1914357456497566
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.39979401024807487
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.5048860610137633
+          },
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.18252916860439505
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 160.2111819651218,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.07340525328330207
+        }
+      },
+      "model_kruskal_h": 160.2111819651218,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.06918386491557223,
+      "coverage": {
+        "ranging_directional": {
+          "count": 266,
+          "pct": 0.06236811254396248
+        },
+        "ranging_directional_down": {
+          "count": 839,
+          "pct": 0.1967174677608441
+        },
+        "ranging_directional_up": {
+          "count": 557,
+          "pct": 0.1305978898007034
+        },
+        "ranging_volatile": {
+          "count": 805,
+          "pct": 0.18874560375146543
+        },
+        "trending_down_choppy": {
+          "count": 1231,
+          "pct": 0.28862837045720985
+        },
+        "trending_up_choppy": {
+          "count": 353,
+          "pct": 0.08276670574443142
+        },
+        "trending_up_clean": {
+          "count": 214,
+          "pct": 0.050175849941383355
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.2361904761904762,
+          "transition_rate": 0.06668077900084673,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0667 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.28862837045720985,
+          "transition_rate": 0.07340525328330207,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.23171301706006076,
+          "transition_rate": 0.0636905457520159,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0637 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.20374898125509372,
+          "transition_rate": 0.07184443409408477,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.2398168233309231,
+          "transition_rate": 0.06846673095467695,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0685 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_up_clean",
+        "ranging_directional",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.12702346054417635,
+            0.19916066424546075,
+            0.2535238207212325,
+            31.434908485775942,
+            0.19475804481027092
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.3207648323226955,
+          "centroid_raw": [
+            -0.006615051754833264,
+            0.12879870247482125,
+            0.06324455493276473,
+            21.250545199584284,
+            0.16495318052454344
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.8725562410813615,
+          "centroid_raw": [
+            0.2085465028073811,
+            0.260595111011987,
+            0.39670171983677227,
+            44.76838260924695,
+            0.20825177639392628
+          ],
+          "volatility_rank": 6
+        },
+        "3": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.3050072671281314,
+          "centroid_raw": [
+            0.01231757392273914,
+            0.13789435566779393,
+            0.08641372754960323,
+            21.71779636171656,
+            0.22915556760775746
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.38243066464851366,
+          "centroid_raw": [
+            0.0762700615232289,
+            0.15426809135044023,
+            0.14991011197128742,
+            21.65826532499588,
+            0.1530753350355968
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.007132068690909784,
+            0.1338511916243254,
+            0.0715861339375853,
+            20.579779673166307,
+            0.11338616335357765
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12118414616956846,
+            0.19360277386053049,
+            0.23850106603339882,
+            37.05398480592805,
+            0.17165401004203543
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.3207648323226955
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.8725562410813615
+          },
+          "3": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.3050072671281314
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.38243066464851366
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 105.3092622103195,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.03025328330206379
+        }
+      },
+      "model_kruskal_h": 105.3092622103195,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.11233583489681051,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1717,
+          "pct": 0.40257913247362254
+        },
+        "ranging_volatile": {
+          "count": 2548,
+          "pct": 0.5974208675263775
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6088888888888889,
+          "transition_rate": 0.03217612193056731,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.609 > 0.400",
+            "min_transition_rate: 0.0322 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5974208675263775,
+          "transition_rate": 0.03025328330206379,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.597 > 0.400",
+            "min_transition_rate: 0.0303 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6495676559943913,
+          "transition_rate": 0.027930349421526234,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.650 > 0.400",
+            "min_transition_rate: 0.0279 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.6108976597974153,
+          "transition_rate": 0.028761061946902654,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.611 > 0.400",
+            "min_transition_rate: 0.0288 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.6440106049650518,
+          "transition_rate": 0.03254580520732883,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.644 > 0.400",
+            "min_transition_rate: 0.0325 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.016780734154174977,
+            0.21231169760260923,
+            0.2830181706425401,
+            37.84690321093151,
+            0.18693508283594767
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.004249253169095793,
+            0.13846004560538255,
+            0.09171473499448682,
+            21.78130018189347,
+            0.16095036028125864
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 116.74150193290734,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.008333333333333333,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.0349437148217636
+        }
+      },
+      "model_kruskal_h": 116.74150193290734,
+      "model_p_value": 0.008333333333333333,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.10764540337711069,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2522,
+          "pct": 0.591324736225088
+        },
+        "trending_down_choppy": {
+          "count": 1153,
+          "pct": 0.27033997655334113
+        },
+        "trending_up_choppy": {
+          "count": 590,
+          "pct": 0.13833528722157093
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5934391534391534,
+          "transition_rate": 0.03556308213378493,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.593 > 0.400",
+            "min_transition_rate: 0.0356 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.591324736225088,
+          "transition_rate": 0.0349437148217636,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.591 > 0.400",
+            "min_transition_rate: 0.0349 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.646880112175742,
+          "transition_rate": 0.02980016360874138,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.647 > 0.400",
+            "min_transition_rate: 0.0298 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6142740714867855,
+          "transition_rate": 0.034699580810433166,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.614 > 0.400",
+            "min_transition_rate: 0.0347 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.64352856109906,
+          "transition_rate": 0.03833172613307618,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.644 > 0.400",
+            "min_transition_rate: 0.0383 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.009933049610985378,
+            0.13842892564770876,
+            0.08945425021678713,
+            21.628172266540055,
+            0.1616074723738555
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12678681341819184,
+            0.19626404171011344,
+            0.24901353552666,
+            37.93701045601447,
+            0.17329254074525988
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1642703395092552,
+            0.2266613231718531,
+            0.31870034640883715,
+            37.286104765781786,
+            0.1990589112764592
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 120.52199928545633,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.09216697936210132
+        }
+      },
+      "model_kruskal_h": 120.52199928545633,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.050422138836772976,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1634,
+          "pct": 0.3831184056271981
+        },
+        "ranging_volatile": {
+          "count": 1436,
+          "pct": 0.336694021101993
+        },
+        "trending_down_choppy": {
+          "count": 792,
+          "pct": 0.18569753810082062
+        },
+        "trending_up_choppy": {
+          "count": 403,
+          "pct": 0.09449003516998827
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.3691005291005291,
+          "transition_rate": 0.09398814563928874,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3831184056271981,
+          "transition_rate": 0.09216697936210132,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.3993923813975228,
+          "transition_rate": 0.08636204277199953,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.36930958202351843,
+          "transition_rate": 0.09024219841639497,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.38467100506146057,
+          "transition_rate": 0.09305689488910318,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1809384657930981,
+            0.24011838168349856,
+            0.3489927268835633,
+            40.025526561948126,
+            0.20299044640453554
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0033502328616117957,
+            0.16096498094723366,
+            0.16037984462286947,
+            26.03570144012729,
+            0.1664183060892308
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.14835072118552312,
+            0.21410899056970448,
+            0.28907531197204217,
+            41.409390386555124,
+            0.18157714072841158
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.00446743416381886,
+            0.12680260338636187,
+            0.05172983707836752,
+            20.347144262125724,
+            0.15929689659665444
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 123.1417413975123,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.09849906191369606
+        }
+      },
+      "model_kruskal_h": 123.1417413975123,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.04409005628517823,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 775,
+          "pct": 0.1817116060961313
+        },
+        "ranging_directional_up": {
+          "count": 712,
+          "pct": 0.16694021101992965
+        },
+        "ranging_volatile": {
+          "count": 1767,
+          "pct": 0.41430246189917935
+        },
+        "trending_down_choppy": {
+          "count": 634,
+          "pct": 0.14865181711606096
+        },
+        "trending_up_choppy": {
+          "count": 377,
+          "pct": 0.0883939038686987
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.4002116402116402,
+          "transition_rate": 0.10457239627434378,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.400 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.41430246189917935,
+          "transition_rate": 0.09849906191369606,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.414 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.472774012619771,
+          "transition_rate": 0.09290639242725254,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.473 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.4286878565607172,
+          "transition_rate": 0.091988821611551,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.429 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.46324415521812484,
+          "transition_rate": 0.09811957569913211,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.463 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.40112846814857506,
+          "centroid_raw": [
+            -0.09148454960668098,
+            0.16693091822345774,
+            0.18152509801332517,
+            31.517788876328623,
+            0.16150099605046245
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.39346622606865006,
+          "centroid_raw": [
+            0.08907989944412063,
+            0.1628641286445737,
+            0.17839445215512356,
+            23.71821116340751,
+            0.17577540836722505
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1843304144389902,
+            0.24198042659230395,
+            0.3552029918718801,
+            40.559036332583574,
+            0.2024704568461149
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0023154716925138834,
+            0.13129703581222604,
+            0.05758841394481577,
+            21.011374878664235,
+            0.15942442320615194
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16684383149810228,
+            0.23009185735388357,
+            0.3243465488894811,
+            42.572914339507584,
+            0.18925867049084608
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.40112846814857506
+          },
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.39346622606865006
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 140.6870096434177,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.004166666666666667,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.09099437148217636
+        }
+      },
+      "model_kruskal_h": 140.6870096434177,
+      "model_p_value": 0.004166666666666667,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.051594746716697934,
+      "coverage": {
+        "ranging_directional": {
+          "count": 326,
+          "pct": 0.07643610785463072
+        },
+        "ranging_directional_down": {
+          "count": 717,
+          "pct": 0.16811254396248534
+        },
+        "ranging_directional_up": {
+          "count": 648,
+          "pct": 0.15193434935521688
+        },
+        "ranging_volatile": {
+          "count": 1636,
+          "pct": 0.3835873388042204
+        },
+        "trending_down_choppy": {
+          "count": 621,
+          "pct": 0.14560375146541618
+        },
+        "trending_up_choppy": {
+          "count": 317,
+          "pct": 0.07432590855803048
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.35894179894179895,
+          "transition_rate": 0.08996613039796783,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.3835873388042204,
+          "transition_rate": 0.09099437148217636,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.4073381631222248,
+          "transition_rate": 0.08122005375715788,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.407 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.32588194201886134,
+          "transition_rate": 0.08744760130414532,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.3865991805254278,
+          "transition_rate": 0.08944069431051109,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "ranging_directional",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1920411705017448,
+            0.2473211414653357,
+            0.3687449909283733,
+            41.61789868771314,
+            0.20389716615773276
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.42424063894493574,
+          "centroid_raw": [
+            -0.0938748012892531,
+            0.16839490824046466,
+            0.1862368692596278,
+            32.12155329357365,
+            0.1615689679939354
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.4912905783537523,
+          "centroid_raw": [
+            0.10080907985185002,
+            0.17237716075531762,
+            0.2018429271884888,
+            25.940331646248055,
+            0.1806691653448059
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.006055514498142519,
+            0.13348421135325006,
+            0.06661184887939417,
+            20.462377243708406,
+            0.14449939263711803
+          ],
+          "volatility_rank": 1
+        },
+        "4": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.18067931207005697,
+          "centroid_raw": [
+            0.006197977162416817,
+            0.1318805468366793,
+            0.06396542450476204,
+            23.007586034178107,
+            0.22241461744308055
+          ],
+          "volatility_rank": 0
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16748522236861524,
+            0.2306880871853019,
+            0.3255540866407826,
+            42.62860562244262,
+            0.18952534224392
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.42424063894493574
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.4912905783537523
+          },
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.18067931207005697
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 126.16884311616741,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0075,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.10553470919324578
+        }
+      },
+      "model_kruskal_h": 126.16884311616741,
+      "model_p_value": 0.0075,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.03705440900562851,
+      "coverage": {
+        "ranging_directional": {
+          "count": 270,
+          "pct": 0.06330597889800703
+        },
+        "ranging_directional_down": {
+          "count": 749,
+          "pct": 0.17561547479484174
+        },
+        "ranging_directional_up": {
+          "count": 510,
+          "pct": 0.11957796014067995
+        },
+        "ranging_volatile": {
+          "count": 723,
+          "pct": 0.16951934349355216
+        },
+        "trending_down_choppy": {
+          "count": 1370,
+          "pct": 0.3212192262602579
+        },
+        "trending_up_choppy": {
+          "count": 415,
+          "pct": 0.09730363423212192
+        },
+        "trending_up_clean": {
+          "count": 228,
+          "pct": 0.05345838218053927
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.2723809523809524,
+          "transition_rate": 0.10880609652836579,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.3212192262602579,
+          "transition_rate": 0.10553470919324578,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.23089506894134143,
+          "transition_rate": 0.09758092789529041,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.2330888345558272,
+          "transition_rate": 0.11469492314857942,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.2783803326102675,
+          "transition_rate": 0.10583413693346191,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_up_clean",
+        "ranging_directional",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.12368339034941409,
+            0.19270456835756958,
+            0.2467013628977318,
+            30.137974074729044,
+            0.18658666399376894
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.3724485223544142,
+          "centroid_raw": [
+            -0.002853001970846005,
+            0.13136633047021753,
+            0.058955051078690326,
+            20.646408959681047,
+            0.16132643735898117
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.9158558006980497,
+          "centroid_raw": [
+            0.2054503560578968,
+            0.2565535752283019,
+            0.391575666260345,
+            43.74907718920316,
+            0.20737930753726755
+          ],
+          "volatility_rank": 6
+        },
+        "3": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.1314154311866586,
+          "centroid_raw": [
+            0.0004633805655245675,
+            0.12651717095329093,
+            0.0448416351758994,
+            23.46476392068508,
+            0.21900508159744547
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.41468931319701874,
+          "centroid_raw": [
+            0.07087604952125365,
+            0.14909587467682384,
+            0.14226986910408518,
+            20.765691362451108,
+            0.1711100469782303
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.007103816305075715,
+            0.13199186477597685,
+            0.06016605466202839,
+            20.381129450040042,
+            0.11400147168258724
+          ],
+          "volatility_rank": 2
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1145676585038702,
+            0.18798107835018668,
+            0.22548593630661573,
+            35.310822756250296,
+            0.17205663779578445
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.3724485223544142
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.9158558006980497
+          },
+          "3": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.1314154311866586
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.41468931319701874
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 98.09941967097984,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.02673545966228893
+        }
+      },
+      "model_kruskal_h": 98.09941967097984,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.11585365853658536,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1367,
+          "pct": 0.3205158264947245
+        },
+        "ranging_volatile": {
+          "count": 2898,
+          "pct": 0.6794841735052755
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6865608465608466,
+          "transition_rate": 0.027095681625740897,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.687 > 0.400",
+            "min_transition_rate: 0.0271 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.6794841735052755,
+          "transition_rate": 0.02673545966228893,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.679 > 0.400",
+            "min_transition_rate: 0.0267 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.7171068006543585,
+          "transition_rate": 0.02021736589926376,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.717 > 0.400",
+            "min_transition_rate: 0.0202 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.676795901734777,
+          "transition_rate": 0.026665114112715417,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.677 > 0.400",
+            "min_transition_rate: 0.0267 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.7124608339358882,
+          "transition_rate": 0.02579556412729026,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.712 > 0.400",
+            "min_transition_rate: 0.0258 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0395331066210884,
+            0.22607003208783916,
+            0.3096019841912122,
+            40.223425641216856,
+            0.1975308253896981
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.003044154198886517,
+            0.14306181032223003,
+            0.10721601367763822,
+            23.026138962510466,
+            0.16029371868986972
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 115.96893763222579,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.006666666666666667,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.03119136960600375
+        }
+      },
+      "model_kruskal_h": 115.96893763222579,
+      "model_p_value": 0.006666666666666667,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.11139774859287055,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2572,
+          "pct": 0.6030480656506448
+        },
+        "trending_down_choppy": {
+          "count": 1130,
+          "pct": 0.264947245017585
+        },
+        "trending_up_choppy": {
+          "count": 563,
+          "pct": 0.13200468933177023
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.6014814814814815,
+          "transition_rate": 0.03048264182895851,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.601 > 0.400",
+            "min_transition_rate: 0.0305 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.6030480656506448,
+          "transition_rate": 0.03119136960600375,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.603 > 0.400",
+            "min_transition_rate: 0.0312 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.653306847394251,
+          "transition_rate": 0.02816407619492813,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.653 > 0.400",
+            "min_transition_rate: 0.0282 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.6231225986727209,
+          "transition_rate": 0.03213786679087098,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.623 > 0.400",
+            "min_transition_rate: 0.0321 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6488310436249699,
+          "transition_rate": 0.033992285438765674,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.649 > 0.400",
+            "min_transition_rate: 0.0340 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.010827993684025481,
+            0.13884941743562706,
+            0.09290845747270374,
+            21.49093933546125,
+            0.1605563904013232
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1265106024466458,
+            0.1973355856430425,
+            0.24840514729767238,
+            38.68152561208445,
+            0.17399419354976717
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.16662332244374836,
+            0.22980822524041122,
+            0.3226069326180082,
+            38.05516151228598,
+            0.20430562144555658
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 141.56567340149013,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.03400562851782364
+        }
+      },
+      "model_kruskal_h": 141.56567340149013,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.10858348968105065,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 413,
+          "pct": 0.09683470105509964
+        },
+        "ranging_volatile": {
+          "count": 2264,
+          "pct": 0.5308323563892146
+        },
+        "trending_down_choppy": {
+          "count": 1085,
+          "pct": 0.2543962485345838
+        },
+        "trending_up_choppy": {
+          "count": 503,
+          "pct": 0.11793669402110199
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.4622222222222222,
+          "transition_rate": 0.030059271803556307,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.462 > 0.400",
+            "min_transition_rate: 0.0301 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5308323563892146,
+          "transition_rate": 0.03400562851782364,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.531 > 0.400",
+            "min_transition_rate: 0.0340 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.5153073147931759,
+          "transition_rate": 0.028631529741731915,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.515 > 0.400",
+            "min_transition_rate: 0.0286 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.42018861334264757,
+          "transition_rate": 0.03400093153237075,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.420 > 0.400",
+            "min_transition_rate: 0.0340 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.5015666425644734,
+          "transition_rate": 0.03158148505303761,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.502 > 0.400",
+            "min_transition_rate: 0.0316 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1755234875178817,
+            0.23737588174729546,
+            0.33830960437621016,
+            39.74250731709796,
+            0.2011423238139872
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.1451114751167607,
+          "centroid_raw": [
+            0.022614036944388058,
+            0.1467072612072752,
+            0.11494015671431745,
+            23.3037762804852,
+            0.22132624060525047
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12927214104080822,
+            0.1984500522355812,
+            0.25324927406140013,
+            39.3050518521937,
+            0.17362267208326768
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.008755563568953684,
+            0.13892591045063088,
+            0.09269155342692889,
+            21.254981209313485,
+            0.1409109162546187
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.1451114751167607
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 200.21076172369794,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.05042213883677298
+        }
+      },
+      "model_kruskal_h": 200.21076172369794,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.0921669793621013,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 756,
+          "pct": 0.1772567409144197
+        },
+        "ranging_directional_up": {
+          "count": 377,
+          "pct": 0.0883939038686987
+        },
+        "ranging_volatile": {
+          "count": 2012,
+          "pct": 0.47174677608440796
+        },
+        "trending_down_choppy": {
+          "count": 592,
+          "pct": 0.1388042203985932
+        },
+        "trending_up_choppy": {
+          "count": 528,
+          "pct": 0.12379835873388043
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.411005291005291,
+          "transition_rate": 0.03937341236240474,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.411 > 0.400",
+            "min_transition_rate: 0.0394 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.47174677608440796,
+          "transition_rate": 0.05042213883677298,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.472 > 0.400",
+            "min_transition_rate: 0.0504 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.46506193035756016,
+          "transition_rate": 0.04405749678625687,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.465 > 0.400",
+            "min_transition_rate: 0.0441 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3773431132844336,
+          "transition_rate": 0.04552864462040056,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "min_transition_rate: 0.0455 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.4386599180525428,
+          "transition_rate": 0.04773384763741562,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.439 > 0.400",
+            "min_transition_rate: 0.0477 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_down",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.37275672169699703,
+          "centroid_raw": [
+            -0.0885503546627741,
+            0.17202881821159907,
+            0.18615511478416574,
+            32.40887166641097,
+            0.15622673363078393
+          ],
+          "volatility_rank": 2
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.16376816199447103,
+          "centroid_raw": [
+            0.030252155809757077,
+            0.14633259775206267,
+            0.11144593426206181,
+            23.085696250742068,
+            0.22359181368996373
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1762401687103304,
+            0.23761675322471465,
+            0.339834345354554,
+            39.73207309866581,
+            0.2015213234190066
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.018776003431460905,
+            0.1351153110951957,
+            0.08493847860446493,
+            20.25642427979416,
+            0.14051449212852138
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1655572227234858,
+            0.23184046191332003,
+            0.3223756570833449,
+            45.82952775968972,
+            0.1970298913249664
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.37275672169699703
+          },
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.16376816199447103
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 174.7854745009554,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.0647279549718574
+        }
+      },
+      "model_kruskal_h": 174.7854745009554,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.07786116322701689,
+      "coverage": {
+        "ranging_directional": {
+          "count": 330,
+          "pct": 0.07737397420867527
+        },
+        "ranging_directional_down": {
+          "count": 765,
+          "pct": 0.17936694021101993
+        },
+        "ranging_directional_up": {
+          "count": 628,
+          "pct": 0.14724501758499414
+        },
+        "ranging_volatile": {
+          "count": 1733,
+          "pct": 0.4063305978898007
+        },
+        "trending_down_choppy": {
+          "count": 590,
+          "pct": 0.13833528722157093
+        },
+        "trending_up_choppy": {
+          "count": 219,
+          "pct": 0.05134818288393904
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.36973544973544975,
+          "transition_rate": 0.05779000846740051,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0578 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.4063305978898007,
+          "transition_rate": 0.0647279549718574,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.406 > 0.400",
+            "min_transition_rate: 0.0647 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.42042533302173407,
+          "transition_rate": 0.05983405399088466,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.420 > 0.400",
+            "min_transition_rate: 0.0598 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.34264757247642336,
+          "transition_rate": 0.0643921751280857,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0644 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.39141961918534585,
+          "transition_rate": 0.061957569913211184,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0620 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "ranging_directional",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.20439839861780998,
+            0.2567476603329103,
+            0.39005816654401293,
+            46.01027947572118,
+            0.21796644539657906
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.42696956605637376,
+          "centroid_raw": [
+            -0.09415702586595788,
+            0.17114036127535315,
+            0.18613416196559485,
+            32.318584561661204,
+            0.1568773305154599
+          ],
+          "volatility_rank": 2
+        },
+        "2": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.6903072667859907,
+          "centroid_raw": [
+            0.12139130808893082,
+            0.19438414990744352,
+            0.24004592743021883,
+            29.74353272896396,
+            0.1744871029375746
+          ],
+          "volatility_rank": 3
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.01138841294114279,
+            0.13197777082089107,
+            0.07451904860768814,
+            19.65567590835484,
+            0.14010602168719255
+          ],
+          "volatility_rank": 0
+        },
+        "4": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.2752681485723292,
+          "centroid_raw": [
+            0.01773960845488094,
+            0.1411934809368612,
+            0.09416984228412996,
+            22.483449565139715,
+            0.22585150518397198
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1655572227234858,
+            0.23184046191332003,
+            0.3223756570833449,
+            45.82952775968972,
+            0.1970298913249664
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.42696956605637376
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.6903072667859907
+          },
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.2752681485723292
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "htf",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "htf_range_eff"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 141.69640521729525,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.01,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.07199812382739212
+        }
+      },
+      "model_kruskal_h": 141.69640521729525,
+      "model_p_value": 0.01,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.07059099437148217,
+      "coverage": {
+        "ranging_directional": {
+          "count": 922,
+          "pct": 0.21617819460726848
+        },
+        "ranging_directional_down": {
+          "count": 853,
+          "pct": 0.2
+        },
+        "ranging_directional_up": {
+          "count": 604,
+          "pct": 0.14161781946072685
+        },
+        "ranging_volatile": {
+          "count": 291,
+          "pct": 0.06822977725674091
+        },
+        "trending_down_choppy": {
+          "count": 1120,
+          "pct": 0.26260257913247365
+        },
+        "trending_up_choppy": {
+          "count": 329,
+          "pct": 0.07713950762016412
+        },
+        "trending_up_clean": {
+          "count": 146,
+          "pct": 0.03423212192262603
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.22814814814814816,
+          "transition_rate": 0.06541066892464013,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0654 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.26260257913247365,
+          "transition_rate": 0.07199812382739212,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.2430474409908857,
+          "transition_rate": 0.0617038681780998,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0617 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.22726743509139596,
+          "transition_rate": 0.06590591523055427,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0659 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.2518679199807182,
+          "transition_rate": 0.06485053037608486,
+          "ok": false,
+          "reasons": [
+            "min_transition_rate: 0.0649 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_up_clean",
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14803100628469065,
+            0.22088460395708634,
+            0.2897803776966341,
+            33.39176792105019,
+            0.185572085799443
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.2932265582535114,
+          "centroid_raw": [
+            -0.011329789291733726,
+            0.13216143952058973,
+            0.06923580831230804,
+            21.820643183714925,
+            0.16631162344704448
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.74832115475152,
+          "centroid_raw": [
+            0.2160938693443312,
+            0.26143592343061883,
+            0.4114093915599135,
+            50.23401971169115,
+            0.23338418784965498
+          ],
+          "volatility_rank": 6
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.022864139785704188,
+            0.14421762009449338,
+            0.11079359124887679,
+            21.651608378927886,
+            0.2325255556084864
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.3883693629044839,
+          "centroid_raw": [
+            0.08406423714536318,
+            0.1586418474215524,
+            0.16668456216121108,
+            22.59476033963837,
+            0.1489198297408955
+          ],
+          "volatility_rank": 3
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.33842143281731696,
+          "centroid_raw": [
+            -0.014178586220064697,
+            0.13701133252315387,
+            0.08067371851691486,
+            21.044155287684653,
+            0.1133850130192871
+          ],
+          "volatility_rank": 1
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1291829848914044,
+            0.1985690321976849,
+            0.2530760759880524,
+            39.33687208160283,
+            0.17392312652581227
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.2932265582535114
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 0.74832115475152
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.3883693629044839
+          },
+          "5": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.33842143281731696
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "hmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 115.74543214888217,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.04151031894934334
+        }
+      },
+      "model_kruskal_h": 115.74543214888217,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.10107879924953095,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1974,
+          "pct": 0.4628370457209848
+        },
+        "ranging_volatile": {
+          "count": 2291,
+          "pct": 0.5371629542790153
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5578835978835979,
+          "transition_rate": 0.04403048264182896,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.558 > 0.400",
+            "min_transition_rate: 0.0440 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5371629542790153,
+          "transition_rate": 0.04151031894934334,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.537 > 0.400",
+            "min_transition_rate: 0.0415 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6508190883190883,
+          "transition_rate": 0.047373107747105965,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.651 > 0.400",
+            "min_transition_rate: 0.0474 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.583653510303877,
+          "transition_rate": 0.07487191429902189,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.584 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5432634369727645,
+          "transition_rate": 0.059064609450337514,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.543 > 0.400",
+            "min_transition_rate: 0.0591 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.014589359593424108,
+            0.20372324307171963,
+            0.26017006288127115,
+            36.69436672689709,
+            1.3351980122166377e-05,
+            0.13321885109345777,
+            0.18557733059722858,
+            0.5348226961586192
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.004763770148669713,
+            0.13818398441238045,
+            0.09145908878148183,
+            21.173850848361802,
+            1.0689083526186351e-05,
+            -0.07633043868582143,
+            0.15958061411436603,
+            0.5109421229268448
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "hmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 128.93516954982806,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.0450281425891182
+        }
+      },
+      "model_kruskal_h": 128.93516954982806,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.0975609756097561,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2188,
+          "pct": 0.5130128956623681
+        },
+        "trending_down_choppy": {
+          "count": 1309,
+          "pct": 0.30691676436107856
+        },
+        "trending_up_choppy": {
+          "count": 768,
+          "pct": 0.18007033997655333
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5227513227513227,
+          "transition_rate": 0.04360711261642676,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.523 > 0.400",
+            "min_transition_rate: 0.0436 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5130128956623681,
+          "transition_rate": 0.0450281425891182,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.513 > 0.400",
+            "min_transition_rate: 0.0450 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.48023504273504275,
+          "transition_rate": 0.058949243098842384,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.480 > 0.400",
+            "min_transition_rate: 0.0589 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.4165793456747002,
+          "transition_rate": 0.08302282254308337,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.417 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.5447095685707399,
+          "transition_rate": 0.05159112825458052,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.545 > 0.400",
+            "min_transition_rate: 0.0516 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.11824252088717543,
+            0.19235712406300262,
+            0.2330766113905145,
+            36.7753543590793,
+            5.800286430430981e-06,
+            0.041912251221597176,
+            0.17121684991636538,
+            0.5658468102694715
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.01001373054164681,
+            0.1356600977013582,
+            0.08215367230579522,
+            20.83462916566596,
+            1.0540992261167152e-05,
+            -0.09037285388185347,
+            0.15959314386192006,
+            0.509429708464419
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.14197833348705577,
+            0.21106123902209853,
+            0.28328485073759263,
+            34.88456524930673,
+            2.12914192921693e-05,
+            0.22898091482349275,
+            0.19660352803721826,
+            0.5014984328833305
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "hmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 115.48487216675494,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.10483114446529081
+        }
+      },
+      "model_kruskal_h": 115.48487216675494,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.037757973733583486,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1488,
+          "pct": 0.3488862837045721
+        },
+        "ranging_volatile": {
+          "count": 1212,
+          "pct": 0.28417350527549823
+        },
+        "trending_down_choppy": {
+          "count": 1047,
+          "pct": 0.2454865181711606
+        },
+        "trending_up_choppy": {
+          "count": 518,
+          "pct": 0.12145369284876906
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.4211640211640212,
+          "transition_rate": 0.10372565622353937,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.421 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3488862837045721,
+          "transition_rate": 0.10483114446529081,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4093660968660969,
+          "transition_rate": 0.09581478183437221,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.409 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3634881825590872,
+          "transition_rate": 0.13984629715882627,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3844299831284647,
+          "transition_rate": 0.12198649951783992,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.16809430974616119,
+            0.2328260883519142,
+            0.3280447318476487,
+            38.61930618132266,
+            2.1334719703715755e-05,
+            0.22558158615479643,
+            0.20231621621938242,
+            0.5080653654511209
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.2511413227373093,
+          "centroid_raw": [
+            0.00639081295557512,
+            0.1355404861022466,
+            0.08997123157656611,
+            22.064381929584954,
+            9.313024390871855e-06,
+            0.1516444846835989,
+            0.16446304885420032,
+            0.48873480920339396
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12794698507806201,
+            0.1984039227409,
+            0.251273823331815,
+            39.07150093971513,
+            5.515214878958553e-06,
+            0.06896697690994924,
+            0.17271024565016002,
+            0.5726363475864183
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.012547872259777217,
+            0.14276982662784665,
+            0.10087506523012399,
+            21.669809465133365,
+            1.2479764608639116e-05,
+            -0.16774001683753467,
+            0.16118494189100147,
+            0.5201152463100839
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.2511413227373093
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "hmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 133.69961868839164,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.1226547842401501
+        }
+      },
+      "model_kruskal_h": 133.69961868839164,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.019934333958724196,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1004,
+          "pct": 0.23540445486518172
+        },
+        "ranging_directional_down": {
+          "count": 1274,
+          "pct": 0.29871043376318873
+        },
+        "ranging_volatile": {
+          "count": 817,
+          "pct": 0.19155920281359906
+        },
+        "trending_down_choppy": {
+          "count": 779,
+          "pct": 0.18264947245017585
+        },
+        "trending_up_choppy": {
+          "count": 391,
+          "pct": 0.09167643610785463
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.39195767195767195,
+          "transition_rate": 0.12193056731583404,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.29871043376318873,
+          "transition_rate": 0.1226547842401501,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.3992165242165242,
+          "transition_rate": 0.09688334817453251,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.3024799161718477,
+          "transition_rate": 0.14264089427107593,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3306820920703784,
+          "transition_rate": 0.1485053037608486,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.004985231441522075,
+            0.11830592651077274,
+            0.046514616038530146,
+            17.765114201171215,
+            9.896578777967132e-06,
+            -0.1862600852336416,
+            0.15618193531013325,
+            0.46921006153537564
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0017843329915153312,
+            0.14900743702665117,
+            0.12906260422324606,
+            25.499425675797333,
+            1.0697474078745993e-05,
+            0.288501305676375,
+            0.16971981347338172,
+            0.5133011846506037
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17910656297048413,
+            0.23955008866537503,
+            0.34565813651053184,
+            39.998664502813796,
+            2.2767630397495368e-05,
+            0.19348233100555642,
+            0.20315694366963247,
+            0.5107719294745645
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": true,
+          "displacement_z": 0.004841144574014613,
+          "centroid_raw": [
+            -0.0005006692822396158,
+            0.15761297012103967,
+            0.13855615208648853,
+            25.376776455679632,
+            1.2480995184653243e-05,
+            -0.13818162215748223,
+            0.16344429713272365,
+            0.545494043636038
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.15068196520151983,
+            0.2196119893904721,
+            0.2921875208665015,
+            43.19776284463592,
+            9.006305316735583e-07,
+            0.19865804492364797,
+            0.18309288754002803,
+            0.554299654335611
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "3": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.004841144574014613
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "hmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 158.22754943145083,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.12711069418386492
+        }
+      },
+      "model_kruskal_h": 158.22754943145083,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.015478424015009373,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1227,
+          "pct": 0.2876905041031653
+        },
+        "ranging_directional_down": {
+          "count": 609,
+          "pct": 0.14279015240328252
+        },
+        "ranging_directional_up": {
+          "count": 564,
+          "pct": 0.13223915592028135
+        },
+        "ranging_volatile": {
+          "count": 1027,
+          "pct": 0.24079718640093786
+        },
+        "trending_down_choppy": {
+          "count": 599,
+          "pct": 0.14044548651817115
+        },
+        "trending_up_choppy": {
+          "count": 239,
+          "pct": 0.056037514654161784
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.36592592592592593,
+          "transition_rate": 0.10922946655376799,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.2876905041031653,
+          "transition_rate": 0.12711069418386492,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.3903133903133903,
+          "transition_rate": 0.10970614425645592,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.31295843520782396,
+          "transition_rate": 0.15416860735910573,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.34803567124608337,
+          "transition_rate": 0.13211186113789777,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.19799240336230095,
+            0.2530803114806056,
+            0.37913481917993197,
+            43.17000426095065,
+            2.6447575989084315e-05,
+            0.11770167503183697,
+            0.2073953647722472,
+            0.5199579823399344
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.27486263112939274,
+          "centroid_raw": [
+            0.001640688164068052,
+            0.13134356333999483,
+            0.06697393684743033,
+            21.792457035343688,
+            9.551553653152843e-06,
+            -0.10346916507269074,
+            0.16387977042158847,
+            0.4794221785379491
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1677003253485519,
+            0.2321045280533975,
+            0.3252547709564947,
+            43.350387938547115,
+            4.821404888479599e-07,
+            0.30775255710527305,
+            0.19141859862183344,
+            0.5460419582559816
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 0.6190755564407351,
+          "centroid_raw": [
+            0.11402455240832435,
+            0.18477149084189226,
+            0.22729683060032047,
+            28.817901511152368,
+            1.3547612041038496e-05,
+            0.28278089500013304,
+            0.185208005901945,
+            0.498227056010431
+          ],
+          "volatility_rank": 3
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.012170619430490507,
+            0.13730230206370947,
+            0.08296389717012809,
+            20.66993418533142,
+            1.2484699091014207e-05,
+            -0.05156799747559075,
+            0.15855196471824212,
+            0.5204093494677317
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.45837815933071724,
+          "centroid_raw": [
+            -0.0974052903229272,
+            0.17131662056326694,
+            0.19402472986594885,
+            33.009334691859316,
+            8.396451028006039e-06,
+            -0.12461210919131913,
+            0.16255872652898806,
+            0.5742137443408994
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.27486263112939274
+          },
+          "3": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.6190755564407351
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.45837815933071724
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "hmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 145.99197417247342,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.12218574108818012
+        }
+      },
+      "model_kruskal_h": 145.99197417247342,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.020403377110694176,
+      "coverage": {
+        "ranging_directional": {
+          "count": 932,
+          "pct": 0.21852286049237984
+        },
+        "ranging_directional_down": {
+          "count": 1188,
+          "pct": 0.27854630715123097
+        },
+        "ranging_directional_up": {
+          "count": 169,
+          "pct": 0.03962485345838218
+        },
+        "ranging_volatile": {
+          "count": 692,
+          "pct": 0.1622508792497069
+        },
+        "trending_down_choppy": {
+          "count": 767,
+          "pct": 0.17983587338804222
+        },
+        "trending_up_choppy": {
+          "count": 245,
+          "pct": 0.05744431418522861
+        },
+        "trending_up_clean": {
+          "count": 272,
+          "pct": 0.0637749120750293
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.3566137566137566,
+          "transition_rate": 0.12404741744284505,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.27854630715123097,
+          "transition_rate": 0.12218574108818012,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.2567663817663818,
+          "transition_rate": 0.12662511130899376,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.28326929793922456,
+          "transition_rate": 0.1668607359105729,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.3234514340805013,
+          "transition_rate": 0.1598360655737705,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_up_clean",
+        "ranging_directional_down",
+        "ranging_directional",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.13006080086357316,
+            0.2042517875290518,
+            0.2531105979752206,
+            31.645231287836133,
+            1.2483363909455439e-05,
+            0.255353439692123,
+            0.18426358703956147,
+            0.5146954765416052
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.2124806536874568,
+          "centroid_raw": [
+            0.018005471175422616,
+            0.12820454362711872,
+            0.08732749741315975,
+            22.516290669413465,
+            2.194489221443968e-05,
+            -0.08115819261820739,
+            0.23737546536734072,
+            0.40972860149379386
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.1744941178409054,
+          "centroid_raw": [
+            0.1836186991789588,
+            0.24269156321950497,
+            0.36095655876068616,
+            41.35727688179261,
+            2.5639202447349245e-05,
+            0.16922784102805252,
+            0.21234115016825347,
+            0.5044165443650168
+          ],
+          "volatility_rank": 6
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.01748118798130749,
+            0.15494026422052373,
+            0.13438708687156606,
+            26.700376979944995,
+            4.625184333280946e-06,
+            0.3278565438366475,
+            0.1564100962296496,
+            0.5517732077550864
+          ],
+          "volatility_rank": 3
+        },
+        "4": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.14421218994499352,
+          "centroid_raw": [
+            -0.010758600267651608,
+            0.14896185313196705,
+            0.11314526618995842,
+            23.832539541639726,
+            1.2481358199977588e-05,
+            -0.24608193530310987,
+            0.1550064645343883,
+            0.5511984022913976
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.007914665550070405,
+            0.11395691250195175,
+            0.051581825617237384,
+            16.78713329930747,
+            9.55697012584201e-06,
+            -0.059704922429183405,
+            0.14086488687616697,
+            0.44344807958361343
+          ],
+          "volatility_rank": 0
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.15104877202757555,
+            0.22111491703757447,
+            0.293347104948374,
+            42.74301475877036,
+            3.590889998283053e-06,
+            0.18158823008800565,
+            0.18531755046809886,
+            0.5536795043201079
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.2124806536874568
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.1744941178409054
+          },
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.14421218994499352
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "gmm",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 122.86647629759682,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.08630393996247655
+        }
+      },
+      "model_kruskal_h": 122.86647629759682,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.05628517823639774,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 2038,
+          "pct": 0.4778429073856975
+        },
+        "ranging_volatile": {
+          "count": 2227,
+          "pct": 0.5221570926143024
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.5665608465608466,
+          "transition_rate": 0.08086367485182049,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.567 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.5221570926143024,
+          "transition_rate": 0.08630393996247655,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.522 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.6611467236467237,
+          "transition_rate": 0.06767586821015138,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.661 > 0.400",
+            "min_transition_rate: 0.0677 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5816742344859704,
+          "transition_rate": 0.10584536562645552,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.582 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.5295251867919981,
+          "transition_rate": 0.10824493731918997,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.530 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.019326925449649875,
+            0.20223545251161057,
+            0.25625179000184456,
+            35.930385526918236,
+            1.3114232165978886e-05,
+            0.3439256519206695,
+            0.1846532139133014,
+            0.5266684560931925
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0015013572111264688,
+            0.14056932849356302,
+            0.09766394974244016,
+            22.03913562722957,
+            1.0915385227102399e-05,
+            -0.22593899745992213,
+            0.16077049827867304,
+            0.517366246796102
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "gmm",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 145.8026334623446,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.11233583489681051
+        }
+      },
+      "model_kruskal_h": 145.8026334623446,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.030253283302063783,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 1958,
+          "pct": 0.45908558030480656
+        },
+        "trending_down_choppy": {
+          "count": 662,
+          "pct": 0.1552168815943728
+        },
+        "trending_up_choppy": {
+          "count": 1645,
+          "pct": 0.38569753810082064
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.49227513227513225,
+          "transition_rate": 0.09610499576629974,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.492 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.45908558030480656,
+          "transition_rate": 0.11233583489681051,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.459 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.6207264957264957,
+          "transition_rate": 0.08495102404274266,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.621 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5310280591454185,
+          "transition_rate": 0.12133209129017233,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.531 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.48204386599180526,
+          "transition_rate": 0.12777242044358728,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.482 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.10311129865674563,
+            0.17624564678031812,
+            0.20433645141706297,
+            33.729997569835476,
+            8.43896704546035e-06,
+            -0.3559057943460087,
+            0.16360581237269403,
+            0.5775316261881422
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.012974073938467744,
+            0.1363279984251296,
+            0.08279724239958444,
+            20.840373989183842,
+            1.0950277718769045e-05,
+            -0.1822539455416546,
+            0.16030533788198625,
+            0.5099269836180362
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.056309792650627695,
+            0.2061806606032253,
+            0.2651159057127095,
+            35.44525160165946,
+            1.4756898785877452e-05,
+            0.4768978799615752,
+            0.1896586153115694,
+            0.5112670036742353
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "gmm",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 112.40652673075783,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.11819887429643527
+        }
+      },
+      "model_kruskal_h": 112.40652673075783,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.02439024390243902,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1255,
+          "pct": 0.29425556858147717
+        },
+        "ranging_volatile": {
+          "count": 1617,
+          "pct": 0.3791324736225088
+        },
+        "trending_down_choppy": {
+          "count": 929,
+          "pct": 0.21781946072684644
+        },
+        "trending_up_choppy": {
+          "count": 464,
+          "pct": 0.10879249706916765
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.45354497354497353,
+          "transition_rate": 0.13166807790008467,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.454 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.3791324736225088,
+          "transition_rate": 0.11819887429643527,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4182692307692308,
+          "transition_rate": 0.1093499554764025,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.418 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.3737338456164862,
+          "transition_rate": 0.16010712622263623,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.3969631236442516,
+          "transition_rate": 0.15067502410800385,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17308816422596537,
+            0.23497340210241863,
+            0.33872782219813247,
+            39.06806940614129,
+            2.2079260493743946e-05,
+            0.273628166562852,
+            0.20308064324903524,
+            0.510142008319368
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0033850319608725882,
+            0.1380108774591447,
+            0.09320984881694948,
+            22.649317203190968,
+            9.316762873365285e-06,
+            0.3000195078380604,
+            0.1633318764296432,
+            0.4929232104408462
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.14221606163915268,
+            0.20952211001123838,
+            0.2781414715272284,
+            40.741663545195664,
+            3.298467485588024e-06,
+            0.2064842837592469,
+            0.17860047974832954,
+            0.5629659834150377
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.12336334787132418,
+          "centroid_raw": [
+            0.0036241149248435424,
+            0.14835064203571993,
+            0.11611089567138252,
+            23.5579924908783,
+            1.2473957111912646e-05,
+            -0.2852482805014159,
+            0.1625185916904143,
+            0.5287549042965233
+          ],
+          "volatility_rank": 1
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "3": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.12336334787132418
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "gmm",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 127.92033969474869,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.16393058161350843
+        }
+      },
+      "model_kruskal_h": 127.92033969474869,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": -0.021341463414634138,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1079,
+          "pct": 0.252989449003517
+        },
+        "ranging_directional_up": {
+          "count": 1352,
+          "pct": 0.31699882766705745
+        },
+        "ranging_volatile": {
+          "count": 785,
+          "pct": 0.18405627198124266
+        },
+        "trending_down_choppy": {
+          "count": 714,
+          "pct": 0.16740914419695194
+        },
+        "trending_up_choppy": {
+          "count": 335,
+          "pct": 0.07854630715123095
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.42052910052910053,
+          "transition_rate": 0.17739204064352243,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.421 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.31699882766705745,
+          "transition_rate": 0.16393058161350843,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.41239316239316237,
+          "transition_rate": 0.13268032056990206,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6",
+            "max_occupancy: 0.412 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.32227267435091395,
+          "transition_rate": 0.18421052631578946,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.34249216678717764,
+          "transition_rate": 0.195274831243973,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0008468455035850839,
+            0.12086483570521163,
+            0.0380302983047838,
+            18.82123726874645,
+            9.233857589589921e-06,
+            -0.43599225513583956,
+            0.15892306761651617,
+            0.479924985434864
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0023299995555065064,
+            0.15111374003388037,
+            0.1351666582882895,
+            25.642552293464597,
+            1.0562040229815164e-05,
+            0.47140206263896517,
+            0.16765258821510157,
+            0.5099305490785863
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1887990737849103,
+            0.2455423291664725,
+            0.3632172413222229,
+            41.292227442702135,
+            2.4340314849570414e-05,
+            0.18593715386455462,
+            0.2067669098535433,
+            0.5118241282907954
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": true,
+          "displacement_z": 0.015397348501989804,
+          "centroid_raw": [
+            0.0015923877721527408,
+            0.15669431579085505,
+            0.1392365890394131,
+            25.236601711845758,
+            1.2476861133125365e-05,
+            -0.1542495018590252,
+            0.1636244514010237,
+            0.5381841319976499
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1591781401674201,
+            0.2245666930955711,
+            0.30899629339895185,
+            43.76853928110135,
+            8.530989989923672e-09,
+            0.2557800703075118,
+            0.18623614300198463,
+            0.5489893741730983
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "3": {
+            "from": "ranging_directional_up",
+            "to": "ranging_directional",
+            "displacement_z": 0.015397348501989804
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "gmm",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 169.5097208191255,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.1803470919324578
+        }
+      },
+      "model_kruskal_h": 169.5097208191255,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": -0.0377579737335835,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1037,
+          "pct": 0.24314185228604923
+        },
+        "ranging_directional_down": {
+          "count": 531,
+          "pct": 0.12450175849941383
+        },
+        "ranging_directional_up": {
+          "count": 700,
+          "pct": 0.16412661195779601
+        },
+        "ranging_volatile": {
+          "count": 1122,
+          "pct": 0.2630715123094959
+        },
+        "trending_down_choppy": {
+          "count": 535,
+          "pct": 0.1254396248534584
+        },
+        "trending_up_choppy": {
+          "count": 340,
+          "pct": 0.07971864009378664
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.395978835978836,
+          "transition_rate": 0.17167654530059273,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.2630715123094959,
+          "transition_rate": 0.1803470919324578,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.34971509971509973,
+          "transition_rate": 0.16705253784505789,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.3443939923157527,
+          "transition_rate": 0.20062878435025616,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.36635333815377197,
+          "transition_rate": 0.18997107039537126,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.18366714404439863,
+            0.24206004585298302,
+            0.35356111431306403,
+            40.96945911226848,
+            2.4777212055626663e-05,
+            0.015972344618463464,
+            0.20550036240632408,
+            0.5117498284395607
+          ],
+          "volatility_rank": 5
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.31544258193881913,
+          "centroid_raw": [
+            0.002629251778246725,
+            0.12967477438185657,
+            0.0670166318234145,
+            21.324752458717665,
+            1.0036128333128999e-05,
+            -0.30261083572699227,
+            0.16435128651344846,
+            0.47409740179039284
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.17420910413713697,
+            0.23635299857801836,
+            0.337202227173789,
+            44.1341426766925,
+            -2.7043217593917607e-07,
+            0.31147328566670635,
+            0.19035106071792074,
+            0.5472069778347778
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.04534502303603947,
+            0.16913467371033938,
+            0.1779840707489707,
+            27.47008070880299,
+            1.027084292625615e-05,
+            1.372268488866522,
+            0.17190048641290195,
+            0.5187452943725692
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.014651210851496415,
+            0.14206885069172642,
+            0.09679037003539502,
+            21.557684398769347,
+            1.247710959798704e-05,
+            -0.19124656299908446,
+            0.16123025912357078,
+            0.520652542427295
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.5154597822289091,
+          "centroid_raw": [
+            -0.10330864948284803,
+            0.1748900792126793,
+            0.20504508797860083,
+            34.503587581146874,
+            7.506206013619452e-06,
+            -0.376203751820394,
+            0.1641251075878946,
+            0.5756233341218945
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.31544258193881913
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.5154597822289091
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "gmm",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 167.84934307334152,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0016666666666666668,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.16041275797373358
+        }
+      },
+      "model_kruskal_h": 167.84934307334152,
+      "model_p_value": 0.0016666666666666668,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": -0.01782363977485929,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1048,
+          "pct": 0.24572098475967175
+        },
+        "ranging_directional_down": {
+          "count": 1215,
+          "pct": 0.28487690504103164
+        },
+        "ranging_directional_up": {
+          "count": 95,
+          "pct": 0.022274325908558032
+        },
+        "ranging_volatile": {
+          "count": 809,
+          "pct": 0.18968347010550995
+        },
+        "trending_down_choppy": {
+          "count": 673,
+          "pct": 0.15779601406799532
+        },
+        "trending_up_choppy": {
+          "count": 238,
+          "pct": 0.055803048065650646
+        },
+        "trending_up_clean": {
+          "count": 187,
+          "pct": 0.04384525205158265
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.4014814814814815,
+          "transition_rate": 0.17400508044030483,
+          "ok": false,
+          "reasons": [
+            "max_occupancy: 0.401 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.28487690504103164,
+          "transition_rate": 0.16041275797373358,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.22382478632478633,
+          "transition_rate": 0.15138023152270705,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.3191291186401211,
+          "transition_rate": 0.21425244527247322,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.35237406604000965,
+          "transition_rate": 0.19117647058823528,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_up_clean",
+        "ranging_directional_down",
+        "ranging_directional",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1522437224589978,
+            0.22204842396040142,
+            0.2951506133396663,
+            36.51122088559203,
+            1.2483263160970709e-05,
+            0.044649453302623515,
+            0.18351090998413147,
+            0.5215773402049114
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0246362345912862,
+            0.13577093706628626,
+            0.11590347031401003,
+            25.52945128901467,
+            3.56824080109504e-05,
+            0.0503544748999944,
+            0.24091468679045436,
+            0.40037365532846375
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.0275687866873737,
+          "centroid_raw": [
+            0.19726048924363632,
+            0.24899154209820853,
+            0.378350433568989,
+            42.024981109895855,
+            3.07439336837441e-05,
+            0.2446058788063386,
+            0.21818620445988085,
+            0.4999090228964506
+          ],
+          "volatility_rank": 6
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_directional_down",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.010182722189963531,
+            0.16087515666797353,
+            0.15628382112474776,
+            27.875774547188218,
+            6.8807594078879074e-06,
+            0.5489278871750436,
+            0.1601297802190623,
+            0.5436720887198649
+          ],
+          "volatility_rank": 3
+        },
+        "4": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.11557772561103781,
+          "centroid_raw": [
+            -0.005038493146853043,
+            0.14837127378561485,
+            0.11640460249108654,
+            23.774890230132804,
+            1.247509823602883e-05,
+            -0.3343010010865178,
+            0.16236955509968318,
+            0.5350301067429808
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.003954551433195709,
+            0.12119669350788571,
+            0.04512964433224871,
+            18.220834119373507,
+            7.93453444315612e-06,
+            0.028988790652529958,
+            0.15163455103258125,
+            0.4664635706462297
+          ],
+          "volatility_rank": 0
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.16329615754046653,
+            0.22833855693308122,
+            0.316953635759261,
+            43.80801086461006,
+            3.763895378341004e-07,
+            0.20694428262211254,
+            0.18902595685359383,
+            0.5479266874376608
+          ],
+          "volatility_rank": 5
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.0275687866873737
+          },
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.11557772561103781
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "kmeans",
+      "k": 2,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 115.04993313776868,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0025,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.03142589118198874
+        }
+      },
+      "model_kruskal_h": 115.04993313776868,
+      "model_p_value": 0.0025,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.11116322701688555,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 1357,
+          "pct": 0.31817116060961315
+        },
+        "ranging_volatile": {
+          "count": 2908,
+          "pct": 0.6818288393903869
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 2,
+          "max_occupancy": 0.6888888888888889,
+          "transition_rate": 0.03090601185436071,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.689 > 0.400",
+            "min_transition_rate: 0.0309 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 2,
+          "max_occupancy": 0.6818288393903869,
+          "transition_rate": 0.03142589118198874,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.682 > 0.400",
+            "min_transition_rate: 0.0314 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 2,
+          "max_occupancy": 0.5430911680911681,
+          "transition_rate": 0.04915405164737311,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.543 > 0.400",
+            "min_transition_rate: 0.0492 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 2,
+          "max_occupancy": 0.5966934451042031,
+          "transition_rate": 0.04902189101071262,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.597 > 0.400",
+            "min_transition_rate: 0.0490 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 2,
+          "max_occupancy": 0.7008917811520848,
+          "transition_rate": 0.034474445515911285,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 2 < 6",
+            "max_occupancy: 0.701 > 0.400",
+            "min_transition_rate: 0.0345 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=2 can emit at most 2 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_directional_up",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.039403708688147875,
+            0.22502854884395757,
+            0.3081940851976144,
+            40.1418052270343,
+            1.439124838235297e-05,
+            0.22941021475973944,
+            0.19674481465720012,
+            0.5302358510649909
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.0032575691434393664,
+            0.1429647061779808,
+            0.10652199800171192,
+            22.951803373516547,
+            1.081315583952454e-05,
+            -0.07239046699593459,
+            0.16037900705703192,
+            0.5176754064028178
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "kmeans",
+      "k": 3,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 123.51329027467364,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0033333333333333335,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.035881801125703564
+        }
+      },
+      "model_kruskal_h": 123.51329027467364,
+      "model_p_value": 0.0033333333333333335,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.10670731707317073,
+      "coverage": {
+        "ranging_volatile": {
+          "count": 2545,
+          "pct": 0.5967174677608441
+        },
+        "trending_down_choppy": {
+          "count": 1150,
+          "pct": 0.2696365767878077
+        },
+        "trending_up_choppy": {
+          "count": 570,
+          "pct": 0.1336459554513482
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 3,
+          "max_occupancy": 0.5951322751322752,
+          "transition_rate": 0.03640982218458933,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.595 > 0.400",
+            "min_transition_rate: 0.0364 < 0.0695"
+          ]
+        },
+        "oos": {
+          "active_labels": 3,
+          "max_occupancy": 0.5967174677608441,
+          "transition_rate": 0.035881801125703564,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.597 > 0.400",
+            "min_transition_rate: 0.0359 < 0.0695"
+          ]
+        },
+        "2023": {
+          "active_labels": 3,
+          "max_occupancy": 0.49252136752136755,
+          "transition_rate": 0.05983971504897596,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.493 > 0.400",
+            "min_transition_rate: 0.0598 < 0.0695"
+          ]
+        },
+        "2024": {
+          "active_labels": 3,
+          "max_occupancy": 0.5432529980207241,
+          "transition_rate": 0.052980903586399626,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.543 > 0.400",
+            "min_transition_rate: 0.0530 < 0.0695"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 3,
+          "max_occupancy": 0.6322005302482526,
+          "transition_rate": 0.040501446480231434,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 3 < 6",
+            "max_occupancy: 0.632 > 0.400",
+            "min_transition_rate: 0.0405 < 0.0695"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=3 can emit at most 3 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_down_choppy",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1223063377742239,
+            0.19719810324137277,
+            0.24355786771475588,
+            38.42198381819453,
+            4.945726310583615e-06,
+            0.06682731517593624,
+            0.173075383880493,
+            0.5800482539285131
+          ],
+          "volatility_rank": 1
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.01075881961304501,
+            0.13853015157693938,
+            0.09300263664073943,
+            21.391310832091893,
+            1.1329333574629457e-05,
+            -0.06376683752547867,
+            0.1605560371136021,
+            0.5052642509646832
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.16613492674108757,
+            0.22862461330253214,
+            0.32171319309976965,
+            38.037952148285996,
+            2.2253187207871853e-05,
+            0.22857214102148482,
+            0.20479216471213593,
+            0.5054097456624809
+          ],
+          "volatility_rank": 2
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "kmeans",
+      "k": 4,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 142.02876497723628,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.11913696060037524
+        }
+      },
+      "model_kruskal_h": 142.02876497723628,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.023452157598499057,
+      "coverage": {
+        "ranging_directional_up": {
+          "count": 341,
+          "pct": 0.07995310668229777
+        },
+        "ranging_volatile": {
+          "count": 2375,
+          "pct": 0.5568581477139508
+        },
+        "trending_down_choppy": {
+          "count": 1063,
+          "pct": 0.2492379835873388
+        },
+        "trending_up_choppy": {
+          "count": 486,
+          "pct": 0.11395076201641266
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 4,
+          "max_occupancy": 0.548994708994709,
+          "transition_rate": 0.12806943268416596,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.549 > 0.400"
+          ]
+        },
+        "oos": {
+          "active_labels": 4,
+          "max_occupancy": 0.5568581477139508,
+          "transition_rate": 0.11913696060037524,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.557 > 0.400"
+          ]
+        },
+        "2023": {
+          "active_labels": 4,
+          "max_occupancy": 0.4567307692307692,
+          "transition_rate": 0.1385574354407836,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.457 > 0.400"
+          ]
+        },
+        "2024": {
+          "active_labels": 4,
+          "max_occupancy": 0.5004074979625102,
+          "transition_rate": 0.14543549138332557,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.500 > 0.400"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 4,
+          "max_occupancy": 0.5854422752470475,
+          "transition_rate": 0.14971070395371264,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 4 < 6",
+            "max_occupancy: 0.585 > 0.400"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=4 can emit at most 4 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "ranging_volatile"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.16929940765169532,
+            0.23201614633290446,
+            0.3270026177139772,
+            38.81367571620586,
+            2.2711032166890767e-05,
+            -0.021415664773446766,
+            0.20618347322449926,
+            0.5066034519706525
+          ],
+          "volatility_rank": 3
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.0066459355290912885,
+            0.1607848241054808,
+            0.15726159265366244,
+            26.546592220187673,
+            1.1783023577235776e-05,
+            2.746268793153902,
+            0.16362046910292494,
+            0.5145671039448027
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.12325260609085106,
+            0.19769496774520537,
+            0.2446725413344666,
+            38.71418289656607,
+            4.789495824411169e-06,
+            -0.1674013724653104,
+            0.1739984035866582,
+            0.5811825656465535
+          ],
+          "volatility_rank": 2
+        },
+        "3": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.011012858395527462,
+            0.1383913273693152,
+            0.09259942250370952,
+            21.288679749483716,
+            1.129628424785369e-05,
+            -0.2884301953089189,
+            0.1609419649219797,
+            0.5054096145987912
+          ],
+          "volatility_rank": 0
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "kmeans",
+      "k": 5,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": true,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": true,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 178.78358326377747,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.10741088180112571
+        }
+      },
+      "model_kruskal_h": 178.78358326377747,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": 0.035178236397748586,
+      "coverage": {
+        "ranging_directional_down": {
+          "count": 839,
+          "pct": 0.1967174677608441
+        },
+        "ranging_directional_up": {
+          "count": 456,
+          "pct": 0.10691676436107854
+        },
+        "ranging_volatile": {
+          "count": 1532,
+          "pct": 0.35920281359906214
+        },
+        "trending_down_choppy": {
+          "count": 992,
+          "pct": 0.23259085580304806
+        },
+        "trending_up_choppy": {
+          "count": 446,
+          "pct": 0.10457209847596717
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 5,
+          "max_occupancy": 0.295026455026455,
+          "transition_rate": 0.10139712108382727,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "oos": {
+          "active_labels": 5,
+          "max_occupancy": 0.35920281359906214,
+          "transition_rate": 0.10741088180112571,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2023": {
+          "active_labels": 5,
+          "max_occupancy": 0.3037749287749288,
+          "transition_rate": 0.1145146927871772,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2024": {
+          "active_labels": 5,
+          "max_occupancy": 0.25229945278845034,
+          "transition_rate": 0.11970190964136004,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        },
+        "2025H1": {
+          "active_labels": 5,
+          "max_occupancy": 0.3571945046999277,
+          "transition_rate": 0.12174541947926712,
+          "ok": false,
+          "reasons": [
+            "min_active_labels: 5 < 6"
+          ]
+        }
+      },
+      "non_degenerate_all": false,
+      "structurally_ineligible": true,
+      "structural_ineligibility_reason": "k=5 can emit at most 5 distinct labels < min_active_labels=6: non-degeneracy is unsatisfiable",
+      "states": [
+        "ranging_volatile",
+        "ranging_directional_up",
+        "trending_up_choppy",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.01058659011154606,
+            0.1349343918856215,
+            0.09036757282375936,
+            20.194688567718284,
+            9.988480912280721e-06,
+            -0.2325916520775123,
+            0.13907264061211483,
+            0.4510632106125863
+          ],
+          "volatility_rank": 0
+        },
+        "1": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.19889557894885865,
+          "centroid_raw": [
+            0.03417660856454277,
+            0.14307461082428063,
+            0.11763929886140329,
+            22.6750880766099,
+            1.6802788679245317e-05,
+            0.7045869190579521,
+            0.2162101777440346,
+            0.42435591533169714
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17715828217406174,
+            0.23782866779076903,
+            0.3420679075639189,
+            40.16817781376314,
+            2.2411061176470607e-05,
+            0.15148552340265445,
+            0.2020157914920656,
+            0.5116634995305243
+          ],
+          "volatility_rank": 4
+        },
+        "3": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.03369143140711867,
+          "centroid_raw": [
+            -0.006340352885781565,
+            0.15160185078320706,
+            0.11003965690597667,
+            24.606177216163108,
+            1.0282120871751909e-05,
+            -0.20745259791016124,
+            0.16356541472291358,
+            0.6349377666054271
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.1353963099790385,
+            0.203860429473256,
+            0.2656316131005201,
+            40.4012084736862,
+            4.465381163084733e-06,
+            0.12163159003102458,
+            0.17579752564373508,
+            0.5626183659657948
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.19889557894885865
+          },
+          "3": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.03369143140711867
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": false
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "kmeans",
+      "k": 6,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 182.63886770294994,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.15666041275797374
+        }
+      },
+      "model_kruskal_h": 182.63886770294994,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": -0.014071294559099445,
+      "coverage": {
+        "ranging_directional": {
+          "count": 1174,
+          "pct": 0.27526377491207504
+        },
+        "ranging_directional_down": {
+          "count": 722,
+          "pct": 0.16928487690504104
+        },
+        "ranging_directional_up": {
+          "count": 316,
+          "pct": 0.07409144196951935
+        },
+        "ranging_volatile": {
+          "count": 1079,
+          "pct": 0.252989449003517
+        },
+        "trending_down_choppy": {
+          "count": 507,
+          "pct": 0.11887456037514654
+        },
+        "trending_up_choppy": {
+          "count": 467,
+          "pct": 0.10949589683470105
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 6,
+          "max_occupancy": 0.2920634920634921,
+          "transition_rate": 0.14458086367485182,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 6,
+          "max_occupancy": 0.27526377491207504,
+          "transition_rate": 0.15666041275797374,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 6,
+          "max_occupancy": 0.31552706552706555,
+          "transition_rate": 0.1545859305431879,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 6,
+          "max_occupancy": 0.3135405751542671,
+          "transition_rate": 0.1629017233348859,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 6,
+          "max_occupancy": 0.3234514340805013,
+          "transition_rate": 0.18876567020250723,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_directional",
+        "ranging_directional_down"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.1743996450862235,
+            0.2358050427308538,
+            0.33672171561242453,
+            39.63166666027437,
+            2.3125532365747487e-05,
+            0.0016119918580787384,
+            0.20509839249080924,
+            0.5094279754367783
+          ],
+          "volatility_rank": 4
+        },
+        "1": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.017837049909187143,
+            0.13526736584237545,
+            0.09023791957925502,
+            20.589523645825526,
+            1.1413501558654637e-05,
+            -0.22721557389899166,
+            0.18088977262783554,
+            0.4049526881831262
+          ],
+          "volatility_rank": 0
+        },
+        "2": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.17113987794324306,
+            0.23650476677989538,
+            0.3319965409305484,
+            47.531122739901946,
+            -1.4580445993031242e-06,
+            0.20179795134499648,
+            0.20013736600171791,
+            0.5256059133074816
+          ],
+          "volatility_rank": 5
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.015592414951878807,
+            0.16116586665098068,
+            0.16163975127341193,
+            26.53929682568184,
+            1.2116332352941182e-05,
+            2.94756092473008,
+            0.16222003720109107,
+            0.5122903937932433
+          ],
+          "volatility_rank": 2
+        },
+        "4": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.3554974347251892,
+          "centroid_raw": [
+            0.017913921572331917,
+            0.1395126682923624,
+            0.08972173293708624,
+            21.371201618376105,
+            1.1681280794701996e-05,
+            -0.28443298970024605,
+            0.14414274568190463,
+            0.5862253215464804
+          ],
+          "volatility_rank": 1
+        },
+        "5": {
+          "name": "ranging_directional_down",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": true,
+          "displacement_z": 0.40272043005234026,
+          "centroid_raw": [
+            -0.09164918968539071,
+            0.17683598825771465,
+            0.19527466696209458,
+            33.08081589950957,
+            8.032158959537607e-06,
+            -0.26480477361410815,
+            0.1646961093797343,
+            0.5944223449954359
+          ],
+          "volatility_rank": 3
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.3554974347251892
+          },
+          "5": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.40272043005234026
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    },
+    {
+      "subset": "all_enriched",
+      "columns": [
+        "return_eff",
+        "range_eff",
+        "efficiency",
+        "adx",
+        "funding_rate",
+        "volume_z",
+        "htf_range_eff",
+        "hurst"
+      ],
+      "family": "kmeans",
+      "k": 7,
+      "verdict": {
+        "target": "volatility",
+        "gate_semantics": "candidate-self-v2 (#1211)",
+        "separation_ok": true,
+        "stability_ok": false,
+        "model_separation_real": true,
+        "incumbent_trustworthy": true,
+        "ship": false,
+        "detail": {
+          "handrule_kruskal_h": 88.72068555027909,
+          "model_kruskal_h": 194.30985034415062,
+          "handrule_p_value": 0.005,
+          "model_p_value": 0.0008333333333333334,
+          "handrule_transition_rate": 0.1425891181988743,
+          "model_transition_rate": 0.14352720450281425
+        }
+      },
+      "model_kruskal_h": 194.30985034415062,
+      "model_p_value": 0.0008333333333333334,
+      "handrule_kruskal_h": 88.72068555027909,
+      "stability_gain": -0.0009380863039399612,
+      "coverage": {
+        "ranging_directional": {
+          "count": 281,
+          "pct": 0.06588511137162954
+        },
+        "ranging_directional_down": {
+          "count": 815,
+          "pct": 0.1910902696365768
+        },
+        "ranging_directional_up": {
+          "count": 285,
+          "pct": 0.0668229777256741
+        },
+        "ranging_volatile": {
+          "count": 1505,
+          "pct": 0.3528722157092614
+        },
+        "trending_down_choppy": {
+          "count": 944,
+          "pct": 0.22133645955451348
+        },
+        "trending_up_choppy": {
+          "count": 428,
+          "pct": 0.10035169988276671
+        },
+        "trending_up_clean": {
+          "count": 7,
+          "pct": 0.0016412661195779601
+        }
+      },
+      "non_degeneracy": {
+        "is": {
+          "active_labels": 7,
+          "max_occupancy": 0.2855026455026455,
+          "transition_rate": 0.14817950889077053,
+          "ok": true,
+          "reasons": []
+        },
+        "oos": {
+          "active_labels": 7,
+          "max_occupancy": 0.3528722157092614,
+          "transition_rate": 0.14352720450281425,
+          "ok": true,
+          "reasons": []
+        },
+        "2023": {
+          "active_labels": 7,
+          "max_occupancy": 0.34277065527065526,
+          "transition_rate": 0.14906500445235976,
+          "ok": true,
+          "reasons": []
+        },
+        "2024": {
+          "active_labels": 7,
+          "max_occupancy": 0.28257073000349286,
+          "transition_rate": 0.1740801117838845,
+          "ok": true,
+          "reasons": []
+        },
+        "2025H1": {
+          "active_labels": 7,
+          "max_occupancy": 0.3581585924319113,
+          "transition_rate": 0.16441658630665382,
+          "ok": true,
+          "reasons": []
+        }
+      },
+      "non_degenerate_all": true,
+      "structurally_ineligible": false,
+      "structural_ineligibility_reason": null,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional",
+        "trending_up_clean",
+        "ranging_directional_up",
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "mapping": {
+        "0": {
+          "name": "trending_up_choppy",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.17372129646710593,
+            0.23869331887214798,
+            0.334546697328203,
+            39.74712117059186,
+            1.3933323613595731e-05,
+            0.006717246828212726,
+            0.18751026298508677,
+            0.5150621576306407
+          ],
+          "volatility_rank": 6
+        },
+        "1": {
+          "name": "ranging_directional",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.3708162026462492,
+          "centroid_raw": [
+            0.03041899050679761,
+            0.142999006611564,
+            0.11378899702509317,
+            22.360456222629857,
+            1.6999948088531224e-05,
+            -0.21518078506994687,
+            0.23459390073742498,
+            0.4307373626515416
+          ],
+          "volatility_rank": 1
+        },
+        "2": {
+          "name": "trending_up_clean",
+          "handrule_name": "trending_up_choppy",
+          "relabeled": true,
+          "displacement_z": 1.274204763602899,
+          "centroid_raw": [
+            0.17702015087049966,
+            0.2296128555265336,
+            0.3491522328774468,
+            40.43585261678381,
+            6.457225737704915e-05,
+            0.05888596651987263,
+            0.26432571532126653,
+            0.49554796068059404
+          ],
+          "volatility_rank": 5
+        },
+        "3": {
+          "name": "ranging_directional_up",
+          "handrule_name": "ranging_directional_up",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.007143020718019607,
+            0.16605022005919493,
+            0.1720598697781215,
+            27.27886201788827,
+            1.0996594699646647e-05,
+            3.10797905196281,
+            0.1627709923785853,
+            0.5138929492564107
+          ],
+          "volatility_rank": 3
+        },
+        "4": {
+          "name": "ranging_directional_down",
+          "handrule_name": "ranging_volatile",
+          "relabeled": true,
+          "displacement_z": 0.05331087253169517,
+          "centroid_raw": [
+            -0.0048515037066584246,
+            0.1487139782577974,
+            0.10556748452079032,
+            24.37684344795247,
+            1.0276035376532419e-05,
+            -0.27462680170935266,
+            0.1596364528283326,
+            0.6324347079363568
+          ],
+          "volatility_rank": 2
+        },
+        "5": {
+          "name": "ranging_volatile",
+          "handrule_name": "ranging_volatile",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            0.010696762239995185,
+            0.13463225135086482,
+            0.08956218716775066,
+            20.0729049110788,
+            9.968242846661796e-06,
+            -0.22719741549400277,
+            0.14055867369920927,
+            0.44179388570079375
+          ],
+          "volatility_rank": 0
+        },
+        "6": {
+          "name": "trending_down_choppy",
+          "handrule_name": "trending_down_choppy",
+          "relabeled": false,
+          "displacement_z": 0.0,
+          "centroid_raw": [
+            -0.13472769740223065,
+            0.20326072301526615,
+            0.2636428192700073,
+            40.37295046372824,
+            4.491259552042192e-06,
+            -0.12102028315648708,
+            0.17607203097658597,
+            0.5675997709149234
+          ],
+          "volatility_rank": 4
+        }
+      },
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.3708162026462492
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.274204763602899
+          },
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.05331087253169517
+          }
+        },
+        "duplicate_names": []
+      },
+      "passes_bonferroni": true
+    }
+  ],
+  "winner": {
+    "subset": "funding",
+    "family": "kmeans",
+    "k": 7
+  },
+  "live_wiring_delta": "Enriched models decode from ENRICHED_COLUMNS; live check_regime.py builds only CANONICAL_COLUMNS. Live wiring (#1074) must feed funding_rate + volume_z + htf_range_eff + hurst on-cycle in this exact order, or forward_filter_labels reads garbage."
+}

--- a/docs/research/1499-distinct-latent-state-labels.md
+++ b/docs/research/1499-distinct-latent-state-labels.md
@@ -1,0 +1,264 @@
+# #1499: Re-run of the #1080/#1095 vol-regime bake-offs with distinct latent-state labels
+
+**Verdict: POSITIVE for the first time. Five candidates clear the full promotion bar** (raw
+`verdict.ship`, family-wise Bonferroni significance, non-degeneracy on all five eval windows):
+two on BTC (`htf:hmm:k=6`, `htf:kmeans:k=7`) and three on ETH (`canonical:kmeans:k=7`,
+`funding:kmeans:k=7`, `all_enriched:hmm:k=7`). The gate code, its thresholds, and the
+incumbent hand-rule path are unchanged. The only change is how a fitted model names its
+latent states.
+
+## What changed and why
+
+The #1218 runs named every latent state by pushing its centroid through the hand-rule
+`map_composite_label`. Two or more centroids that fall in the same hand-rule cell received
+the same name, so the decoder emitted the same string for separate states. `non_degeneracy`
+counts distinct emitted labels, so a k=6 model that kept six separate states was scored as
+four active labels and failed the floor (5 on BTC, 6 on ETH). In #1218, 9 of 18 (1080),
+48 of 90 (1095 BTC) and 60 of 90 (1095 ETH) candidates carried duplicate names.
+
+`regime_vol_model.py` now applies the naming rule `distinct_nearest_cell`
+(`MODEL_VERSION=2`):
+
+- A state whose hand-rule name is uncontested keeps that name.
+- Colliding states are resolved by a minimum-cost assignment over the nine hand-rule
+  cells. The cost is the z-scaled distance from the centroid to the nearest point of each
+  cell (per-feature violation divided by the in-sample feature standard deviation), plus
+  a large fixed penalty per relabel, so the assignment first minimises the number of
+  relabeled states and then the total displacement.
+- k larger than the nine-label vocabulary falls back to hand-rule names and records the
+  duplicates in `naming.duplicate_names`.
+- Every model records `mapping[i].handrule_name`, `relabeled`, and `displacement_z`, and a
+  `naming` summary with the relabeled states. Every harness artifact carries it.
+
+`non_degeneracy`, `derive_thresholds`, `gate_verdict`, the alpha resolution and the
+permutation-count resolution are byte-identical to #1218.
+
+## Commands (harnesses unchanged apart from recording `naming`)
+
+Run at branch base `87430501` (`origin/main`), 2026-09-01, against a frozen copy of the
+OHLCV cache truncated at 2026-07-05 20:00 UTC (the last bar the #1218 run saw), selected
+through `GO_TRADER_OHLCV_CACHE_DB`:
+
+```
+uv run --no-sync python backtest/research/regime_1080_unsupervised_vol_model.py \
+    --json docs/research/1499-artifacts/regime_1080_btc.json
+uv run --no-sync python backtest/research/regime_1095_enriched_vol_model.py \
+    --json docs/research/1499-artifacts/regime_1095_btc.json
+uv run --no-sync python backtest/research/regime_1095_enriched_vol_model.py \
+    --symbol ETH/USDT --timeframe 1h \
+    --json docs/research/1499-artifacts/regime_1095_eth.json
+```
+
+Full per-candidate reports are the three JSON artifacts in `docs/research/1499-artifacts/`.
+
+## Incumbent reproduction against the #1218 artifacts
+
+| Run | swept | eligible (Bonferroni denom) | `n_perm` | corrected alpha | incumbent p | steps to alpha | transition rate |
+|---|---|---|---|---|---|---|---|
+| 1080 BTC/USDT 1h | 18 | 9 | 1000 | 0.005556 | 0.005994 | 44 | 0.137353 |
+| 1095 BTC/USDT 1h | 90 | 45 | 1799 | 0.001111 | 0.004444 | 82 | 0.137353 |
+| 1095 ETH/USDT 1h | 90 | 30 | 1199 | 0.001667 | 0.005833 | 53 | 0.140752 |
+
+Every value in this table, the non-degeneracy thresholds, and all five
+`subset_status="ok"` flags are identical to #1218. Among the candidates whose state names
+did not change (9 of 18 in 1080, 40 of 90 on BTC, 30 of 90 on ETH), every `canonical`,
+`funding` and `htf` candidate reproduces its #1218 p-value and stability gain exactly.
+
+The incumbent Kruskal-Wallis H differs in the fourth significant figure (BTC canonical
+85.6906 in #1218 vs 85.6949 here; ETH 85.2101 vs 85.2110). The cause is the data and it
+is measured. The last cached candle (2026-07-05 20:00 UTC) was still in progress when
+#1218 ran. Replacing its final close with the in-progress close (BTC 62719.11 for the
+finalized 62731.66; ETH 1777.81 for 1777.67) reproduces the #1218 H to the last digit in
+both runs. The incumbent label streams are identical, so every gate arm that depends on
+them is identical. The same partial candle also changes the volume and combined
+subsets at the tail of the held-out window: among unchanged-name candidates, three BTC
+`volume` candidates move their stability gain by at most 0.0002, and the `all_enriched`
+candidates move gain by at most 0.0026 and p by at most 0.024 on BTC (on the
+structurally ineligible `kmeans:k=3`) and 0.0017 on ETH. The only arm flip among
+unchanged-name candidates is BTC `all_enriched:kmeans:k=3` (ineligible) gaining raw
+`ship`. No full-bar result depends on these tail differences.
+
+## Results
+
+### Duplicate names and arm counts, #1218 vs this run
+
+| Run | duplicate-name candidates | raw `ship` | Bonferroni | non-degenerate all windows | full bar |
+|---|---|---|---|---|---|
+| 1080 BTC | 9 → 0 (of 18) | 3 → 6 | 0 → 0 | 0 → 8 | 0 → 0 |
+| 1095 BTC | 48 → 0 (of 90) | 15 → 25 | 7 → 15 | 2 → 31 | 0 → 2 |
+| 1095 ETH | 60 → 0 (of 90) | 60 → 61 | 5 → 15 | 0 → 18 | 0 → 3 |
+
+### #1080 (canonical four features, BTC 1h): winner = none
+
+Six candidates ship and eight are non-degenerate on all windows, but none reaches the
+corrected alpha 0.005556. The closest are `gmm:k=5` (p 0.005994, non-degenerate, but its
+stability gain +0.0129 is below the 0.02 floor so it does not ship) and `hmm:k=6`
+(ships, non-degenerate on all windows, p 0.007992). The 1080 grid has only 9 eligible
+candidates and 1000 permutations, so the corrected alpha sits close to the minimum
+achievable p.
+
+### #1095 BTC: winner = `htf:hmm:k=6`
+
+Candidates clearing the full bar:
+
+| candidate | ship | separation | stability (gain) | Bonferroni (p vs 0.001111) | non-degenerate all | KW-H |
+|---|---|---|---|---|---|---|
+| `htf:hmm:k=6` | yes | yes | yes (+0.0349) | yes (0.001111) | yes, 6 active on all five windows | 179.8 |
+| `htf:kmeans:k=7` | yes | yes | yes (+0.0378) | yes (0.001111) | yes, 7 active on all five windows | 176.1 |
+
+Both p-values equal the corrected alpha exactly: one of 1799 block-shuffled permutations
+matched or exceeded the observed H, so p = 2/1800. This is a knife-edge pass on the
+significance arm and the record should carry it forward.
+
+The #1218 BTC near-misses, arm by arm:
+
+- `htf:hmm:k=6`: in #1218 it failed only non-degeneracy (4 active labels on all five
+  windows because states 0 and 4 both read `trending_up_choppy` and states 2 and 5 both
+  read `trending_down_choppy`). Now state 0 is `ranging_directional` (from
+  `trending_up_choppy`, 0.80 z) and state 5 is `ranging_directional_down` (from
+  `trending_down_choppy`, 0.18 z). It passes separation, stability, Bonferroni and
+  non-degeneracy. Its p moved from 0.00056 to 0.00111 and its stability gain from +0.0647
+  to +0.0349, because the decoded stream now switches between six names instead of four.
+- `volume:gmm:k=5`: no collision, so nothing changed. It passes separation, Bonferroni
+  (p 0.00056) and non-degeneracy, and still fails stability (gain −0.1167). That is #1500.
+
+New BTC near-misses (pass every arm but one):
+
+- Stability only: `htf:hmm:k=7` (gain +0.0190, floor 0.02), `volume:hmm:k=7`,
+  `volume:gmm:k=6`, `volume:gmm:k=7`, `all_enriched:kmeans:k=5/6/7`,
+  `all_enriched:gmm:k=7`, `all_enriched:hmm:k=6`.
+- Bonferroni only: `canonical:hmm:k=6` (p 0.00722), `funding:kmeans:k=7` (p 0.00222),
+  `funding:kmeans:k=6`, `canonical:kmeans:k=6`, `canonical:hmm:k=5`, `htf:hmm:k=5`.
+- Two arms, Bonferroni and non-degeneracy: `htf:kmeans:k=6` (p 0.00167; six states on
+  every window, but occupancy or transition rate breaches the floor on three of them),
+  `htf:kmeans:k=5`.
+
+### #1095 ETH: winner = `funding:kmeans:k=7`
+
+Candidates clearing the full bar:
+
+| candidate | ship | separation | stability (gain) | Bonferroni (p vs 0.001667) | non-degenerate all | KW-H |
+|---|---|---|---|---|---|---|
+| `funding:kmeans:k=7` | yes | yes | yes (+0.0279) | yes (0.00083) | yes, 7 active on all five windows | 176.2 |
+| `canonical:kmeans:k=7` | yes | yes | yes (+0.0351) | yes (0.00083) | yes, 7 active on all five windows | 173.8 |
+| `all_enriched:hmm:k=7` | yes | yes | yes (+0.0204) | yes (0.00167) | yes, 7 active on all five windows | 146.0 |
+
+`funding:kmeans:k=7` and `canonical:kmeans:k=7` are near-identical models (the funding
+centroid coordinate is zero to four decimals on every state), so the funding column adds
+almost nothing on ETH. `all_enriched:hmm:k=7` passes Bonferroni at exactly the corrected
+alpha and stability at +0.0204 against the 0.02 floor, so both of those arms are
+knife-edge.
+
+The #1218 ETH near-misses, arm by arm:
+
+- `canonical:kmeans:k=7`: in #1218 it failed only non-degeneracy (three of its seven
+  states read `trending_up_choppy` and two read `trending_down_choppy`). Now states 4, 5
+  and 6 are `trending_up_clean` (0.76 z), `ranging_directional_up` (0.44 z) and
+  `ranging_directional` (1.05 z). It clears the full bar.
+- `funding:kmeans:k=6`: in #1218 it failed only non-degeneracy. Now it is non-degenerate
+  on all windows and still ships (gain +0.0392), but its p moved from 0.00167 to 0.00333
+  and misses the corrected alpha 0.001667. It fails Bonferroni only.
+- `all_enriched:kmeans:k=6`: in #1218 it failed only non-degeneracy. Now it is
+  non-degenerate on all windows and passes Bonferroni (p 0.00083), but its stability gain
+  moved from +0.0314 to −0.0141, so it fails stability only.
+
+New ETH near-misses:
+
+- Stability only: `all_enriched:kmeans:k=7` (gain −0.0009), `all_enriched:hmm:k=6`
+  (+0.0155), `all_enriched:gmm:k=6`, `funding:gmm:k=7`, `volume:gmm:k=7`.
+- Non-degeneracy only: `htf:hmm:k=6` (2023 window transition rate 0.0684 vs floor 0.0695),
+  `htf:hmm:k=7` (three windows under the transition-rate floor).
+- Bonferroni only: `funding:kmeans:k=6` (above), `htf:gmm:k=7` (p 0.0075).
+
+### Which arm binds now
+
+- **Non-degeneracy** was the dominant failure in #1218. With distinct names it binds only
+  where a model's decoded stream really is degenerate (`kmeans:k=3/4` on BTC with three or
+  four states and occupancy over 0.39; ETH `htf:hmm` at the transition-rate floor).
+- **Stability** is now the most common single failing arm for the high-separation models
+  (BTC volume and all_enriched subsets, ETH all_enriched). Distinct names raise the
+  measured transition rate, because a switch between two states that used to share a name
+  now counts as a transition. Several #1218 stability passes turned into failures for
+  this reason. That is a true property of the model, and #1218 was under-counting it.
+- **Bonferroni** binds on the 1080 grid and on several BTC `canonical`/`funding` models
+  whose p sits between 0.002 and 0.008.
+
+## Does the corrected mapping change what a label means?
+
+Yes, for relabeled states only. Every uncontested state keeps its hand-rule name and its
+meaning is unchanged. A relabeled state carries the name of the nearest free hand-rule
+cell, measured in in-sample standard deviations, and its centroid does **not** satisfy that
+cell's rule. The name says where the state sits in the vocabulary. It does not say the
+hand-rule condition holds. Examples from the passing models (out-of-sample median forward
+realized volatility at horizon 4, in log-return units):
+
+BTC `htf:hmm:k=6` (states sorted by forward vol):
+
+| state | name | hand-rule name | displacement | centroid (ret_eff, range_eff, eff, adx) | oos bars | median fwd vol |
+|---|---|---|---|---|---|---|
+| 3 | `ranging_volatile` | same | 0 | 0.000, 0.118, 0.041, 21.1 | 1101 | 0.00555 |
+| 0 | `ranging_directional` | `trending_up_choppy` | 0.80 z | 0.069, 0.136, 0.145, 23.8 | 809 | 0.00603 |
+| 5 | `ranging_directional_down` | `trending_down_choppy` | 0.18 z | −0.066, 0.146, 0.137, 28.4 | 675 | 0.00616 |
+| 4 | `trending_up_choppy` | same | 0 | 0.152, 0.204, 0.303, 37.3 | 541 | 0.00630 |
+| 2 | `trending_down_choppy` | same | 0 | −0.130, 0.189, 0.261, 41.6 | 842 | 0.00753 |
+| 1 | `ranging_directional_up` | same | 0 | 0.008, 0.139, 0.093, 28.2 | 293 | 0.00914 |
+
+State 0 is a weak up-drift with ADX below 25. The hand rule calls it
+`trending_up_choppy` because return efficiency clears 0.05. The nearest free cell is
+`ranging_directional` (return efficiency at zero, ADX at 25), 0.80 z away. Its forward vol
+sits between `ranging_volatile` and the true `trending_up_choppy` state, so the model
+separates it from state 4 for a reason, and the old mapping was merging two states with
+different forward vol.
+
+ETH `funding:kmeans:k=7`:
+
+| state | name | hand-rule name | displacement | centroid (ret_eff, range_eff, eff, adx) | oos bars | median fwd vol |
+|---|---|---|---|---|---|---|
+| 1 | `ranging_volatile` | same | 0 | 0.005, 0.121, 0.051, 17.9 | 983 | 0.00669 |
+| 5 | `ranging_directional_up` | `trending_up_choppy` | 0.44 z | 0.073, 0.150, 0.153, 20.6 | 600 | 0.00788 |
+| 0 | `ranging_directional_down` | same | 0 | −0.029, 0.152, 0.092, 27.1 | 1072 | 0.00814 |
+| 6 | `ranging_directional` | `trending_down_choppy` | 1.07 z | −0.111, 0.182, 0.220, 34.4 | 673 | 0.00840 |
+| 2 | `trending_up_choppy` | same | 0 | 0.138, 0.211, 0.269, 32.0 | 440 | 0.00881 |
+| 4 | `trending_up_clean` | `trending_up_choppy` | 0.90 z | 0.205, 0.255, 0.394, 46.3 | 177 | 0.01035 |
+| 3 | `trending_down_choppy` | same | 0 | −0.178, 0.245, 0.343, 47.8 | 464 | 0.01137 |
+
+State 4 is the strongest up-trend state (ADX 46, efficiency 0.39). The hand rule calls it
+`trending_up_choppy` because efficiency is under 0.5. `trending_up_clean` is the nearest
+free cell and the forward vol ordering agrees that it is a separate, higher-vol state.
+State 6 is a mid-strength down-trend that the vocabulary has no free cell for after the
+true `trending_down_choppy` state takes its name, so it lands on `ranging_directional`
+1.07 z away. This name is the least faithful of the set, and a consumer must read
+`handrule_name` to see that the state is a down-trend.
+
+The same per-state pass was run for every ship+Bonferroni candidate and every #1218
+near-miss. The refit reproduced the artifact's state names for every candidate except
+the two ETH `all_enriched` ones (`hmm:k=7`, `kmeans:k=6`), where the refit swapped the
+order of two states with the same hand-rule name. Those two candidates' per-state rows
+are therefore not reported here; their arm results above come from the artifact.
+
+Consequence for #1074 live wiring: a model label must be consumed through
+`mapping[i]`. String-matching the name against the hand-rule vocabulary is unsafe.
+`relabeled=true` means the name is a position in the vocabulary and the hand-rule
+condition for that name is false at the centroid. Any live gate that keys on model labels
+(for example an `allowed_regimes` list) has to be authored per model from the mapping,
+and a model with a relabeled state must not share an `allowed_regimes` list with the
+hand-rule classifier.
+
+## Disposition
+
+- **#1074 blocker 2 is now measured positive on both assets.** BTC `htf:hmm:k=6` and ETH
+  `funding:kmeans:k=7` (with `canonical:kmeans:k=7` as an equivalent) clear the full bar.
+  Both BTC passers and ETH `all_enriched:hmm:k=7` sit exactly on the corrected alpha, so
+  the significance evidence is thin; the ETH k-means pair pass at half the alpha.
+- Hand-off to the #1081 economic gate and #1082 bounded-window validation is now
+  possible for those candidates. Nothing in this issue promotes a model or writes live
+  config.
+- Stability is the arm to watch next. Distinct names raised measured churn across the
+  board, and #1500 (`volume:gmm:k=5` churn) applies to more candidates than it did under
+  the old mapping.
+- No gate-semantics or threshold change is proposed. The knife-edge Bonferroni passes are
+  a property of `n_perm` resolution at 1799 permutations; raising `n_perm` for a
+  confirmation run would tighten the p-value estimate without changing the gate.
+
+---
+Created with LLM: Fable 5.1 | high | Harness: Claude Code


### PR DESCRIPTION
Closes #1499

## Summary

- `backtest/regime_vol_model.py`: new naming rule `distinct_nearest_cell` (`MODEL_VERSION` 2). A state whose hand-rule name is uncontested keeps it. Colliding states are assigned distinct names by a minimum-cost assignment over the nine hand-rule cells (rectangular Hungarian). Cost is the z-scaled distance from the centroid to the nearest point of each cell plus a fixed penalty per relabel, so the assignment minimises the relabel count first and the total displacement second, with a deterministic tiebreak. k above the vocabulary size keeps hand-rule names and records the duplicates in `naming.duplicate_names`.
- Every `mapping[i]` now records `handrule_name`, `relabeled` and `displacement_z`; the fitted model carries a `naming` summary and the 1080, 1083 and 1095 harness records copy it into their artifacts.
- `non_degeneracy`, `derive_thresholds`, `gate_verdict`, the alpha resolution and the permutation-count resolution are unchanged (`git diff` touches none of them).
- `docs/research/1499-distinct-latent-state-labels.md` plus three artifacts in `docs/research/1499-artifacts/` record the BTC and ETH re-run of the 1080 and 1095 harnesses on a cache frozen at the last bar the 1218 run saw.

## Results of the re-run

- Duplicate-name candidates: 9 of 18 (1080), 48 of 90 (1095 BTC), 60 of 90 (1095 ETH) in 1218. Zero in every run now.
- Five candidates clear the full bar (raw ship, Bonferroni, non-degenerate on all five windows): BTC `htf:hmm:k=6` and `htf:kmeans:k=7`; ETH `canonical:kmeans:k=7`, `funding:kmeans:k=7` and `all_enriched:hmm:k=7`. The BTC pair and ETH `all_enriched:hmm:k=7` pass Bonferroni at exactly the corrected alpha (knife edge, recorded).
- Every 1218 near-miss has a per-arm pass/fail entry in the document. BTC `volume:gmm:k=5` (no collision) is unchanged and still fails stability only (that is #1500).
- Label meaning: uncontested states keep their meaning. A relabeled state's name is the nearest free hand-rule cell in z units and its centroid does not satisfy that cell's rule. `mapping[i].handrule_name` and `relabeled` carry the truth for #1074 live wiring; the document states the consequence.

## Verification

- Incumbent hand-rule held-out p-values, permutation steps to alpha and transition rates reproduce the 1218 artifacts exactly for all three runs. The incumbent Kruskal-Wallis H differs in the fourth digit; the 1218 run saw the final cached candle in progress, and substituting that in-progress close (BTC 62719.11, ETH 1777.81) reproduces the 1218 H to the last digit. Unchanged-name `canonical`, `funding` and `htf` candidates reproduce their p-value and stability gain exactly; the `volume` and `all_enriched` tails move by the amounts listed in the document.
- Regression proof: with the old `regime_vol_model.py` swapped in, the new tests in `backtest/tests/test_regime_vol_model.py` give 7 failed, 1 passed; with the fix, the file passes 70 tests.
- Full suite: `uv run --no-sync python -m pytest shared_strategies/ shared_tools/ platforms/ backtest/` gives 2858 passed. `py_compile` passes on every changed Python file.

## Test edits

None of the pre-existing tests were edited. All test changes are additions.

## Adopted plan

None. The issue carried no implementation plan comment.

## Plain simple English

The regime model gave two different market states the same name when their centres fell in the same hand-rule box. The gate then counted them as one state and rejected good models. Now each state gets its own name, chosen from the nearest free box. Five models pass the full gate for the first time. The gate rules did not change.

---
Created with LLM: Fable 5.1 | high | Harness: Claude Code

https://claude.ai/code/session_013E8gonXiGvgzZKEHYZKuHi
