### PR TITLE
docs: remove LLM attribution footers from research and plan docs [C10, Sonnet 5, medium]

### DIFF
--- a/backtest/candidates/breakout_984/README.md
+++ b/backtest/candidates/breakout_984/README.md
@@ -346,7 +346,3 @@ flips PASS → FAIL under the intra-bar walk, but the protocol verdict is
 unchanged in both modes (judged-OOS FAIL, held-out 0/3, matching the
 documented table). The #1243 finding that `tp_tight`'s documented continuous
 collapse was refuted stands (it is intrabar-unreached; only fees moved it).
-
----
-Updated with LLM: Opus 4.8 | high | Harness: Claude Code
-Updated with LLM: Fable 5 | high | Harness: Claude Code

--- a/backtest/candidates/rahtf_1054/README.md
+++ b/backtest/candidates/rahtf_1054/README.md
@@ -61,6 +61,3 @@ uv run --no-sync python backtest/candidates/rahtf_1054/entry_condition_split.py 
 Runs executed 2026-07-01 (data cache through 2026-06-04/12 per dataset — the
 same cache state the M5 audit saw; the fee-audit row reproduces exactly).
 Stats are deterministic under the default seed (1066, 10000 resamples).
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/backtest/candidates/squeeze_983/README.md
+++ b/backtest/candidates/squeeze_983/README.md
@@ -272,7 +272,3 @@ fee-model-driven; #1271 additionally shifts that candidate's numbers (its
 trailing stop is engine-tracked) without moving any verdict. With 0/3
 held-out windows it remains a non-shipper, so the keep-baseline verdict is
 unaffected.
-
----
-Updated with LLM: Opus 4.8 | high | Harness: Claude Code
-Updated with LLM: Fable 5 | high | Harness: Claude Code

--- a/backtest/research/README_1085_certification.md
+++ b/backtest/research/README_1085_certification.md
@@ -294,6 +294,3 @@ via `GO_TRADER_DIRECTIONAL_CERT_PATH`).
   `(asset, timeframe, classifier)` gate (classifier = the one the backtester
   actually models — composite if a windows spec is configured, else legacy ADX),
   so a backtest can never show a directional edge the live path suppresses.
-
----
-Created with LLM: Opus 4.8 | high | Harness: Claude Code

--- a/docs/research/1054-regime-adaptive-htf-m1.md
+++ b/docs/research/1054-regime-adaptive-htf-m1.md
@@ -215,8 +215,3 @@ same gross +0.27; hyperliquid 0.045%/side prices ~0.35pp less round-trip drag
 than binanceus 0.1%/side). The verdict rests on the gross-edge noise gates,
 which are unchanged — **`NO_POSITIVE_EDGE` and the deprecate recommendation
 hold under the current engine.**
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code + live M1 runs
-Updated with LLM: Opus 4.8 | high | Harness: Claude Code
-Updated with LLM: Fable 5 | high | Harness: Claude Code

