### PR TITLE
feat(#1500): sweep decoder smoothing for the volume gmm regime candidate [C37, Fable 5.1, low]

### DIFF
--- a/backtest/regime_hmm.py
+++ b/backtest/regime_hmm.py
@@ -4,6 +4,8 @@ import numpy as np
 MODEL_TYPE = "label_anchored_hmm"
 MODEL_VERSION = 1
 FEATURES = ["return_eff", "range_eff", "efficiency", "adx"]
+DECODE_MIN_DWELL_KEY = "decode_min_dwell"
+DECODE_STICKINESS_KEY = "decode_stickiness"
 
 
 def stationary_distribution(transition: np.ndarray) -> np.ndarray:
@@ -65,12 +67,23 @@ def forward_filter_labels(features: np.ndarray, model: dict):
     em_mean = np.array([e["mean"] for e in model["emissions"]], dtype=float)
     em_var = np.array([e["var"] for e in model["emissions"]], dtype=float)
     log_init = np.log(np.asarray(model["init"], dtype=float) + 1e-300)
-    log_A = np.log(np.asarray(model["transition"], dtype=float) + 1e-300)
+    A = np.asarray(model["transition"], dtype=float)
+    stickiness = float(model.get(DECODE_STICKINESS_KEY) or 0.0)
+    if stickiness < 0:
+        raise ValueError(f"{DECODE_STICKINESS_KEY} must be >= 0")
+    if stickiness > 0:
+        A = A + stickiness * np.eye(k)
+        A = A / A.sum(1, keepdims=True)
+    log_A = np.log(A + 1e-300)
     w = int(model["filter_window"])
+    min_dwell = int(model.get(DECODE_MIN_DWELL_KEY) or 0)
+    if min_dwell < 0:
+        raise ValueError(f"{DECODE_MIN_DWELL_KEY} must be >= 0")
     default_label = states[int(np.argmax(model["init"]))]
 
     labels = np.array([default_label] * n, dtype=object)
     conf = np.zeros(n, dtype=float)
+    held, pending, pending_run = None, None, 0
     for i in range(n):
         lo = max(0, i - w + 1)
         alpha = log_init.copy()
@@ -88,6 +101,17 @@ def forward_filter_labels(features: np.ndarray, model: dict):
             seen = True
         if seen:
             j = int(np.argmax(alpha))
+            if min_dwell > 1:
+                if held is None or j == held:
+                    pending, pending_run = None, 0
+                else:
+                    pending_run = pending_run + 1 if pending == j else 1
+                    pending = j
+                    if pending_run >= min_dwell:
+                        pending, pending_run = None, 0
+                    else:
+                        j = held
+                held = j
             labels[i] = states[j]
             conf[i] = float(np.exp(alpha[j] - _logsumexp(alpha)))
     return labels, conf

--- a/backtest/research/regime_1500_gmm_stability_sweep.py
+++ b/backtest/research/regime_1500_gmm_stability_sweep.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+import os, sys
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_BACKTEST = os.path.abspath(os.path.join(_THIS_DIR, ".."))
+_ROOT = os.path.abspath(os.path.join(_BACKTEST, ".."))
+for _p in (_BACKTEST, _ROOT, os.path.join(_ROOT, "shared_tools")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import importlib.util
+import json
+import time
+
+import numpy as np
+
+from regime import compute_regime_composite, _DEFAULT_COMPOSITE_THRESHOLDS
+from regime_calibrate import gate_verdict, STABILITY_MIN_GAIN
+from regime_diagnostics import forward_realized_vol, separation
+from regime_hmm import DECODE_MIN_DWELL_KEY, DECODE_STICKINESS_KEY
+import regime_vol_model as rvm
+from regime_enriched_features import canonical_indices_for, decode_with_model
+
+PRIMARY = ("volume", "gmm", 5)
+CONTEXT = (("volume", "hmm", 7), ("volume", "gmm", 6), ("volume", "gmm", 7),
+           ("htf", "hmm", 7), ("all_enriched", "kmeans", 5), ("all_enriched", "kmeans", 6),
+           ("all_enriched", "kmeans", 7), ("all_enriched", "gmm", 7), ("all_enriched", "hmm", 6))
+FILTER_WINDOWS = (8, 16, 32, 64, 128, 256, 512)
+DWELLS = (2, 3, 4, 6, 8, 12, 24)
+STICKINESS = (1.0, 2.0, 5.0, 10.0, 20.0, 50.0)
+COMBOS = ((256, 0, 0.0), (256, 3, 0.0), (256, 6, 0.0), (64, 3, 5.0), (64, 3, 20.0),
+          (64, 6, 5.0), (64, 6, 20.0), (256, 3, 20.0), (256, 6, 20.0),
+          (64, 0, 100.0), (64, 0, 200.0), (64, 0, 500.0), (64, 0, 1000.0),
+          (64, 2, 1.0), (64, 2, 2.0), (64, 2, 5.0), (64, 2, 10.0), (64, 2, 20.0), (64, 2, 50.0),
+          (64, 2, 100.0), (64, 3, 1.0), (64, 3, 2.0), (64, 3, 3.0), (64, 3, 10.0))
+CONTEXT_SETTINGS = ((16, 0, 0.0), (256, 0, 0.0), (64, 3, 0.0), (64, 6, 0.0),
+                    (64, 0, 5.0), (64, 0, 20.0), (64, 6, 20.0))
+PRIMARY_HORIZON = 4
+
+
+def _load(name, filename):
+    path = os.path.join(_THIS_DIR, filename)
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def primary_settings():
+    seen, out = set(), []
+    for fw in FILTER_WINDOWS:
+        out.append((fw, 0, 0.0))
+    for d in DWELLS:
+        out.append((64, d, 0.0))
+    for s in STICKINESS:
+        out.append((64, 0, s))
+    out.extend(COMBOS)
+    uniq = []
+    for st in out:
+        if st not in seen:
+            seen.add(st)
+            uniq.append(st)
+    return uniq
+
+
+def apply_setting(model, setting):
+    fw, dwell, stick = setting
+    out = dict(model)
+    out["filter_window"] = int(fw)
+    out.pop(DECODE_MIN_DWELL_KEY, None)
+    out.pop(DECODE_STICKINESS_KEY, None)
+    if dwell:
+        out[DECODE_MIN_DWELL_KEY] = int(dwell)
+    if stick:
+        out[DECODE_STICKINESS_KEY] = float(stick)
+    return out
+
+
+def setting_name(setting):
+    fw, dwell, stick = setting
+    parts = [f"fw={fw}"]
+    if dwell:
+        parts.append(f"dwell={dwell}")
+    if stick:
+        parts.append(f"stick={stick:g}")
+    return " ".join(parts)
+
+
+def held_out_h(df, labels, mat, horizon=PRIMARY_HORIZON):
+    arr = mat.to_numpy(dtype=float)
+    valid = ~np.isnan(arr).any(axis=1)
+    fwd = forward_realized_vol(df["close"].to_numpy(), horizon)
+    return separation(np.asarray(labels, dtype=object)[valid], fwd[valid])["kruskal_h"]
+
+
+def evaluate_setting(model, setting, wins, eval_windows, held_out, thresholds):
+    m = apply_setting(model, setting)
+    per_window = {}
+    for w in eval_windows:
+        wdf, wmat = wins[w]
+        labels, _ = decode_with_model(wmat, m)
+        valid = ~np.isnan(wmat.to_numpy(dtype=float)).any(axis=1)
+        nd = rvm.non_degeneracy(np.asarray(labels, dtype=object)[valid], thresholds)
+        per_window[w] = nd
+        if w == held_out:
+            per_window[w]["kruskal_h"] = float(held_out_h(wdf, labels, wmat))
+    return {
+        "setting": {"filter_window": setting[0], DECODE_MIN_DWELL_KEY: setting[1],
+                    DECODE_STICKINESS_KEY: setting[2]},
+        "label": setting_name(setting),
+        "windows": per_window,
+        "non_degenerate_all": all(per_window[w]["ok"] for w in eval_windows),
+        "held_out_transition_rate": per_window[held_out]["transition_rate"],
+        "held_out_kruskal_h": per_window[held_out]["kruskal_h"],
+        "min_active_labels": min(per_window[w]["active_labels"] for w in eval_windows),
+        "min_transition_rate": min(per_window[w]["transition_rate"] for w in eval_windows),
+    }
+
+
+def reaches_band(row, hr_rate):
+    return row["non_degenerate_all"] and (hr_rate - row["held_out_transition_rate"]) >= STABILITY_MIN_GAIN
+
+
+def best_reachable(rows, hr_rate):
+    in_band = [r for r in rows if reaches_band(r, hr_rate)]
+    if in_band:
+        return max(in_band, key=lambda r: r["held_out_kruskal_h"]), True
+    nd = [r for r in rows if r["non_degenerate_all"]]
+    pool = nd if nd else rows
+    return min(pool, key=lambda r: r["held_out_transition_rate"]), False
+
+
+def run(symbol="BTC/USDT", timeframe="1h", *, in_sample="is", held_out="oos",
+        eval_windows=("is", "oos", "2023", "2024", "2025H1"), period=48, base_filter_window=64,
+        htf_multiple=4, vol_window=None, seed=0, n_perm=None, context=True):
+    m1095 = _load("regime_1095_for_1500", "regime_1095_enriched_vol_model.py")
+    m1080 = m1095._load_1080()
+    th = dict(_DEFAULT_COMPOSITE_THRESHOLDS)
+    coin = symbol.split("/")[0]
+
+    hr_streams = m1080._handrule_streams(symbol, timeframe, eval_windows, period, th)
+    thresholds = rvm.derive_thresholds(list(hr_streams.values()))
+    all_windows = list(dict.fromkeys((in_sample, held_out, *eval_windows)))
+    funding_by_window = {w: m1095._funding_for_window(coin, w) for w in all_windows}
+
+    plan, ineligible, denominator = m1095.combined_family_plan(
+        list(m1095.SUBSETS), ("hmm", "gmm", "kmeans"), range(2, 8), thresholds,
+        ineligible_reason_fn=m1080.structurally_ineligible_reason)
+    alpha = m1080.bonferroni_alpha(denominator)
+    n_perm = m1080.resolve_bakeoff_n_perm(denominator, requested=n_perm)
+    print(f"NOTE: n_perm={n_perm} alpha={alpha:.6f} denominator={denominator} "
+          f"thresholds={vars(thresholds)}", file=sys.stderr)
+
+    targets = [PRIMARY] + (list(CONTEXT) if context else [])
+    needed = sorted({t[0] for t in targets})
+    built = {}
+    for sub_name in needed:
+        columns = m1095.SUBSETS[sub_name]
+        built[sub_name] = {w: m1095._enriched(symbol, timeframe, w, period, th, columns,
+                                              funding_by_window[w], htf_multiple=htf_multiple,
+                                              vol_window=vol_window) for w in all_windows}
+
+    handrule = {}
+    for sub_name in needed:
+        held_df, held_mat = built[sub_name][held_out]
+        hr_labels = compute_regime_composite(held_df, period=period, thresholds=th)["regime"].to_numpy()
+        t0 = time.time()
+        handrule[sub_name] = m1095._score(held_df, hr_labels, held_mat, n_perm=n_perm, seed=seed)
+        print(f"NOTE: hand-rule {sub_name} scored in {time.time() - t0:.0f}s "
+              f"(H={handrule[sub_name]['h4']['separation']['kruskal_h']:.2f}, "
+              f"rate={handrule[sub_name]['stability']['transition_rate']:.4f})", file=sys.stderr)
+
+    report = {"issue": 1500, "symbol": symbol, "timeframe": timeframe, "in_sample": in_sample,
+              "held_out": held_out, "eval_windows": list(eval_windows),
+              "base_filter_window": base_filter_window, "n_perm": int(n_perm),
+              "bonferroni_alpha": alpha, "bonferroni_denominator": denominator,
+              "non_degeneracy_thresholds": vars(thresholds),
+              "handrule_held_out": {s: {"kruskal_h": h["h4"]["separation"]["kruskal_h"],
+                                        "p_value": h["h4"]["significance"]["p_value"],
+                                        "transition_rate": h["stability"]["transition_rate"]}
+                                    for s, h in handrule.items()},
+              "candidates": []}
+
+    for sub_name, family, k in targets:
+        wins = built[sub_name]
+        fit_df, fit_mat = wins[in_sample]
+        held_df, held_mat = wins[held_out]
+        columns = list(fit_mat.columns)
+        model = rvm.fit_unsupervised(fit_mat.to_numpy(dtype=float), family=family, k=k,
+                                     filter_window=base_filter_window, period=period,
+                                     thresholds=th, seed=seed, feature_names=columns,
+                                     canonical_indices=canonical_indices_for(columns),
+                                     fitted_on={"symbol": symbol, "timeframe": timeframe,
+                                                "window": in_sample, "subset": sub_name})
+        hr_rate = handrule[sub_name]["stability"]["transition_rate"]
+        is_primary = (sub_name, family, k) == PRIMARY
+        settings = primary_settings() if is_primary else list(CONTEXT_SETTINGS)
+        settings = list(dict.fromkeys([(base_filter_window, 0, 0.0)] + settings))
+        rows = []
+        for st in settings:
+            t0 = time.time()
+            row = evaluate_setting(model, st, wins, eval_windows, held_out, thresholds)
+            row["reaches_band"] = reaches_band(row, hr_rate)
+            rows.append(row)
+            print(f"{sub_name}:{family}:k={k} {row['label']:<28} oos_rate={row['held_out_transition_rate']:.4f} "
+                  f"min_active={row['min_active_labels']} min_rate={row['min_transition_rate']:.4f} "
+                  f"H={row['held_out_kruskal_h']:.2f} nd_all={row['non_degenerate_all']} "
+                  f"band={row['reaches_band']} ({time.time() - t0:.0f}s)", file=sys.stderr)
+        best, in_band = best_reachable(rows, hr_rate)
+        entry = {"subset": sub_name, "family": family, "k": k, "primary": is_primary,
+                 "states": model["states"], "naming": model["naming"],
+                 "transition_diagonal": [float(model["transition"][i][i]) for i in range(k)],
+                 "handrule_transition_rate": hr_rate, "sweep": rows,
+                 "best_setting": best["setting"], "best_label": best["label"],
+                 "best_reaches_band": in_band}
+        if is_primary or in_band:
+            best_model = apply_setting(model, tuple(best["setting"][key] for key in
+                                                    ("filter_window", DECODE_MIN_DWELL_KEY,
+                                                     DECODE_STICKINESS_KEY)))
+            labels, _ = decode_with_model(held_mat, best_model)
+            t0 = time.time()
+            md = m1095._score(held_df, labels, held_mat, n_perm=n_perm, seed=seed)
+            verdict = gate_verdict(handrule[sub_name], md)
+            p = md["h4"]["significance"]["p_value"]
+            entry["rescored"] = {
+                "verdict": verdict, "model_kruskal_h": md["h4"]["separation"]["kruskal_h"],
+                "model_p_value": p, "passes_bonferroni": bool(p <= alpha),
+                "stability_gain": float(hr_rate - md["stability"]["transition_rate"]),
+                "non_degenerate_all": best["non_degenerate_all"],
+                "coverage": md["coverage"],
+                "full_bar": bool(verdict["ship"] and p <= alpha and best["non_degenerate_all"]),
+            }
+            print(f"{sub_name}:{family}:k={k} rescored at {best['label']}: ship={verdict['ship']} "
+                  f"p={p:.5f} H={entry['rescored']['model_kruskal_h']:.2f} "
+                  f"gain={entry['rescored']['stability_gain']:.4f} ({time.time() - t0:.0f}s)",
+                  file=sys.stderr)
+        report["candidates"].append(entry)
+    return report
+
+
+def build_parser():
+    import argparse
+    p = argparse.ArgumentParser(description="#1500 decoder-smoothing sweep for the volume GMM k=5 candidate")
+    p.add_argument("--symbol", default="BTC/USDT")
+    p.add_argument("--timeframe", default="1h")
+    p.add_argument("--period", type=int, default=48)
+    p.add_argument("--filter-window", type=int, default=64)
+    p.add_argument("--htf-multiple", type=int, default=4)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--n-perm", type=int, default=None)
+    p.add_argument("--no-context", action="store_true", help="sweep only the primary candidate")
+    p.add_argument("--json", default=None, help="write the sweep report JSON here")
+    return p
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    report = run(args.symbol, args.timeframe, period=args.period,
+                 base_filter_window=args.filter_window, htf_multiple=args.htf_multiple,
+                 seed=args.seed, n_perm=args.n_perm, context=not args.no_context)
+    text = json.dumps(report, indent=2, default=float)
+    if args.json:
+        with open(args.json, "w") as fh:
+            fh.write(text)
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backtest/tests/test_regime_hmm.py
+++ b/backtest/tests/test_regime_hmm.py
@@ -83,3 +83,120 @@ def test_forward_filter_nan_carry():
     feats[50] = np.nan
     lab, _ = forward_filter_labels(feats, m)
     assert lab[50] in STATES
+
+
+def _reference_forward_filter(features, model):
+    from regime_hmm import _logsumexp
+    features = np.asarray(features, dtype=float)
+    n = len(features)
+    states = list(model["states"])
+    k = len(states)
+    mean = np.asarray(model["feature_means"], dtype=float)
+    std = np.asarray(model["feature_stds"], dtype=float)
+    em_mean = np.array([e["mean"] for e in model["emissions"]], dtype=float)
+    em_var = np.array([e["var"] for e in model["emissions"]], dtype=float)
+    log_init = np.log(np.asarray(model["init"], dtype=float) + 1e-300)
+    log_A = np.log(np.asarray(model["transition"], dtype=float) + 1e-300)
+    w = int(model["filter_window"])
+    default_label = states[int(np.argmax(model["init"]))]
+    labels = np.array([default_label] * n, dtype=object)
+    conf = np.zeros(n, dtype=float)
+    for i in range(n):
+        lo = max(0, i - w + 1)
+        alpha = log_init.copy()
+        seen = False
+        for t in range(lo, i + 1):
+            x = features[t]
+            pred = np.array([_logsumexp(alpha + log_A[:, j]) for j in range(k)])
+            if np.isnan(x).any():
+                alpha = pred
+                continue
+            z = (x - mean) / std
+            log_emit = -0.5 * (np.log(2 * np.pi * em_var) + (z - em_mean) ** 2 / em_var).sum(1)
+            alpha = pred + log_emit
+            alpha -= _logsumexp(alpha)
+            seen = True
+        if seen:
+            j = int(np.argmax(alpha))
+            labels[i] = states[j]
+            conf[i] = float(np.exp(alpha[j] - _logsumexp(alpha)))
+    return labels, conf
+
+
+def _noisy_fixture(seed=3, n=60, sep=0.7):
+    rng = np.random.default_rng(seed)
+    feats = np.vstack([rng.normal(0, 1, (n, 4)), rng.normal(sep, 1, (n, 4))])
+    labels = np.array(["s0"] * n + ["s1"] * n, dtype=object)
+    feats[17] = np.nan
+    return feats, labels
+
+
+def _transition_rate(labels):
+    labels = np.asarray(labels, dtype=object)
+    return float((labels[1:] != labels[:-1]).sum() / (len(labels) - 1))
+
+
+def test_forward_filter_without_decode_options_matches_reference_decoder():
+    from regime_hmm import forward_filter_labels
+    feats, labels = _noisy_fixture()
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=8)
+    ref_lab, ref_conf = _reference_forward_filter(feats, m)
+    for model in (m, {**m, "decode_min_dwell": 0, "decode_stickiness": 0.0},
+                  {**m, "decode_min_dwell": None, "decode_stickiness": None},
+                  {**m, "decode_min_dwell": 1}):
+        lab, conf = forward_filter_labels(feats, model)
+        assert lab.tolist() == ref_lab.tolist()
+        assert conf.tobytes() == ref_conf.tobytes()
+
+
+def test_decode_min_dwell_holds_label_until_run_persists():
+    from regime_hmm import forward_filter_labels
+    feats, labels = _noisy_fixture()
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=2)
+    base, _ = forward_filter_labels(feats, m)
+    assert _transition_rate(base) > 0.05
+    prev = _transition_rate(base)
+    for dwell in (2, 4, 8):
+        lab, conf = forward_filter_labels(feats, {**m, "decode_min_dwell": dwell})
+        assert set(lab.tolist()) <= set(STATES)
+        assert (conf >= 0).all() and (conf <= 1.0 + 1e-9).all()
+        rate = _transition_rate(lab)
+        assert rate <= prev
+        prev = rate
+    held, _ = forward_filter_labels(feats, {**m, "decode_min_dwell": 3})
+    assert (held[80:115] == "s1").mean() > 0.8
+
+
+def test_decode_min_dwell_is_look_ahead_safe():
+    from regime_hmm import forward_filter_labels
+    feats, labels = _noisy_fixture()
+    m = {**fit_label_anchored_hmm(feats, labels, STATES, filter_window=8), "decode_min_dwell": 3}
+    lab_a, _ = forward_filter_labels(feats, m)
+    perturbed = feats.copy()
+    perturbed[71:] += 100.0
+    lab_b, _ = forward_filter_labels(perturbed, m)
+    assert list(lab_a[:71]) == list(lab_b[:71])
+
+
+def test_decode_stickiness_reduces_churn_without_mutating_the_model():
+    from regime_hmm import forward_filter_labels
+    feats, labels = _noisy_fixture()
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=2)
+    before = [row[:] for row in m["transition"]]
+    base, _ = forward_filter_labels(feats, m)
+    sticky, conf = forward_filter_labels(feats, {**m, "decode_stickiness": 5.0})
+    assert _transition_rate(sticky) < _transition_rate(base)
+    assert set(sticky.tolist()) <= set(STATES)
+    assert (conf >= 0).all() and (conf <= 1.0 + 1e-9).all()
+    assert m["transition"] == before
+
+
+def test_decode_options_reject_negative_values():
+    import pytest
+    from regime_hmm import forward_filter_labels
+    feats, labels = _noisy_fixture()
+    m = fit_label_anchored_hmm(feats, labels, STATES, filter_window=4)
+    with pytest.raises(ValueError):
+        forward_filter_labels(feats, {**m, "decode_min_dwell": -1})
+    with pytest.raises(ValueError):
+        forward_filter_labels(feats, {**m, "decode_stickiness": -0.5})

