### PR TITLE
fix(#1515): alert on Hyperliquid reconciliation closes [C37, GPT-5, high]

### DIFF
--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -27,10 +27,21 @@ type HLPosition struct {
 }
 
 type hyperliquidTradeAlertState struct {
-	sc       StrategyConfig
-	ss       *StrategyState
-	baseline int
-	count    int
+	sc        StrategyConfig
+	ss        *StrategyState
+	baseline  int
+	newTrades []Trade
+}
+
+func hyperliquidPublicTradeAlertRows(trades []Trade) []Trade {
+	rows := make([]Trade, 0, len(trades))
+	for _, trade := range trades {
+		if trade.TradeType == hedgeTradeType {
+			continue
+		}
+		rows = append(rows, trade)
+	}
+	return rows
 }
 
 func hlExecuteSnapshotForCoin(positions []HLPosition, coin string) hlExecuteSnapshot {
@@ -599,14 +610,14 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 		if ok && !isNilSender(notifier) {
 			ids := make([]string, 0, len(tradeAlertStates))
 			for id, alert := range tradeAlertStates {
-				if alert.count > 0 {
+				if len(alert.newTrades) > 0 {
 					ids = append(ids, id)
 				}
 			}
 			sort.Strings(ids)
 			for _, id := range ids {
 				alert := tradeAlertStates[id]
-				sendTradeAlerts(alert.sc, alert.ss, alert.count, mu, tradeNotifier)
+				sendTradeAlertRows(alert.sc, alert.newTrades, tradeNotifier)
 			}
 		}
 		if notifier != nil && !isNilSender(notifier) {
@@ -1118,13 +1129,8 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 	}
 
 	for id, alert := range tradeAlertStates {
-		for _, trade := range alert.ss.TradeHistory[alert.baseline:] {
-			if trade.TradeType == hedgeTradeType {
-				continue
-			}
-			alert.count++
-		}
-		if alert.count > 0 {
+		alert.newTrades = hyperliquidPublicTradeAlertRows(alert.ss.TradeHistory[alert.baseline:])
+		if len(alert.newTrades) > 0 {
 			tradeAlertStates[id] = alert
 		}
 	}

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -1118,9 +1118,13 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 	}
 
 	for id, alert := range tradeAlertStates {
-		count := len(alert.ss.TradeHistory) - alert.baseline
-		if count > 0 {
-			alert.count = count
+		for _, trade := range alert.ss.TradeHistory[alert.baseline:] {
+			if trade.TradeType == hedgeTradeType {
+				continue
+			}
+			alert.count++
+		}
+		if alert.count > 0 {
 			tradeAlertStates[id] = alert
 		}
 	}

--- a/scheduler/hyperliquid_balance.go
+++ b/scheduler/hyperliquid_balance.go
@@ -26,6 +26,13 @@ type HLPosition struct {
 	LiquidationPx float64
 }
 
+type hyperliquidTradeAlertState struct {
+	sc       StrategyConfig
+	ss       *StrategyState
+	baseline int
+	count    int
+}
+
 func hlExecuteSnapshotForCoin(positions []HLPosition, coin string) hlExecuteSnapshot {
 	if coin == "" {
 		return hlExecuteSnapshot{}
@@ -522,6 +529,21 @@ func reconcileHyperliquidPositionsWithResolver(stratState *StrategyState, sym st
 					statePos.Quantity = lookup.FilledQty
 				}
 				if recordPerpsStopLossCloseWithFillFee(stratState, sym, statePos.StopLossTriggerPx, lookup.Fee, useFillFee, oidStr, "stop_loss", logger) {
+					if pendingAlerts != nil {
+						*pendingAlerts = append(*pendingAlerts, ProtectionFillAlert{
+							StrategyID:      sc.ID,
+							Symbol:          sym,
+							Side:            statePos.Side,
+							FillType:        "SL",
+							IsPartial:       false,
+							FillPrice:       statePos.StopLossTriggerPx,
+							CloseQty:        statePos.Quantity,
+							RemainingQty:    0,
+							RealizedPnL:     lastBookedTradePnL(stratState),
+							HasPnL:          true,
+							ExchangeOrderID: oidStr,
+						})
+					}
 					return true
 				}
 			} else if useFillFee {
@@ -568,9 +590,24 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 	var pendingAlerts []ProtectionFillAlert
 	var pendingOrphanCloses []RegimeDirectionOrphanCloseJob
 	var pendingHedgeAlerts []string
+	tradeAlertStates := make(map[string]hyperliquidTradeAlertState, len(allStrategies))
 	defer func() {
 		for _, a := range pendingAlerts {
 			notifyProtectionFill(notifier, notifyTPSLFills, a)
+		}
+		tradeNotifier, ok := notifier.(tradeAlertRouter)
+		if ok && !isNilSender(notifier) {
+			ids := make([]string, 0, len(tradeAlertStates))
+			for id, alert := range tradeAlertStates {
+				if alert.count > 0 {
+					ids = append(ids, id)
+				}
+			}
+			sort.Strings(ids)
+			for _, id := range ids {
+				alert := tradeAlertStates[id]
+				sendTradeAlerts(alert.sc, alert.ss, alert.count, mu, tradeNotifier)
+			}
 		}
 		if notifier != nil && !isNilSender(notifier) {
 			for _, msg := range pendingHedgeAlerts {
@@ -583,6 +620,17 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 	defer mu.Unlock()
 
 	changed := false
+	for _, sc := range allStrategies {
+		ss := state.Strategies[sc.ID]
+		if ss == nil {
+			continue
+		}
+		tradeAlertStates[sc.ID] = hyperliquidTradeAlertState{
+			sc:       sc,
+			ss:       ss,
+			baseline: len(ss.TradeHistory),
+		}
+	}
 
 	coinStrategies := make(map[string][]string)
 	for _, sc := range allStrategies {
@@ -1066,6 +1114,14 @@ func reconcileHyperliquidAccountPositions(dueStrategies, allStrategies []Strateg
 			}
 			fmt.Printf("[WARN] hl-sync: unowned on-chain position: %s %.6f %s @ $%.2f (no strategy claims it)\n",
 				side, qty, p.Coin, p.EntryPrice)
+		}
+	}
+
+	for id, alert := range tradeAlertStates {
+		count := len(alert.ss.TradeHistory) - alert.baseline
+		if count > 0 {
+			alert.count = count
+			tradeAlertStates[id] = alert
 		}
 	}
 

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1340,6 +1340,74 @@ func TestReconcileSharedCoinSLAndExternal_SendsTradeAlertPerBookedTrade(t *testi
 	}
 }
 
+func TestReconcileHyperliquidHedgeCloseSkipsPublicTradeAlerts(t *testing.T) {
+	prev := tradeRecorder
+	tradeRecorder = nil
+	t.Cleanup(func() { tradeRecorder = prev })
+
+	cases := []struct {
+		name                 string
+		positions            []HLPosition
+		wantPublicAlerts     int
+		wantPrimaryTradeRows int
+		wantHedgeTradeRows   int
+	}{
+		{
+			name:                 "hedge-only external close",
+			positions:            []HLPosition{{Coin: "ETH", Size: 10, EntryPrice: testPrimaryPx}},
+			wantPublicAlerts:     0,
+			wantPrimaryTradeRows: 0,
+			wantHedgeTradeRows:   1,
+		},
+		{
+			name:                 "primary and hedge external close",
+			wantPublicAlerts:     1,
+			wantPrimaryTradeRows: 1,
+			wantHedgeTradeRows:   1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := hedgeTestConfig()
+			s := hedgeTestState(sc.ID)
+			s.Positions["ETH"] = primaryPos(10, "long")
+			s.Positions["BTC"] = hedgePos(0.4, "short", 10)
+			state := &AppState{Strategies: map[string]*StrategyState{sc.ID: s}}
+			mock := &mockNotifier{}
+			mn := NewMultiNotifier(notifierBackend{
+				notifier:           mock,
+				tradeAlertChannels: map[string]string{"hyperliquid": "trade-alerts"},
+				ownerID:            "owner",
+			})
+			logMgr, err := NewLogManager(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			var mu sync.RWMutex
+			reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, tc.positions, nil, "", mn, false)
+
+			if len(mock.messages) != tc.wantPublicAlerts {
+				t.Fatalf("public trade alerts = %d, want %d: %+v", len(mock.messages), tc.wantPublicAlerts, mock.messages)
+			}
+			if tc.wantPublicAlerts == 1 && (mock.messages[0].channelID != "trade-alerts" || !strings.Contains(mock.messages[0].content, "TRADE CLOSED")) {
+				t.Errorf("public trade alert = %+v, want primary close alert", mock.messages[0])
+			}
+			if len(mock.dms) != 1 || !strings.Contains(mock.dms[0].content, "Hedge leg closed externally") {
+				t.Errorf("hedge DMs = %+v, want one hedge close DM", mock.dms)
+			}
+
+			tradeRows := map[string]int{}
+			for _, trade := range s.TradeHistory {
+				tradeRows[trade.TradeType]++
+			}
+			if tradeRows["perps"] != tc.wantPrimaryTradeRows || tradeRows[hedgeTradeType] != tc.wantHedgeTradeRows {
+				t.Errorf("trade rows by type = %v, want perps=%d hedge=%d", tradeRows, tc.wantPrimaryTradeRows, tc.wantHedgeTradeRows)
+			}
+		})
+	}
+}
+
 func TestReconcileSharedCoin_MultipleStopLossOwnersConfirmed_ClosesOwners(t *testing.T) {
 	state := &AppState{
 		Strategies: map[string]*StrategyState{

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1408,6 +1408,78 @@ func TestReconcileHyperliquidHedgeCloseSkipsPublicTradeAlerts(t *testing.T) {
 	}
 }
 
+func TestHyperliquidPublicTradeAlertRowsSkipsHedgeRows(t *testing.T) {
+	cases := []struct {
+		name      string
+		trades    []Trade
+		wantCoins []string
+	}{
+		{
+			name: "hedge-only close",
+			trades: []Trade{
+				{Symbol: "BTC", TradeType: hedgeTradeType},
+			},
+		},
+		{
+			name: "primary rows around hedge close",
+			trades: []Trade{
+				{Symbol: "ETH", TradeType: "perps"},
+				{Symbol: "BTC", TradeType: hedgeTradeType},
+				{Symbol: "SOL", TradeType: "perps"},
+			},
+			wantCoins: []string{"ETH", "SOL"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hyperliquidPublicTradeAlertRows(tc.trades)
+			if len(got) != len(tc.wantCoins) {
+				t.Fatalf("public rows = %d, want %d: %+v", len(got), len(tc.wantCoins), got)
+			}
+			for i, want := range tc.wantCoins {
+				if got[i].Symbol != want {
+					t.Errorf("public row %d symbol = %q, want %q", i, got[i].Symbol, want)
+				}
+			}
+		})
+	}
+}
+
+func TestReconcileHyperliquidHedgeClosePublishesPrimaryTradeData(t *testing.T) {
+	prev := tradeRecorder
+	tradeRecorder = nil
+	t.Cleanup(func() { tradeRecorder = prev })
+
+	sc := hedgeTestConfig()
+	s := hedgeTestState(sc.ID)
+	s.Positions["ETH"] = primaryPos(10, "long")
+	s.Positions["BTC"] = hedgePos(0.4, "short", 10)
+	state := &AppState{Strategies: map[string]*StrategyState{sc.ID: s}}
+	mock := &mockNotifier{}
+	mn := NewMultiNotifier(notifierBackend{
+		notifier:           mock,
+		tradeAlertChannels: map[string]string{"hyperliquid": "trade-alerts"},
+		ownerID:            "owner",
+	})
+	logMgr, err := NewLogManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "", mn, false)
+
+	if len(mock.messages) != 1 {
+		t.Fatalf("public trade alerts = %d, want 1: %+v", len(mock.messages), mock.messages)
+	}
+	if !strings.Contains(mock.messages[0].content, "\nETH") || strings.Contains(mock.messages[0].content, "\nBTC") {
+		t.Errorf("public trade alert = %q, want primary ETH data only", mock.messages[0].content)
+	}
+	if len(mock.dms) != 1 || !strings.Contains(mock.dms[0].content, "Hedge leg closed externally") {
+		t.Errorf("hedge DMs = %+v, want one hedge close DM", mock.dms)
+	}
+}
+
 func TestReconcileSharedCoin_MultipleStopLossOwnersConfirmed_ClosesOwners(t *testing.T) {
 	state := &AppState{
 		Strategies: map[string]*StrategyState{

--- a/scheduler/hyperliquid_balance_test.go
+++ b/scheduler/hyperliquid_balance_test.go
@@ -1214,6 +1214,132 @@ func TestReconcileSharedCoin_OwnerStopLossFired_ClosesOwnerOnly(t *testing.T) {
 	}
 }
 
+func TestReconcileSoleOwnerSL_SendsTradeAlertAndProtectionDM(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: 1000, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						StopLossOID: 42, StopLossTriggerPx: 2900},
+				},
+			},
+		},
+	}
+	sc := StrategyConfig{
+		ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps",
+		Args: []string{"tema", "ETH", "1h", "--mode=live"},
+	}
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, _ string, oid int64, _ float64) (HLFillLookup, bool) {
+		if oid == 42 {
+			return HLFillLookup{Fee: 0.05, FilledQty: 1, Px: 2900, Count: 1, OID: 42}, true
+		}
+		return HLFillLookup{}, false
+	}
+
+	mock := &mockNotifier{}
+	mn := NewMultiNotifier(notifierBackend{
+		notifier:           mock,
+		tradeAlertChannels: map[string]string{"hyperliquid": "trade-alerts"},
+		ownerID:            "owner",
+	})
+	logMgr, err := NewLogManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions([]StrategyConfig{sc}, []StrategyConfig{sc}, state, &mu, logMgr, nil, nil, "0xtest", mn, true)
+
+	if len(mock.messages) != 1 {
+		t.Fatalf("trade alert messages = %d, want 1", len(mock.messages))
+	}
+	if mock.messages[0].channelID != "trade-alerts" || !strings.Contains(mock.messages[0].content, "TRADE CLOSED") {
+		t.Errorf("trade alert = %+v, want configured live close alert", mock.messages[0])
+	}
+	if len(mock.dms) != 1 || !strings.Contains(mock.dms[0].content, "SL filled") {
+		t.Errorf("protection DMs = %+v, want one sole-owner SL fill DM", mock.dms)
+	}
+}
+
+func TestReconcileSharedCoinSLAndExternal_SendsTradeAlertPerBookedTrade(t *testing.T) {
+	state := &AppState{
+		Strategies: map[string]*StrategyState{
+			"hl-owner-eth": {
+				ID: "hl-owner-eth", Cash: 1000, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 1, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-owner-eth",
+						StopLossOID: 42, StopLossTriggerPx: 2900},
+				},
+			},
+			"hl-peer-eth": {
+				ID: "hl-peer-eth", Cash: 500, Platform: "hyperliquid", Type: "perps",
+				Positions: map[string]*Position{
+					"ETH": {Symbol: "ETH", Quantity: 0.5, AvgCost: 3000, Side: "long",
+						Multiplier: 1, Leverage: 10, OwnerStrategyID: "hl-peer-eth"},
+				},
+			},
+		},
+	}
+	strategies := []StrategyConfig{
+		{ID: "hl-owner-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"tema", "ETH", "1h", "--mode=live"}},
+		{ID: "hl-peer-eth", Platform: "hyperliquid", Type: "perps", Args: []string{"rmc", "ETH", "1h", "--mode=live"}},
+	}
+	origLookup := lookupHyperliquidReconcileFillFee
+	defer func() { lookupHyperliquidReconcileFillFee = origLookup }()
+	lookupHyperliquidReconcileFillFee = func(_, coin string, oid int64, qty float64) (HLFillLookup, bool) {
+		if coin != "ETH" {
+			return HLFillLookup{}, false
+		}
+		if oid == 42 {
+			return HLFillLookup{Fee: 0.05, FilledQty: 1, Px: 2900, Count: 1, OID: 42}, true
+		}
+		if oid == 0 && math.Abs(qty-1.5) < 1e-9 {
+			return HLFillLookup{Fee: 0.15, FilledQty: 1.5, Px: 2850, Count: 1, OID: 99}, true
+		}
+		return HLFillLookup{}, false
+	}
+
+	mock := &mockNotifier{}
+	mn := NewMultiNotifier(notifierBackend{
+		notifier:           mock,
+		tradeAlertChannels: map[string]string{"hyperliquid": "trade-alerts"},
+		ownerID:            "owner",
+	})
+	logMgr, err := NewLogManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mu sync.RWMutex
+	reconcileHyperliquidAccountPositions(strategies, strategies, state, &mu, logMgr, nil, nil, "0xtest", mn, true)
+
+	if len(mock.messages) != 2 {
+		t.Fatalf("trade alert messages = %d, want 2", len(mock.messages))
+	}
+	counts := map[string]int{}
+	for _, message := range mock.messages {
+		if message.channelID != "trade-alerts" || !strings.Contains(message.content, "TRADE CLOSED") {
+			t.Errorf("trade alert = %+v, want configured live close alert", message)
+		}
+		for _, id := range []string{"hl-owner-eth", "hl-peer-eth"} {
+			if strings.Contains(message.content, "Strategy: "+id) {
+				counts[id]++
+			}
+		}
+	}
+	for _, id := range []string{"hl-owner-eth", "hl-peer-eth"} {
+		if counts[id] != 1 {
+			t.Errorf("trade alerts for %s = %d, want 1", id, counts[id])
+		}
+	}
+	if len(mock.dms) != 1 || !strings.Contains(mock.dms[0].content, "SL filled") {
+		t.Errorf("protection DMs = %+v, want one owner SL fill DM", mock.dms)
+	}
+}
+
 func TestReconcileSharedCoin_MultipleStopLossOwnersConfirmed_ClosesOwners(t *testing.T) {
 	state := &AppState{
 		Strategies: map[string]*StrategyState{

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -3123,7 +3123,7 @@ func isFreshPerStrategyCircuitBreaker(reason string) bool {
 		strings.HasPrefix(reason, RiskReasonConsecutiveLosses)
 }
 
-func sendTradeAlerts(sc StrategyConfig, stratState *StrategyState, trades int, mu *sync.RWMutex, notifier *MultiNotifier) {
+func sendTradeAlerts(sc StrategyConfig, stratState *StrategyState, trades int, mu *sync.RWMutex, notifier tradeAlertRouter) {
 	isLive := isLiveArgs(sc.Args)
 	mode := "paper"
 	if isLive {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -3124,12 +3124,6 @@ func isFreshPerStrategyCircuitBreaker(reason string) bool {
 }
 
 func sendTradeAlerts(sc StrategyConfig, stratState *StrategyState, trades int, mu *sync.RWMutex, notifier tradeAlertRouter) {
-	isLive := isLiveArgs(sc.Args)
-	mode := "paper"
-	if isLive {
-		mode = "live"
-	}
-
 	mu.RLock()
 	n := len(stratState.TradeHistory)
 	if n == 0 || trades <= 0 {
@@ -3143,6 +3137,15 @@ func sendTradeAlerts(sc StrategyConfig, stratState *StrategyState, trades int, m
 	newTrades := make([]Trade, trades)
 	copy(newTrades, stratState.TradeHistory[start:n])
 	mu.RUnlock()
+	sendTradeAlertRows(sc, newTrades, notifier)
+}
+
+func sendTradeAlertRows(sc StrategyConfig, newTrades []Trade, notifier tradeAlertRouter) {
+	isLive := isLiveArgs(sc.Args)
+	mode := "paper"
+	if isLive {
+		mode = "live"
+	}
 
 	for _, route := range notifier.tradeAlertRoutes(sc.Platform, sc.Type, isLive) {
 		for _, t := range newTrades {

--- a/scheduler/notifier.go
+++ b/scheduler/notifier.go
@@ -306,6 +306,10 @@ type tradeAlertRoute struct {
 	liveChan  string
 }
 
+type tradeAlertRouter interface {
+	tradeAlertRoutes(platform, stratType string, isLive bool) []tradeAlertRoute
+}
+
 func (m *MultiNotifier) tradeAlertRoutes(platform, stratType string, isLive bool) []tradeAlertRoute {
 	var routes []tradeAlertRoute
 	dmKey := platform

--- a/scheduler/trade_alert_source_test.go
+++ b/scheduler/trade_alert_source_test.go
@@ -49,6 +49,26 @@ func TestFormatTradeDMCloseTradeIncludesSource(t *testing.T) {
 	}
 }
 
+func TestFormatTradeDM_HyperliquidReconcileSLIncludesOID(t *testing.T) {
+	sc := StrategyConfig{ID: "hl-sync-eth", Platform: "hyperliquid", Type: "perps"}
+	trade := Trade{
+		IsClose:         true,
+		Symbol:          "ETH",
+		Side:            "sell",
+		Quantity:        1,
+		Price:           2900,
+		Value:           2900,
+		Details:         "Stop loss close, PnL: $-100.05 (fee $0.05)",
+		ExchangeOrderID: "42",
+	}
+	msg := FormatTradeDM(sc, trade, "live")
+	for _, want := range []string{"TRADE CLOSED - LIVE", "OID: 42", "Source: exchange SL"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
 func TestFormatTradeDMOpenTradeOmitsSource(t *testing.T) {
 	sc := StrategyConfig{ID: "hl-rmc-eth-live", Platform: "hyperliquid", Type: "perps"}
 	trade := Trade{


### PR DESCRIPTION
Closes #1515

## Summary

- Track each strategy's new trade-history rows during Hyperliquid reconciliation.
- Dispatch the existing trade alerts after the state lock is released, with stable strategy ordering and nil-safe routing.
- Exclude internal hedge-leg close rows from the public trade-alert stream.
- Pass the exact filtered reconciliation rows to the alert sender, preserving each row's data.
- Queue the existing protection-fill DM for sole-owner confirmed stop-loss fills.

## Verification

- New regression tests failed before the original fix because the reconciler sent zero trade alerts; they pass after the original fix.
- Review regression tests pass after the exact-row fix.
- Full Go tests pass.
- Full race tests pass.
- Go build, Go vet, and `git diff --check` pass.

Adopted implementation plan: none. Deviations: none.
Test edits: Added `TestReconcileHyperliquidHedgeCloseSkipsPublicTradeAlerts`, `TestHyperliquidPublicTradeAlertRowsSkipsHedgeRows`, and `TestReconcileHyperliquidHedgeClosePublishesPrimaryTradeData`. Ground: the review invariant requires each non-hedge close to retain its own public alert data while hedge rows stay in the owner notification path. The tests cover hedge-only close, primary rows around a hedge row, and simultaneous primary and hedge closes.

## Plain simple English

The bot sends public close alerts for strategy positions. Internal hedge closes use the hedge owner warning only. This keeps the public alert stream focused on operator-facing strategy activity.

---
Updated with LLM: GPT-5 | high | Harness: Claude Code