--- a/docs/research/1138-analog-retrieval-m1.md
+++ b/docs/research/1138-analog-retrieval-m1.md
@@ -56,6 +56,3 @@ uv run --no-sync python backtest/run_backtest.py --strategy analog_retrieval \
 
 Verdict: strategy stays backtest-only research; no promotion candidate.
 Promotion to live would additionally require explicit human sign-off (#1138).
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/docs/research/1152-ranging-exit-geometry-m6.md
+++ b/docs/research/1152-ranging-exit-geometry-m6.md
@@ -232,8 +232,3 @@ not merely reproduce the legacy bar-close pass. Committed artifact
 `backtest/research/regime_1152_exit_retune.json` remains the full 18-run
 2026-07-05 matrix; this addendum's two-candidate re-runs live in the PR record
 only.
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code
-Updated with LLM: Fable 5 | high | Harness: Claude Code
-Updated with LLM: Opus 4.8 | high | Harness: Claude Code

--- a/docs/research/1166-momentum-pro-directional-gate.md
+++ b/docs/research/1166-momentum-pro-directional-gate.md
@@ -212,6 +212,3 @@ conditions on the same information. No certification evidence is generated,
 harness threading stays: it is strategy-agnostic and lets the next
 directional-gate candidate (one whose entries do NOT already self-select for
 local downtrends) be measured on the M1 bar without new plumbing.
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/docs/research/1181-htf-filter-baseline-revalidation.md
+++ b/docs/research/1181-htf-filter-baseline-revalidation.md
@@ -164,8 +164,3 @@ no surface to act on — `ohlc_walk` vs `bar_close` produce byte-identical
 output. And `run_backtest.py` prices the default `binanceus` platform fee,
 which #1320 did not change. **These baselines are current under the new
 default; no verdict or number changes.**
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code
-Updated with LLM: Opus 4.8 | high | Harness: Claude Code
-Updated with LLM: Fable 5 | high | Harness: Claude Code

--- a/docs/research/1218-vol-regime-bakeoff-rerun-v2.md
+++ b/docs/research/1218-vol-regime-bakeoff-rerun-v2.md
@@ -99,6 +99,3 @@ window (plus `max_occupancy` breaches for the funding/all_enriched arms).
   the evidence points at the state-collapse problem (fit-time K ≠ decoded effective
   states), not at significance power — `n_perm` resolution is no longer the binding
   constraint anywhere.
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/docs/research/1277-wilder-atr-cutover.md
+++ b/docs/research/1277-wilder-atr-cutover.md
@@ -86,6 +86,3 @@ unaffected because those sites are frozen (roster above).
 
 The wilder path never applies the `>= 100` integer rounding; the simple path
 keeps it frozen (#887) so historical baselines stay reproducible.
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/docs/research/1280-edge-verdicts.md
+++ b/docs/research/1280-edge-verdicts.md
@@ -222,8 +222,3 @@ the verdict rests on the 2023–2024 evidence and should be re-confirmed once
 funding history is backfilled for the remaining windows. Disposition:
 `delta_neutral_funding` stays registered and live-eligible, now with a
 demonstrated carry edge rather than a withheld verdict.
-
----
-Created with LLM: Fable 5 | medium | Harness: Claude Code
-Updated with LLM: Opus 4.8 | high | Harness: Claude Code | fableplan-work-on-issue
-Updated with LLM: Opus 4.8 | high | Harness: Claude Code | fix-pr-review

--- a/docs/research/1294-intrabar-baseline-rerun.md
+++ b/docs/research/1294-intrabar-baseline-rerun.md
@@ -74,6 +74,3 @@ modes), and the #1054 gross noise gates reproduce **bit-for-bit** (n=37 mean
 +0.082%/trade p=0.3913; n=173 mean -0.022%/trade p=0.5516). Where `bar_close`
 re-runs differ from documented numbers (983/984 nets), the entire difference
 is the #1320 fee model, as designed — the pinned mode itself is intact.
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/docs/research/1315-fee-rescreen-m5.md
+++ b/docs/research/1315-fee-rescreen-m5.md
@@ -173,6 +173,3 @@ additionally rested on M1 protocol failures vs the incumbent bar, which the
 fee change moves on both sides. `regime_adaptive` spot stays `graduate_m1` on
 the M5 screen exactly as it was pre-change; its quarantine (PR #1314) came
 from the deeper M1/noise protocol, not this screen.
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/docs/research/1329-rsi-bb-combo-m1.md
+++ b/docs/research/1329-rsi-bb-combo-m1.md
@@ -87,6 +87,3 @@ uv run --no-sync python backtest/eval_windows.py \
 uv run --no-sync python backtest/eval_windows.py --strategy mean_reversion_pro \
   --json /tmp/m1-mrpro.json
 ```
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/docs/research/1499-distinct-latent-state-labels.md
+++ b/docs/research/1499-distinct-latent-state-labels.md
@@ -259,6 +259,3 @@ hand-rule classifier.
 - No gate-semantics or threshold change is proposed. The knife-edge Bonferroni passes are
   a property of `n_perm` resolution at 1799 permutations; raising `n_perm` for a
   confirmation run would tighten the p-value estimate without changing the gate.
-
----
-Created with LLM: Fable 5.1 | high | Harness: Claude Code

--- a/docs/research/1500-gmm-regime-stability-smoothing.md
+++ b/docs/research/1500-gmm-regime-stability-smoothing.md
@@ -205,6 +205,3 @@ null), and the hand-rule path are not touched by this change. `git diff 17cdacb9
   not promoted by this document. A follow-up that re-runs the #1499 bake-off with
   `decode_stickiness=20` on every candidate, on both symbols, and with a higher `n_perm`
   to get off the alpha edge, would be the next research step. That follow-up is unfiled.
-
----
-Created with LLM: Fable 5.1 | low | Harness: Claude Code

--- a/docs/research/985-donchian-regime-gate-m1.md
+++ b/docs/research/985-donchian-regime-gate-m1.md
@@ -206,6 +206,3 @@ configs/backtests:
 Status: M1 protocol complete (baseline both legs + 7 gate/profile candidates +
 8 plateau sweeps + 1 OOS look, all 6 datasets × 5 windows). Verdict: deprecate
 — **implemented.**
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code + live M1 runs

--- a/docs/research/amd_ifvg_1023.md
+++ b/docs/research/amd_ifvg_1023.md
@@ -154,6 +154,3 @@ held-outs while keeping the chop-window edge) — out of scope here.
 Status: M1 protocol complete (corrected baseline, both 15m and 1h/4h, all 5
 windows). Verdict: deprecate — **implemented** (hidden from discovery, kept
 loadable).