--- a/docs/backtesting-registry.md
+++ b/docs/backtesting-registry.md
@@ -73,6 +73,7 @@ its row here in the same PR. A new row is part of the change, not a follow-up.
 | `research/regime_1076_aggregate.py` | Aggregates the #1076 battery under one global multiple-comparisons correction. | one-shot | #1076 |
 | `research/regime_1080_unsupervised_vol_model.py` | Evidence run for the unsupervised vol-state bake-off. | one-shot | #1080 |
 | `research/regime_1095_enriched_vol_model.py` | Evidence run extending the bake-off to the enriched feature matrix. | one-shot | #1095 |
+| `research/regime_1500_gmm_stability_sweep.py` | Decoder-smoothing sweep (`filter_window`, off-by-default `decode_min_dwell` / `decode_stickiness`) for the #1095 `volume:gmm:k=5` stability near-miss, re-scored through the unchanged gate; context sweep over the other Bonferroni-passing BTC candidates. | one-shot | #1500 |
 | `research/regime_1120_trail_validation.py` | Incumbent vs proposed regime opening-trail defaults. | one-shot | #1120 |
 | `research/regime_1152_exit_retune.py` | M6 entry-locked retune of ranging ratchet ladders + B2 ranging TP group. | one-shot | #1152 |
 | `research/regime_1211_incumbent_baseline.py` | Re-measures whether the promotion gate's incumbent baseline is trustworthy, or whether the shipping rule must be redesigned. | one-shot | #1211 |