-
----
-Created with LLM: Opus 4.8 | xhigh | Harness: Claude Code + live M1 runs

--- a/docs/research/mean_reversion_pro_981.md
+++ b/docs/research/mean_reversion_pro_981.md
@@ -225,6 +225,3 @@ binanceus fee model, 5 bps slippage, long-leg open-as-close harness);
 Caveat (same class as #980's): a run against a cold or partially-populated
 cache is not reproducible — populate 2023-01-01→now first; with a warm cache
 back-to-back runs reproduce to the digit.
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/docs/research/momentum_pro_980.md
+++ b/docs/research/momentum_pro_980.md
@@ -153,6 +153,3 @@ No registry defaults change; `--list-json` verified byte-identical against
 `main` for both registries. The engine gains the `entry_fraction` surface
 (+ tests) and momentum_pro gains the default-off sizing kwargs (+ tests);
 both are inert unless explicitly enabled.
-
----
-Created with LLM: Fable 5 | high | Harness: Claude Code

--- a/docs/superpowers/plans/2026-06-20-unsupervised-vol-regime-model.md
+++ b/docs/superpowers/plans/2026-06-20-unsupervised-vol-regime-model.md
@@ -1222,6 +1222,3 @@ git commit -m "test(#1080): cache-guarded bake-off smoke + full-suite regression
 **Placeholder scan:** none — every code step shows complete code; no TBD/TODO/"handle edge cases".
 
 **Type consistency:** the fitter signature `(z,k,*,seed,...) -> (assign,em_mean,em_var,counts)` is identical across Tasks 2/3/4 and consumed by `fit_unsupervised` (Task 6). `non_degeneracy`/`derive_thresholds`/`NonDegeneracyThresholds` names match between Task 7 definition and Task 8 use. `select_winner` candidate dict keys (`verdict.ship`, `non_degenerate_all`, `model_kruskal_h`, `stability_gain`) match between Task 8's test and `run_bakeoff` output.
-
----
-Created with LLM: Opus 4.8 | xhigh | Harness: Claude Code

--- a/docs/superpowers/specs/2026-06-20-unsupervised-vol-regime-model-design.md
+++ b/docs/superpowers/specs/2026-06-20-unsupervised-vol-regime-model-design.md
@@ -203,6 +203,3 @@ order-independent and unaffected. No action needed here; flagged so #1074 doesn'
 - Live / Go classifier wiring and parity — **#1074**.
 - Economic payoff of regime-conditioned ATR sizing vs flat ATR — **#1081**.
 - Multi-asset validation beyond BTC/USDT 1h — **#1083**.
-
----
-Created with LLM: Opus 4.8 | xhigh | Harness: Claude Code


### PR DESCRIPTION
## Summary
- Strip the trailing "Created/Updated with LLM: ..." footer lines from 22 markdown files under docs/research, docs/superpowers, backtest/candidates, and backtest/research.
- No content or code changes, footers only.

## Test plan
- Visual diff review; grep confirms no remaining LLM attribution footers in docs/*.md.

## Plain simple English
This change deletes leftover "made by LLM" footer lines at the bottom of research and plan documents. It does not change any document content or code.

---
Created with LLM: Sonnet 5 | medium | Harness: Claude Code