--- a/docs/research/1500-artifacts/regime_1500_btc.json
+++ b/docs/research/1500-artifacts/regime_1500_btc.json
@@ -1,0 +1,7224 @@
+{
+  "issue": 1500,
+  "symbol": "BTC/USDT",
+  "timeframe": "1h",
+  "in_sample": "is",
+  "held_out": "oos",
+  "eval_windows": [
+    "is",
+    "oos",
+    "2023",
+    "2024",
+    "2025H1"
+  ],
+  "base_filter_window": 64,
+  "n_perm": 1799,
+  "bonferroni_alpha": 0.0011111111111111111,
+  "bonferroni_denominator": 45,
+  "non_degeneracy_thresholds": {
+    "min_active_labels": 5,
+    "max_occupancy": 0.39199381938880623,
+    "min_transition_rate": 0.0686763372620127
+  },
+  "handrule_held_out": {
+    "all_enriched": {
+      "kruskal_h": 80.47242092503984,
+      "p_value": 0.005,
+      "transition_rate": 0.13860225140712945
+    },
+    "htf": {
+      "kruskal_h": 80.47242092503984,
+      "p_value": 0.005,
+      "transition_rate": 0.13860225140712945
+    },
+    "volume": {
+      "kruskal_h": 85.6949486268586,
+      "p_value": 0.0044444444444444444,
+      "transition_rate": 0.1373526745240254
+    }
+  },
+  "candidates": [
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 5,
+      "primary": true,
+      "states": [
+        "ranging_directional_down",
+        "trending_down_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_up_choppy"
+      ],
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {},
+        "duplicate_names": []
+      },
+      "transition_diagonal": [
+        0.4321475625823452,
+        0.8207236842105263,
+        0.7069575471698113,
+        0.7685525349008082,
+        0.8202959830866807
+      ],
+      "handrule_transition_rate": 0.1373526745240254,
+      "sweep": [
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.32464600861892057,
+              "transition_rate": 0.2395320197044335,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3170179016542035,
+              "transition_rate": 0.2540797824116047,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 107.8221828444548
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.28405697220307835,
+              "transition_rate": 0.2530729465824239,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.30559688680325053,
+              "transition_rate": 0.2557234432234432,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3383756108913195,
+              "transition_rate": 0.2532588454376164,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2540797824116047,
+          "held_out_kruskal_h": 107.8221828444548,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.2395320197044335,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 8,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=8",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.32464600861892057,
+              "transition_rate": 0.2395320197044335,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3170179016542035,
+              "transition_rate": 0.2540797824116047,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 107.8221828444548
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.28405697220307835,
+              "transition_rate": 0.2530729465824239,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.30559688680325053,
+              "transition_rate": 0.2557234432234432,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3383756108913195,
+              "transition_rate": 0.2532588454376164,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2540797824116047,
+          "held_out_kruskal_h": 107.8221828444548,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.2395320197044335,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 16,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=16",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.32464600861892057,
+              "transition_rate": 0.2395320197044335,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3170179016542035,
+              "transition_rate": 0.2540797824116047,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 107.8221828444548
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.28405697220307835,
+              "transition_rate": 0.2530729465824239,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.30559688680325053,
+              "transition_rate": 0.2557234432234432,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3383756108913195,
+              "transition_rate": 0.2532588454376164,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2540797824116047,
+          "held_out_kruskal_h": 107.8221828444548,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.2395320197044335,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 32,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=32",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.32464600861892057,
+              "transition_rate": 0.2395320197044335,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3170179016542035,
+              "transition_rate": 0.2540797824116047,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 107.8221828444548
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.28405697220307835,
+              "transition_rate": 0.2530729465824239,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.30559688680325053,
+              "transition_rate": 0.2557234432234432,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3383756108913195,
+              "transition_rate": 0.2532588454376164,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2540797824116047,
+          "held_out_kruskal_h": 107.8221828444548,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.2395320197044335,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 128,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=128",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.32464600861892057,
+              "transition_rate": 0.2395320197044335,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3170179016542035,
+              "transition_rate": 0.2540797824116047,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 107.8221828444548
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.28405697220307835,
+              "transition_rate": 0.2530729465824239,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.30559688680325053,
+              "transition_rate": 0.2557234432234432,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3383756108913195,
+              "transition_rate": 0.2532588454376164,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2540797824116047,
+          "held_out_kruskal_h": 107.8221828444548,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.2395320197044335,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=256",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.32464600861892057,
+              "transition_rate": 0.2395320197044335,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3170179016542035,
+              "transition_rate": 0.2540797824116047,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 107.8221828444548
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.28405697220307835,
+              "transition_rate": 0.2530729465824239,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.30559688680325053,
+              "transition_rate": 0.2557234432234432,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3383756108913195,
+              "transition_rate": 0.2532588454376164,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2540797824116047,
+          "held_out_kruskal_h": 107.8221828444548,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.2395320197044335,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 512,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=512",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.32464600861892057,
+              "transition_rate": 0.2395320197044335,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3170179016542035,
+              "transition_rate": 0.2540797824116047,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 107.8221828444548
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.28405697220307835,
+              "transition_rate": 0.2530729465824239,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.30559688680325053,
+              "transition_rate": 0.2557234432234432,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3383756108913195,
+              "transition_rate": 0.2532588454376164,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2540797824116047,
+          "held_out_kruskal_h": 107.8221828444548,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.2395320197044335,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 2,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=2",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.32669813256720703,
+              "transition_rate": 0.10652709359605911,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.32313618853387716,
+              "transition_rate": 0.11831368993653672,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 73.01711034126674
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.30151619572708477,
+              "transition_rate": 0.12257323377369328,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.3153256266453016,
+              "transition_rate": 0.111492673992674,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3500116360251338,
+              "transition_rate": 0.11941340782122906,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.11831368993653672,
+          "held_out_kruskal_h": 73.01711034126674,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.10652709359605911,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=3",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.33490662836035295,
+              "transition_rate": 0.07163382594417077,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3342397462043961,
+              "transition_rate": 0.07932910244786945,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 78.86487746584316
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3226510452561452,
+              "transition_rate": 0.07581849511774842,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.32356644157033304,
+              "transition_rate": 0.07177197802197802,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3516406795438678,
+              "transition_rate": 0.07518621973929236,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.07932910244786945,
+          "held_out_kruskal_h": 78.86487746584316,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.07163382594417077,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 4,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=4",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.33059716806895134,
+              "transition_rate": 0.05213464696223317,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0521 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.31452526625878086,
+              "transition_rate": 0.05666364460562103,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0567 < 0.0687"
+              ],
+              "kruskal_h": 75.35819897392139
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3335630599586492,
+              "transition_rate": 0.050660539919586446,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0507 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.33318072564953644,
+              "transition_rate": 0.04990842490842491,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0499 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.34791715150104724,
+              "transition_rate": 0.05330540037243948,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0533 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.05666364460562103,
+          "held_out_kruskal_h": 75.35819897392139,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.04990842490842491,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=6",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.34988713318284426,
+              "transition_rate": 0.03345648604269294,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0335 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.32154996600951735,
+              "transition_rate": 0.033318223028105165,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0333 < 0.0687"
+              ],
+              "kruskal_h": 54.56305192739637
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3610153916838962,
+              "transition_rate": 0.03170591614014934,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0317 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.31944603410781736,
+              "transition_rate": 0.029990842490842492,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0300 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3418664184314638,
+              "transition_rate": 0.033054003724394786,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0331 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.033318223028105165,
+          "held_out_kruskal_h": 54.56305192739637,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.029990842490842492,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 8,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=8",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.36343115124153497,
+              "transition_rate": 0.02442528735632184,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0244 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.32789485610695673,
+              "transition_rate": 0.02470534904805077,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0247 < 0.0687"
+              ],
+              "kruskal_h": 76.10398687865381
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3753733057661383,
+              "transition_rate": 0.021826536473291212,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0218 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.32379535309602836,
+              "transition_rate": 0.020833333333333332,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0208 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3618803816616244,
+              "transition_rate": 0.02281191806331471,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0228 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.02470534904805077,
+          "held_out_kruskal_h": 76.10398687865381,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.020833333333333332,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 12,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=12",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.32423558382926326,
+              "transition_rate": 0.013546798029556651,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0135 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.36301835486063905,
+              "transition_rate": 0.012919310970081596,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0129 < 0.0687"
+              ],
+              "kruskal_h": 105.79558176364299
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.36526533425223984,
+              "transition_rate": 0.012291786329695577,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0123 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 4,
+              "max_occupancy": 0.2657662813322651,
+              "transition_rate": 0.012591575091575092,
+              "ok": false,
+              "reasons": [
+                "min_active_labels: 4 < 5",
+                "min_transition_rate: 0.0126 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.34442634396090294,
+              "transition_rate": 0.012802607076350093,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0128 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.012919310970081596,
+          "held_out_kruskal_h": 105.79558176364299,
+          "min_active_labels": 4,
+          "min_transition_rate": 0.012291786329695577,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 24,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=24",
+          "windows": {
+            "is": {
+              "active_labels": 4,
+              "max_occupancy": 0.38107941719679866,
+              "transition_rate": 0.0028735632183908046,
+              "ok": false,
+              "reasons": [
+                "min_active_labels: 4 < 5",
+                "min_transition_rate: 0.0029 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 4,
+              "max_occupancy": 0.5687740765918876,
+              "transition_rate": 0.001813236627379873,
+              "ok": false,
+              "reasons": [
+                "min_active_labels: 4 < 5",
+                "max_occupancy: 0.569 > 0.392",
+                "min_transition_rate: 0.0018 < 0.0687"
+              ],
+              "kruskal_h": 356.2432573089918
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.4130484723179417,
+              "transition_rate": 0.002871912693854107,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.413 > 0.392",
+                "min_transition_rate: 0.0029 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 4,
+              "max_occupancy": 0.7155774293235665,
+              "transition_rate": 0.0013736263736263737,
+              "ok": false,
+              "reasons": [
+                "min_active_labels: 4 < 5",
+                "max_occupancy: 0.716 > 0.392",
+                "min_transition_rate: 0.0014 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 3,
+              "max_occupancy": 0.6101931580172213,
+              "transition_rate": 0.0011638733705772813,
+              "ok": false,
+              "reasons": [
+                "min_active_labels: 3 < 5",
+                "max_occupancy: 0.610 > 0.392",
+                "min_transition_rate: 0.0012 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.001813236627379873,
+          "held_out_kruskal_h": 356.2432573089918,
+          "min_active_labels": 3,
+          "min_transition_rate": 0.0011638733705772813,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 1.0
+          },
+          "label": "fw=64 stick=1",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.32115739790683356,
+              "transition_rate": 0.22311165845648603,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.31067301155676413,
+              "transition_rate": 0.23526745240253852,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 103.82584886488439
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.28210429588789343,
+              "transition_rate": 0.23136128661688685,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.29987409866086756,
+              "transition_rate": 0.23363095238095238,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3353502443565278,
+              "transition_rate": 0.23905959031657356,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.23526745240253852,
+          "held_out_kruskal_h": 103.82584886488439,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.22311165845648603,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 2.0
+          },
+          "label": "fw=64 stick=2",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.316232300430946,
+              "transition_rate": 0.21120689655172414,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.30636755041921593,
+              "transition_rate": 0.22121486854034453,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 108.88423470992893
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.2813002526992878,
+              "transition_rate": 0.2209075244112579,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.2967837930639808,
+              "transition_rate": 0.22538919413919414,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3299976727949732,
+              "transition_rate": 0.2325418994413408,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.22121486854034453,
+          "held_out_kruskal_h": 108.88423470992893,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.21120689655172414,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.3104863533757439,
+              "transition_rate": 0.19601806239737274,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.2957171991842284,
+              "transition_rate": 0.20489573889392565,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 114.10599001587616
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.27705031013094417,
+              "transition_rate": 0.20344629523262492,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.28694059745908207,
+              "transition_rate": 0.21153846153846154,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3206888526879218,
+              "transition_rate": 0.2181098696461825,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.20489573889392565,
+          "held_out_kruskal_h": 114.10599001587616,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.19601806239737274,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 10.0
+          },
+          "label": "fw=64 stick=10",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.30248306997742663,
+              "transition_rate": 0.18411330049261085,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.285746657602538,
+              "transition_rate": 0.19265639165911153,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 115.1759807480521
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.2741787273144958,
+              "transition_rate": 0.18793796668581275,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.27320590591736293,
+              "transition_rate": 0.19539835164835165,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3113800325808704,
+              "transition_rate": 0.2048417132216015,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.19265639165911153,
+          "held_out_kruskal_h": 115.1759807480521,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.18411330049261085,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.29222245023599425,
+              "transition_rate": 0.17118226600985223,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.2748697031497847,
+              "transition_rate": 0.18177697189483227,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 110.71117580833743
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.2694693314955203,
+              "transition_rate": 0.17323377369327972,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.2634771660753119,
+              "transition_rate": 0.18017399267399267,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.2978822434256458,
+              "transition_rate": 0.18808193668528864,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.18177697189483227,
+          "held_out_kruskal_h": 110.71117580833743,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.17118226600985223,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 50.0
+          },
+          "label": "fw=64 stick=50",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.2864765031807921,
+              "transition_rate": 0.16071428571428573,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.27147065488329936,
+              "transition_rate": 0.17203082502266545,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 114.74148849471385
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.2839421088904204,
+              "transition_rate": 0.1614014933946008,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.25741101064438593,
+              "transition_rate": 0.17021520146520147,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.2904351873400047,
+              "transition_rate": 0.17946927374301677,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.17203082502266545,
+          "held_out_kruskal_h": 114.74148849471385,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.16071428571428573,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=256 dwell=3",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.33490662836035295,
+              "transition_rate": 0.07163382594417077,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3342397462043961,
+              "transition_rate": 0.07932910244786945,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 78.86487746584316
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3226510452561452,
+              "transition_rate": 0.07581849511774842,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.32356644157033304,
+              "transition_rate": 0.07177197802197802,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3516406795438678,
+              "transition_rate": 0.07518621973929236,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.07932910244786945,
+          "held_out_kruskal_h": 78.86487746584316,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.07163382594417077,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=256 dwell=6",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.34988713318284426,
+              "transition_rate": 0.03345648604269294,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0335 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.32154996600951735,
+              "transition_rate": 0.033318223028105165,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0333 < 0.0687"
+              ],
+              "kruskal_h": 54.56305192739637
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3610153916838962,
+              "transition_rate": 0.03170591614014934,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0317 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.31944603410781736,
+              "transition_rate": 0.029990842490842492,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0300 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3418664184314638,
+              "transition_rate": 0.033054003724394786,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0331 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.033318223028105165,
+          "held_out_kruskal_h": 54.56305192739637,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.029990842490842492,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 dwell=3 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.31500102606197417,
+              "transition_rate": 0.07614942528735633,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3013822796283707,
+              "transition_rate": 0.08930190389845875,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 80.28401210196353
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.29037445439926485,
+              "transition_rate": 0.08052843193566915,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.29621151424974246,
+              "transition_rate": 0.07783882783882784,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3288340702815918,
+              "transition_rate": 0.0824022346368715,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.08930190389845875,
+          "held_out_kruskal_h": 80.28401210196353,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.07614942528735633,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 dwell=3 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.29345372460496616,
+              "transition_rate": 0.0827175697865353,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.274643099932019,
+              "transition_rate": 0.0929283771532185,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 57.55411074019685
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.277394900068918,
+              "transition_rate": 0.08294083859850661,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.26496509099233145,
+              "transition_rate": 0.08173076923076923,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.30207121247381896,
+              "transition_rate": 0.08682495344506518,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.0929283771532185,
+          "held_out_kruskal_h": 57.55411074019685,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.08173076923076923,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 dwell=6 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.3363431151241535,
+              "transition_rate": 0.039614121510673235,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0396 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.30319510537049627,
+              "transition_rate": 0.04079782411604715,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0408 < 0.0687"
+              ],
+              "kruskal_h": 80.65148806215439
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.315759246496669,
+              "transition_rate": 0.03917288914417002,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0392 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.3170424630880165,
+              "transition_rate": 0.0347985347985348,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0348 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3341866418431464,
+              "transition_rate": 0.03677839851024209,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0368 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.04079782411604715,
+          "held_out_kruskal_h": 80.65148806215439,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.0347985347985348,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 dwell=6 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.3178739995895752,
+              "transition_rate": 0.041666666666666664,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0417 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.2957171991842284,
+              "transition_rate": 0.04465095194922938,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0447 < 0.0687"
+              ],
+              "kruskal_h": 77.3898213685934
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3000229726625316,
+              "transition_rate": 0.04250430786904078,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0425 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.28808515508755866,
+              "transition_rate": 0.04006410256410257,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0401 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.324877821736095,
+              "transition_rate": 0.039804469273743016,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0398 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.04465095194922938,
+          "held_out_kruskal_h": 77.3898213685934,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.039804469273743016,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=256 dwell=3 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.29345372460496616,
+              "transition_rate": 0.0827175697865353,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.274643099932019,
+              "transition_rate": 0.0929283771532185,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 57.55411074019685
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.277394900068918,
+              "transition_rate": 0.08294083859850661,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.26496509099233145,
+              "transition_rate": 0.08173076923076923,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.30207121247381896,
+              "transition_rate": 0.08682495344506518,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.0929283771532185,
+          "held_out_kruskal_h": 57.55411074019685,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.08173076923076923,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=256 dwell=6 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.3178739995895752,
+              "transition_rate": 0.041666666666666664,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0417 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.2957171991842284,
+              "transition_rate": 0.04465095194922938,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0447 < 0.0687"
+              ],
+              "kruskal_h": 77.3898213685934
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3000229726625316,
+              "transition_rate": 0.04250430786904078,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0425 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.28808515508755866,
+              "transition_rate": 0.04006410256410257,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0401 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.324877821736095,
+              "transition_rate": 0.039804469273743016,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0398 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.04465095194922938,
+          "held_out_kruskal_h": 77.3898213685934,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.039804469273743016,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 100.0
+          },
+          "label": "fw=64 stick=100",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.2825774676790478,
+              "transition_rate": 0.15373563218390804,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.2648991615680943,
+              "transition_rate": 0.1613780598368087,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 113.68433629156243
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.2968067999081094,
+              "transition_rate": 0.1514072372199885,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.2521460455533936,
+              "transition_rate": 0.16311813186813187,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.2832208517570398,
+              "transition_rate": 0.17318435754189945,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.1613780598368087,
+          "held_out_kruskal_h": 113.68433629156243,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.1514072372199885,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 200.0
+          },
+          "label": "fw=64 stick=200",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.2774471578083316,
+              "transition_rate": 0.14675697865353038,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.274643099932019,
+              "transition_rate": 0.15616500453309157,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 105.59361225186876
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3087525844245348,
+              "transition_rate": 0.14474439977024697,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.2637060776010072,
+              "transition_rate": 0.15556318681318682,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.2767046776821038,
+              "transition_rate": 0.16410614525139663,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.15616500453309157,
+          "held_out_kruskal_h": 105.59361225186876,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.14474439977024697,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 500.0
+          },
+          "label": "fw=64 stick=500",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.2717012107531295,
+              "transition_rate": 0.14183087027914615,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.28891910265125764,
+              "transition_rate": 0.14936536718041704,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 90.68338243267499
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.32219159200551345,
+              "transition_rate": 0.13360137851809306,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.2756094769371638,
+              "transition_rate": 0.14846611721611722,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.2680940190830812,
+              "transition_rate": 0.15758845437616387,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.14936536718041704,
+          "held_out_kruskal_h": 90.68338243267499,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.13360137851809306,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 1000.0
+          },
+          "label": "fw=64 stick=1000",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.266160476092756,
+              "transition_rate": 0.13793103448275862,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.2954905959664627,
+              "transition_rate": 0.14641885766092474,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 90.70978048247525
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.33264415345738574,
+              "transition_rate": 0.12578977599080987,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.2860249513563008,
+              "transition_rate": 0.1423992673992674,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.26064696299744006,
+              "transition_rate": 0.14967411545623835,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.14641885766092474,
+          "held_out_kruskal_h": 90.70978048247525,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.12578977599080987,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 2,
+            "decode_stickiness": 1.0
+          },
+          "label": "fw=64 dwell=2 stick=1",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.32751898214652164,
+              "transition_rate": 0.10940065681444992,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.31905733061409475,
+              "transition_rate": 0.1199002719854941,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 74.7842232522562
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.29623248334481966,
+              "transition_rate": 0.12199885123492246,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.3065125329060318,
+              "transition_rate": 0.11332417582417582,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3416336979287875,
+              "transition_rate": 0.11941340782122906,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.1199002719854941,
+          "held_out_kruskal_h": 74.7842232522562,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.10940065681444992,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 2,
+            "decode_stickiness": 2.0
+          },
+          "label": "fw=64 dwell=2 stick=2",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.3227990970654628,
+              "transition_rate": 0.11001642036124795,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3136188533877181,
+              "transition_rate": 0.12330009066183137,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 77.28142161527649
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.2939352170916609,
+              "transition_rate": 0.11843767949454337,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.3014764793407348,
+              "transition_rate": 0.1130952380952381,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.33302303932976496,
+              "transition_rate": 0.12174115456238362,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.12330009066183137,
+          "held_out_kruskal_h": 77.28142161527649,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.11001642036124795,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 2,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 dwell=2 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.3125384773240304,
+              "transition_rate": 0.11042692939244664,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.29979605710401086,
+              "transition_rate": 0.1242067089755213,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 80.94504620547195
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.28750287158281645,
+              "transition_rate": 0.11556576680068927,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.2896875357674259,
+              "transition_rate": 0.11767399267399267,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3206888526879218,
+              "transition_rate": 0.12406890130353818,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.1242067089755213,
+          "held_out_kruskal_h": 80.94504620547195,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.11042692939244664,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 2,
+            "decode_stickiness": 10.0
+          },
+          "label": "fw=64 dwell=2 stick=10",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.30084137081879747,
+              "transition_rate": 0.11371100164203612,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.2873328801268978,
+              "transition_rate": 0.12669990933816863,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 74.71261024429987
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.28233402251320927,
+              "transition_rate": 0.11395749569213096,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.27354927320590594,
+              "transition_rate": 0.11836080586080586,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3076565045380498,
+              "transition_rate": 0.12406890130353818,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.12669990933816863,
+          "held_out_kruskal_h": 74.71261024429987,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.11371100164203612,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 2,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 dwell=2 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.28832341473424994,
+              "transition_rate": 0.11781609195402298,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.2735100838431906,
+              "transition_rate": 0.1285131459655485,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 59.58809688727706
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.2739490006891799,
+              "transition_rate": 0.11315336013785181,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.2622181526839876,
+              "transition_rate": 0.11916208791208792,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.29508959739353036,
+              "transition_rate": 0.12779329608938547,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.1285131459655485,
+          "held_out_kruskal_h": 59.58809688727706,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.11315336013785181,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 2,
+            "decode_stickiness": 50.0
+          },
+          "label": "fw=64 dwell=2 stick=50",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.28586086599630617,
+              "transition_rate": 0.11863711001642036,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.2698844323589395,
+              "transition_rate": 0.12601994560290117,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 66.73562301450329
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.28600964851826327,
+              "transition_rate": 0.10993681792073522,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.25454961657319447,
+              "transition_rate": 0.11492673992673992,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.2846171747730975,
+              "transition_rate": 0.12756052141527002,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.12601994560290117,
+          "held_out_kruskal_h": 66.73562301450329,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.10993681792073522,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 2,
+            "decode_stickiness": 100.0
+          },
+          "label": "fw=64 dwell=2 stick=100",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.2809357685204186,
+              "transition_rate": 0.11802134646962233,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.26444595513256286,
+              "transition_rate": 0.12330009066183137,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 71.95126312243883
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3002526992878475,
+              "transition_rate": 0.10867317633543941,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.2496280187707451,
+              "transition_rate": 0.11240842490842491,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.27740283919013264,
+              "transition_rate": 0.12569832402234637,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.12330009066183137,
+          "held_out_kruskal_h": 71.95126312243883,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.10867317633543941,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 1.0
+          },
+          "label": "fw=64 dwell=3 stick=1",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.3299815308844654,
+              "transition_rate": 0.0736863711001642,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.32426920462270564,
+              "transition_rate": 0.08318223028105168,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 86.12890834078644
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3090971743625086,
+              "transition_rate": 0.07765651924181505,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.3150967151196063,
+              "transition_rate": 0.07451923076923077,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3490807540144287,
+              "transition_rate": 0.0765828677839851,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.08318223028105168,
+          "held_out_kruskal_h": 86.12890834078644,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.0736863711001642,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 2.0
+          },
+          "label": "fw=64 dwell=3 stick=2",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.32115739790683356,
+              "transition_rate": 0.07573891625615764,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.31588488556537503,
+              "transition_rate": 0.08567543064369901,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 87.58269502223993
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3054215483574546,
+              "transition_rate": 0.07800114876507754,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.3089161039258327,
+              "transition_rate": 0.07566391941391941,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3393064929020247,
+              "transition_rate": 0.08007448789571694,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.08567543064369901,
+          "held_out_kruskal_h": 87.58269502223993,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.07566391941391941,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 3.0
+          },
+          "label": "fw=64 dwell=3 stick=3",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.319720911143033,
+              "transition_rate": 0.0769704433497537,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3102198051212327,
+              "transition_rate": 0.08703535811423391,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 86.81217778488099
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.2972662531587411,
+              "transition_rate": 0.07869040781160253,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.3020487581549731,
+              "transition_rate": 0.07692307692307693,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3276704677682104,
+              "transition_rate": 0.08077281191806332,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.08703535811423391,
+          "held_out_kruskal_h": 86.81217778488099,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.07692307692307693,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 10.0
+          },
+          "label": "fw=64 dwell=3 stick=10",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.3061768930843423,
+              "transition_rate": 0.0798440065681445,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.28755948334466347,
+              "transition_rate": 0.09338168631006347,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 68.05518362931616
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.2831380657018148,
+              "transition_rate": 0.0832854681217691,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.27480828659723017,
+              "transition_rate": 0.07921245421245421,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3216197346986269,
+              "transition_rate": 0.08356610800744879,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.09338168631006347,
+          "held_out_kruskal_h": 68.05518362931616,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.07921245421245421,
+          "reaches_band": true
+        }
+      ],
+      "best_setting": {
+        "filter_window": 64,
+        "decode_min_dwell": 3,
+        "decode_stickiness": 2.0
+      },
+      "best_label": "fw=64 dwell=3 stick=2",
+      "best_reaches_band": true,
+      "rescored": {
+        "verdict": {
+          "target": "volatility",
+          "gate_semantics": "candidate-self-v2 (#1211)",
+          "separation_ok": true,
+          "stability_ok": true,
+          "model_separation_real": true,
+          "incumbent_trustworthy": true,
+          "ship": true,
+          "detail": {
+            "handrule_kruskal_h": 85.6949486268586,
+            "model_kruskal_h": 87.58269502223993,
+            "handrule_p_value": 0.0044444444444444444,
+            "model_p_value": 0.016666666666666666,
+            "handrule_transition_rate": 0.1373526745240254,
+            "model_transition_rate": 0.08567543064369901
+          }
+        },
+        "model_kruskal_h": 87.58269502223993,
+        "model_p_value": 0.016666666666666666,
+        "passes_bonferroni": false,
+        "stability_gain": 0.05167724388032638,
+        "non_degenerate_all": true,
+        "coverage": {
+          "ranging_directional_down": {
+            "count": 643,
+            "pct": 0.14570586902334012
+          },
+          "ranging_directional_up": {
+            "count": 1394,
+            "pct": 0.31588488556537503
+          },
+          "ranging_volatile": {
+            "count": 1124,
+            "pct": 0.25470201676863813
+          },
+          "trending_down_choppy": {
+            "count": 752,
+            "pct": 0.1704056197598006
+          },
+          "trending_up_choppy": {
+            "count": 500,
+            "pct": 0.11330160888284614
+          }
+        },
+        "full_bar": false
+      }
+    },
+    {
+      "subset": "volume",
+      "family": "hmm",
+      "k": 7,
+      "primary": false,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional",
+        "ranging_directional_down",
+        "trending_down_clean",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.038148833842680155
+          },
+          "3": {
+            "from": "trending_down_choppy",
+            "to": "trending_down_clean",
+            "displacement_z": 2.1201433775261105
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.26759073239144593
+          }
+        },
+        "duplicate_names": []
+      },
+      "transition_diagonal": [
+        0.8895348837209303,
+        0.5282331511839709,
+        0.8312236286919831,
+        0.8917431192660551,
+        0.8335500650195059,
+        0.8261997405966277,
+        0.9319852941176471
+      ],
+      "handrule_transition_rate": 0.1373526745240254,
+      "sweep": [
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.20357069567001848,
+              "transition_rate": 0.20853858784893267,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.1731248583729889,
+              "transition_rate": 0.2042157751586582,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 165.55203122345847
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.19722030783367792,
+              "transition_rate": 0.21355542791499138,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.1839304108961886,
+              "transition_rate": 0.21943681318681318,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.1999069117989295,
+              "transition_rate": 0.2169459962756052,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2042157751586582,
+          "held_out_kruskal_h": 165.55203122345847,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.2042157751586582,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 16,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=16",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.20357069567001848,
+              "transition_rate": 0.20853858784893267,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.1731248583729889,
+              "transition_rate": 0.2042157751586582,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 165.55203122345847
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.1968757178957041,
+              "transition_rate": 0.21355542791499138,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.1839304108961886,
+              "transition_rate": 0.21943681318681318,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.1999069117989295,
+              "transition_rate": 0.2169459962756052,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2042157751586582,
+          "held_out_kruskal_h": 165.55203122345847,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.2042157751586582,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=256",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.20357069567001848,
+              "transition_rate": 0.20853858784893267,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.1731248583729889,
+              "transition_rate": 0.2042157751586582,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 165.55203122345847
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.19722030783367792,
+              "transition_rate": 0.21355542791499138,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.1839304108961886,
+              "transition_rate": 0.21943681318681318,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.1999069117989295,
+              "transition_rate": 0.2169459962756052,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2042157751586582,
+          "held_out_kruskal_h": 165.55203122345847,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.2042157751586582,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=3",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.22019289965113892,
+              "transition_rate": 0.08045977011494253,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.19782460910944935,
+              "transition_rate": 0.0727561196736174,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 164.2963888820923
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.22237537330576615,
+              "transition_rate": 0.07271682940838599,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.18862309717294265,
+              "transition_rate": 0.07738095238095238,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.22015359553176636,
+              "transition_rate": 0.07309124767225327,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.0727561196736174,
+          "held_out_kruskal_h": 164.2963888820923,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.07271682940838599,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=6",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.24871742253232096,
+              "transition_rate": 0.04310344827586207,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0431 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.2173124858372989,
+              "transition_rate": 0.03830462375339982,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0383 < 0.0687"
+              ],
+              "kruskal_h": 136.18805327650807
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.2396048702044567,
+              "transition_rate": 0.03813900057438254,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0381 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.20499027126015795,
+              "transition_rate": 0.03663003663003663,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0366 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.2390039562485455,
+              "transition_rate": 0.03910614525139665,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0391 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.03830462375339982,
+          "held_out_kruskal_h": 136.18805327650807,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.03663003663003663,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.2002872973527601,
+              "transition_rate": 0.17959770114942528,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.17471108089734874,
+              "transition_rate": 0.17316409791477788,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 173.71246007078116
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.1919365954514128,
+              "transition_rate": 0.1765651924181505,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.1850749685246652,
+              "transition_rate": 0.18108974358974358,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.19501978124272748,
+              "transition_rate": 0.18202979515828677,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.17316409791477788,
+          "held_out_kruskal_h": 173.71246007078116,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.17316409791477788,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.19597783706135852,
+              "transition_rate": 0.16194581280788178,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.17539089055064583,
+              "transition_rate": 0.15231187669990934,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 172.80410785316417
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.18780151619572708,
+              "transition_rate": 0.15462377943710512,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.18724962801877074,
+              "transition_rate": 0.16563644688644688,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.19036537118920177,
+              "transition_rate": 0.162243947858473,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.15231187669990934,
+          "held_out_kruskal_h": 172.80410785316417,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.15231187669990934,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 dwell=6 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.21588343935973733,
+              "transition_rate": 0.04700328407224959,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0470 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.2080217539089055,
+              "transition_rate": 0.04465095194922938,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0447 < 0.0687"
+              ],
+              "kruskal_h": 136.37914612446548
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.20778773259820812,
+              "transition_rate": 0.045605973578403215,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0456 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.20052649650909923,
+              "transition_rate": 0.042010073260073263,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0420 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.20898301140330464,
+              "transition_rate": 0.043761638733705775,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0438 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.04465095194922938,
+          "held_out_kruskal_h": 136.37914612446548,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.042010073260073263,
+          "reaches_band": false
+        }
+      ],
+      "best_setting": {
+        "filter_window": 64,
+        "decode_min_dwell": 3,
+        "decode_stickiness": 0.0
+      },
+      "best_label": "fw=64 dwell=3",
+      "best_reaches_band": true,
+      "rescored": {
+        "verdict": {
+          "target": "volatility",
+          "gate_semantics": "candidate-self-v2 (#1211)",
+          "separation_ok": true,
+          "stability_ok": true,
+          "model_separation_real": true,
+          "incumbent_trustworthy": true,
+          "ship": true,
+          "detail": {
+            "handrule_kruskal_h": 85.6949486268586,
+            "model_kruskal_h": 164.2963888820923,
+            "handrule_p_value": 0.0044444444444444444,
+            "model_p_value": 0.0022222222222222222,
+            "handrule_transition_rate": 0.1373526745240254,
+            "model_transition_rate": 0.0727561196736174
+          }
+        },
+        "model_kruskal_h": 164.2963888820923,
+        "model_p_value": 0.0022222222222222222,
+        "passes_bonferroni": false,
+        "stability_gain": 0.06459655485040798,
+        "non_degenerate_all": true,
+        "coverage": {
+          "ranging_directional": {
+            "count": 278,
+            "pct": 0.06299569453886245
+          },
+          "ranging_directional_down": {
+            "count": 573,
+            "pct": 0.12984364377974167
+          },
+          "ranging_directional_up": {
+            "count": 789,
+            "pct": 0.1787899388171312
+          },
+          "ranging_volatile": {
+            "count": 873,
+            "pct": 0.19782460910944935
+          },
+          "trending_down_choppy": {
+            "count": 527,
+            "pct": 0.11941989576251982
+          },
+          "trending_down_clean": {
+            "count": 821,
+            "pct": 0.18604124178563336
+          },
+          "trending_up_choppy": {
+            "count": 552,
+            "pct": 0.12508497620666215
+          }
+        },
+        "full_bar": false
+      }
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 6,
+      "primary": false,
+      "states": [
+        "ranging_directional_up",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_down",
+        "trending_up_choppy"
+      ],
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.2518614670708566
+          },
+          "1": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.8258689590142336
+          }
+        },
+        "duplicate_names": []
+      },
+      "transition_diagonal": [
+        0.69875,
+        0.7137850467289719,
+        0.8067729083665338,
+        0.7812097812097812,
+        0.4145985401459854,
+        0.8434442270058709
+      ],
+      "handrule_transition_rate": 0.1373526745240254,
+      "sweep": [
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3143853888774882,
+              "transition_rate": 0.23399014778325122,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.271017448447768,
+              "transition_rate": 0.2454669084315503,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 112.1905908468234
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.3136917068688261,
+              "transition_rate": 0.23653072946582424,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.27000114455762847,
+              "transition_rate": 0.24565018315018314,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.3090528275541075,
+              "transition_rate": 0.24371508379888268,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2454669084315503,
+          "held_out_kruskal_h": 112.1905908468234,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.23399014778325122,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 16,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=16",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3143853888774882,
+              "transition_rate": 0.23399014778325122,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.271017448447768,
+              "transition_rate": 0.2454669084315503,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 112.1905908468234
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.3136917068688261,
+              "transition_rate": 0.23653072946582424,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.27000114455762847,
+              "transition_rate": 0.24565018315018314,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.3090528275541075,
+              "transition_rate": 0.24371508379888268,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2454669084315503,
+          "held_out_kruskal_h": 112.1905908468234,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.23399014778325122,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=256",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3143853888774882,
+              "transition_rate": 0.23399014778325122,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.271017448447768,
+              "transition_rate": 0.2454669084315503,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 112.1905908468234
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.3136917068688261,
+              "transition_rate": 0.23653072946582424,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.27000114455762847,
+              "transition_rate": 0.24565018315018314,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.3090528275541075,
+              "transition_rate": 0.24371508379888268,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2454669084315503,
+          "held_out_kruskal_h": 112.1905908468234,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.23399014778325122,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=3",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3449620357069567,
+              "transition_rate": 0.0722495894909688,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.3077271697258101,
+              "transition_rate": 0.07615593834995467,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 87.79698532955263
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.3524006432345509,
+              "transition_rate": 0.0739804709936818,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.2955247796726565,
+              "transition_rate": 0.07383241758241758,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.3576914126134512,
+              "transition_rate": 0.07192737430167598,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.07615593834995467,
+          "held_out_kruskal_h": 87.79698532955263,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.07192737430167598,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=6",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3868253642520008,
+              "transition_rate": 0.03776683087027915,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0378 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.3455699070926807,
+              "transition_rate": 0.03377153218495014,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0338 < 0.0687"
+              ],
+              "kruskal_h": 79.28141211880029
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.3744543992648748,
+              "transition_rate": 0.03469270534175761,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0347 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.3291747739498684,
+              "transition_rate": 0.03239468864468865,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0324 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.38212706539446123,
+              "transition_rate": 0.031424581005586594,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0314 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.03377153218495014,
+          "held_out_kruskal_h": 79.28141211880029,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.031424581005586594,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3080238046378001,
+              "transition_rate": 0.19540229885057472,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.2601404939950147,
+              "transition_rate": 0.20874886672710788,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 122.76516886447462
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.30450264185619114,
+              "transition_rate": 0.19701321079839174,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.26050131624127276,
+              "transition_rate": 0.2071886446886447,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.3011403304631138,
+              "transition_rate": 0.2090316573556797,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.20874886672710788,
+          "held_out_kruskal_h": 122.76516886447462,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.19540229885057472,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.30391955674122717,
+              "transition_rate": 0.17754515599343185,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.25470201676863813,
+              "transition_rate": 0.18336355394378967,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 121.83586969844873
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.29738111647139903,
+              "transition_rate": 0.17346352670878806,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.251001487924917,
+              "transition_rate": 0.183264652014652,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.29578775890155923,
+              "transition_rate": 0.18528864059590316,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.18336355394378967,
+          "held_out_kruskal_h": 121.83586969844873,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.17346352670878806,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 dwell=6 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3642520008208496,
+              "transition_rate": 0.04146141215106732,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0415 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.3047813278948561,
+              "transition_rate": 0.03989120580235721,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0399 < 0.0687"
+              ],
+              "kruskal_h": 104.49524473863676
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.33252929014472776,
+              "transition_rate": 0.04273406088454911,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0427 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.2848803937278242,
+              "transition_rate": 0.03983516483516483,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0398 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.34628810798231324,
+              "transition_rate": 0.040968342644320296,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0410 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.03989120580235721,
+          "held_out_kruskal_h": 104.49524473863676,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.03983516483516483,
+          "reaches_band": false
+        }
+      ],
+      "best_setting": {
+        "filter_window": 64,
+        "decode_min_dwell": 3,
+        "decode_stickiness": 0.0
+      },
+      "best_label": "fw=64 dwell=3",
+      "best_reaches_band": true,
+      "rescored": {
+        "verdict": {
+          "target": "volatility",
+          "gate_semantics": "candidate-self-v2 (#1211)",
+          "separation_ok": true,
+          "stability_ok": true,
+          "model_separation_real": true,
+          "incumbent_trustworthy": true,
+          "ship": true,
+          "detail": {
+            "handrule_kruskal_h": 85.6949486268586,
+            "model_kruskal_h": 87.79698532955263,
+            "handrule_p_value": 0.0044444444444444444,
+            "model_p_value": 0.034444444444444444,
+            "handrule_transition_rate": 0.1373526745240254,
+            "model_transition_rate": 0.07615593834995467
+          }
+        },
+        "model_kruskal_h": 87.79698532955263,
+        "model_p_value": 0.034444444444444444,
+        "passes_bonferroni": false,
+        "stability_gain": 0.06119673617407072,
+        "non_degenerate_all": true,
+        "coverage": {
+          "ranging_directional": {
+            "count": 610,
+            "pct": 0.13822796283707228
+          },
+          "ranging_directional_down": {
+            "count": 358,
+            "pct": 0.08112395196011783
+          },
+          "ranging_directional_up": {
+            "count": 827,
+            "pct": 0.1874008610922275
+          },
+          "ranging_volatile": {
+            "count": 1358,
+            "pct": 0.3077271697258101
+          },
+          "trending_down_choppy": {
+            "count": 754,
+            "pct": 0.17085882619533196
+          },
+          "trending_up_choppy": {
+            "count": 506,
+            "pct": 0.11466122818944029
+          }
+        },
+        "full_bar": false
+      }
+    },
+    {
+      "subset": "volume",
+      "family": "gmm",
+      "k": 7,
+      "primary": false,
+      "states": [
+        "ranging_volatile",
+        "ranging_directional",
+        "ranging_directional_down",
+        "trending_down_clean",
+        "ranging_directional_up",
+        "trending_down_choppy",
+        "trending_up_choppy"
+      ],
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.05544765839004477
+          },
+          "3": {
+            "from": "trending_down_choppy",
+            "to": "trending_down_clean",
+            "displacement_z": 2.0169512121570423
+          },
+          "4": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.2448873720148283
+          }
+        },
+        "duplicate_names": []
+      },
+      "transition_diagonal": [
+        0.7271914132379249,
+        0.41124260355029585,
+        0.5555555555555556,
+        0.7890995260663507,
+        0.6853503184713375,
+        0.6823899371069182,
+        0.8276515151515151
+      ],
+      "handrule_transition_rate": 0.1373526745240254,
+      "sweep": [
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.2308639441822286,
+              "transition_rate": 0.2723727422003284,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.18830727396329028,
+              "transition_rate": 0.27810516772438804,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 107.40465933865744
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.244543992648748,
+              "transition_rate": 0.2707639287765652,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.1929724161611537,
+              "transition_rate": 0.27850274725274726,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.21805911100767977,
+              "transition_rate": 0.28049348230912474,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.27810516772438804,
+          "held_out_kruskal_h": 107.40465933865744,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.2707639287765652,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 16,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=16",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.2308639441822286,
+              "transition_rate": 0.2723727422003284,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.18830727396329028,
+              "transition_rate": 0.27810516772438804,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 107.40465933865744
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.244543992648748,
+              "transition_rate": 0.2707639287765652,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.1929724161611537,
+              "transition_rate": 0.27850274725274726,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.21805911100767977,
+              "transition_rate": 0.28049348230912474,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.27810516772438804,
+          "held_out_kruskal_h": 107.40465933865744,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.2707639287765652,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=256",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.2308639441822286,
+              "transition_rate": 0.2723727422003284,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.18830727396329028,
+              "transition_rate": 0.27810516772438804,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 107.40465933865744
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.244543992648748,
+              "transition_rate": 0.2707639287765652,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.1929724161611537,
+              "transition_rate": 0.27850274725274726,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.21805911100767977,
+              "transition_rate": 0.28049348230912474,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.27810516772438804,
+          "held_out_kruskal_h": 107.40465933865744,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.2707639287765652,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=3",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.26841781243587115,
+              "transition_rate": 0.08251231527093596,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.21844550192612736,
+              "transition_rate": 0.08204895738893926,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 81.79215906876925
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.2831380657018148,
+              "transition_rate": 0.08121769098219414,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.21918278585326773,
+              "transition_rate": 0.08092948717948718,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.2569234349546195,
+              "transition_rate": 0.08100558659217877,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.08204895738893926,
+          "held_out_kruskal_h": 81.79215906876925,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.08092948717948718,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=6",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.30699774266365687,
+              "transition_rate": 0.03940886699507389,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0394 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.27169725810106504,
+              "transition_rate": 0.03671804170444243,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0367 < 0.0687"
+              ],
+              "kruskal_h": 75.52871068685272
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.3007121525384792,
+              "transition_rate": 0.03434807581849512,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0343 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.24470642096829576,
+              "transition_rate": 0.033195970695970696,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0332 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.2801954852222481,
+              "transition_rate": 0.03468342644320298,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0347 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.03671804170444243,
+          "held_out_kruskal_h": 75.52871068685272,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.033195970695970696,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.22388672275805457,
+              "transition_rate": 0.2261904761904762,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.18354860639021073,
+              "transition_rate": 0.22642792384406166,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 115.52361280256991
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.23971973351711465,
+              "transition_rate": 0.22354968408960368,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.18587615886459882,
+              "transition_rate": 0.23179945054945056,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.21131021643006748,
+              "transition_rate": 0.23161080074487897,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.22642792384406166,
+          "held_out_kruskal_h": 115.52361280256991,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.22354968408960368,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.21937205007182434,
+              "transition_rate": 0.20053366174055828,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.19306594153636983,
+              "transition_rate": 0.1956029011786038,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 101.81540688594578
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.23535492763611301,
+              "transition_rate": 0.19954049396898335,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.18690626073022776,
+              "transition_rate": 0.20409798534798534,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.21014661391668607,
+              "transition_rate": 0.21252327746741154,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.1956029011786038,
+          "held_out_kruskal_h": 101.81540688594578,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.1956029011786038,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 dwell=6 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.29653191052739586,
+              "transition_rate": 0.044129720853858787,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0441 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.23340131429866304,
+              "transition_rate": 0.04306436990027199,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0431 < 0.0687"
+              ],
+              "kruskal_h": 120.0672540582982
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.2690098782448886,
+              "transition_rate": 0.04250430786904078,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0425 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.21849605127618177,
+              "transition_rate": 0.04178113553113553,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0418 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.2604142424947638,
+              "transition_rate": 0.04422718808193669,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0442 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.04306436990027199,
+          "held_out_kruskal_h": 120.0672540582982,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.04178113553113553,
+          "reaches_band": false
+        }
+      ],
+      "best_setting": {
+        "filter_window": 64,
+        "decode_min_dwell": 3,
+        "decode_stickiness": 0.0
+      },
+      "best_label": "fw=64 dwell=3",
+      "best_reaches_band": true,
+      "rescored": {
+        "verdict": {
+          "target": "volatility",
+          "gate_semantics": "candidate-self-v2 (#1211)",
+          "separation_ok": false,
+          "stability_ok": true,
+          "model_separation_real": false,
+          "incumbent_trustworthy": true,
+          "ship": false,
+          "detail": {
+            "handrule_kruskal_h": 85.6949486268586,
+            "model_kruskal_h": 81.79215906876925,
+            "handrule_p_value": 0.0044444444444444444,
+            "model_p_value": 0.06666666666666667,
+            "handrule_transition_rate": 0.1373526745240254,
+            "model_transition_rate": 0.08204895738893926
+          }
+        },
+        "model_kruskal_h": 81.79215906876925,
+        "model_p_value": 0.06666666666666667,
+        "passes_bonferroni": false,
+        "stability_gain": 0.055303717135086125,
+        "non_degenerate_all": true,
+        "coverage": {
+          "ranging_directional": {
+            "count": 426,
+            "pct": 0.09653297076818491
+          },
+          "ranging_directional_down": {
+            "count": 535,
+            "pct": 0.12123272150464537
+          },
+          "ranging_directional_up": {
+            "count": 811,
+            "pct": 0.18377520960797644
+          },
+          "ranging_volatile": {
+            "count": 964,
+            "pct": 0.21844550192612736
+          },
+          "trending_down_choppy": {
+            "count": 446,
+            "pct": 0.10106503512349875
+          },
+          "trending_down_clean": {
+            "count": 678,
+            "pct": 0.15363698164513936
+          },
+          "trending_up_choppy": {
+            "count": 553,
+            "pct": 0.12531157942442783
+          }
+        },
+        "full_bar": false
+      }
+    },
+    {
+      "subset": "htf",
+      "family": "hmm",
+      "k": 7,
+      "primary": false,
+      "states": [
+        "trending_up_choppy",
+        "trending_up_clean",
+        "ranging_directional",
+        "trending_down_choppy",
+        "ranging_volatile",
+        "ranging_directional_up",
+        "ranging_directional_down"
+      ],
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "trending_up_clean",
+            "displacement_z": 1.3646168140583195
+          },
+          "2": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional",
+            "displacement_z": 0.7366919128894944
+          },
+          "6": {
+            "from": "trending_down_choppy",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.1624036478355435
+          }
+        },
+        "duplicate_names": []
+      },
+      "transition_diagonal": [
+        0.8859060402684564,
+        0.9207547169811321,
+        0.8462585034013606,
+        0.9453237410071943,
+        0.9022662889518414,
+        0.9553571428571429,
+        0.874189364461738
+      ],
+      "handrule_transition_rate": 0.13860225140712945,
+      "sweep": [
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.29693121693121693,
+              "transition_rate": 0.12023708721422523,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.2553341148886284,
+              "transition_rate": 0.11960600375234522,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 164.95642206018056
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.2730778219210096,
+              "transition_rate": 0.11499357251373145,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.23565025032017697,
+              "transition_rate": 0.12377736376339078,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.26223186309954205,
+              "transition_rate": 0.12270973963355834,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.11960600375234522,
+          "held_out_kruskal_h": 164.95642206018056,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.11499357251373145,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 16,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=16",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.29693121693121693,
+              "transition_rate": 0.12023708721422523,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.2550996483001172,
+              "transition_rate": 0.12101313320825516,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 164.80981192336185
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.27331152138350084,
+              "transition_rate": 0.11511043590043239,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.23553382233088835,
+              "transition_rate": 0.12354448067070331,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.26199084116654614,
+              "transition_rate": 0.12270973963355834,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.12101313320825516,
+          "held_out_kruskal_h": 164.80981192336185,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.11511043590043239,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=256",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.29693121693121693,
+              "transition_rate": 0.12023708721422523,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.2553341148886284,
+              "transition_rate": 0.11960600375234522,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 164.95642206018056
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.2730778219210096,
+              "transition_rate": 0.11499357251373145,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.23565025032017697,
+              "transition_rate": 0.12377736376339078,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.26223186309954205,
+              "transition_rate": 0.12270973963355834,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.11960600375234522,
+          "held_out_kruskal_h": 164.95642206018056,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.11499357251373145,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=3",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.3039153439153439,
+              "transition_rate": 0.06562235393734124,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0656 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.26025791324736225,
+              "transition_rate": 0.07434333958724203,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 160.60008957564787
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.2804393549894835,
+              "transition_rate": 0.06474231623232442,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0647 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.23599953428804285,
+              "transition_rate": 0.07149510945505357,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.27042660882140274,
+              "transition_rate": 0.07352941176470588,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.07434333958724203,
+          "held_out_kruskal_h": 160.60008957564787,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.06474231623232442,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=6",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.30158730158730157,
+              "transition_rate": 0.04339542760372565,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0434 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.27033997655334113,
+              "transition_rate": 0.042682926829268296,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0427 < 0.0687"
+              ],
+              "kruskal_h": 188.7688139561069
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.28324374853937834,
+              "transition_rate": 0.036928830197499124,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0369 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.2390266620095471,
+              "transition_rate": 0.04389846297158826,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0439 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.2766931790792962,
+              "transition_rate": 0.041465766634522665,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0415 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.042682926829268296,
+          "held_out_kruskal_h": 188.7688139561069,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.036928830197499124,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.2958730158730159,
+              "transition_rate": 0.10351397121083827,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.25205158264947247,
+              "transition_rate": 0.10084427767354597,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 170.19694921053997
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.270507127833606,
+              "transition_rate": 0.09886642514900082,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.23169169868436373,
+              "transition_rate": 0.10421518397764322,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.26078573150156664,
+              "transition_rate": 0.109450337512054,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.10084427767354597,
+          "held_out_kruskal_h": 170.19694921053997,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.09886642514900082,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.29439153439153437,
+              "transition_rate": 0.09546994072819644,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.24783118405627197,
+              "transition_rate": 0.0975609756097561,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 180.8187865147338
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.2694554802523954,
+              "transition_rate": 0.09115344162673834,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.22808243101641634,
+              "transition_rate": 0.09664648346530041,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.25958062183658714,
+              "transition_rate": 0.10583413693346191,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.0975609756097561,
+          "held_out_kruskal_h": 180.8187865147338,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.09115344162673834,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 dwell=6 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.302010582010582,
+              "transition_rate": 0.04403048264182896,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0440 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.2492379835873388,
+              "transition_rate": 0.04643527204502814,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0464 < 0.0687"
+              ],
+              "kruskal_h": 187.7959635779498
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.28137415283944844,
+              "transition_rate": 0.03879864438471427,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0388 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.22598672720922108,
+              "transition_rate": 0.04261760596180717,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0426 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.2769342010122921,
+              "transition_rate": 0.041947926711668276,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0419 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.04643527204502814,
+          "held_out_kruskal_h": 187.7959635779498,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.03879864438471427,
+          "reaches_band": false
+        }
+      ],
+      "best_setting": {
+        "filter_window": 64,
+        "decode_min_dwell": 0,
+        "decode_stickiness": 20.0
+      },
+      "best_label": "fw=64 stick=20",
+      "best_reaches_band": true,
+      "rescored": {
+        "verdict": {
+          "target": "volatility",
+          "gate_semantics": "candidate-self-v2 (#1211)",
+          "separation_ok": true,
+          "stability_ok": true,
+          "model_separation_real": true,
+          "incumbent_trustworthy": true,
+          "ship": true,
+          "detail": {
+            "handrule_kruskal_h": 80.47242092503984,
+            "model_kruskal_h": 180.8187865147338,
+            "handrule_p_value": 0.005,
+            "model_p_value": 0.0011111111111111111,
+            "handrule_transition_rate": 0.13860225140712945,
+            "model_transition_rate": 0.0975609756097561
+          }
+        },
+        "model_kruskal_h": 180.8187865147338,
+        "model_p_value": 0.0011111111111111111,
+        "passes_bonferroni": true,
+        "stability_gain": 0.04104127579737335,
+        "non_degenerate_all": true,
+        "coverage": {
+          "ranging_directional": {
+            "count": 645,
+            "pct": 0.15123094958968347
+          },
+          "ranging_directional_down": {
+            "count": 690,
+            "pct": 0.16178194607268465
+          },
+          "ranging_directional_up": {
+            "count": 293,
+            "pct": 0.06869871043376319
+          },
+          "ranging_volatile": {
+            "count": 1057,
+            "pct": 0.24783118405627197
+          },
+          "trending_down_choppy": {
+            "count": 839,
+            "pct": 0.1967174677608441
+          },
+          "trending_up_choppy": {
+            "count": 582,
+            "pct": 0.13645955451348182
+          },
+          "trending_up_clean": {
+            "count": 159,
+            "pct": 0.03728018757327081
+          }
+        },
+        "full_bar": true
+      }
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 5,
+      "primary": false,
+      "states": [
+        "ranging_volatile",
+        "trending_up_choppy",
+        "ranging_directional",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.05861796504437978
+          }
+        },
+        "duplicate_names": []
+      },
+      "transition_diagonal": [
+        0.8658399098083427,
+        0.8943894389438944,
+        0.8114942528735632,
+        0.2635135135135135,
+        0.8723958333333334
+      ],
+      "handrule_transition_rate": 0.13860225140712945,
+      "sweep": [
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.35873015873015873,
+              "transition_rate": 0.14775613886536834,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3559202813599062,
+              "transition_rate": 0.16604127579737335,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 174.5526835714245
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.33725071225071224,
+              "transition_rate": 0.1435440783615316,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.28780998952148096,
+              "transition_rate": 0.1679087098276665,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.37020968908170643,
+              "transition_rate": 0.14151398264223722,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.16604127579737335,
+          "held_out_kruskal_h": 174.5526835714245,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.14151398264223722,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 16,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=16",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.35873015873015873,
+              "transition_rate": 0.14775613886536834,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3559202813599062,
+              "transition_rate": 0.16604127579737335,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 174.5526835714245
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.33725071225071224,
+              "transition_rate": 0.1435440783615316,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.28780998952148096,
+              "transition_rate": 0.1679087098276665,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.37020968908170643,
+              "transition_rate": 0.14151398264223722,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.16604127579737335,
+          "held_out_kruskal_h": 174.5526835714245,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.14151398264223722,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=256",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.35873015873015873,
+              "transition_rate": 0.14775613886536834,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3559202813599062,
+              "transition_rate": 0.16604127579737335,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 174.5526835714245
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.33725071225071224,
+              "transition_rate": 0.1435440783615316,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.28780998952148096,
+              "transition_rate": 0.1679087098276665,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.37020968908170643,
+              "transition_rate": 0.14151398264223722,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.16604127579737335,
+          "held_out_kruskal_h": 174.5526835714245,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.14151398264223722,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=3",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.3843386243386243,
+              "transition_rate": 0.05059271803556308,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0506 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3788980070339977,
+              "transition_rate": 0.04971857410881801,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0497 < 0.0687"
+              ],
+              "kruskal_h": 209.47061294152627
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.35274216524216523,
+              "transition_rate": 0.05040071237756011,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0504 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.29316567702875773,
+              "transition_rate": 0.056939916162086636,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0569 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3969631236442516,
+              "transition_rate": 0.044599807135969144,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.397 > 0.392",
+                "min_transition_rate: 0.0446 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.04971857410881801,
+          "held_out_kruskal_h": 209.47061294152627,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.044599807135969144,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=6",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.40296296296296297,
+              "transition_rate": 0.026883996613039796,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.403 > 0.392",
+                "min_transition_rate: 0.0269 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.39202813599062136,
+              "transition_rate": 0.02626641651031895,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.392 > 0.392",
+                "min_transition_rate: 0.0263 < 0.0687"
+              ],
+              "kruskal_h": 235.2830725981603
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.34775641025641024,
+              "transition_rate": 0.027782724844167408,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0278 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.3023634881825591,
+              "transition_rate": 0.02841173730787145,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0284 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.41118341769100986,
+              "transition_rate": 0.025554484088717456,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.411 > 0.392",
+                "min_transition_rate: 0.0256 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.02626641651031895,
+          "held_out_kruskal_h": 235.2830725981603,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.025554484088717456,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.3511111111111111,
+              "transition_rate": 0.12425910245554615,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.3531066822977726,
+              "transition_rate": 0.13203564727954972,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 198.8889559599229
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.3424145299145299,
+              "transition_rate": 0.11611754229741764,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.2902549772965421,
+              "transition_rate": 0.13809967396367023,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.36514822848879247,
+              "transition_rate": 0.12174541947926712,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.13203564727954972,
+          "held_out_kruskal_h": 198.8889559599229,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.11611754229741764,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.3485714285714286,
+              "transition_rate": 0.11409822184589331,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.35427901524032823,
+              "transition_rate": 0.11796435272045028,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 201.06820654826697
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.34472934472934474,
+              "transition_rate": 0.10774710596616206,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.2903714052858307,
+              "transition_rate": 0.12470889613414066,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.3615328994938539,
+              "transition_rate": 0.10920925747348119,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.11796435272045028,
+          "held_out_kruskal_h": 201.06820654826697,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.10774710596616206,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 dwell=6 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 5,
+              "max_occupancy": 0.3904761904761905,
+              "transition_rate": 0.028789161727349702,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0288 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 5,
+              "max_occupancy": 0.38522860492379835,
+              "transition_rate": 0.028846153846153848,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0288 < 0.0687"
+              ],
+              "kruskal_h": 219.22166553510942
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.359508547008547,
+              "transition_rate": 0.028495102404274265,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0285 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.30923273955058794,
+              "transition_rate": 0.03178854215183978,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0318 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 5,
+              "max_occupancy": 0.39840925524222703,
+              "transition_rate": 0.028206364513018323,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.398 > 0.392",
+                "min_transition_rate: 0.0282 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.028846153846153848,
+          "held_out_kruskal_h": 219.22166553510942,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.028206364513018323,
+          "reaches_band": false
+        }
+      ],
+      "best_setting": {
+        "filter_window": 64,
+        "decode_min_dwell": 0,
+        "decode_stickiness": 20.0
+      },
+      "best_label": "fw=64 stick=20",
+      "best_reaches_band": true,
+      "rescored": {
+        "verdict": {
+          "target": "volatility",
+          "gate_semantics": "candidate-self-v2 (#1211)",
+          "separation_ok": true,
+          "stability_ok": true,
+          "model_separation_real": true,
+          "incumbent_trustworthy": true,
+          "ship": true,
+          "detail": {
+            "handrule_kruskal_h": 80.47242092503984,
+            "model_kruskal_h": 201.06820654826697,
+            "handrule_p_value": 0.005,
+            "model_p_value": 0.0005555555555555556,
+            "handrule_transition_rate": 0.13860225140712945,
+            "model_transition_rate": 0.11796435272045028
+          }
+        },
+        "model_kruskal_h": 201.06820654826697,
+        "model_p_value": 0.0005555555555555556,
+        "passes_bonferroni": true,
+        "stability_gain": 0.020637898686679174,
+        "non_degenerate_all": true,
+        "coverage": {
+          "ranging_directional": {
+            "count": 876,
+            "pct": 0.20539273153575616
+          },
+          "ranging_directional_down": {
+            "count": 349,
+            "pct": 0.08182883939038688
+          },
+          "ranging_volatile": {
+            "count": 1511,
+            "pct": 0.35427901524032823
+          },
+          "trending_down_choppy": {
+            "count": 920,
+            "pct": 0.21570926143024619
+          },
+          "trending_up_choppy": {
+            "count": 609,
+            "pct": 0.14279015240328252
+          }
+        },
+        "full_bar": true
+      }
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 6,
+      "primary": false,
+      "states": [
+        "ranging_directional",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional_up"
+      ],
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_directional_down",
+            "to": "ranging_directional",
+            "displacement_z": 0.038769250271505795
+          }
+        },
+        "duplicate_names": []
+      },
+      "transition_diagonal": [
+        0.8107913669064748,
+        0.8636647904940588,
+        0.8696219035202086,
+        0.254416961130742,
+        0.8764415156507414,
+        0.6578947368421053
+      ],
+      "handrule_transition_rate": 0.13860225140712945,
+      "sweep": [
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3233862433862434,
+              "transition_rate": 0.15050804403048265,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.31582649472450175,
+              "transition_rate": 0.17166979362101314,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 179.6832995552868
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.35648148148148145,
+              "transition_rate": 0.15316117542297417,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.22808243101641634,
+              "transition_rate": 0.18770377270610153,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.341528079055194,
+              "transition_rate": 0.15646094503375121,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.17166979362101314,
+          "held_out_kruskal_h": 179.6832995552868,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.15050804403048265,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 16,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=16",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3233862433862434,
+              "transition_rate": 0.15050804403048265,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.31582649472450175,
+              "transition_rate": 0.17166979362101314,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 179.6832995552868
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.35648148148148145,
+              "transition_rate": 0.15316117542297417,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.22808243101641634,
+              "transition_rate": 0.18770377270610153,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.341528079055194,
+              "transition_rate": 0.15646094503375121,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.17166979362101314,
+          "held_out_kruskal_h": 179.6832995552868,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.15050804403048265,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=256",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3233862433862434,
+              "transition_rate": 0.15050804403048265,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.31582649472450175,
+              "transition_rate": 0.17166979362101314,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 179.6832995552868
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.35648148148148145,
+              "transition_rate": 0.15316117542297417,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.22808243101641634,
+              "transition_rate": 0.18770377270610153,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.341528079055194,
+              "transition_rate": 0.15646094503375121,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.17166979362101314,
+          "held_out_kruskal_h": 179.6832995552868,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.15050804403048265,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=3",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.34264550264550264,
+              "transition_rate": 0.05122777307366638,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0512 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.3395076201641266,
+              "transition_rate": 0.055581613508442776,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0556 < 0.0687"
+              ],
+              "kruskal_h": 217.66702184667338
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.36004273504273504,
+              "transition_rate": 0.05360641139804096,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0536 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.24624519734544184,
+              "transition_rate": 0.0647414997671169,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0647 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.3627380091588335,
+              "transition_rate": 0.05231436837029894,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0523 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.055581613508442776,
+          "held_out_kruskal_h": 217.66702184667338,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.05122777307366638,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=6",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3585185185185185,
+              "transition_rate": 0.029000846740050806,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0290 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.3390386869871043,
+              "transition_rate": 0.028611632270168854,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0286 < 0.0687"
+              ],
+              "kruskal_h": 254.3497910966089
+            },
+            "2023": {
+              "active_labels": 5,
+              "max_occupancy": 0.37428774928774927,
+              "transition_rate": 0.027248441674087267,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0272 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 5,
+              "max_occupancy": 0.258004424263593,
+              "transition_rate": 0.030507685142058687,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0305 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.4020245842371656,
+              "transition_rate": 0.028688524590163935,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.402 > 0.392",
+                "min_transition_rate: 0.0287 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.028611632270168854,
+          "held_out_kruskal_h": 254.3497910966089,
+          "min_active_labels": 5,
+          "min_transition_rate": 0.027248441674087267,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3147089947089947,
+              "transition_rate": 0.12595258255715494,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.3097303634232122,
+              "transition_rate": 0.1353189493433396,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 180.06295735605272
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.3701923076923077,
+              "transition_rate": 0.12484416740872663,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.2265688671556642,
+              "transition_rate": 0.15789473684210525,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.33574355266329237,
+              "transition_rate": 0.13379942140790743,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.1353189493433396,
+          "held_out_kruskal_h": 180.06295735605272,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.12484416740872663,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3136507936507936,
+              "transition_rate": 0.11600338696020322,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.3071512309495897,
+              "transition_rate": 0.12453095684803002,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 185.93557392389812
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.3751780626780627,
+              "transition_rate": 0.11237756010685664,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.23006170683432298,
+              "transition_rate": 0.14182580344666978,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.3335743552663292,
+              "transition_rate": 0.11981677917068467,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.12453095684803002,
+          "held_out_kruskal_h": 185.93557392389812,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.11237756010685664,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 dwell=6 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.3502645502645503,
+              "transition_rate": 0.0283657917019475,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0284 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.3237983587338804,
+              "transition_rate": 0.03119136960600375,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0312 < 0.0687"
+              ],
+              "kruskal_h": 249.8391142182045
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.37784900284900286,
+              "transition_rate": 0.02956366874443455,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0296 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.24333449761322623,
+              "transition_rate": 0.033535165346995806,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0335 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.3774403470715835,
+              "transition_rate": 0.03158148505303761,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0316 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.03119136960600375,
+          "held_out_kruskal_h": 249.8391142182045,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.0283657917019475,
+          "reaches_band": false
+        }
+      ],
+      "best_setting": {
+        "filter_window": 64,
+        "decode_min_dwell": 0,
+        "decode_stickiness": 20.0
+      },
+      "best_label": "fw=64 stick=20",
+      "best_reaches_band": false
+    },
+    {
+      "subset": "all_enriched",
+      "family": "kmeans",
+      "k": 7,
+      "primary": false,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "ranging_directional",
+        "trending_down_clean",
+        "ranging_directional_down",
+        "ranging_volatile",
+        "trending_down_choppy"
+      ],
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "2": {
+            "from": "ranging_directional_up",
+            "to": "ranging_directional",
+            "displacement_z": 0.05689107234003933
+          },
+          "3": {
+            "from": "trending_down_choppy",
+            "to": "trending_down_clean",
+            "displacement_z": 2.1323236692331022
+          },
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.1302795309282207
+          }
+        },
+        "duplicate_names": []
+      },
+      "transition_diagonal": [
+        0.881326352530541,
+        0.686046511627907,
+        0.8203883495145631,
+        0.8325471698113207,
+        0.6916951080773607,
+        0.8538961038961039,
+        0.7534456355283308
+      ],
+      "handrule_transition_rate": 0.13860225140712945,
+      "sweep": [
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.3166137566137566,
+              "transition_rate": 0.13251481795088907,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.31582649472450175,
+              "transition_rate": 0.1325046904315197,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 236.27466801305673
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.33885327635327633,
+              "transition_rate": 0.13446126447016918,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.20700896495517523,
+              "transition_rate": 0.1724499301350722,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.3152566883586406,
+              "transition_rate": 0.1446480231436837,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.1325046904315197,
+          "held_out_kruskal_h": 236.27466801305673,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.1325046904315197,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 16,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=16",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.3166137566137566,
+              "transition_rate": 0.13251481795088907,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.31582649472450175,
+              "transition_rate": 0.1325046904315197,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 236.27466801305673
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.33885327635327633,
+              "transition_rate": 0.13446126447016918,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.20700896495517523,
+              "transition_rate": 0.1724499301350722,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.31549771029163654,
+              "transition_rate": 0.1446480231436837,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.1325046904315197,
+          "held_out_kruskal_h": 236.27466801305673,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.1325046904315197,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=256",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.3166137566137566,
+              "transition_rate": 0.13251481795088907,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.31582649472450175,
+              "transition_rate": 0.1325046904315197,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 236.27466801305673
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.33885327635327633,
+              "transition_rate": 0.13446126447016918,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.20700896495517523,
+              "transition_rate": 0.1724499301350722,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.3152566883586406,
+              "transition_rate": 0.1446480231436837,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.1325046904315197,
+          "held_out_kruskal_h": 236.27466801305673,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.1325046904315197,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=3",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.3314285714285714,
+              "transition_rate": 0.06075359864521592,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0608 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.32989449003516996,
+              "transition_rate": 0.06378986866791744,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0638 < 0.0687"
+              ],
+              "kruskal_h": 232.74343774731824
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.343482905982906,
+              "transition_rate": 0.05752448797862867,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0575 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.21003609267667947,
+              "transition_rate": 0.07207731718677224,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.3330923114003374,
+              "transition_rate": 0.06171648987463838,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0617 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.06378986866791744,
+          "held_out_kruskal_h": 232.74343774731824,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.05752448797862867,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=6",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.33714285714285713,
+              "transition_rate": 0.03577476714648603,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0358 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.3357561547479484,
+              "transition_rate": 0.03400562851782364,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0340 < 0.0687"
+              ],
+              "kruskal_h": 296.51712694690286
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.33938746438746437,
+              "transition_rate": 0.033125556544968834,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0331 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.20747467691232974,
+              "transition_rate": 0.03574755472752678,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0357 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.3641841407568089,
+              "transition_rate": 0.03230472516875603,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0323 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.03400562851782364,
+          "held_out_kruskal_h": 296.51712694690286,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.03230472516875603,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.2926984126984127,
+              "transition_rate": 0.10309060118543607,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.3015240328253224,
+              "transition_rate": 0.1050656660412758,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 274.07490784351467
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.35131766381766383,
+              "transition_rate": 0.10685663401602849,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.2157410641518221,
+              "transition_rate": 0.13553795994410806,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.2966979995179561,
+              "transition_rate": 0.11668273866923819,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.1050656660412758,
+          "held_out_kruskal_h": 274.07490784351467,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.10309060118543607,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.28634920634920635,
+              "transition_rate": 0.09441151566469094,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.2958968347010551,
+              "transition_rate": 0.09380863039399624,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 283.3156004828488
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.3559472934472934,
+              "transition_rate": 0.09492430988423865,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.21958318779834674,
+              "transition_rate": 0.12179785747554728,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.2928416485900217,
+              "transition_rate": 0.10342333654773385,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.09380863039399624,
+          "held_out_kruskal_h": 283.3156004828488,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.09380863039399624,
+          "reaches_band": true
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 dwell=6 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.3056084656084656,
+              "transition_rate": 0.03746824724809483,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0375 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.311137162954279,
+              "transition_rate": 0.03775797373358349,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0378 < 0.0687"
+              ],
+              "kruskal_h": 289.6585498241966
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.3575498575498576,
+              "transition_rate": 0.033125556544968834,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0331 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.2134125043660496,
+              "transition_rate": 0.04052165812761994,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0405 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.3220053024825259,
+              "transition_rate": 0.03712632594021215,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0371 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.03775797373358349,
+          "held_out_kruskal_h": 289.6585498241966,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.033125556544968834,
+          "reaches_band": false
+        }
+      ],
+      "best_setting": {
+        "filter_window": 64,
+        "decode_min_dwell": 0,
+        "decode_stickiness": 20.0
+      },
+      "best_label": "fw=64 stick=20",
+      "best_reaches_band": true,
+      "rescored": {
+        "verdict": {
+          "target": "volatility",
+          "gate_semantics": "candidate-self-v2 (#1211)",
+          "separation_ok": true,
+          "stability_ok": true,
+          "model_separation_real": true,
+          "incumbent_trustworthy": true,
+          "ship": true,
+          "detail": {
+            "handrule_kruskal_h": 80.47242092503984,
+            "model_kruskal_h": 283.3156004828488,
+            "handrule_p_value": 0.005,
+            "model_p_value": 0.0005555555555555556,
+            "handrule_transition_rate": 0.13860225140712945,
+            "model_transition_rate": 0.09380863039399624
+          }
+        },
+        "model_kruskal_h": 283.3156004828488,
+        "model_p_value": 0.0005555555555555556,
+        "passes_bonferroni": true,
+        "stability_gain": 0.04479362101313321,
+        "non_degenerate_all": true,
+        "coverage": {
+          "ranging_directional": {
+            "count": 315,
+            "pct": 0.0738569753810082
+          },
+          "ranging_directional_down": {
+            "count": 774,
+            "pct": 0.18147713950762018
+          },
+          "ranging_directional_up": {
+            "count": 116,
+            "pct": 0.02719812426729191
+          },
+          "ranging_volatile": {
+            "count": 1262,
+            "pct": 0.2958968347010551
+          },
+          "trending_down_choppy": {
+            "count": 506,
+            "pct": 0.1186400937866354
+          },
+          "trending_down_clean": {
+            "count": 646,
+            "pct": 0.15146541617819462
+          },
+          "trending_up_choppy": {
+            "count": 646,
+            "pct": 0.15146541617819462
+          }
+        },
+        "full_bar": true
+      }
+    },
+    {
+      "subset": "all_enriched",
+      "family": "gmm",
+      "k": 7,
+      "primary": false,
+      "states": [
+        "trending_up_choppy",
+        "ranging_directional_up",
+        "ranging_volatile",
+        "trending_down_clean",
+        "ranging_directional",
+        "ranging_directional_down",
+        "trending_down_choppy"
+      ],
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "1": {
+            "from": "trending_up_choppy",
+            "to": "ranging_directional_up",
+            "displacement_z": 0.2246111340480704
+          },
+          "3": {
+            "from": "trending_down_choppy",
+            "to": "trending_down_clean",
+            "displacement_z": 2.645216709214373
+          },
+          "4": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.23061750565412587
+          },
+          "5": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional_down",
+            "displacement_z": 0.20020406640472682
+          }
+        },
+        "duplicate_names": []
+      },
+      "transition_diagonal": [
+        0.7354709418837675,
+        0.6589473684210526,
+        0.7134986225895317,
+        0.8064516129032258,
+        0.3324175824175824,
+        0.8010204081632653,
+        0.6637931034482759
+      ],
+      "handrule_transition_rate": 0.13860225140712945,
+      "sweep": [
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.3580952380952381,
+              "transition_rate": 0.23221845893310752,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.311137162954279,
+              "transition_rate": 0.2621951219512195,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 122.22544245776226
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.3863960113960114,
+              "transition_rate": 0.21602849510240427,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.26499010362091047,
+              "transition_rate": 0.26525384257102935,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.3289949385394071,
+              "transition_rate": 0.24541947926711669,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2621951219512195,
+          "held_out_kruskal_h": 122.22544245776226,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.21602849510240427,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 16,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=16",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.3580952380952381,
+              "transition_rate": 0.23221845893310752,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.311137162954279,
+              "transition_rate": 0.2621951219512195,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 122.22544245776226
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.3863960113960114,
+              "transition_rate": 0.21602849510240427,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.26499010362091047,
+              "transition_rate": 0.26525384257102935,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.3289949385394071,
+              "transition_rate": 0.24541947926711669,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2621951219512195,
+          "held_out_kruskal_h": 122.22544245776226,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.21602849510240427,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=256",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.3580952380952381,
+              "transition_rate": 0.23221845893310752,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.311137162954279,
+              "transition_rate": 0.2621951219512195,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 122.22544245776226
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.3863960113960114,
+              "transition_rate": 0.21602849510240427,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.26499010362091047,
+              "transition_rate": 0.26525384257102935,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.3289949385394071,
+              "transition_rate": 0.24541947926711669,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.2621951219512195,
+          "held_out_kruskal_h": 122.22544245776226,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.21602849510240427,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=3",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.39746031746031746,
+              "transition_rate": 0.07049110922946655,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.397 > 0.392"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.34654161781946075,
+              "transition_rate": 0.07176360225140713,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 89.1348559031976
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.38621794871794873,
+              "transition_rate": 0.06340160284951024,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0634 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.2908371172429852,
+              "transition_rate": 0.07137866790870982,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.3543022415039769,
+              "transition_rate": 0.06822565091610415,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0682 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.07176360225140713,
+          "held_out_kruskal_h": 89.1348559031976,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.06340160284951024,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=6",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.41523809523809524,
+              "transition_rate": 0.03408128704487722,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.415 > 0.392",
+                "min_transition_rate: 0.0341 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.37373974208675265,
+              "transition_rate": 0.03212945590994371,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0321 < 0.0687"
+              ],
+              "kruskal_h": 73.28617542675238
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.37446581196581197,
+              "transition_rate": 0.026001780943900266,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0260 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.3077191756898358,
+              "transition_rate": 0.029809035863996275,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0298 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.38201976379850566,
+              "transition_rate": 0.028688524590163935,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0287 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.03212945590994371,
+          "held_out_kruskal_h": 73.28617542675238,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.026001780943900266,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.344973544973545,
+              "transition_rate": 0.20237087214225233,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.2958968347010551,
+              "transition_rate": 0.21951219512195122,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 120.58625364753789
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.3977920227920228,
+              "transition_rate": 0.18040961709706144,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.398 > 0.392"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.2759343346140412,
+              "transition_rate": 0.22950628784350255,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.3152566883586406,
+              "transition_rate": 0.2148023143683703,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.21951219512195122,
+          "held_out_kruskal_h": 120.58625364753789,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.18040961709706144,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.33015873015873015,
+              "transition_rate": 0.18670618120237087,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.28815943728018756,
+              "transition_rate": 0.19582551594746717,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 112.11241879464615
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.40900997150997154,
+              "transition_rate": 0.15903829029385574,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.409 > 0.392"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.28408429386424494,
+              "transition_rate": 0.209944108057755,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.3032055917088455,
+              "transition_rate": 0.19744455159112825,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.19582551594746717,
+          "held_out_kruskal_h": 112.11241879464615,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.15903829029385574,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 dwell=6 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 7,
+              "max_occupancy": 0.3746031746031746,
+              "transition_rate": 0.03831498729889924,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0383 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 7,
+              "max_occupancy": 0.3463071512309496,
+              "transition_rate": 0.04151031894934334,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0415 < 0.0687"
+              ],
+              "kruskal_h": 79.4593191990898
+            },
+            "2023": {
+              "active_labels": 7,
+              "max_occupancy": 0.40224358974358976,
+              "transition_rate": 0.03170080142475512,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.402 > 0.392",
+                "min_transition_rate: 0.0317 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 7,
+              "max_occupancy": 0.2893235533822331,
+              "transition_rate": 0.03493246390312063,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0349 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 7,
+              "max_occupancy": 0.33574355266329237,
+              "transition_rate": 0.034233365477338476,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0342 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.04151031894934334,
+          "held_out_kruskal_h": 79.4593191990898,
+          "min_active_labels": 7,
+          "min_transition_rate": 0.03170080142475512,
+          "reaches_band": false
+        }
+      ],
+      "best_setting": {
+        "filter_window": 64,
+        "decode_min_dwell": 0,
+        "decode_stickiness": 0.0
+      },
+      "best_label": "fw=64",
+      "best_reaches_band": false
+    },
+    {
+      "subset": "all_enriched",
+      "family": "hmm",
+      "k": 6,
+      "primary": false,
+      "states": [
+        "ranging_directional",
+        "ranging_volatile",
+        "trending_down_choppy",
+        "ranging_directional_down",
+        "trending_up_choppy",
+        "ranging_directional_up"
+      ],
+      "naming": {
+        "rule": "distinct_nearest_cell",
+        "distinct": true,
+        "relabeled": {
+          "0": {
+            "from": "ranging_volatile",
+            "to": "ranging_directional",
+            "displacement_z": 0.2811748610275747
+          }
+        },
+        "duplicate_names": []
+      },
+      "transition_diagonal": [
+        0.8397515527950311,
+        0.8556338028169014,
+        0.8939873417721519,
+        0.8479880774962743,
+        0.8815165876777251,
+        0.706855791962175
+      ],
+      "handrule_transition_rate": 0.13860225140712945,
+      "sweep": [
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.29164021164021164,
+              "transition_rate": 0.18014394580863674,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.36107854630715125,
+              "transition_rate": 0.21130393996247654,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 108.61308209492927
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.37197293447293445,
+              "transition_rate": 0.15262689225289403,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.25602514844568636,
+              "transition_rate": 0.23090358639962738,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.27789828874427575,
+              "transition_rate": 0.21600771456123433,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.21130393996247654,
+          "held_out_kruskal_h": 108.61308209492927,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.15262689225289403,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 16,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=16",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.29164021164021164,
+              "transition_rate": 0.18014394580863674,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.36107854630715125,
+              "transition_rate": 0.21130393996247654,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 108.61308209492927
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.37197293447293445,
+              "transition_rate": 0.15262689225289403,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.25602514844568636,
+              "transition_rate": 0.23090358639962738,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.27789828874427575,
+              "transition_rate": 0.21600771456123433,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.21130393996247654,
+          "held_out_kruskal_h": 108.61308209492927,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.15262689225289403,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 256,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=256",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.29164021164021164,
+              "transition_rate": 0.18014394580863674,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.36107854630715125,
+              "transition_rate": 0.21130393996247654,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 108.61308209492927
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.37197293447293445,
+              "transition_rate": 0.15262689225289403,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.25602514844568636,
+              "transition_rate": 0.23090358639962738,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.27789828874427575,
+              "transition_rate": 0.21600771456123433,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.21130393996247654,
+          "held_out_kruskal_h": 108.61308209492927,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.15262689225289403,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 3,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=3",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.2893121693121693,
+              "transition_rate": 0.07557154953429297,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.3953106682297773,
+              "transition_rate": 0.07176360225140713,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.395 > 0.392"
+              ],
+              "kruskal_h": 110.91531134076104
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.3596866096866097,
+              "transition_rate": 0.06268922528940338,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0627 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.2641751076958901,
+              "transition_rate": 0.0788309268747089,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.27789828874427575,
+              "transition_rate": 0.08365477338476374,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.07176360225140713,
+          "held_out_kruskal_h": 110.91531134076104,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.06268922528940338,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 0.0
+          },
+          "label": "fw=64 dwell=6",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.2816931216931217,
+              "transition_rate": 0.04381879762912786,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0438 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.4232121922626026,
+              "transition_rate": 0.037288930581613505,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.423 > 0.392",
+                "min_transition_rate: 0.0373 < 0.0687"
+              ],
+              "kruskal_h": 101.31286986547457
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.35523504273504275,
+              "transition_rate": 0.029741763134461266,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0297 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.27756432646408197,
+              "transition_rate": 0.035398230088495575,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0354 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.28946734152807907,
+              "transition_rate": 0.04001928640308582,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0400 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.037288930581613505,
+          "held_out_kruskal_h": 101.31286986547457,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.029741763134461266,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 5.0
+          },
+          "label": "fw=64 stick=5",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.28994708994708995,
+              "transition_rate": 0.16045723962743438,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.36811254396248533,
+              "transition_rate": 0.17166979362101314,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 113.96176467649275
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.38746438746438744,
+              "transition_rate": 0.12858414959928763,
+              "ok": true,
+              "reasons": []
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.2642915356851787,
+              "transition_rate": 0.19632044713553795,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.27090865268739456,
+              "transition_rate": 0.18924783027965283,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": true,
+          "held_out_transition_rate": 0.17166979362101314,
+          "held_out_kruskal_h": 113.96176467649275,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.12858414959928763,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 0,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.29248677248677246,
+              "transition_rate": 0.14775613886536834,
+              "ok": true,
+              "reasons": []
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.37233294255568583,
+              "transition_rate": 0.15103189493433397,
+              "ok": true,
+              "reasons": [],
+              "kruskal_h": 119.58508529084065
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.39636752136752135,
+              "transition_rate": 0.11736420302760463,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.396 > 0.392"
+              ]
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.27383863080684595,
+              "transition_rate": 0.1751280857009781,
+              "ok": true,
+              "reasons": []
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.26898047722342733,
+              "transition_rate": 0.17478302796528447,
+              "ok": true,
+              "reasons": []
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.15103189493433397,
+          "held_out_kruskal_h": 119.58508529084065,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.11736420302760463,
+          "reaches_band": false
+        },
+        {
+          "setting": {
+            "filter_window": 64,
+            "decode_min_dwell": 6,
+            "decode_stickiness": 20.0
+          },
+          "label": "fw=64 dwell=6 stick=20",
+          "windows": {
+            "is": {
+              "active_labels": 6,
+              "max_occupancy": 0.28444444444444444,
+              "transition_rate": 0.04530059271803556,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0453 < 0.0687"
+              ]
+            },
+            "oos": {
+              "active_labels": 6,
+              "max_occupancy": 0.43048065650644785,
+              "transition_rate": 0.038930581613508444,
+              "ok": false,
+              "reasons": [
+                "max_occupancy: 0.430 > 0.392",
+                "min_transition_rate: 0.0389 < 0.0687"
+              ],
+              "kruskal_h": 104.42237746891442
+            },
+            "2023": {
+              "active_labels": 6,
+              "max_occupancy": 0.38799857549857547,
+              "transition_rate": 0.03348174532502226,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0335 < 0.0687"
+              ]
+            },
+            "2024": {
+              "active_labels": 6,
+              "max_occupancy": 0.26219583187798345,
+              "transition_rate": 0.04052165812761994,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0405 < 0.0687"
+              ]
+            },
+            "2025H1": {
+              "active_labels": 6,
+              "max_occupancy": 0.27066763075439865,
+              "transition_rate": 0.04339440694310511,
+              "ok": false,
+              "reasons": [
+                "min_transition_rate: 0.0434 < 0.0687"
+              ]
+            }
+          },
+          "non_degenerate_all": false,
+          "held_out_transition_rate": 0.038930581613508444,
+          "held_out_kruskal_h": 104.42237746891442,
+          "min_active_labels": 6,
+          "min_transition_rate": 0.03348174532502226,
+          "reaches_band": false
+        }
+      ],
+      "best_setting": {
+        "filter_window": 64,
+        "decode_min_dwell": 0,
+        "decode_stickiness": 5.0
+      },
+      "best_label": "fw=64 stick=5",
+      "best_reaches_band": false
+    }
+  ]
+}

--- a/docs/research/1500-gmm-regime-stability-smoothing.md
+++ b/docs/research/1500-gmm-regime-stability-smoothing.md
@@ -1,0 +1,210 @@
+# #1500: Decoder smoothing sweep for the `volume:gmm:k=5` regime candidate
+
+**Verdict: the candidate does not ship.** With a three-bar dwell hold and a small
+stickiness the model passes the raw `gate_verdict` for the first time (separation and
+stability both true), but its permutation p-value of 0.01667 misses the family-wise
+Bonferroni alpha of 0.001111. Bonferroni is the binding arm at every in-band setting.
+Without smoothing the binding arm is stability, as the issue recorded.
+
+Three context candidates clear the full bar under stickiness 20: `htf:hmm:k=7`,
+`all_enriched:kmeans:k=5` and `all_enriched:kmeans:k=7`. They are reported for context
+only. The gate code, its thresholds, and the incumbent hand-rule path are byte-identical
+to `origin/main` at `17cdacb9`.
+
+## What was run
+
+- Branch base: `17cdacb9` (the #1499 merge). Data: the frozen OHLCV cache used by #1218
+  and #1499 (truncated 2026-07-05 20:00 UTC), selected with `GO_TRADER_OHLCV_CACHE_DB`.
+- Script: `backtest/research/regime_1500_gmm_stability_sweep.py` (one-shot, registered in
+  `docs/backtesting-registry.md`). Artifact: `docs/research/1500-artifacts/regime_1500_btc.json`.
+- Command:
+
+```
+GO_TRADER_OHLCV_CACHE_DB=<frozen cache> uv run --no-sync python \
+  backtest/research/regime_1500_gmm_stability_sweep.py \
+  --json docs/research/1500-artifacts/regime_1500_btc.json
+```
+
+- Fit settings: BTC/USDT 1h, seed 0, `period=48`, base `filter_window=64`, five eval windows
+  (`is`, `oos`, `2023`, `2024`, `2025H1`). Scoring: `n_perm=1799`, Bonferroni denominator 45,
+  alpha 0.001111. Non-degeneracy thresholds: 5 active labels, occupancy at most 0.3920,
+  transition rate at least 0.0687.
+- Incumbent hand-rule on the held-out window: H 85.69, transition rate 0.1374 (volume
+  subset), and H 80.47, rate 0.1386 (`htf` and `all_enriched` subsets). A model on the
+  volume subset therefore needs H at least 81.41 (0.95 x 85.69) and a transition rate at
+  most 0.1174 (0.1374 minus 0.02) to pass the raw gate.
+
+The in-band condition in the tables below means: every eval window keeps every latent
+state active, the occupancy and churn floors hold on every window, and the held-out
+transition rate is at most the incumbent's rate minus 0.02.
+
+## Decoder options added (both off by default)
+
+`forward_filter_labels` in `backtest/regime_hmm.py` reads two optional model-dict keys.
+Both are absent on every existing model, and an absent, `0`, `None`, or `1` value gives a
+byte-identical decode (labels and confidence bytes) to the pre-change decoder. The test
+`test_forward_filter_without_decode_options_matches_reference_decoder` holds a frozen copy
+of the old decoder and proves this.
+
+- `decode_min_dwell` (int, default off). Hysteresis: the emitted label switches to a new
+  state only after the filtered argmax has pointed at that same new state for N consecutive
+  bars. The filtered posterior is untouched, so confidence still reports the filter's view.
+  Look-ahead safety is tested.
+- `decode_stickiness` (float, default off). Adds s to the diagonal of the transition
+  matrix and renormalises rows for decoding only. The stored model is not mutated.
+
+Both keys live on the model dict, not on the fit path, so they survive a move of the
+decoder into `shared_tools/` (#1074): the live decoder reads the same dict and will honour
+or ignore the keys the same way. Negative values raise.
+
+## Step 1: `filter_window` sweep (inert)
+
+Every filter window from 8 to 512 gives the identical label stream on every window. The
+forward filter forgets its initial distribution within a few bars, so a longer window
+only replays the same posterior. The issue's proposed knob has no effect on this candidate.
+
+| filter_window | held-out rate | min active | min rate | held-out H | non-degenerate all |
+|---|---|---|---|---|---|
+| 8, 16, 32, 64, 128, 256, 512 | 0.2541 | 5 | 0.2395 | 107.82 | yes |
+
+The same holds for every context candidate (rows at 16, 64 and 256 are identical, with
+one 0.0014 difference on `htf:hmm:k=7` at 16).
+
+## Step 2: dwell and stickiness sweep on `volume:gmm:k=5`
+
+Dwell rows (filter_window 64; identical at 256):
+
+| dwell | held-out rate | min active | min rate | held-out H | non-degenerate all | in band |
+|---|---|---|---|---|---|---|
+| 2 | 0.1183 | 5 | 0.1065 | 73.02 | yes | no (rate 0.0009 above the floor) |
+| 3 | 0.0793 | 5 | 0.0716 | 78.86 | yes | yes |
+| 4 | 0.0567 | 5 | 0.0499 | 75.36 | no (churn floor) | no |
+| 6 | 0.0333 | 5 | 0.0300 | 54.56 | no | no |
+| 8 | 0.0247 | 5 | 0.0208 | 76.10 | no | no |
+| 12 | 0.0129 | 4 | 0.0123 | 105.80 | no | no |
+| 24 | 0.0018 | 3 | 0.0012 | 356.24 | no | no |
+
+Dwell 3 is the only dwell inside the band. Dwell 2 stays just above the stability floor
+and dwell 4 already breaks the churn floor on at least one window. The band is one bar wide.
+
+Stickiness-only rows (filter_window 64):
+
+| stickiness | held-out rate | min rate | held-out H | in band |
+|---|---|---|---|---|
+| 1 | 0.2353 | 0.2231 | 103.83 | no |
+| 2 | 0.2212 | 0.2112 | 108.88 | no |
+| 5 | 0.2049 | 0.1960 | 114.11 | no |
+| 10 | 0.1927 | 0.1841 | 115.18 | no |
+| 20 | 0.1818 | 0.1712 | 110.71 | no |
+| 50 | 0.1720 | 0.1607 | 114.74 | no |
+| 100 | 0.1614 | 0.1514 | 113.68 | no |
+| 200 | 0.1562 | 0.1447 | 105.59 | no |
+| 500 | 0.1494 | 0.1336 | 90.68 | no |
+| 1000 | 0.1464 | 0.1258 | 90.71 | no |
+
+Stickiness alone plateaus near 0.15 and never reaches the 0.1174 stability floor, even at
+1000 (a transition matrix that is almost the identity). The GMM emissions are separated
+enough that the filtered posterior still flips on single bars.
+
+Combined rows (all with five active labels):
+
+| dwell | stickiness | held-out rate | min rate | held-out H | non-degenerate all | in band |
+|---|---|---|---|---|---|---|
+| 2 | 1 | 0.1199 | 0.1094 | 74.78 | yes | no |
+| 2 | 2 | 0.1233 | 0.1100 | 77.28 | yes | no |
+| 2 | 5 | 0.1242 | 0.1104 | 80.95 | yes | no |
+| 2 | 10 | 0.1267 | 0.1137 | 74.71 | yes | no |
+| 2 | 20 | 0.1285 | 0.1132 | 59.59 | yes | no |
+| 2 | 50 | 0.1260 | 0.1099 | 66.74 | yes | no |
+| 2 | 100 | 0.1233 | 0.1087 | 71.95 | yes | no |
+| 3 | 1 | 0.0832 | 0.0737 | 86.13 | yes | yes |
+| 3 | 2 | 0.0857 | 0.0757 | 87.58 | yes | yes |
+| 3 | 3 | 0.0870 | 0.0769 | 86.81 | yes | yes |
+| 3 | 5 | 0.0893 | 0.0761 | 80.28 | yes | yes |
+| 3 | 10 | 0.0934 | 0.0792 | 68.06 | yes | yes |
+| 3 | 20 | 0.0929 | 0.0817 | 57.55 | yes | yes |
+| 6 | 5 | 0.0408 | 0.0348 | 80.65 | no | no |
+| 6 | 20 | 0.0447 | 0.0398 | 77.39 | no | no |
+
+Stickiness on top of a dwell hold raises the transition rate slightly (the held state
+lasts longer, so the pending run resets less often), which is why dwell 2 plus stickiness
+never crosses the floor. Small stickiness (1 to 3) with dwell 3 lifts H above the
+separation floor of 81.41; larger stickiness lowers H again.
+
+## Step 3: re-score through the unchanged gate
+
+Best reachable setting (highest held-out H inside the band): `filter_window=64`,
+`decode_min_dwell=3`, `decode_stickiness=2`.
+
+| arm | value | threshold | pass |
+|---|---|---|---|
+| separation, H | 87.58 | at least 81.41 | yes |
+| separation, p | 0.01667 | at most 0.05 | yes |
+| stability gain | +0.0517 | at least 0.02 | yes |
+| raw `verdict.ship` | true | | yes |
+| Bonferroni p | 0.01667 | at most 0.001111 | **no** |
+| non-degenerate all windows | true | | yes |
+| full bar | | | **no** |
+
+The permutation null uses a block length derived from the mean dwell of the model's
+labels. Smoothing lengthens the dwell, so the null draws longer blocks, and the same
+separation becomes less unusual under the null. The unsmoothed model reached the minimum
+achievable p (0.00056); at dwell 3 plus stickiness 2 the p rises to 0.01667. The gain in stability is paid for in significance.
+
+## Step 4: the same sweep on the other Bonferroni-passing BTC candidates
+
+Settings tried per context candidate: filter windows 16, 64, 256; dwell 3 and 6;
+stickiness 5 and 20; dwell 6 with stickiness 20. Re-score at the best in-band setting.
+
+| candidate | best in-band setting | held-out rate | H | raw ship | p | Bonferroni | non-degenerate all | full bar |
+|---|---|---|---|---|---|---|---|---|
+| `volume:hmm:k=7` | dwell 3 | 0.0728 | 164.30 | yes | 0.00222 | no | yes | no |
+| `volume:gmm:k=6` | dwell 3 | 0.0762 | 87.80 | yes | 0.03444 | no | yes | no |
+| `volume:gmm:k=7` | dwell 3 | 0.0820 | 81.79 | no (p 0.0667 above 0.05) | 0.06667 | no | yes | no |
+| `htf:hmm:k=7` | stickiness 20 | 0.0976 | 180.82 | yes | 0.00111 | yes (at the alpha) | yes | **yes** |
+| `all_enriched:kmeans:k=5` | stickiness 20 | 0.1180 | 201.07 | yes | 0.00056 | yes | yes | **yes** |
+| `all_enriched:kmeans:k=6` | none in band | | | | | | | no |
+| `all_enriched:kmeans:k=7` | stickiness 20 | 0.0938 | 283.32 | yes | 0.00056 | yes | yes | **yes** |
+| `all_enriched:gmm:k=7` | none in band | | | | | | | no |
+| `all_enriched:hmm:k=6` | none in band | | | | | | | no |
+
+Notes on the class:
+
+- Dwell 3 breaks the churn floor on at least one window for every `htf` and
+  `all_enriched` candidate (their unsmoothed rates are already lower, 0.12 to 0.17), so
+  only stickiness stays in band for them. On the `volume` candidates, whose unsmoothed
+  rates are 0.20 to 0.28, only dwell reaches the floor.
+- Smoothing helps the class, and it is the `kmeans` and `hmm` families with wide feature
+  sets that benefit, because their unsmoothed p-values already sat at the achievable
+  minimum and stayed there. The `volume:gmm` family loses significance as soon as it is
+  smoothed enough to pass stability.
+- `htf:hmm:k=7` passes Bonferroni at exactly the corrected alpha (2 of 1800), the same
+  knife-edge #1499 reported for other candidates. `all_enriched:kmeans:k=5` clears the
+  stability floor by 0.0006 (gain 0.0206). Both are fragile results.
+- `all_enriched:hmm:k=6` fits are slow (about 1000 s each) and no setting stays in band.
+
+## Step 5: gate held fixed
+
+`backtest/regime_calibrate.py` (`gate_verdict`, `SIGNIFICANCE_ALPHA`, `SEPARATION_TOLERANCE`,
+`STABILITY_MIN_GAIN`), `backtest/regime_diagnostics.py` (`non_degeneracy`, permutation
+null), and the hand-rule path are not touched by this change. `git diff 17cdacb9 -- backtest/regime_calibrate.py backtest/regime_diagnostics.py` is empty.
+
+## Answer to the issue
+
+- Does decoder smoothing bring `volume:gmm:k=5` under the incumbent's transition rate
+  while keeping five active labels above the churn floor? Yes, at `decode_min_dwell=3`
+  (with stickiness 0 to 20). The window is one dwell value wide.
+- Does it then pass the gate? It passes the raw `gate_verdict` at dwell 3 with stickiness
+  1 to 3, and fails the family-wise Bonferroni bar at every one of those settings.
+  **The candidate does not ship. The binding arm is Bonferroni significance.**
+- The issue text quotes the #1218 numbers (transition rate 0.2539, gain -0.1165). The
+  current record after #1499 is rate 0.2541 and gain -0.1167, reproduced here at every
+  filter window. The difference does not change any conclusion.
+- Because the candidate does not ship, #1081 and #1082 are not triggered by it. The three
+  context candidates that clear the full bar under stickiness 20 are new evidence and are
+  not promoted by this document. A follow-up that re-runs the #1499 bake-off with
+  `decode_stickiness=20` on every candidate, on both symbols, and with a higher `n_perm`
+  to get off the alpha edge, would be the next research step. That follow-up is unfiled.
+
+---
+Created with LLM: Fable 5.1 | low | Harness: Claude Code


### PR DESCRIPTION
Closes #1500

## Summary

- Adds two off-by-default decoder options to `forward_filter_labels` in `backtest/regime_hmm.py`: `decode_min_dwell` (label hysteresis) and `decode_stickiness` (diagonal boost for decoding only). Absent, `0`, `None`, or `1` gives a byte-identical decode. Both live on the model dict, so they survive the #1074 move to `shared_tools/`.
- Adds the one-shot sweep script `backtest/research/regime_1500_gmm_stability_sweep.py` (registered in `docs/backtesting-registry.md`), its BTC artifact, and the research record `docs/research/1500-gmm-regime-stability-smoothing.md`.
- Result: `filter_window` is inert for this candidate (identical decode from 8 to 512). Dwell 3 is the only in-band dwell. At dwell 3 with stickiness 2 the model passes the raw `gate_verdict` (H 87.58, stability gain +0.0517) but its p of 0.01667 misses the Bonferroni alpha of 0.001111. **The candidate does not ship. Bonferroni significance is the binding arm.**
- Context: `htf:hmm:k=7`, `all_enriched:kmeans:k=5` and `all_enriched:kmeans:k=7` clear the full bar under stickiness 20. They are recorded, and no promotion is proposed. A follow-up bake-off re-run with stickiness is unfiled.
- Gate code and thresholds in `regime_calibrate.py` and `regime_diagnostics.py` are byte-identical to `origin/main`.

## Verification

- `uv run --no-sync python -m pytest backtest/tests/test_regime_hmm.py backtest/tests/test_regime_vol_model.py backtest/tests/test_regime_calibrate.py`: 100 passed.
- `py_compile` on the two touched Python files passes.
- Full sweep run on the frozen #1218 OHLCV cache with `n_perm=1799`; artifact committed.
- Test edits: none. Five tests added in `backtest/tests/test_regime_hmm.py`, including a byte-identical decode check against a frozen copy of the old decoder, look-ahead safety under dwell, and negative-value rejection.
- Plan: none.

## Plain simple English

We tried to make the volume-based regime model change its label less often. A three-bar hold does that and keeps all five labels. But the smoothed model no longer passes the strict significance test, so it does not ship. The gate is unchanged. Three other models look better with smoothing and are recorded for later.

https://claude.ai/code/session_01EhWRwr4TWSf7J9oByhhL2k

---
Created with LLM: Fable 5.1 | low | Harness: Claude Code
